### PR TITLE
Remove runtime type validation in dataclass post-init

### DIFF
--- a/tabula/tabula/domain/model/column.py
+++ b/tabula/tabula/domain/model/column.py
@@ -18,6 +18,4 @@ class Column:
     is_nullable: bool = True
 
     def __post_init__(self) -> None:
-        if not isinstance(self.data_type, DataType):
-            raise TypeError(f"data_type must be DataType, got {type(self.data_type).__name__}")
         object.__setattr__(self, "name", normalize_identifier(self.name))

--- a/tabula/tabula/domain/model/data_type/data_type.py
+++ b/tabula/tabula/domain/model/data_type/data_type.py
@@ -17,7 +17,6 @@ class DataType:
     def __post_init__(self) -> None:
         normalized_name = normalize_identifier(self.name)
         coerced = _coerce_params(self.parameters)
-        _validate_param_types(coerced)
         _validate_by_type(normalized_name, coerced)
 
         object.__setattr__(self, "name", normalized_name)
@@ -50,14 +49,6 @@ def _coerce_params(raw: tuple[Param, ...] | object) -> tuple[Param, ...]:
 def _is_datatype_like(x: object) -> bool:
     # Structural check so helpers remain independent of import order.
     return hasattr(x, "name") and hasattr(x, "parameters")
-
-
-def _validate_param_types(params: tuple[Param, ...]) -> None:
-    for value in params:
-        if not (isinstance(value, int) or _is_datatype_like(value)):
-            raise TypeError(
-                f"Invalid parameter type: {type(value).__name__}; expected int or DataType"
-            )
 
 
 # ---- Per-type rules via a tiny registry --------------------------------------

--- a/tabula/tabula/domain/plan/actions.py
+++ b/tabula/tabula/domain/plan/actions.py
@@ -18,20 +18,11 @@ class Action:
 class CreateTable(Action):
     columns: tuple[Column, ...]
 
-    def __post_init__(self) -> None:
-        # Strict shape only — upstream model guarantees the rest.
-        if not isinstance(self.columns, tuple):
-            raise TypeError("columns must be a tuple[Column, ...]")
-
 
 
 @dataclass(frozen=True, slots=True)
 class AddColumn(Action):
     column: Column
-
-    def __post_init__(self) -> None:
-        if not isinstance(self.column, Column):
-            raise TypeError("AddColumn.column must be a Column")
         
 
 

--- a/tabula/tests/domain/model/data_type/test_data_type.py
+++ b/tabula/tests/domain/model/data_type/test_data_type.py
@@ -2,9 +2,8 @@ from __future__ import annotations
 from dataclasses import FrozenInstanceError
 import pytest
 from tabula.domain.model.data_type.data_type import (
-    DataType, 
-    _coerce_params, 
-    _validate_param_types, 
+    DataType,
+    _coerce_params,
     _validate_by_type,
     register_type,
 )
@@ -88,7 +87,7 @@ def test_nested_datatype_parameter_value_semantics():
 def test_decimal_requires_two_ints():
     with pytest.raises(ValueError): DataType("decimal")                    # missing params
     with pytest.raises(ValueError): DataType("decimal", (18,))             # one param
-    with pytest.raises(TypeError):  DataType("decimal", (18, "2"))         # wrong type
+    with pytest.raises(ValueError): DataType("decimal", (18, "2"))         # wrong type
     with pytest.raises(ValueError): DataType("decimal", (18, 19))          # scale > precision
 
 @pytest.mark.parametrize("precision, scale", [(0, 0), (-1, 0), (10, -1)])
@@ -128,15 +127,6 @@ def test__coerce_params_non_iterable_raises(bad):
     with pytest.raises(TypeError) as exc:
         _coerce_params(bad)  # type: ignore[arg-type]
     assert "iterable" in str(exc.value)
-
-def test__validate_param_types_accepts_int_and_datatype():
-    _validate_param_types((18, DataType("int")))  # no raise
-
-@pytest.mark.parametrize("bad", [(DataType("int"), "18"), ([],), ({},), (1.2,)])
-def test__validate_param_types_rejects_others(bad):
-    with pytest.raises(TypeError) as exc:
-        _validate_param_types(bad)  # type: ignore[arg-type]
-    assert "Invalid parameter type" in str(exc.value)
 
 
 def test__validate_by_type_noop_for_unknown():

--- a/tabula/tests/domain/model/test_column.py
+++ b/tabula/tests/domain/model/test_column.py
@@ -52,10 +52,6 @@ def test_non_string_name_raises_type_error():
     with pytest.raises(TypeError):
         Column(123, integer())  # type: ignore[arg-type]
 
-def test_data_type_must_be_datatype_instance():
-    with pytest.raises(TypeError):
-        Column("id", None)  # type: ignore[arg-type]
-
 # ---------------------------
 # Equality & hashing
 # ---------------------------

--- a/tabula/tests/domain/plan/test_actions.py
+++ b/tabula/tests/domain/plan/test_actions.py
@@ -25,10 +25,6 @@ def test_action_isinstance() -> None:
 # AddColumn
 # ---------------------------
 
-def test_addcolumn_requires_column_type() -> None:
-    with pytest.raises(TypeError):
-        AddColumn("id")  # type: ignore[arg-type]
-
 def test_addcolumn_normalizes_nested_column_name() -> None:
     a = AddColumn(Column("UserID", integer()))
     assert a.column.name == "userid"
@@ -55,10 +51,6 @@ def test_drop_column_rejects_non_string() -> None:
 # ---------------------------
 # CreateTable (thin action: only shape enforced here)
 # ---------------------------
-
-def test_create_table_requires_tuple_columns() -> None:
-    with pytest.raises(TypeError):
-        CreateTable([Column("a", integer()), Column("b", integer())])  # type: ignore[arg-type]
 
 def test_create_table_preserves_columns_order_and_identity() -> None:
     c1 = Column("A", integer())


### PR DESCRIPTION
## Summary
- drop post-init type checks from CreateTable and AddColumn actions
- stop runtime DataType and Column type validation
- update tests to reflect reliance on static type checking only

## Testing
- `pytest tabula/tests/domain/model tabula/tests/domain/plan tabula/tests/application`
- `pytest` *(fails: ModuleNotFoundError: No module named 'pyspark')*
- `pip install pyspark` *(fails: Could not find a version that satisfies the requirement pyspark)*

------
https://chatgpt.com/codex/tasks/task_e_68a8ba3485d48330ac3e10a6fb632c9a