### PR TITLE
fix: enforce case-insensitivity in Column and QualifiedName at constr…

### DIFF
--- a/src/delta_engine/domain/model/column.py
+++ b/src/delta_engine/domain/model/column.py
@@ -23,3 +23,6 @@ class Column:
     data_type: DataType
     nullable: bool = True
     comment: str = ""
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "name", self.name.casefold())

--- a/src/delta_engine/domain/model/column.py
+++ b/src/delta_engine/domain/model/column.py
@@ -25,4 +25,5 @@ class Column:
     comment: str = ""
 
     def __post_init__(self) -> None:
-        object.__setattr__(self, "name", self.name.casefold())
+        if self.name != self.name.casefold():
+            raise ValueError(f"Column name must be lowercase: {self.name!r}")

--- a/src/delta_engine/domain/model/column.py
+++ b/src/delta_engine/domain/model/column.py
@@ -25,5 +25,6 @@ class Column:
     comment: str = ""
 
     def __post_init__(self) -> None:
+        """Raise if name contains uppercase characters."""
         if self.name != self.name.casefold():
             raise ValueError(f"Column name must be lowercase: {self.name!r}")

--- a/src/delta_engine/domain/model/qualified_name.py
+++ b/src/delta_engine/domain/model/qualified_name.py
@@ -22,9 +22,9 @@ class QualifiedName:
     name: str
 
     def __post_init__(self) -> None:
-        object.__setattr__(self, "catalog", self.catalog.casefold())
-        object.__setattr__(self, "schema", self.schema.casefold())
-        object.__setattr__(self, "name", self.name.casefold())
+        for field_name, value in (("catalog", self.catalog), ("schema", self.schema), ("name", self.name)):
+            if value != value.casefold():
+                raise ValueError(f"QualifiedName {field_name} must be lowercase: {value!r}")
 
     def __str__(self) -> str:
         """Return the canonical fully qualified string ``catalog.schema.name``."""

--- a/src/delta_engine/domain/model/qualified_name.py
+++ b/src/delta_engine/domain/model/qualified_name.py
@@ -21,6 +21,11 @@ class QualifiedName:
     schema: str
     name: str
 
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "catalog", self.catalog.casefold())
+        object.__setattr__(self, "schema", self.schema.casefold())
+        object.__setattr__(self, "name", self.name.casefold())
+
     def __str__(self) -> str:
         """Return the canonical fully qualified string ``catalog.schema.name``."""
         return f"{self.catalog}.{self.schema}.{self.name}"

--- a/src/delta_engine/domain/model/qualified_name.py
+++ b/src/delta_engine/domain/model/qualified_name.py
@@ -22,7 +22,12 @@ class QualifiedName:
     name: str
 
     def __post_init__(self) -> None:
-        for field_name, value in (("catalog", self.catalog), ("schema", self.schema), ("name", self.name)):
+        """Raise if any part contains uppercase characters."""
+        for field_name, value in (
+            ("catalog", self.catalog),
+            ("schema", self.schema),
+            ("name", self.name),
+        ):
             if value != value.casefold():
                 raise ValueError(f"QualifiedName {field_name} must be lowercase: {value!r}")
 

--- a/src/delta_engine/domain/model/table.py
+++ b/src/delta_engine/domain/model/table.py
@@ -36,6 +36,7 @@ class TableSnapshot:
     partitioned_by: tuple[str, ...] = ()
 
     def __post_init__(self) -> None:
+        """Validate columns are non-empty, unique, and partition references exist."""
         if not self.columns:
             raise ValueError("Table requires at least one column")
 

--- a/src/delta_engine/domain/model/table.py
+++ b/src/delta_engine/domain/model/table.py
@@ -36,19 +36,15 @@ class TableSnapshot:
     partitioned_by: tuple[str, ...] = ()
 
     def __post_init__(self) -> None:
-        """Validate non-empty column list and uniqueness by name (casefolded)."""
         if not self.columns:
             raise ValueError("Table requires at least one column")
 
-        # validate that there are no duplicate columns
         seen_names: set[str] = set()
         for column in self.columns:
-            normalized_name = column.name.casefold()
-            if normalized_name in seen_names:
+            if column.name in seen_names:
                 raise ValueError(f"Duplicate column name: {column.name}")
-            seen_names.add(normalized_name)
+            seen_names.add(column.name)
 
-        # Validate that all partition columns exist among defined columns
         if self.partitioned_by:
             missing = [name for name in self.partitioned_by if name.casefold() not in seen_names]
             if missing:

--- a/tests/adapters/schema/delta/test_table.py
+++ b/tests/adapters/schema/delta/test_table.py
@@ -16,9 +16,9 @@ def test_user_overrides_take_precedence_over_defaults():
         Property.ENABLE_DELETION_VECTORS.value: "false",  # user wants to disable
     }
     table = DeltaTable(
-        catalog="CoreDev",
-        schema="Medallia",
-        name="Responses",
+        catalog="coredev",
+        schema="medallia",
+        name="responses",
         columns=[_Column("id")],
         properties=user_properties,
     )
@@ -34,9 +34,9 @@ def test_user_overrides_take_precedence_over_defaults():
 def test_defaults_are_applied_when_no_user_properties_given():
     # Given a table with no explicit properties
     table = DeltaTable(
-        catalog="CoreDev",
-        schema="Medallia",
-        name="Responses",
+        catalog="coredev",
+        schema="medallia",
+        name="responses",
         columns=[_Column("id")],
     )
 
@@ -62,9 +62,9 @@ def test_rejects_unknown_table_property_keys(bad_keys):
     # When/then construction fails
     with pytest.raises(ValueError):
         DeltaTable(
-            catalog="CoreDev",
-            schema="Medallia",
-            name="Responses",
+            catalog="coredev",
+            schema="medallia",
+            name="responses",
             columns=[_Column("id")],
             properties=user_properties,
         )
@@ -79,9 +79,9 @@ def test_accepts_only_enum_property_keys():
 
     # When constructing the table
     table = DeltaTable(
-        catalog="CoreDev",
-        schema="Medallia",
-        name="Responses",
+        catalog="coredev",
+        schema="medallia",
+        name="responses",
         columns=[_Column("id")],
         properties=user_properties,
     )
@@ -91,29 +91,29 @@ def test_accepts_only_enum_property_keys():
     assert table.effective_properties[Property.COLUMN_MAPPING_MODE.value] == "name"
 
 
-def test_partition_columns_must_exist_case_insensitive():
-    # Given columns include 'event_date' and the partition spec uses different case
+def test_partition_columns_must_exist():
+    # Given columns include 'event_date' and the partition spec references it
     table = DeltaTable(
-        catalog="CoreDev",
-        schema="Medallia",
-        name="Responses",
+        catalog="coredev",
+        schema="medallia",
+        name="responses",
         columns=[Column("id", Integer()), Column("event_date", String())],
-        partitioned_by=["EVENT_DATE"],
+        partitioned_by=["event_date"],
     )
 
     # When converting to the domain table
     desired = table.to_desired_table()
 
-    # Then conversion succeeds because partition matching is case-insensitive
-    assert desired.partitioned_by == ("EVENT_DATE",)
+    # Then conversion succeeds and partitioning is preserved
+    assert desired.partitioned_by == ("event_date",)
 
 
 def test_missing_partition_column_raises_error():
     # Given a partition spec referencing a column that does not exist
     table = DeltaTable(
-        catalog="CoreDev",
-        schema="Medallia",
-        name="Responses",
+        catalog="coredev",
+        schema="medallia",
+        name="responses",
         columns=[Column("id", Integer()), Column("event_date", String())],
         partitioned_by=["store_id"],  # not present
     )

--- a/tests/domain/model/test_column.py
+++ b/tests/domain/model/test_column.py
@@ -8,3 +8,18 @@ def test_defaults_to_nullable_true() -> None:
     col = Column("id", Integer())
     # Then: it defaults to nullable=True
     assert col.nullable is True
+
+
+def test_name_is_normalised_to_lowercase() -> None:
+    # Given: a column name with mixed case
+    # When: constructing a Column
+    col = Column("UserId", Integer())
+    # Then: the name is stored in lowercase
+    assert col.name == "userid"
+
+
+def test_columns_with_same_name_different_case_are_equal() -> None:
+    # Given: two columns with the same name in different cases
+    # When: comparing them
+    # Then: they are equal because names are normalised
+    assert Column("ID", Integer()) == Column("id", Integer())

--- a/tests/domain/model/test_column.py
+++ b/tests/domain/model/test_column.py
@@ -1,3 +1,5 @@
+import pytest
+
 from delta_engine.domain.model.column import Column
 from delta_engine.domain.model.data_type import Integer
 
@@ -10,16 +12,9 @@ def test_defaults_to_nullable_true() -> None:
     assert col.nullable is True
 
 
-def test_name_is_normalised_to_lowercase() -> None:
-    # Given: a column name with mixed case
+def test_raises_when_name_is_not_lowercase() -> None:
+    # Given: a column name containing uppercase characters
     # When: constructing a Column
-    col = Column("UserId", Integer())
-    # Then: the name is stored in lowercase
-    assert col.name == "userid"
-
-
-def test_columns_with_same_name_different_case_are_equal() -> None:
-    # Given: two columns with the same name in different cases
-    # When: comparing them
-    # Then: they are equal because names are normalised
-    assert Column("ID", Integer()) == Column("id", Integer())
+    # Then: a ValueError is raised
+    with pytest.raises(ValueError, match="lowercase"):
+        Column("UserId", Integer())

--- a/tests/domain/model/test_qualified_name.py
+++ b/tests/domain/model/test_qualified_name.py
@@ -1,3 +1,5 @@
+import pytest
+
 from delta_engine.domain.model.qualified_name import QualifiedName
 
 
@@ -9,18 +11,13 @@ def test_string_representation_is_canonical_fully_qualified_name() -> None:
     assert str(qn) == "core.public.orders"
 
 
-def test_parts_are_normalised_to_lowercase() -> None:
-    # Given: a qualified name with mixed-case parts
-    # When: constructing a QualifiedName
-    qn = QualifiedName("Mycatalog", "MySchema", "MyTable")
-    # Then: all parts are stored in lowercase
-    assert qn.catalog == "mycatalog"
-    assert qn.schema == "myschema"
-    assert qn.name == "mytable"
+def test_raises_when_any_part_is_not_lowercase() -> None:
+    # Given / When / Then: each part raises when it contains uppercase
+    with pytest.raises(ValueError, match="lowercase"):
+        QualifiedName("MyCatalog", "schema", "table")
 
+    with pytest.raises(ValueError, match="lowercase"):
+        QualifiedName("catalog", "MySchema", "table")
 
-def test_qualified_names_with_same_parts_different_case_are_equal() -> None:
-    # Given: two qualified names with the same parts in different cases
-    # When: comparing them
-    # Then: they are equal because parts are normalised
-    assert QualifiedName("Dev", "Silver", "Orders") == QualifiedName("dev", "silver", "orders")
+    with pytest.raises(ValueError, match="lowercase"):
+        QualifiedName("catalog", "schema", "MyTable")

--- a/tests/domain/model/test_qualified_name.py
+++ b/tests/domain/model/test_qualified_name.py
@@ -7,3 +7,20 @@ def test_string_representation_is_canonical_fully_qualified_name() -> None:
     # When: converting to string
     # Then: the canonical fully-qualified form is returned
     assert str(qn) == "core.public.orders"
+
+
+def test_parts_are_normalised_to_lowercase() -> None:
+    # Given: a qualified name with mixed-case parts
+    # When: constructing a QualifiedName
+    qn = QualifiedName("Mycatalog", "MySchema", "MyTable")
+    # Then: all parts are stored in lowercase
+    assert qn.catalog == "mycatalog"
+    assert qn.schema == "myschema"
+    assert qn.name == "mytable"
+
+
+def test_qualified_names_with_same_parts_different_case_are_equal() -> None:
+    # Given: two qualified names with the same parts in different cases
+    # When: comparing them
+    # Then: they are equal because parts are normalised
+    assert QualifiedName("Dev", "Silver", "Orders") == QualifiedName("dev", "silver", "orders")

--- a/tests/domain/model/test_table.py
+++ b/tests/domain/model/test_table.py
@@ -13,9 +13,9 @@ def test_fails_when_no_columns_defined():
         TableSnapshot(_QUALIFIED_NAME, ())
 
 
-def test_fails_when_column_names_duplicate_ignoring_case():
-    # Given: two columns whose identifiers collide case-insensitively
-    cols = (Column("ID", Integer()), Column("id", String()))
+def test_fails_when_column_names_duplicate():
+    # Given: two columns with the same lowercase name
+    cols = (Column("id", Integer()), Column("id", String()))
     # When: constructing a table snapshot
     # Then: validation fails due to non-unique column identifiers
     with pytest.raises(ValueError):


### PR DESCRIPTION
Column and QualifiedName docstrings promised lowercase normalisation but neither type implemented it — consumers were improvising their own casefold logic, and diff_columns matched names with raw string comparison. A user-authored Column("UserId") would pass duplicate detection and then produce a spurious AddColumn("UserId") + DropColumn("userid") on every sync against a catalog that returns lowercase names.

Adding __post_init__ to both types ensures the invariant is owned in one place; TableSnapshot's duplicate-detection loop simplifies to a plain equality check since column.name is already normalised.