### PR TITLE
docs: fix backtick docstrings that contained a copy-pasted junk token

### DIFF
--- a/src/delta_engine/adapters/databricks/sql/dialect.py
+++ b/src/delta_engine/adapters/databricks/sql/dialect.py
@@ -6,7 +6,7 @@ from delta_engine.domain.model import QualifiedName
 
 
 def backtick(raw: str) -> str:
-    """Backtick-quote an identifier part, escaping backtick_qualified_names."""
+    """Backtick-quote an identifier part, doubling any embedded backtick."""
     return f"`{raw.replace('`', '``')}`"
 
 
@@ -16,5 +16,5 @@ def quote_literal(literal: str) -> str:
 
 
 def backtick_qualified_name(qualified_name: QualifiedName) -> str:
-    """Render a fully qualified table name with dot separators and backtick_qualified_names."""
+    """Render a QualifiedName as backtick-quoted, dot-separated parts."""
     return ".".join(backtick(p) for p in qualified_name.parts)


### PR DESCRIPTION
Both backtick and backtick_qualified_name described themselves as escaping "backtick_qualified_names" — the name of a sibling function pasted where a description belongs. The docstrings now state what each function does, including the one non-obvious fact: an embedded backtick is doubled.