### PR TITLE
Table properties

### DIFF
--- a/delta-engine/delta_engine/application/registry.py
+++ b/delta-engine/delta_engine/application/registry.py
@@ -51,7 +51,9 @@ class Registry:
         """Convert a table-like object into a :class:`DesiredTable`."""
         qualified_name = QualifiedName(spec.catalog, spec.schema, spec.name)
         columns = tuple(self._to_domain_column(c) for c in spec.columns)
-        properties = getattr(spec, "effective_properties", {})
+        properties = getattr(spec, "effective_properties", None)
+        if properties is None:
+            properties = getattr(spec, "properties", None) or {}
         return DesiredTable(
             qualified_name=qualified_name,
             columns=columns,


### PR DESCRIPTION
## Summary
- preserve table properties when converting table specs to DesiredTable
- cover property handling with registry tests

## Testing
- `pytest delta-engine/tests/application/test_registry.py -q`
- `pytest -q` *(fails: Py4JError: An error occurred while calling None.org.apache.spark.sql.classic.SparkSession)*

------
https://chatgpt.com/codex/tasks/task_e_68b59f1bd27c8330aa0b92c333bde0cf