### PR TITLE
refactor: remove stale TODO comments and fix misleading diff_partitio…

### DIFF
--- a/src/delta_engine/adapters/databricks/sql/compile.py
+++ b/src/delta_engine/adapters/databricks/sql/compile.py
@@ -38,7 +38,7 @@ def compile_plan(plan: ActionPlan) -> tuple[str, ...]:
 @singledispatch
 def _compile_action(
     action: Action, backticked_table_name: str
-) -> str:  # TODO: fix unaccessed backticked_table_name
+) -> str:
     """Dispatch to action-specific SQL compiler."""
     raise NotImplementedError(f"No SQL compiler for action {type(action).__name__}")
 
@@ -116,7 +116,7 @@ def _column_definition(column) -> str:
     """Render a single column definition fragment."""
     column_name = backtick(column.name)
     type = sql_type_for_data_type(column.data_type)
-    nullable = "" if column.nullable else "NOT NULL"  # TODO: or be explicit?
+    nullable = "" if column.nullable else "NOT NULL"
     return f"{column_name} {type} {nullable}".strip()
 
 

--- a/src/delta_engine/application/results.py
+++ b/src/delta_engine/application/results.py
@@ -116,7 +116,7 @@ class ValidationResult:
 
 
 @dataclass(frozen=True, slots=True)
-class ExecutionResult:  # do we want an ActionResult and then an aggregate ExecutionResult?
+class ExecutionResult:
     """Result of executing a single action in a plan."""
 
     action: str

--- a/src/delta_engine/application/validation.py
+++ b/src/delta_engine/application/validation.py
@@ -8,10 +8,6 @@ from delta_engine.application.plan import PlanContext
 from delta_engine.application.results import ValidationFailure
 from delta_engine.domain.plan import AddColumn, PartitionBy
 
-# TODO: Rules to add:
-# - no setting existing columns to NOT NULL if table is populated
-
-
 class Rule(ABC):
     """Abstract interface for plan validation rules."""
 
@@ -30,7 +26,7 @@ class Rule(ABC):
         ...
 
 
-class NonNullableColumnAdd(Rule):  # Are classes and ABCs the best approach?
+class NonNullableColumnAdd(Rule):
     """
     Disallow adding non-nullable columns to existing tables.
 

--- a/src/delta_engine/domain/plan/actions.py
+++ b/src/delta_engine/domain/plan/actions.py
@@ -157,7 +157,7 @@ class SetColumnNullability(Action):
 
 
 @dataclass(frozen=True, slots=True)
-class PartitionBy(Action):  # consider replacing with a RequireTableRecreate action
+class PartitionBy(Action):
     """
     Partition the table.
 

--- a/src/delta_engine/domain/services/table_diff.py
+++ b/src/delta_engine/domain/services/table_diff.py
@@ -45,11 +45,7 @@ def diff_table_comments(
 def diff_partition_columns(
     desired: DesiredTable, observed: ObservedTable
 ) -> tuple[PartitionBy, ...]:
-    """
-    Return the desired parition columns if different from observed.
-
-    Note: This is operation is currently disallowed. We surface this action only to warn the user.
-    """
+    """Return the desired partition columns if different from observed."""
     if desired.partitioned_by == observed.partitioned_by:
         return ()
     else:


### PR DESCRIPTION
Deletes seven in-source TODO/design-question comments that left readers uncertain whether current designs were final or provisional (finding 10), and replaces the diff_partition_columns docstring that leaked validation policy and contained a typo with a concise, layer-appropriate description (finding 11).