### PR TITLE
refactor: extract shared failure-rendering helper; delete dead format…

### DIFF
--- a/src/delta_engine/application/errors.py
+++ b/src/delta_engine/application/errors.py
@@ -1,11 +1,7 @@
 """Application-level exception types for sync operations."""
 
-from delta_engine.application.results import (
-    ExecutionFailure,
-    ReadFailure,
-    SyncReport,
-    ValidationFailure,
-)
+from delta_engine.application.format_report import format_failure_detail
+from delta_engine.application.results import SyncReport
 
 
 class SyncFailedError(Exception):
@@ -16,33 +12,10 @@ class SyncFailedError(Exception):
         self.report = report
 
         failed_tables = [t for t in report.table_reports if t.has_failures]
-        num_failed = len(failed_tables)
-        total = len(report.table_reports)
+        header = f"Sync failed: {len(failed_tables)}/{len(report.table_reports)} tables failed"
 
-        header = f"Sync failed: {num_failed}/{total} tables failed"
         details: list[str] = []
-
-        for t in failed_tables:
-            # Table headline
-            details.append(f"\n❌ {t.fully_qualified_name} [{t.status.value}]")
-
-            # Top-level & aggregated failures (read, validation, execution)
-            for fail in t.all_failures:
-                if isinstance(fail, ReadFailure):
-                    details.append(f"    Read error: {fail.exception_type} - {fail.message}")
-                elif isinstance(fail, ValidationFailure):
-                    details.append(f"    Validation failed: {fail.rule_name} - {fail.message}")
-                elif isinstance(fail, ExecutionFailure):
-                    details.append(
-                        f"    Execution failed at action {fail.action_index}: "
-                        f"{fail.exception_type} - {fail.message}"
-                    )
-
-            # Failed SQL previews for failed actions (if provided)
-            if t.execution_results:
-                for result in t.execution_results:
-                    if result.failure:
-                        details.append(f"    Failed SQL preview (action {result.action_index}):")
-                        details.append(f"        {result.statement_preview}")
+        for table_report in failed_tables:
+            details.extend(format_failure_detail(table_report))
 
         super().__init__("\n".join([header, *details]))

--- a/src/delta_engine/application/format_report.py
+++ b/src/delta_engine/application/format_report.py
@@ -1,74 +1,43 @@
 """
-Human-readable formatting for sync run reports.
+Human-readable formatting for sync failures.
 
-Transforms a `SyncReport` into a concise text summary: computes durations,
-summarizes per-table status, and includes brief previews of failed actions
-when present.
+Turns a failed `TableRunReport` into the per-table detail lines shared by the
+`SyncFailedError` message.
 """
 
 from __future__ import annotations
 
-from datetime import timedelta
-
-from delta_engine.application.results import ActionStatus, SyncReport, TableRunStatus
-
-
-def _format_duration(duration: timedelta) -> str:
-    """Format a timedelta as seconds with two decimals (e.g., '1.23s')."""
-    return f"{duration.total_seconds():.2f}s"
+from delta_engine.application.results import (
+    ExecutionFailure,
+    ReadFailure,
+    TableRunReport,
+    ValidationFailure,
+)
 
 
-def format_sync_report(report: SyncReport) -> str:
-    """Return a human-readable summary of a SyncReport."""
-    started = report.started_at
-    ended = report.ended_at
-    duration = ended - started
-    duration_str = _format_duration(duration)
+def format_failure_detail(table_report: TableRunReport) -> list[str]:
+    """
+    Return the detail lines describing why a single table failed.
 
-    lines: list[str] = []
-    lines.append(f"Sync run: {started.isoformat()} → {ended.isoformat()} ({duration_str})")
+    Covers the table headline, each top-level failure (read, validation,
+    execution), and SQL previews for any failed actions.
+    """
+    lines = [f"\n❌ {table_report.fully_qualified_name} [{table_report.status.value}]"]
 
-    # --- Header
-    lines.append(f"{started:%Y-%m-%d %H:%M:%S} | INFO | Engine Sync Report")
-    lines.append("=" * 55)
-    lines.append(f"Started:  {started.isoformat()}")
-    lines.append(f"Ended:    {ended.isoformat()}")
-    lines.append(f"Duration: {int(duration.total_seconds())}s")
-    lines.append("")
-
-    total = len(report.table_reports)
-    failed = sum(1 for table in report.table_reports if table.has_failures)
-    ok = total - failed
-    lines.append(f"Tables: {total}  |  OK: {ok}  |  Failed: {failed}")
-    lines.append("─" * 78)
-
-    # --- Per-table summaries
-    for table in report.table_reports:
-        status_icon = "❌" if table.has_failures else "✅"
-        status_text = table.status.value
-        table_duration = _format_duration(table.ended_at - table.started_at)
-
-        if table.status is TableRunStatus.READ_FAILED:
-            summary = "read failed"
-        elif table.status is TableRunStatus.VALIDATION_FAILED:
-            summary = f"{len(table.validation.failures)} validation failure(s)"
-        elif table.status is TableRunStatus.EXECUTION_FAILED:
-            total_actions = len(table.execution_results)
-            failed_actions = sum(
-                1 for result in table.execution_results if result.status is ActionStatus.FAILED
+    for failure in table_report.all_failures:
+        if isinstance(failure, ReadFailure):
+            lines.append(f"    Read error: {failure.exception_type} - {failure.message}")
+        elif isinstance(failure, ValidationFailure):
+            lines.append(f"    Validation failed: {failure.rule_name} - {failure.message}")
+        elif isinstance(failure, ExecutionFailure):
+            lines.append(
+                f"    Execution failed at action {failure.action_index}: "
+                f"{failure.exception_type} - {failure.message}"
             )
-            summary = f"{failed_actions}/{total_actions} actions failed"
-        else:
-            total_actions = len(table.execution_results)
-            summary = f"executed {total_actions} actions" if total_actions else "no-op"
 
-        lines.append(
-            f"{status_icon} {table.fully_qualified_name:<30} "
-            f"{summary:<28} {status_text} ({table_duration})"
-        )
+    for result in table_report.execution_results:
+        if result.failure:
+            lines.append(f"    Failed SQL preview (action {result.action_index}):")
+            lines.append(f"        {result.statement_preview}")
 
-    # --- Footer
-    lines.append("─" * 78)
-    lines.append("Run completed with failures." if failed else "All tables synced successfully ✅")
-
-    return "\n".join(lines)
+    return lines

--- a/tests/application/test_format_report.py
+++ b/tests/application/test_format_report.py
@@ -1,0 +1,84 @@
+from datetime import UTC, datetime
+
+from delta_engine.application.format_report import format_failure_detail
+from delta_engine.application.results import (
+    ActionStatus,
+    ExecutionFailure,
+    ExecutionResult,
+    ReadFailure,
+    ReadResult,
+    TableRunReport,
+    ValidationFailure,
+    ValidationResult,
+)
+
+_AT = datetime(2026, 1, 1, tzinfo=UTC)
+_NO_VALIDATION_FAILURES = ValidationResult()
+
+
+def _table_report(
+    *,
+    read: ReadResult,
+    validation: ValidationResult = _NO_VALIDATION_FAILURES,
+    execution_results: tuple[ExecutionResult, ...] = (),
+) -> TableRunReport:
+    return TableRunReport(
+        fully_qualified_name="cat.sch.tbl",
+        started_at=_AT,
+        ended_at=_AT,
+        read=read,
+        validation=validation,
+        execution_results=execution_results,
+    )
+
+
+def test_renders_read_failure_detail():
+    # Given: a table whose read phase failed
+    report = _table_report(
+        read=ReadResult.create_failed(ReadFailure("AnalysisException", "table not found"))
+    )
+
+    # When: rendering its failure detail
+    lines = format_failure_detail(report)
+
+    # Then: the headline and the read error line are present
+    assert lines[0] == "\n❌ cat.sch.tbl [READ_FAILED]"
+    assert "    Read error: AnalysisException - table not found" in lines
+
+
+def test_renders_validation_failure_detail():
+    # Given: a table whose validation phase failed
+    report = _table_report(
+        read=ReadResult.create_absent(),
+        validation=ValidationResult(
+            failures=(ValidationFailure("DisallowPartitioningChange", "cannot repartition"),)
+        ),
+    )
+
+    # When: rendering its failure detail
+    lines = format_failure_detail(report)
+
+    # Then: the validation failure line is present
+    assert lines[0] == "\n❌ cat.sch.tbl [VALIDATION_FAILED]"
+    assert "    Validation failed: DisallowPartitioningChange - cannot repartition" in lines
+
+
+def test_renders_execution_failure_detail_with_sql_preview():
+    # Given: a table whose execution phase failed on one action
+    failed_result = ExecutionResult(
+        action="AddColumn",
+        action_index=2,
+        status=ActionStatus.FAILED,
+        statement_preview="ALTER TABLE cat.sch.tbl ADD COLUMN x INT",
+        failure=ExecutionFailure(action_index=2, exception_type="SparkException", message="boom"),
+    )
+    report = _table_report(read=ReadResult.create_absent(), execution_results=(failed_result,))
+
+    # When: rendering its failure detail
+    lines = format_failure_detail(report)
+
+    # Then: both the failure line and the SQL preview are present
+    assert lines[0] == "\n❌ cat.sch.tbl [EXECUTION_FAILED]"
+    assert "    Execution failed at action 2: SparkException - boom" in lines
+    assert "    Failed SQL preview (action 2):" in lines
+    assert "        ALTER TABLE cat.sch.tbl ADD COLUMN x INT" in lines


### PR DESCRIPTION
SyncFailedError.__init__ contained its own isinstance-dispatch over the failure-type hierarchy (ReadFailure / ValidationFailure / ExecutionFailure) plus SQL-preview walking — leaked knowledge of how a failed table renders to text. Meanwhile format_report.py's format_sync_report was never called anywhere: one live renderer, one dead one, both encoding overlapping report-to-text knowledge.

Extract the failure-detail rendering into format_failure_detail(table_report) in format_report.py (which now owns the isinstance dispatch) and have SyncFailedError call it. Delete the dead format_sync_report and its _format_duration helper. Add focused tests for the shared helper across read, validation, and execution failures (previously untested).

The exception message is byte-for-byte unchanged.