### PR TITLE
refactor: remove ActionPlan.target; thread table identity through execute(target, plan)

### DIFF
--- a/src/delta_engine/adapters/databricks/catalog/executor.py
+++ b/src/delta_engine/adapters/databricks/catalog/executor.py
@@ -20,6 +20,7 @@ from delta_engine.application.results import (
     ExecutionResult,
     ExecutionSucceeded,
 )
+from delta_engine.domain.model import QualifiedName
 from delta_engine.domain.plan.actions import ActionPlan
 
 logger = logging.getLogger(__name__)
@@ -31,14 +32,16 @@ class DatabricksExecutor:
     def __init__(
         self,
         spark: SparkSession,
-        compiler: Callable[[ActionPlan], Iterable[str]] = compile_plan,
+        compiler: Callable[[QualifiedName, ActionPlan], Iterable[str]] = compile_plan,
     ) -> None:
         self.spark = spark
         self._compiler = compiler
 
-    def execute(self, plan: ActionPlan) -> tuple[ExecutionResult, ...]:
+    def execute(
+        self, target: QualifiedName, plan: ActionPlan
+    ) -> tuple[ExecutionResult, ...]:
         """
-        Execute the plan's actions in order, returning a per-action result.
+        Execute the plan's actions against ``target``, returning a per-action result.
 
         Execution stops at the first failure: the actions form a dependency
         chain, and the engine is not transactional, so continuing past a failure
@@ -46,7 +49,7 @@ class DatabricksExecutor:
         actions attempted, ending at the one that failed; actions after it are
         left unattempted rather than run against an inconsistent table.
         """
-        statements = self._compiler(plan)
+        statements = self._compiler(target, plan)
         results: list[ExecutionResult] = []
         for action_index, statement in enumerate(statements):
             result = self._run_statement(plan[action_index], action_index, statement)

--- a/src/delta_engine/adapters/databricks/sql/compile.py
+++ b/src/delta_engine/adapters/databricks/sql/compile.py
@@ -16,6 +16,7 @@ from delta_engine.adapters.databricks.sql import (
     quote_literal,
     sql_type_for_data_type,
 )
+from delta_engine.domain.model import QualifiedName
 from delta_engine.domain.plan.actions import (
     Action,
     ActionPlan,
@@ -29,9 +30,9 @@ from delta_engine.domain.plan.actions import (
 )
 
 
-def compile_plan(plan: ActionPlan) -> tuple[str, ...]:
-    """Compile an :class:`ActionPlan` into Spark SQL statements."""
-    backticked_table_name = backtick_qualified_name(plan.target)
+def compile_plan(target: QualifiedName, plan: ActionPlan) -> tuple[str, ...]:
+    """Compile an :class:`ActionPlan` for ``target`` into Spark SQL statements."""
+    backticked_table_name = backtick_qualified_name(target)
     return tuple(_compile_action(action, backticked_table_name) for action in plan)
 
 

--- a/src/delta_engine/application/engine.py
+++ b/src/delta_engine/application/engine.py
@@ -137,7 +137,7 @@ class Engine:
                 )
             else:
                 logger.info("Validation passed for %s", fully_qualified_name)
-                executions = self.executor.execute(context.plan)
+                executions = self.executor.execute(desired.qualified_name, context.plan)
                 failed_count = sum(1 for e in executions if isinstance(e, ExecutionFailed))
                 logger.info(
                     "Executed %d action(s) for %s (%d failed)",

--- a/src/delta_engine/application/ports.py
+++ b/src/delta_engine/application/ports.py
@@ -28,6 +28,8 @@ class CatalogStateReader(Protocol):
 class PlanExecutor(Protocol):
     """Executes an action plan against a backing engine."""
 
-    def execute(self, plan: ActionPlan) -> tuple[ExecutionResult, ...]:
-        """Run the plan and return the execution outcome."""
+    def execute(
+        self, target: QualifiedName, plan: ActionPlan
+    ) -> tuple[ExecutionResult, ...]:
+        """Run the plan against ``target`` and return the execution outcome."""
         ...

--- a/src/delta_engine/domain/plan/actions.py
+++ b/src/delta_engine/domain/plan/actions.py
@@ -7,7 +7,7 @@ from dataclasses import dataclass
 from enum import IntEnum, auto
 from typing import ClassVar
 
-from delta_engine.domain.model import Column, DesiredTable, QualifiedName
+from delta_engine.domain.model import Column, DesiredTable
 
 
 class ActionPhase(IntEnum):
@@ -159,9 +159,8 @@ class SetColumnNullability(Action):
 
 @dataclass(frozen=True, slots=True)
 class ActionPlan:
-    """Collection of actions targeting a single qualified name."""
+    """An ordered set of actions to apply to a table."""
 
-    target: QualifiedName
     actions: tuple[Action, ...] = ()
 
     def __len__(self) -> int:

--- a/src/delta_engine/domain/services/differ.py
+++ b/src/delta_engine/domain/services/differ.py
@@ -46,7 +46,7 @@ def diff_tables(desired: DesiredTable, observed: ObservedTable | None) -> Action
             + _diff_properties(desired.properties, observed.properties)
             + _diff_table_comment(desired.comment, observed.comment)
         )
-    return ActionPlan(desired.qualified_name, actions)
+    return ActionPlan(actions)
 
 
 def _diff_columns(desired: tuple[Column, ...], observed: tuple[Column, ...]) -> tuple[Action, ...]:

--- a/tests/adapters/databricks/catalog/test_executor.py
+++ b/tests/adapters/databricks/catalog/test_executor.py
@@ -79,16 +79,15 @@ class _FakeSpark:
 
 def test_execute_maps_success_and_failure_without_leakage():
     # Given a 2-action plan whose statements run OK → FAIL
-    plan = ActionPlan(
-        target=_dummy_target(),
-        actions=(AddColumn(Column("a", Integer())), DropColumn("b")),
-    )
+    plan = ActionPlan(actions=(AddColumn(Column("a", Integer())), DropColumn("b")))
 
-    def _fake_compiler(_plan):
+    def _fake_compiler(_target, _plan):
         return ["SELECT 1", "SELECT * FROM __nope__"]  # OK, then FAIL
 
     # When we execute
-    results = DatabricksExecutor(_FakeSpark(), compiler=_fake_compiler).execute(plan)
+    results = DatabricksExecutor(_FakeSpark(), compiler=_fake_compiler).execute(
+        _dummy_target(), plan
+    )
 
     # Then the success and failure are mapped with correct metadata and no leakage
     assert [r.action for r in results] == ["AddColumn", "DropColumn"]
@@ -102,7 +101,6 @@ def test_execute_stops_at_first_failure_to_avoid_half_migrating():
     # Given a 3-action plan whose middle statement fails
     spark = _FakeSpark()
     plan = ActionPlan(
-        target=_dummy_target(),
         actions=(
             AddColumn(Column("a", Integer())),
             DropColumn("b"),
@@ -110,7 +108,7 @@ def test_execute_stops_at_first_failure_to_avoid_half_migrating():
         ),
     )
 
-    def _fake_compiler(_plan):
+    def _fake_compiler(_target, _plan):
         return [
             "SELECT 1",  # OK
             "SELECT * FROM __nope__",  # FAIL
@@ -118,7 +116,7 @@ def test_execute_stops_at_first_failure_to_avoid_half_migrating():
         ]
 
     # When we execute
-    results = DatabricksExecutor(spark, compiler=_fake_compiler).execute(plan)
+    results = DatabricksExecutor(spark, compiler=_fake_compiler).execute(_dummy_target(), plan)
 
     # Then execution stops at the failure: the third statement never runs
     assert spark.executed == ["SELECT 1", "SELECT * FROM __nope__"]
@@ -130,10 +128,10 @@ def test_execute_stops_at_first_failure_to_avoid_half_migrating():
 
 def test_execute_returns_empty_tuple_for_empty_plan():
     # Given an empty plan
-    plan = ActionPlan(target=_dummy_target(), actions=())
+    plan = ActionPlan(actions=())
 
     # When we execute the plan
-    results = DatabricksExecutor(_FakeSpark()).execute(plan)
+    results = DatabricksExecutor(_FakeSpark()).execute(_dummy_target(), plan)
 
     # Then no results are returned
     assert results == ()
@@ -145,11 +143,11 @@ def test_createtable_action_creates_table_with_correct_schema(spark, test_table)
         qualified_name=QualifiedName(TEST_CATALOG, TEST_SCHEMA, "customers"),
         columns=(Column(name="id", data_type=Integer()),),
     )
-    plan = ActionPlan(target=desired.qualified_name, actions=(CreateTable(table=desired),))
+    plan = ActionPlan(actions=(CreateTable(table=desired),))
     executor = DatabricksExecutor(spark)
 
     # When we apply the plan (compile → execute)
-    executor.execute(plan)
+    executor.execute(desired.qualified_name, plan)
 
     # Then the table exists and its schema matches exactly
     assert spark.catalog.tableExists(str(desired.qualified_name))
@@ -164,13 +162,10 @@ def test_addcolumn_action_adds_column_to_existing_table(spark, test_table):
     column_name = "age"
     data_type = Integer()
     actions = (AddColumn(column=Column(name=column_name, data_type=data_type)),)
-    plan = ActionPlan(
-        target=test_table,
-        actions=actions,
-    )
+    plan = ActionPlan(actions=actions)
 
     # When we apply the plan (compile → execute)
-    DatabricksExecutor(spark).execute(plan)
+    DatabricksExecutor(spark).execute(test_table, plan)
 
     # Then the new column exists
     actual_schema = spark.table(str(test_table)).schema
@@ -187,13 +182,10 @@ def test_dropcolumn_action_removes_column_from_existing_table(spark, test_table)
     # Given an existing table (test_table)
     # And a plan that drops the 'name' column
     actions = (DropColumn(column_name="column_to_drop"),)
-    plan = ActionPlan(
-        target=test_table,
-        actions=actions,
-    )
+    plan = ActionPlan(actions=actions)
 
     # When we apply the plan (compile → execute)
-    DatabricksExecutor(spark).execute(plan)
+    DatabricksExecutor(spark).execute(test_table, plan)
 
     # Then the 'name' column no longer exists
     actual_columns = spark.table(str(test_table)).columns
@@ -205,10 +197,10 @@ def test_setproperty_action_sets_table_property(spark, test_table):
     # And a plan that sets a custom property
     prop = "engine.test.setproperty"
     val = "yes"
-    plan = ActionPlan(target=test_table, actions=(SetProperty(name=prop, value=val),))
+    plan = ActionPlan(actions=(SetProperty(name=prop, value=val),))
 
     # When we apply the plan (compile → execute)
-    DatabricksExecutor(spark).execute(plan)
+    DatabricksExecutor(spark).execute(test_table, plan)
 
     # Then the property exists with the expected value
     props = _get_table_props(spark, str(test_table))
@@ -221,11 +213,8 @@ def test_setcolumncomment_sets_comment_on_column(spark, test_table):
 
     # When we apply a plan to set the column comment
     new_comment = "customer name"
-    plan = ActionPlan(
-        target=test_table,
-        actions=(SetColumnComment(column_name=column, comment=new_comment),),
-    )
-    DatabricksExecutor(spark).execute(plan)
+    plan = ActionPlan(actions=(SetColumnComment(column_name=column, comment=new_comment),))
+    DatabricksExecutor(spark).execute(test_table, plan)
 
     # Then the column metadata contains the new comment
     after_field = next(f for f in spark.table(str(test_table)).schema if f.name == column)
@@ -236,8 +225,8 @@ def test_settablecomment_sets_comment_on_table(spark, test_table):
     # Given an existing Delta table
     # When we set the table comment
     comment = "customers staging table"
-    plan = ActionPlan(target=test_table, actions=(SetTableComment(comment=comment),))
-    DatabricksExecutor(spark).execute(plan)
+    plan = ActionPlan(actions=(SetTableComment(comment=comment),))
+    DatabricksExecutor(spark).execute(test_table, plan)
 
     # Then the comment is set on the table
     after = _get_table_comment(spark, str(test_table))
@@ -248,8 +237,8 @@ def test_setcolumnnullability_sets_nullable(spark, test_table):
     # Given an existing table with a non-nullable 'id' column
     # When we set NULL on 'id'
     full = str(test_table)
-    plan = ActionPlan(test_table, (SetColumnNullability("id", True),))
-    DatabricksExecutor(spark).execute(plan)
+    plan = ActionPlan((SetColumnNullability("id", True),))
+    DatabricksExecutor(spark).execute(test_table, plan)
 
     # Then the column becomes NULLABLE
     field = _get_field(spark, full, "id")

--- a/tests/adapters/databricks/sql/test_compile.py
+++ b/tests/adapters/databricks/sql/test_compile.py
@@ -27,7 +27,7 @@ def _concrete_action_types():
 
 def _compile_single(action) -> str:
     """Compile a one-action plan and return the single SQL statement."""
-    (statement,) = compile_plan(ActionPlan(target=_TARGET, actions=(action,)))
+    (statement,) = compile_plan(_TARGET, ActionPlan(actions=(action,)))
     return statement
 
 

--- a/tests/application/test_engine.py
+++ b/tests/application/test_engine.py
@@ -51,7 +51,9 @@ class _FakeExecutor:
     def __init__(self, results: tuple[ExecutionResult, ...]) -> None:
         self.results = results
 
-    def execute(self, plan: ActionPlan) -> tuple[ExecutionResult, ...]:
+    def execute(
+        self, target: QualifiedName, plan: ActionPlan
+    ) -> tuple[ExecutionResult, ...]:
         return self.results
 
 
@@ -74,7 +76,9 @@ class _SeqExecutor:
     def __init__(self, per_call_results: list[tuple[ExecutionResult, ...]]) -> None:
         self._seq = list(per_call_results)
 
-    def execute(self, plan: ActionPlan) -> tuple[ExecutionResult, ...]:
+    def execute(
+        self, target: QualifiedName, plan: ActionPlan
+    ) -> tuple[ExecutionResult, ...]:
         return self._seq.pop(0)
 
 

--- a/tests/application/test_validation.py
+++ b/tests/application/test_validation.py
@@ -187,7 +187,7 @@ _QUALIFIED_NAME = QualifiedName("dev", "silver", "events")
 def _context(*, observed: ObservedTable | None, actions: tuple) -> PlanContext:
     """Build a real PlanContext with the given plan actions for an existing/absent table."""
     desired = DesiredTable(qualified_name=_QUALIFIED_NAME, columns=(Column("id", Integer()),))
-    plan = ActionPlan(target=_QUALIFIED_NAME, actions=actions)
+    plan = ActionPlan(actions=actions)
     return PlanContext(desired=desired, observed=observed, plan=plan)
 
 
@@ -254,7 +254,7 @@ def _context_for_columns(
         if observed_columns is None
         else ObservedTable(qualified_name=_QUALIFIED_NAME, columns=observed_columns)
     )
-    return PlanContext(desired=desired, observed=observed, plan=ActionPlan(target=_QUALIFIED_NAME))
+    return PlanContext(desired=desired, observed=observed, plan=ActionPlan())
 
 
 def test_rejects_changing_the_type_of_an_existing_column():

--- a/tests/domain/plan/test_actions.py
+++ b/tests/domain/plan/test_actions.py
@@ -1,13 +1,10 @@
-from delta_engine.domain.model import QualifiedName
 from delta_engine.domain.plan.actions import ActionPlan, DropColumn
-
-_QUALIFIED_NAME = QualifiedName("dev", "silver", "orders")
 
 
 def test_actionplan_truthiness_and_length():
     # Given: empty and non-empty plans
-    empty = ActionPlan(_QUALIFIED_NAME, ())
-    non_empty = ActionPlan(_QUALIFIED_NAME, (DropColumn("legacy"),))
+    empty = ActionPlan(())
+    non_empty = ActionPlan((DropColumn("legacy"),))
     # When/Then
     assert bool(empty) is False
     assert len(empty) == 0

--- a/tests/domain/services/test_differ.py
+++ b/tests/domain/services/test_differ.py
@@ -72,7 +72,6 @@ def test_creates_table_when_observed_is_missing():
     plan = diff_tables(desired, observed=None)
 
     # Then: we get a CreateTable wrapped in an ActionPlan
-    assert plan.target == desired.qualified_name
     assert plan.actions == (CreateTable(desired),)
 
 
@@ -100,7 +99,6 @@ def test_no_actions_when_desired_equals_observed():
     plan = diff_tables(desired, observed)
 
     # Then: nothing to do
-    assert plan.target == desired.qualified_name
     assert plan.actions == ()
 
 
@@ -135,7 +133,6 @@ def test_combines_column_property_comment_and_partition_diffs():
 
     # Then: the plan contains the expected representative actions
     assert isinstance(plan, ActionPlan)
-    assert plan.target == desired.qualified_name
 
     # Column add
     assert AddColumn(column=Column("age", Integer())) in plan.actions


### PR DESCRIPTION
## What & why

`ActionPlan.target` carried the table's `QualifiedName` **solely so it could survive the trip from the differ to the SQL compiler** — a pass-through field on a domain value object. Exactly one production reader existed (`compile.py`, in the adapters layer); no domain or application code consulted `.target`, yet every layer already held `desired.qualified_name` independently. Identity was thus reproduced in three forms (the `QualifiedName` on `DesiredTable`, the copy on `ActionPlan.target`, and the recomputed report string).

This was surfaced by an information-flow architecture review as a single root cause: *information belonging to one layer was stamped onto a lower-level carrier because the carrier was the only thing threaded to the consumer.*

## The change

- `ActionPlan` becomes a pure ordered set of actions — `{actions}`, no `target`.
- The differ returns `ActionPlan(actions)`.
- Identity flows **explicitly** to the one consumer that needs it:
  - `PlanExecutor.execute(target, plan)` (the port)
  - `DatabricksExecutor.execute(target, plan)` and `compile_plan(target, plan)`
  - the engine passes `desired.qualified_name` (already in scope).

The data flow is now visible at the call site rather than hidden inside the plan, and the domain `ActionPlan` no longer carries an adapter-layer concern. **Behaviour is unchanged.**

## Note for reviewers

This touches the **`PlanExecutor` port signature** (`execute(plan)` → `execute(target, plan)`) — the hexagonal adapter seam. That's deliberate: making the data flow explicit is the point. The churn is otherwise mechanical (test sites dropping `target=` and threading it into `execute`).

## Verification

145 unit tests pass (including the 6 exercising the new `compile_plan`/`execute` signatures); `differ.py` 100% covered; `ruff` + `mypy` clean. The Spark-backed executor/e2e tests run in CI on a clean network.

Scoped as **PR 1 of 2** from the review; the `AlterationContext` change (validation's redundant `observed` param + Optional handling) is deferred to a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)