### PR TITLE
refactor: replace PlanContext with plan_table; validator takes explicit args

### DIFF
--- a/src/delta_engine/application/engine.py
+++ b/src/delta_engine/application/engine.py
@@ -15,7 +15,7 @@ import logging
 from delta_engine.application.errors import (
     SyncFailedError,
 )
-from delta_engine.application.plan import make_plan_context
+from delta_engine.application.plan import plan_table
 from delta_engine.application.ports import CatalogStateReader, PlanExecutor
 from delta_engine.application.registry import Registry
 from delta_engine.application.results import (
@@ -126,9 +126,12 @@ class Engine:
                 fully_qualified_name,
                 "present" if read_result.observed is not None else "absent",
             )
-            context = make_plan_context(desired, read_result.observed)
-            logger.info("Planned %d action(s) for %s", len(context.plan), fully_qualified_name)
-            validation = ValidationResult(failures=self.validator.validate(context))
+            observed = read_result.observed
+            plan = plan_table(desired, observed)
+            logger.info("Planned %d action(s) for %s", len(plan), fully_qualified_name)
+            validation = ValidationResult(
+                failures=self.validator.validate(desired, observed, plan)
+            )
             if validation.failed:
                 logger.error(
                     "Validation failed for %s (%d failure(s))",
@@ -137,7 +140,7 @@ class Engine:
                 )
             else:
                 logger.info("Validation passed for %s", fully_qualified_name)
-                executions = self.executor.execute(desired.qualified_name, context.plan)
+                executions = self.executor.execute(desired.qualified_name, plan)
                 failed_count = sum(1 for e in executions if isinstance(e, ExecutionFailed))
                 logger.info(
                     "Executed %d action(s) for %s (%d failed)",

--- a/src/delta_engine/application/plan.py
+++ b/src/delta_engine/application/plan.py
@@ -1,38 +1,18 @@
 """
 Compute action plans.
 
-Provides `PlanContext` and `make_plan_context`, which diffs desired vs. observed
-tables into an `ActionPlan`. The plan orders its own actions for deterministic
-execution (see :class:`ActionPlan`), so this module just diffs and bundles.
+`plan_table` diffs a desired table against the observed one and returns an
+`ActionPlan`. The plan orders its own actions for deterministic execution (see
+:class:`ActionPlan`), so this is a thin, named wrapper over the differ.
 """
 
 from __future__ import annotations
-
-from dataclasses import dataclass
 
 from delta_engine.domain.model import DesiredTable, ObservedTable
 from delta_engine.domain.plan import ActionPlan
 from delta_engine.domain.services.differ import diff_tables
 
 
-@dataclass(frozen=True, slots=True)
-class PlanContext:
-    """
-    Planning context capturing desired/observed state and the action plan.
-
-    Attributes:
-        desired: The user-authored desired definition.
-        observed: The currently observed definition or ``None`` if missing.
-        plan: The computed action plan to reach ``desired``.
-
-    """
-
-    desired: DesiredTable
-    observed: ObservedTable | None
-    plan: ActionPlan
-
-
-def make_plan_context(desired: DesiredTable, observed: ObservedTable | None) -> PlanContext:
-    """Create a :class:`PlanContext` for a pair of tables and its plan."""
-    plan = diff_tables(desired=desired, observed=observed)
-    return PlanContext(desired=desired, observed=observed, plan=plan)
+def plan_table(desired: DesiredTable, observed: ObservedTable | None) -> ActionPlan:
+    """Diff ``desired`` against the ``observed`` state and return the action plan."""
+    return diff_tables(desired=desired, observed=observed)

--- a/src/delta_engine/application/validation.py
+++ b/src/delta_engine/application/validation.py
@@ -4,21 +4,26 @@ from __future__ import annotations
 
 from abc import ABC, abstractmethod
 
-from delta_engine.application.plan import PlanContext
 from delta_engine.application.results import ValidationFailure
-from delta_engine.domain.plan import AddColumn, SetColumnNullability
+from delta_engine.domain.model import DesiredTable, ObservedTable
+from delta_engine.domain.plan import ActionPlan, AddColumn, SetColumnNullability
 
 
 class Rule(ABC):
     """Abstract interface for plan validation rules."""
 
     @abstractmethod
-    def evaluate(self, ctx: PlanContext) -> ValidationFailure | None:
+    def evaluate(
+        self, desired: DesiredTable, observed: ObservedTable | None, plan: ActionPlan
+    ) -> ValidationFailure | None:
         """
-        Evaluate the rule against a planning context.
+        Evaluate the rule against a planned change.
 
         Args:
-            ctx: The plan context to validate.
+            desired: The user-authored target definition.
+            observed: The current catalog state, or ``None`` when the table is
+                being created.
+            plan: The action plan to reach ``desired``.
 
         Returns:
             A failure description if the rule is violated, otherwise ``None``.
@@ -35,11 +40,13 @@ class NonNullableColumnAdd(Rule):
     already exists (it does not attempt to infer data emptiness).
     """
 
-    def evaluate(self, ctx: PlanContext) -> ValidationFailure | None:
+    def evaluate(
+        self, desired: DesiredTable, observed: ObservedTable | None, plan: ActionPlan
+    ) -> ValidationFailure | None:
         """Flag the plan if it adds a NOT NULL column to an existing table."""
-        if ctx.observed is None:
+        if observed is None:
             return None
-        for action in ctx.plan.actions:
+        for action in plan.actions:
             if isinstance(action, AddColumn) and (not action.column.nullable):
                 return ValidationFailure(
                     rule_name=self.__class__.__name__,
@@ -63,11 +70,13 @@ class NullabilityTighteningOnExistingColumn(Rule):
     and is not flagged.
     """
 
-    def evaluate(self, ctx: PlanContext) -> ValidationFailure | None:
+    def evaluate(
+        self, desired: DesiredTable, observed: ObservedTable | None, plan: ActionPlan
+    ) -> ValidationFailure | None:
         """Flag the plan if it tightens any existing column to NOT NULL."""
-        if ctx.observed is None:
+        if observed is None:
             return None
-        for action in ctx.plan.actions:
+        for action in plan.actions:
             if isinstance(action, SetColumnNullability) and (not action.nullable):
                 return ValidationFailure(
                     rule_name=self.__class__.__name__,
@@ -91,12 +100,14 @@ class UnsupportedColumnTypeChange(Rule):
     the drift as a validation failure instead of letting it vanish.
     """
 
-    def evaluate(self, ctx: PlanContext) -> ValidationFailure | None:
+    def evaluate(
+        self, desired: DesiredTable, observed: ObservedTable | None, plan: ActionPlan
+    ) -> ValidationFailure | None:
         """Flag any common column whose desired data type differs from observed."""
-        if ctx.observed is None:
+        if observed is None:
             return None
-        observed_types = {column.name: column.data_type for column in ctx.observed.columns}
-        for desired_column in ctx.desired.columns:
+        observed_types = {column.name: column.data_type for column in observed.columns}
+        for desired_column in desired.columns:
             observed_type = observed_types.get(desired_column.name)
             if observed_type is not None and observed_type != desired_column.data_type:
                 return ValidationFailure(
@@ -118,17 +129,19 @@ class DisallowPartitioningChange(Rule):
     Partitioning can only occur during the creation of a table.
     """
 
-    def evaluate(self, ctx: PlanContext) -> ValidationFailure | None:
+    def evaluate(
+        self, desired: DesiredTable, observed: ObservedTable | None, plan: ActionPlan
+    ) -> ValidationFailure | None:
         """Flag the plan if desired and observed partition columns differ."""
-        if ctx.observed is None:
+        if observed is None:
             return None
-        if ctx.desired.partitioned_by != ctx.observed.partitioned_by:
+        if desired.partitioned_by != observed.partitioned_by:
             return ValidationFailure(
                 rule_name=self.__class__.__name__,
                 message=(
                     "Operation not allowed: partitioning changes are not supported."
-                    f" Current partition columns: {ctx.observed.partitioned_by}"
-                    f" - Requested partition columns: {ctx.desired.partitioned_by}."
+                    f" Current partition columns: {observed.partitioned_by}"
+                    f" - Requested partition columns: {desired.partitioned_by}."
                     " Recreate the table with the desired partitioning."
                 ),
             )
@@ -136,18 +149,22 @@ class DisallowPartitioningChange(Rule):
 
 
 class PlanValidator:
-    """Run a sequence of validation rules against a plan."""
+    """Run a sequence of validation rules against a planned change."""
 
     def __init__(self, rules: tuple[Rule, ...]) -> None:
         """Create a validator configured with an ordered set of rules."""
         self.rules = rules
 
-    def validate(self, ctx: PlanContext) -> tuple[ValidationFailure, ...]:
+    def validate(
+        self, desired: DesiredTable, observed: ObservedTable | None, plan: ActionPlan
+    ) -> tuple[ValidationFailure, ...]:
         """
-        Evaluate all rules and collect any failures.
+        Evaluate all rules and collect any failures, in rule order.
 
         Args:
-            ctx: The plan context being validated.
+            desired: The user-authored target definition.
+            observed: The current catalog state, or ``None`` when creating.
+            plan: The action plan to reach ``desired``.
 
         Returns:
             A tuple of failures in rule evaluation order (empty if none).
@@ -155,7 +172,7 @@ class PlanValidator:
         """
         failures: list[ValidationFailure] = []
         for rule in self.rules:
-            failure = rule.evaluate(ctx)
+            failure = rule.evaluate(desired, observed, plan)
             if failure is not None:
                 failures.append(failure)
         return tuple(failures)

--- a/tests/application/test_engine.py
+++ b/tests/application/test_engine.py
@@ -43,8 +43,8 @@ class _FakeValidator:
     ) -> None:
         self.failures_by_fqn = failures_by_fqn or {}
 
-    def validate(self, ctx) -> tuple[ValidationFailure, ...]:
-        return self.failures_by_fqn.get(str(ctx.desired.qualified_name), ())
+    def validate(self, desired, observed, plan) -> tuple[ValidationFailure, ...]:
+        return self.failures_by_fqn.get(str(desired.qualified_name), ())
 
 
 class _FakeExecutor:

--- a/tests/application/test_plan.py
+++ b/tests/application/test_plan.py
@@ -1,4 +1,4 @@
-from delta_engine.application.plan import make_plan_context
+from delta_engine.application.plan import plan_table
 from delta_engine.domain.model import Column, DesiredTable, Integer, ObservedTable, QualifiedName
 from delta_engine.domain.plan.actions import (
     ActionPhase,
@@ -8,28 +8,15 @@ from delta_engine.domain.plan.actions import (
 _QUALIFIED_NAME = QualifiedName("dev", "silver", "test")
 
 
-def test_context_carries_desired_and_observed():
-    # Given a desired and an observed definition
-    desired = DesiredTable(qualified_name=_QUALIFIED_NAME, columns=(Column("id", Integer()),))
-    observed = ObservedTable(qualified_name=_QUALIFIED_NAME, columns=(Column("id", Integer()),))
-
-    # When building the plan context
-    context = make_plan_context(desired, observed)
-
-    # Then it exposes both states it was built from
-    assert context.desired is desired
-    assert context.observed is observed
-
-
 def test_missing_observed_plans_a_create_table():
     # Given a desired table and no observed table
     desired = DesiredTable(qualified_name=_QUALIFIED_NAME, columns=(Column("id", Integer()),))
 
-    # When building the plan context
-    context = make_plan_context(desired, observed=None)
+    # When planning against nothing
+    plan = plan_table(desired, observed=None)
 
     # Then the plan creates the table
-    assert context.plan.actions == (CreateTable(desired),)
+    assert plan.actions == (CreateTable(desired),)
 
 
 def test_plan_actions_are_ordered_by_execution_phase():
@@ -46,11 +33,11 @@ def test_plan_actions_are_ordered_by_execution_phase():
         comment="",
     )
 
-    # When building the plan context
-    context = make_plan_context(desired, observed)
+    # When planning desired against observed
+    plan = plan_table(desired, observed)
 
     # Then actions come out in non-decreasing execution-phase order
-    phases = [action.phase for action in context.plan.actions]
+    phases = [action.phase for action in plan.actions]
     assert phases == sorted(phases)
     # And the phases present are exactly those the diff produced
     assert set(phases) == {
@@ -66,8 +53,8 @@ def test_empty_diff_produces_an_empty_plan():
     desired = DesiredTable(qualified_name=_QUALIFIED_NAME, columns=columns)
     observed = ObservedTable(qualified_name=_QUALIFIED_NAME, columns=columns)
 
-    # When building the plan context
-    context = make_plan_context(desired, observed)
+    # When planning
+    plan = plan_table(desired, observed)
 
     # Then there is nothing to do
-    assert context.plan.actions == ()
+    assert plan.actions == ()

--- a/tests/application/test_validation.py
+++ b/tests/application/test_validation.py
@@ -1,4 +1,3 @@
-from delta_engine.application.plan import PlanContext
 from delta_engine.application.validation import (
     DisallowPartitioningChange,
     NonNullableColumnAdd,
@@ -17,302 +16,253 @@ from delta_engine.domain.model import (
 )
 from delta_engine.domain.plan.actions import ActionPlan, AddColumn, SetColumnNullability
 
-# ---- Test fakes
+_QUALIFIED_NAME = QualifiedName("dev", "silver", "events")
+_BASELINE_COLUMNS = (Column("id", Integer()),)
 
 
-class _FakeColumn:
-    def __init__(self, name: str, nullable: bool) -> None:
-        self.name = name
-        self.nullable = nullable
+# ---- Helpers (real domain objects; no fakes for internal collaborators)
 
 
-class _FakePlan:
-    def __init__(self, actions: tuple) -> None:
-        self.actions = actions
+def _desired(
+    *,
+    columns: tuple[Column, ...] = _BASELINE_COLUMNS,
+    partitioned_by: tuple[str, ...] = (),
+) -> DesiredTable:
+    return DesiredTable(
+        qualified_name=_QUALIFIED_NAME, columns=columns, partitioned_by=partitioned_by
+    )
 
 
-class _FakeObserved:
-    def __init__(self, partitioned_by: tuple[str, ...]) -> None:
-        self.partitioned_by = partitioned_by
+def _observed(
+    *,
+    columns: tuple[Column, ...] = _BASELINE_COLUMNS,
+    partitioned_by: tuple[str, ...] = (),
+) -> ObservedTable:
+    return ObservedTable(
+        qualified_name=_QUALIFIED_NAME, columns=columns, partitioned_by=partitioned_by
+    )
 
 
-class _FakeDesired:
-    def __init__(self, partitioned_by: tuple[str, ...]) -> None:
-        self.partitioned_by = partitioned_by
+def _plan(*actions) -> ActionPlan:
+    return ActionPlan(actions)
 
 
-class _FakeContext:
-    def __init__(self, *, plan, observed, desired) -> None:
-        self.plan = plan
-        self.observed = observed
-        self.desired = desired
-
-
-# ---- Helpers
-
-
-def _ctx_with_existing_table(
-    actions: tuple, current_parts: tuple[str, ...] = (), desired_parts: tuple[str, ...] = ()
-):
-    plan = _FakePlan(actions)
-    observed = _FakeObserved(partitioned_by=current_parts)
-    desired = _FakeDesired(partitioned_by=desired_parts or current_parts)
-    return _FakeContext(plan=plan, observed=observed, desired=desired)
-
-
-def _ctx_for_create(actions: tuple, desired_parts: tuple[str, ...] = ()):
-    plan = _FakePlan(actions)
-    observed = None
-    desired = _FakeDesired(partitioned_by=desired_parts)
-    return _FakeContext(plan=plan, observed=observed, desired=desired)
-
-
-# ---- Tests
+# ---- NonNullableColumnAdd
 
 
 def test_rejects_add_of_non_nullable_column_on_existing_table():
-    # Given an existing table
-    ctx = _ctx_with_existing_table(
-        actions=(AddColumn(column=_FakeColumn(name="order_id", nullable=False)),)
-    )
+    # Given an existing table and a plan adding a NOT NULL column
     rule = NonNullableColumnAdd()
 
-    # When evaluating the plan
-    failure = rule.evaluate(ctx)
-
     # Then the rule flags the operation as invalid
+    failure = rule.evaluate(
+        _desired(), _observed(), _plan(AddColumn(Column("order_id", Integer(), nullable=False)))
+    )
     assert failure is not None
 
 
 def test_allows_add_of_nullable_column_on_existing_table():
-    # Given an existing table
-    ctx = _ctx_with_existing_table(
-        actions=(AddColumn(column=_FakeColumn(name="notes", nullable=True)),)
-    )
+    # Given an existing table and a plan adding a nullable column
     rule = NonNullableColumnAdd()
 
-    # When evaluating the plan
-    failure = rule.evaluate(ctx)
-
     # Then the rule allows it
+    failure = rule.evaluate(
+        _desired(), _observed(), _plan(AddColumn(Column("notes", String(), nullable=True)))
+    )
     assert failure is None
 
 
 def test_allows_non_nullable_column_when_creating_new_table():
     # Given a new table creation (no observed table)
-    ctx = _ctx_for_create(actions=(AddColumn(column=_FakeColumn(name="id", nullable=False)),))
     rule = NonNullableColumnAdd()
 
-    # When evaluating the plan
-    failure = rule.evaluate(ctx)
-
     # Then the rule does not block creation-time constraints
+    failure = rule.evaluate(
+        _desired(), None, _plan(AddColumn(Column("id", Integer(), nullable=False)))
+    )
     assert failure is None
 
 
+# ---- DisallowPartitioningChange
+
+
 def test_rejects_partitioning_change_on_existing_table():
-    # Given an existing table where desired and observed partition specs differ
-    ctx = _ctx_with_existing_table(
-        actions=(),
-        current_parts=("ds",),
-        desired_parts=("country",),
-    )
+    # Given an existing table whose desired and observed partition specs differ
     rule = DisallowPartitioningChange()
 
-    # When evaluating the plan
-    failure = rule.evaluate(ctx)
-
     # Then the rule flags the operation as invalid
+    failure = rule.evaluate(
+        _desired(
+            columns=(Column("id", Integer()), Column("country", String())),
+            partitioned_by=("country",),
+        ),
+        _observed(
+            columns=(Column("id", Integer()), Column("ds", String())),
+            partitioned_by=("ds",),
+        ),
+        _plan(),
+    )
     assert failure is not None
 
 
 def test_allows_partitioning_on_new_table():
     # Given a new table creation (no observed table)
-    ctx = _ctx_for_create(actions=(), desired_parts=("ds",))
     rule = DisallowPartitioningChange()
 
-    # When evaluating the plan
-    failure = rule.evaluate(ctx)
-
     # Then the rule allows it for table creation
+    failure = rule.evaluate(
+        _desired(
+            columns=(Column("id", Integer()), Column("ds", String())),
+            partitioned_by=("ds",),
+        ),
+        None,
+        _plan(),
+    )
     assert failure is None
 
 
 def test_allows_when_partition_spec_unchanged_on_existing_table():
-    # Given an existing table where desired and observed partition specs are identical
-    ctx = _ctx_with_existing_table(
-        actions=(AddColumn(column=_FakeColumn("x", True)),),
-        current_parts=("ds",),
-        desired_parts=("ds",),
-    )
+    # Given an existing table whose desired and observed partition specs are identical
     rule = DisallowPartitioningChange()
 
-    # When evaluating the plan
-    failure = rule.evaluate(ctx)
-
     # Then there is no failure from this rule
+    columns = (Column("id", Integer()), Column("ds", String()))
+    failure = rule.evaluate(
+        _desired(columns=columns, partitioned_by=("ds",)),
+        _observed(columns=columns, partitioned_by=("ds",)),
+        _plan(),
+    )
     assert failure is None
 
 
-def test_validator_returns_empty_tuple_when_no_rules_fail():
-    # Given a plan that violates no rules (new table, nullable column)
-    ctx = _ctx_for_create(actions=(AddColumn(column=_FakeColumn("x", True)),))
-    validator = PlanValidator((NonNullableColumnAdd(), DisallowPartitioningChange()))
-
-    # When validating
-    failures = validator.validate(ctx)
-
-    # Then no failures are returned
-    assert failures == ()
-
-
-def test_empty_plan_produces_no_failures():
-    # Given a plan with no actions
-    empty_actions = tuple()
-    ctx = _ctx_with_existing_table(actions=empty_actions)
-    validator = PlanValidator((NonNullableColumnAdd(), DisallowPartitioningChange()))
-
-    # When validating
-    failures = validator.validate(ctx)
-
-    # Then nothing fails because there is nothing to validate
-    assert failures == ()
-
-
-# ---- NullabilityTighteningOnExistingColumn (real domain objects)
-
-_QUALIFIED_NAME = QualifiedName("dev", "silver", "events")
-
-
-def _context(*, observed: ObservedTable | None, actions: tuple) -> PlanContext:
-    """Build a real PlanContext with the given plan actions for an existing/absent table."""
-    desired = DesiredTable(qualified_name=_QUALIFIED_NAME, columns=(Column("id", Integer()),))
-    plan = ActionPlan(actions=actions)
-    return PlanContext(desired=desired, observed=observed, plan=plan)
-
-
-def _existing_table() -> ObservedTable:
-    return ObservedTable(qualified_name=_QUALIFIED_NAME, columns=(Column("id", Integer()),))
+# ---- NullabilityTighteningOnExistingColumn
 
 
 def test_rejects_tightening_an_existing_column_to_not_null():
     # Given an existing table and a plan that tightens a column to NOT NULL
-    ctx = _context(
-        observed=_existing_table(),
-        actions=(SetColumnNullability(column_name="id", nullable=False),),
-    )
     rule = NullabilityTighteningOnExistingColumn()
 
-    # When evaluating the plan
-    failure = rule.evaluate(ctx)
-
     # Then the rule flags it: tightening can fail at runtime if NULLs already exist
+    failure = rule.evaluate(
+        _desired(), _observed(), _plan(SetColumnNullability(column_name="id", nullable=False))
+    )
     assert failure is not None
     assert "id" in failure.message
 
 
 def test_allows_loosening_an_existing_column_to_nullable():
     # Given an existing table and a plan that loosens a column to NULL (always safe)
-    ctx = _context(
-        observed=_existing_table(),
-        actions=(SetColumnNullability(column_name="id", nullable=True),),
-    )
     rule = NullabilityTighteningOnExistingColumn()
 
-    # When evaluating the plan
-    failure = rule.evaluate(ctx)
-
     # Then the rule allows it
+    failure = rule.evaluate(
+        _desired(), _observed(), _plan(SetColumnNullability(column_name="id", nullable=True))
+    )
     assert failure is None
 
 
 def test_allows_tightening_when_creating_a_new_table():
     # Given a new table creation (no observed table)
-    ctx = _context(
-        observed=None,
-        actions=(SetColumnNullability(column_name="id", nullable=False),),
-    )
     rule = NullabilityTighteningOnExistingColumn()
 
-    # When evaluating the plan
-    failure = rule.evaluate(ctx)
-
     # Then creation-time constraints are not this rule's concern
+    failure = rule.evaluate(
+        _desired(), None, _plan(SetColumnNullability(column_name="id", nullable=False))
+    )
     assert failure is None
 
 
-# ---- UnsupportedColumnTypeChange (real domain objects)
-
-
-def _context_for_columns(
-    *, desired_columns: tuple[Column, ...], observed_columns: tuple[Column, ...] | None
-) -> PlanContext:
-    """Build a real PlanContext from desired/observed column tuples (plan unused by this rule)."""
-    desired = DesiredTable(qualified_name=_QUALIFIED_NAME, columns=desired_columns)
-    observed = (
-        None
-        if observed_columns is None
-        else ObservedTable(qualified_name=_QUALIFIED_NAME, columns=observed_columns)
-    )
-    return PlanContext(desired=desired, observed=observed, plan=ActionPlan())
+# ---- UnsupportedColumnTypeChange
 
 
 def test_rejects_changing_the_type_of_an_existing_column():
     # Given an existing column whose desired type differs from the observed type
-    ctx = _context_for_columns(
-        desired_columns=(Column("id", Long()),),
-        observed_columns=(Column("id", Integer()),),
-    )
     rule = UnsupportedColumnTypeChange()
 
-    # When evaluating the plan
-    failure = rule.evaluate(ctx)
-
     # Then the drift is flagged rather than silently ignored
+    failure = rule.evaluate(
+        _desired(columns=(Column("id", Long()),)),
+        _observed(columns=(Column("id", Integer()),)),
+        _plan(),
+    )
     assert failure is not None
     assert "id" in failure.message
 
 
 def test_allows_columns_whose_type_is_unchanged():
     # Given an existing table where every common column keeps its type
-    ctx = _context_for_columns(
-        desired_columns=(Column("id", Integer()), Column("name", String())),
-        observed_columns=(Column("id", Integer()), Column("name", String())),
-    )
     rule = UnsupportedColumnTypeChange()
 
-    # When evaluating the plan
-    failure = rule.evaluate(ctx)
-
-    # Then nothing is flagged
+    columns = (Column("id", Integer()), Column("name", String()))
+    failure = rule.evaluate(_desired(columns=columns), _observed(columns=columns), _plan())
     assert failure is None
 
 
 def test_ignores_added_and_dropped_columns_for_type_change():
     # Given a column only in desired (add) and one only in observed (drop)
-    ctx = _context_for_columns(
-        desired_columns=(Column("id", Integer()), Column("added", String())),
-        observed_columns=(Column("id", Integer()), Column("dropped", String())),
-    )
     rule = UnsupportedColumnTypeChange()
 
-    # When evaluating the plan
-    failure = rule.evaluate(ctx)
-
-    # Then only common columns are compared; add/drop are not type changes
+    failure = rule.evaluate(
+        _desired(columns=(Column("id", Integer()), Column("added", String()))),
+        _observed(columns=(Column("id", Integer()), Column("dropped", String()))),
+        _plan(),
+    )
     assert failure is None
 
 
 def test_allows_type_specification_when_creating_a_new_table():
     # Given a new table creation (no observed table)
-    ctx = _context_for_columns(
-        desired_columns=(Column("id", Long()),),
-        observed_columns=None,
-    )
     rule = UnsupportedColumnTypeChange()
 
-    # When evaluating the plan
-    failure = rule.evaluate(ctx)
-
-    # Then there is no prior type to conflict with
+    failure = rule.evaluate(_desired(columns=(Column("id", Long()),)), None, _plan())
     assert failure is None
+
+
+# ---- PlanValidator
+
+
+def test_validator_returns_empty_tuple_when_no_rules_fail():
+    # Given a creation plan that violates no rule
+    validator = PlanValidator((NonNullableColumnAdd(), DisallowPartitioningChange()))
+
+    # When validating
+    failures = validator.validate(
+        _desired(), None, _plan(AddColumn(Column("x", String(), nullable=True)))
+    )
+
+    # Then no failures are returned
+    assert failures == ()
+
+
+def test_validator_collects_a_failure_from_every_broken_rule():
+    # Given an existing table whose plan breaks two rules at once
+    validator = PlanValidator(
+        (NonNullableColumnAdd(), NullabilityTighteningOnExistingColumn())
+    )
+
+    # When validating
+    failures = validator.validate(
+        _desired(),
+        _observed(),
+        _plan(
+            AddColumn(Column("order_id", Integer(), nullable=False)),
+            SetColumnNullability(column_name="id", nullable=False),
+        ),
+    )
+
+    # Then both broken rules contribute a failure, named after the rule classes
+    assert {f.rule_name for f in failures} == {
+        "NonNullableColumnAdd",
+        "NullabilityTighteningOnExistingColumn",
+    }
+
+
+def test_empty_plan_produces_no_failures():
+    # Given an existing table with an empty plan
+    validator = PlanValidator((NonNullableColumnAdd(), DisallowPartitioningChange()))
+
+    # When validating
+    failures = validator.validate(_desired(), _observed(), _plan())
+
+    # Then nothing fails because there is nothing to validate
+    assert failures == ()


### PR DESCRIPTION
## What & why

`PlanContext{desired, observed, plan}` + `make_plan_context` was a **named parameter bag**: it bundled the planning *inputs* (`desired`, `observed`) with the *output* (`plan`) under a non-name ("Context"), existing mainly to hand the validator one argument. The engine only ever read `context.plan` and already held `desired`/`observed` in scope. An Ousterhout review flagged it as exactly this input/output bag with an uninformative name.

## The change

- **`plan.py`**: `PlanContext` + `make_plan_context` → a single `plan_table(desired, observed) -> ActionPlan`. The engine calls it directly and passes the `ActionPlan` straight to the executor — no bag, and the name says what it does (*plan a table*) rather than *make a context*.
- **`validation.py`**: `Rule.evaluate` and `PlanValidator.validate` now take `(desired, observed, plan)` explicitly — no `PlanContext`, no replacement type.
- **`engine.py`**: consumes `plan_table` + `validator.validate(desired, observed, plan)`.

`observed` stays `ObservedTable | None` for now (the four `is None` guards remain). Collapsing that into a non-Optional alteration type (the `TableAlteration` idea) is a **deliberate follow-up**, scoped out of this PR.

Validation tests reworked to real domain objects throughout, dropping the `_Fake*` context stand-ins.

**Behaviour unchanged.**

## Verification

145 unit tests pass; `plan.py` + `validation.py` at 100% coverage; `ruff` + `mypy` clean. Spark-backed/e2e tests run in CI on a clean network.

🤖 Generated with [Claude Code](https://claude.com/claude-code)