### PR TITLE
docs: replace fabricated Raises: block in _apply with the true contract

### DIFF
--- a/src/delta_engine/adapters/databricks/catalog/executor.py
+++ b/src/delta_engine/adapters/databricks/catalog/executor.py
@@ -56,12 +56,9 @@ class DatabricksExecutor:
 
     def _apply(self, plan: ActionPlan) -> tuple[_AppliedStep, ...]:
         """
-        Execute all statements for the plan.
+        Run every statement to completion.
 
-        Raises:
-            RuntimeError: if any statement fails.
-            ValueError: if the compiler returns a mismatched count.
-
+        Exceptions are captured in the corresponding _AppliedStep rather than re-raised.
         """
         if not plan:
             return tuple()


### PR DESCRIPTION
The old docstring claimed RuntimeError and ValueError were raised; the method does neither — it wraps every spark.sql() in except Exception and stores the error in _AppliedStep. A caller trusting the old docstring would write error handling that never fires and miss the real contract (inspect ExecutionResult).