### PR TITLE
refactor: validation becomes a pure function (validate_plan)

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -6,7 +6,8 @@ This page shows the high-level design. It focuses on the main components, their 
 
 ```mermaid
 classDiagram
-    %% === Ports (interfaces the Engine talks to) ===
+    %% === What the Engine talks to: ports (reader/executor), the registry,
+    %% === and validate_plan (a pure function, not a port) ===
     class Registry {
       +register(*tables)
       +__iter__()
@@ -14,8 +15,9 @@ classDiagram
     class CatalogStateReader {
       +fetch_state(qualified_name)
     }
-    class PlanValidator {
-      +validate(plan)
+    class validate_plan {
+      <<function>>
+      +validate_plan(desired, observed, plan)
     }
     class PlanExecutor {
       +execute(plan)
@@ -43,7 +45,7 @@ classDiagram
     %% Engine depends on ports (dotted = lightweight dependency)
     Engine ..> Registry : iterates
     Engine ..> CatalogStateReader : reads state
-    Engine ..> PlanValidator : validates
+    Engine ..> validate_plan : validates
     Engine ..> PlanExecutor : executes
 
     %% Port -> Adapter realizations
@@ -67,7 +69,7 @@ sequenceDiagram
     participant R as Registry
     participant E as Engine
     participant CR as CatalogStateReader
-    participant V as PlanValidator
+    participant V as validate_plan
     participant X as PlanExecutor
 
     U->>R: register(DeltaTable)
@@ -77,7 +79,7 @@ sequenceDiagram
         E->>CR: fetch_state(qualified_name)
         CR-->>E: ReadResult
         E->>E: diff(desired, observed) → ActionPlan
-        E->>V: validate(ActionPlan)
+        E->>V: validate_plan(desired, observed, plan)
         V-->>E: ValidationResult
         E->>X: execute(ActionPlan)
         X-->>E: ExecutionResults

--- a/docs/ousterhout-review.md
+++ b/docs/ousterhout-review.md
@@ -551,23 +551,30 @@ prerequisite question (`NOOP`) that must be answered before a tempting change.
   `UnsupportedColumnTypeChange` builds that lookup; single-consumer derived state
   belongs in a local variable.
 
-#### Q3 — Validation: the `Rule` ABC + `PlanValidator` are shallow; consider functions in a future clean-up
+#### Q3 — Validation: `PlanValidator` was shallow ceremony — RESOLVED (PR #44)
 
-- **The `Rule(ABC)` + `PlanValidator` pairing is shallow ceremony.** No concrete
-  rule holds state; `evaluate`'s `self` is never used; `PlanValidator.validate` is
-  a four-line for-loop whose interface is as wide as its implementation. Tellingly,
-  `_FakeValidator` in `test_engine.py` does **not** subclass `PlanValidator` — the
-  nominal type enforces nothing today. Plain predicate functions
-  (`Callable[[PlanContext], ValidationFailure | None]`) collected in a tuple, with
-  `validate_plan` a module function and `DEFAULT_VALIDATOR` a `functools.partial`,
-  would lose nothing and remove the instantiation/`self`-dispatch theatre. Keep
-  `PlanValidator` as a `Callable` type alias so the engine signature is untouched;
-  give `rule_name` explicit string literals (not `__class__.__name__`, which would
-  flip PascalCase→snake_case and break any downstream parsing). *Low severity,
-  purely structural, no behaviour change — batch into a future tightening pass.*
-  - *Dissent:* the ABC is a visible, greppable extension point; a team with many
-    contributors may prefer that explicitness over the (real) Ousterhout win. An
-    ergonomic preference, not a correctness one.
+- **The `PlanValidator` class was shallow ceremony.** No concrete rule holds
+  state and `validate` was a four-line for-loop whose interface was as wide as its
+  implementation. The class existed only to be constructor-injected into the
+  engine, and `_FakeValidator` in `test_engine.py` did **not** subclass it — so the
+  nominal type enforced nothing while letting the engine tests mock an *internal*
+  collaborator (against the project's classical-testing rule).
+- **Resolution (PR #44): dissolved `PlanValidator` into a module function**
+  `validate_plan(desired, observed, plan, rules=DEFAULT_RULES) -> ValidationResult`.
+  The engine now calls it directly, exactly as it calls `plan_table` — two pure
+  phases, one shape. The validator injection is gone from `Engine.__init__` (which
+  now takes only its two genuine ports, reader and executor), the engine tests
+  drive validation through the *real* default rules, and `_FakeValidator` is
+  deleted. The `rules=` default keeps the rule set swappable for scoped tests
+  without a class.
+- **Deliberately kept the `Rule` ABC + subclasses.** The dissent below won on the
+  rules themselves: the ABC is a visible, greppable extension point, and rules-as-
+  classes is the chosen idiom for this codebase. We dissolved only the redundant
+  *aggregator* class, not the rules. `rule_name` still derives from
+  `__class__.__name__`; no downstream parser depends on its case today.
+  - *Dissent (now the accepted position for `Rule`):* the ABC is a visible,
+    greppable extension point; explicitness here is worth more than the marginal
+    Ousterhout win of collapsing rules to bare callables.
 - **Altitude — keep "diff proposes, validator disposes."** The rule mechanism as
   the home for "what is unsafe/unsupported" is the right seam (it absorbed B1/B3/B5
   cleanly). Folding safety checks into the differ, or scattering them as domain

--- a/src/delta_engine/application/engine.py
+++ b/src/delta_engine/application/engine.py
@@ -129,9 +129,7 @@ class Engine:
             observed = read_result.observed
             plan = plan_table(desired, observed)
             logger.info("Planned %d action(s) for %s", len(plan), fully_qualified_name)
-            validation = ValidationResult(
-                failures=self.validator.validate(desired, observed, plan)
-            )
+            validation = self.validator.validate(desired, observed, plan)
             if validation.failed:
                 logger.error(
                     "Validation failed for %s (%d failure(s))",

--- a/src/delta_engine/application/engine.py
+++ b/src/delta_engine/application/engine.py
@@ -26,7 +26,7 @@ from delta_engine.application.results import (
     TableRunReport,
     ValidationResult,
 )
-from delta_engine.application.validation import DEFAULT_VALIDATOR, PlanValidator
+from delta_engine.application.validation import validate_plan
 from delta_engine.domain.model.table import DesiredTable
 
 logger = logging.getLogger(__name__)
@@ -50,20 +50,17 @@ class Engine:
         self,
         reader: CatalogStateReader,
         executor: PlanExecutor,
-        validator: PlanValidator = DEFAULT_VALIDATOR,
     ) -> None:
         """
-        Initialize the engine with adapters and a validator.
+        Initialize the engine with its catalog adapters.
 
         Args:
             reader: Adapter that fetches the current catalog state.
             executor: Adapter that executes action plans.
-            validator: Validator that checks plans for plan violations.
 
         """
         self.reader = reader
         self.executor = executor
-        self.validator = validator
 
     def sync(self, registry: Registry) -> SyncReport:
         """
@@ -129,7 +126,7 @@ class Engine:
             observed = read_result.observed
             plan = plan_table(desired, observed)
             logger.info("Planned %d action(s) for %s", len(plan), fully_qualified_name)
-            validation = self.validator.validate(desired, observed, plan)
+            validation = validate_plan(desired, observed, plan)
             if validation.failed:
                 logger.error(
                     "Validation failed for %s (%d failure(s))",

--- a/src/delta_engine/application/validation.py
+++ b/src/delta_engine/application/validation.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from abc import ABC, abstractmethod
 
-from delta_engine.application.results import ValidationFailure
+from delta_engine.application.results import ValidationFailure, ValidationResult
 from delta_engine.domain.model import DesiredTable, ObservedTable
 from delta_engine.domain.plan import ActionPlan, AddColumn, SetColumnNullability
 
@@ -157,9 +157,9 @@ class PlanValidator:
 
     def validate(
         self, desired: DesiredTable, observed: ObservedTable | None, plan: ActionPlan
-    ) -> tuple[ValidationFailure, ...]:
+    ) -> ValidationResult:
         """
-        Evaluate all rules and collect any failures, in rule order.
+        Evaluate all rules and return the aggregate verdict.
 
         Args:
             desired: The user-authored target definition.
@@ -167,7 +167,8 @@ class PlanValidator:
             plan: The action plan to reach ``desired``.
 
         Returns:
-            A tuple of failures in rule evaluation order (empty if none).
+            A :class:`ValidationResult` whose ``failed`` gates execution. The
+            caller reads the verdict; it does not assemble it.
 
         """
         failures: list[ValidationFailure] = []
@@ -175,7 +176,7 @@ class PlanValidator:
             failure = rule.evaluate(desired, observed, plan)
             if failure is not None:
                 failures.append(failure)
-        return tuple(failures)
+        return ValidationResult(failures=tuple(failures))
 
 
 DEFAULT_RULES: tuple[Rule, ...] = (

--- a/src/delta_engine/application/validation.py
+++ b/src/delta_engine/application/validation.py
@@ -148,41 +148,41 @@ class DisallowPartitioningChange(Rule):
         return None
 
 
-class PlanValidator:
-    """Run a sequence of validation rules against a planned change."""
-
-    def __init__(self, rules: tuple[Rule, ...]) -> None:
-        """Create a validator configured with an ordered set of rules."""
-        self.rules = rules
-
-    def validate(
-        self, desired: DesiredTable, observed: ObservedTable | None, plan: ActionPlan
-    ) -> ValidationResult:
-        """
-        Evaluate all rules and return the aggregate verdict.
-
-        Args:
-            desired: The user-authored target definition.
-            observed: The current catalog state, or ``None`` when creating.
-            plan: The action plan to reach ``desired``.
-
-        Returns:
-            A :class:`ValidationResult` whose ``failed`` gates execution. The
-            caller reads the verdict; it does not assemble it.
-
-        """
-        failures: list[ValidationFailure] = []
-        for rule in self.rules:
-            failure = rule.evaluate(desired, observed, plan)
-            if failure is not None:
-                failures.append(failure)
-        return ValidationResult(failures=tuple(failures))
-
-
 DEFAULT_RULES: tuple[Rule, ...] = (
     NonNullableColumnAdd(),
     NullabilityTighteningOnExistingColumn(),
     UnsupportedColumnTypeChange(),
     DisallowPartitioningChange(),
 )
-DEFAULT_VALIDATOR = PlanValidator(DEFAULT_RULES)
+
+
+def validate_plan(
+    desired: DesiredTable,
+    observed: ObservedTable | None,
+    plan: ActionPlan,
+    rules: tuple[Rule, ...] = DEFAULT_RULES,
+) -> ValidationResult:
+    """
+    Evaluate every rule against a planned change and return the verdict.
+
+    A pure phase alongside :func:`plan_table`: the same inputs always yield the
+    same result. The caller reads ``ValidationResult.failed`` to gate execution;
+    it does not assemble the verdict.
+
+    Args:
+        desired: The user-authored target definition.
+        observed: The current catalog state, or ``None`` when creating.
+        plan: The action plan to reach ``desired``.
+        rules: The rules to apply, in evaluation order. Defaults to the full
+            production set; override only to scope a check (e.g. in tests).
+
+    Returns:
+        A :class:`ValidationResult` carrying a failure from each broken rule.
+
+    """
+    failures = tuple(
+        failure
+        for rule in rules
+        if (failure := rule.evaluate(desired, observed, plan)) is not None
+    )
+    return ValidationResult(failures=failures)

--- a/tests/application/test_engine.py
+++ b/tests/application/test_engine.py
@@ -16,6 +16,7 @@ from delta_engine.application.results import (
     SyncReport,
     TableRunStatus,
     ValidationFailure,
+    ValidationResult,
 )
 from delta_engine.domain.model import QualifiedName
 from delta_engine.domain.plan import ActionPlan
@@ -43,8 +44,9 @@ class _FakeValidator:
     ) -> None:
         self.failures_by_fqn = failures_by_fqn or {}
 
-    def validate(self, desired, observed, plan) -> tuple[ValidationFailure, ...]:
-        return self.failures_by_fqn.get(str(desired.qualified_name), ())
+    def validate(self, desired, observed, plan) -> ValidationResult:
+        failures = self.failures_by_fqn.get(str(desired.qualified_name), ())
+        return ValidationResult(failures=failures)
 
 
 class _FakeExecutor:

--- a/tests/application/test_engine.py
+++ b/tests/application/test_engine.py
@@ -15,10 +15,8 @@ from delta_engine.application.results import (
     ReadSucceeded,
     SyncReport,
     TableRunStatus,
-    ValidationFailure,
-    ValidationResult,
 )
-from delta_engine.domain.model import QualifiedName
+from delta_engine.domain.model import ObservedTable, QualifiedName
 from delta_engine.domain.plan import ActionPlan
 
 # --------- helpers/fakes
@@ -30,23 +28,40 @@ def _spec(fqn: str) -> DeltaTable:
     return DeltaTable(catalog, schema, name, columns=(Column("id", String()),))
 
 
+def _spec_adding_not_null(fqn: str) -> DeltaTable:
+    """
+    Build a spec that adds a NOT NULL column on top of the baseline 'id' column.
+
+    Diffed against an existing 'id'-only table, this trips the real
+    NonNullableColumnAdd rule, so the engine drives a genuine validation failure
+    instead of a faked one.
+    """
+    catalog, schema, name = fqn.split(".")
+    return DeltaTable(
+        catalog,
+        schema,
+        name,
+        columns=(Column("id", String()), Column("order_id", String(), nullable=False)),
+    )
+
+
+def _existing_id_table(fqn: str) -> ReadSucceeded:
+    """Build a successful read of an existing table with a single 'id' column."""
+    catalog, schema, name = fqn.split(".")
+    return ReadSucceeded(
+        observed=ObservedTable(
+            qualified_name=QualifiedName(catalog, schema, name),
+            columns=(Column("id", String()),),
+        )
+    )
+
+
 class _FakeReader:
     def __init__(self, mapping: dict[str, ReadResult]) -> None:
         self.mapping = mapping
 
     def fetch_state(self, qualified_name: QualifiedName) -> ReadResult:
         return self.mapping.get(str(qualified_name), ReadSucceeded(observed=None))
-
-
-class _FakeValidator:
-    def __init__(
-        self, failures_by_fqn: dict[str, tuple[ValidationFailure, ...]] | None = None
-    ) -> None:
-        self.failures_by_fqn = failures_by_fqn or {}
-
-    def validate(self, desired, observed, plan) -> ValidationResult:
-        failures = self.failures_by_fqn.get(str(desired.qualified_name), ())
-        return ValidationResult(failures=failures)
 
 
 class _FakeExecutor:
@@ -93,28 +108,27 @@ def test_raises_when_any_table_has_read_failure():
     reg = Registry()
     reg.register(t)
     reader = _FakeReader({"c.s.read_fail": ReadFailed(ReadFailure("IOError", "cannot read"))})
-    validator = _FakeValidator()  # no validation failures
     executor = _FakeExecutor(results=(_ok_exec(0),))  # would be fine if reached
 
     # When syncing
     # Then the engine raises SyncFailedError because read failed
-    engine = Engine(reader=reader, executor=executor, validator=validator)
+    engine = Engine(reader=reader, executor=executor)
     with pytest.raises(SyncFailedError):
         engine.sync(reg)
 
 
 def test_skips_execution_and_raises_when_validation_fails():
-    # Given a table that reads successfully but fails validation
+    # Given an existing table whose desired spec adds a NOT NULL column
+    # (a real rule violation, not a faked verdict)
     reg = Registry()
-    reg.register(_spec("c.s.val_fail"))
-    reader = _FakeReader({"c.s.val_fail": ReadSucceeded(observed=None)})
-    validator = _FakeValidator({"c.s.val_fail": (ValidationFailure("RuleX", "nope"),)})
+    reg.register(_spec_adding_not_null("c.s.val_fail"))
+    reader = _FakeReader({"c.s.val_fail": _existing_id_table("c.s.val_fail")})
     # Executor would return OK, but must not be used because validation fails
     executor = _FakeExecutor(results=(_ok_exec(0),))
 
     # When syncing
     # Then the engine raises SyncFailedError because validation failed
-    engine = Engine(reader=reader, executor=executor, validator=validator)
+    engine = Engine(reader=reader, executor=executor)
     with pytest.raises(SyncFailedError):
         engine.sync(reg)
 
@@ -124,12 +138,11 @@ def test_raises_when_execution_contains_any_failure():
     reg = Registry()
     reg.register(_spec("c.s.exec_fail"))
     reader = _FakeReader({"c.s.exec_fail": ReadSucceeded(observed=None)})
-    validator = _FakeValidator()  # passes
     executor = _FakeExecutor(results=(_ok_exec(0), _failed_exec(1), _ok_exec(2)))
 
     # When syncing
     # Then the engine raises SyncFailedError because execution failed
-    engine = Engine(reader=reader, executor=executor, validator=validator)
+    engine = Engine(reader=reader, executor=executor)
     with pytest.raises(SyncFailedError):
         engine.sync(reg)
 
@@ -146,9 +159,8 @@ def test_returns_report_when_all_tables_succeed():
             "c.b.orders": ReadSucceeded(observed=None),
         }
     )
-    validator = _FakeValidator()
     executor = _FakeExecutor(results=(_ok_exec(0), _ok_exec(1)))
-    engine = Engine(reader=reader, executor=executor, validator=validator)
+    engine = Engine(reader=reader, executor=executor)
 
     # When syncing
     report = engine.sync(reg)
@@ -172,9 +184,8 @@ def test_engine_reads_all_tables_then_raises_on_any_read_failure():
             "c.s.b": ReadSucceeded(observed=None),
         }
     )
-    validator = _FakeValidator()  # both would pass if reached
     executor = _FakeExecutor(results=(_ok_exec(0),))  # irrelevant for a; used for b
-    engine = Engine(reader=reader, executor=executor, validator=validator)
+    engine = Engine(reader=reader, executor=executor)
 
     # When
     with pytest.raises(SyncFailedError) as err:
@@ -186,23 +197,18 @@ def test_engine_reads_all_tables_then_raises_on_any_read_failure():
 
 
 def test_engine_validates_all_tables_executes_only_the_passing_ones_then_raises():
-    # Given both tables read OK; one fails validation
+    # Given two tables that read OK; 'a' adds a NOT NULL column to an existing
+    # table (a real validation failure) while 'b' is a clean creation
     reg = Registry()
-    reg.register(_spec("c.s.a"), _spec("c.s.b"))
+    reg.register(_spec_adding_not_null("c.s.a"), _spec("c.s.b"))
     reader = _FakeReader(
         {
-            "c.s.a": ReadSucceeded(observed=None),
-            "c.s.b": ReadSucceeded(observed=None),
-        }
-    )
-    validator = _FakeValidator(
-        {
-            "c.s.a": (ValidationFailure("RuleX", "nope"),),  # a fails validation
-            # b passes
+            "c.s.a": _existing_id_table("c.s.a"),  # existing -> add NOT NULL is rejected
+            "c.s.b": ReadSucceeded(observed=None),  # absent -> clean create
         }
     )
     executor = _FakeExecutor(results=(_ok_exec(0), _ok_exec(1)))  # used only for b
-    engine = Engine(reader=reader, executor=executor, validator=validator)
+    engine = Engine(reader=reader, executor=executor)
 
     # When
     with pytest.raises(SyncFailedError) as err:
@@ -226,14 +232,13 @@ def test_engine_executes_all_tables_then_raises_if_any_execution_failed():
             "c.s.b": ReadSucceeded(observed=None),
         }
     )
-    validator = _FakeValidator()  # both pass
     executor = _SeqExecutor(
         [
             (_ok_exec(0), _ok_exec(1)),  # execution for a: all good
             (_ok_exec(0), _failed_exec(1)),  # execution for b: one failed
         ]
     )
-    engine = Engine(reader=reader, executor=executor, validator=validator)
+    engine = Engine(reader=reader, executor=executor)
 
     # When
     with pytest.raises(SyncFailedError) as err:
@@ -254,14 +259,13 @@ def test_engine_executes_remaining_tables_even_if_first_execution_fails():
             "c.s.b": ReadSucceeded(observed=None),
         }
     )
-    validator = _FakeValidator()  # both pass
     executor = _SeqExecutor(
         [
             (_failed_exec(0),),  # execution for 'a' fails
             (_ok_exec(0), _ok_exec(1)),  # execution for 'b' succeeds
         ]
     )
-    engine = Engine(reader=reader, executor=executor, validator=validator)
+    engine = Engine(reader=reader, executor=executor)
 
     # When
     with pytest.raises(SyncFailedError) as err:

--- a/tests/application/test_validation.py
+++ b/tests/application/test_validation.py
@@ -221,17 +221,18 @@ def test_allows_type_specification_when_creating_a_new_table():
 # ---- PlanValidator
 
 
-def test_validator_returns_empty_tuple_when_no_rules_fail():
+def test_validator_passes_when_no_rule_is_broken():
     # Given a creation plan that violates no rule
     validator = PlanValidator((NonNullableColumnAdd(), DisallowPartitioningChange()))
 
     # When validating
-    failures = validator.validate(
+    result = validator.validate(
         _desired(), None, _plan(AddColumn(Column("x", String(), nullable=True)))
     )
 
-    # Then no failures are returned
-    assert failures == ()
+    # Then the verdict is a passing ValidationResult
+    assert not result.failed
+    assert result.failures == ()
 
 
 def test_validator_collects_a_failure_from_every_broken_rule():
@@ -241,7 +242,7 @@ def test_validator_collects_a_failure_from_every_broken_rule():
     )
 
     # When validating
-    failures = validator.validate(
+    result = validator.validate(
         _desired(),
         _observed(),
         _plan(
@@ -250,8 +251,9 @@ def test_validator_collects_a_failure_from_every_broken_rule():
         ),
     )
 
-    # Then both broken rules contribute a failure, named after the rule classes
-    assert {f.rule_name for f in failures} == {
+    # Then the verdict fails, carrying a failure from each broken rule
+    assert result.failed
+    assert {f.rule_name for f in result.failures} == {
         "NonNullableColumnAdd",
         "NullabilityTighteningOnExistingColumn",
     }
@@ -262,7 +264,8 @@ def test_empty_plan_produces_no_failures():
     validator = PlanValidator((NonNullableColumnAdd(), DisallowPartitioningChange()))
 
     # When validating
-    failures = validator.validate(_desired(), _observed(), _plan())
+    result = validator.validate(_desired(), _observed(), _plan())
 
-    # Then nothing fails because there is nothing to validate
-    assert failures == ()
+    # Then the verdict passes with no failures
+    assert not result.failed
+    assert result.failures == ()

--- a/tests/application/test_validation.py
+++ b/tests/application/test_validation.py
@@ -2,8 +2,8 @@ from delta_engine.application.validation import (
     DisallowPartitioningChange,
     NonNullableColumnAdd,
     NullabilityTighteningOnExistingColumn,
-    PlanValidator,
     UnsupportedColumnTypeChange,
+    validate_plan,
 )
 from delta_engine.domain.model import (
     Column,
@@ -218,16 +218,16 @@ def test_allows_type_specification_when_creating_a_new_table():
     assert failure is None
 
 
-# ---- PlanValidator
+# ---- validate_plan
 
 
-def test_validator_passes_when_no_rule_is_broken():
+def test_validation_passes_when_no_rule_is_broken():
     # Given a creation plan that violates no rule
-    validator = PlanValidator((NonNullableColumnAdd(), DisallowPartitioningChange()))
+    rules = (NonNullableColumnAdd(), DisallowPartitioningChange())
 
     # When validating
-    result = validator.validate(
-        _desired(), None, _plan(AddColumn(Column("x", String(), nullable=True)))
+    result = validate_plan(
+        _desired(), None, _plan(AddColumn(Column("x", String(), nullable=True))), rules=rules
     )
 
     # Then the verdict is a passing ValidationResult
@@ -235,20 +235,19 @@ def test_validator_passes_when_no_rule_is_broken():
     assert result.failures == ()
 
 
-def test_validator_collects_a_failure_from_every_broken_rule():
+def test_validation_collects_a_failure_from_every_broken_rule():
     # Given an existing table whose plan breaks two rules at once
-    validator = PlanValidator(
-        (NonNullableColumnAdd(), NullabilityTighteningOnExistingColumn())
-    )
+    rules = (NonNullableColumnAdd(), NullabilityTighteningOnExistingColumn())
 
     # When validating
-    result = validator.validate(
+    result = validate_plan(
         _desired(),
         _observed(),
         _plan(
             AddColumn(Column("order_id", Integer(), nullable=False)),
             SetColumnNullability(column_name="id", nullable=False),
         ),
+        rules=rules,
     )
 
     # Then the verdict fails, carrying a failure from each broken rule
@@ -261,11 +260,25 @@ def test_validator_collects_a_failure_from_every_broken_rule():
 
 def test_empty_plan_produces_no_failures():
     # Given an existing table with an empty plan
-    validator = PlanValidator((NonNullableColumnAdd(), DisallowPartitioningChange()))
+    rules = (NonNullableColumnAdd(), DisallowPartitioningChange())
 
     # When validating
-    result = validator.validate(_desired(), _observed(), _plan())
+    result = validate_plan(_desired(), _observed(), _plan(), rules=rules)
 
     # Then the verdict passes with no failures
     assert not result.failed
     assert result.failures == ()
+
+
+def test_validation_uses_the_default_rules_when_none_are_supplied():
+    # Given an existing table whose plan adds a non-nullable column
+    # (no rules argument -> the engine's real default rule set applies)
+    result = validate_plan(
+        _desired(),
+        _observed(),
+        _plan(AddColumn(Column("order_id", Integer(), nullable=False))),
+    )
+
+    # Then the default NonNullableColumnAdd rule rejects it
+    assert result.failed
+    assert {f.rule_name for f in result.failures} == {"NonNullableColumnAdd"}


### PR DESCRIPTION
## What

Validation is now a pure module function, called by the engine exactly the way `plan_table` is:

```python
plan = plan_table(desired, observed)
validation = validate_plan(desired, observed, plan)
if validation.failed:
    ...
```

Two changes, one story:

1. **`validate_plan` returns a `ValidationResult`** (not a raw `tuple[ValidationFailure, ...]`). The engine reads the verdict; it no longer assembles it.
2. **`PlanValidator` is dissolved into `validate_plan`.** The aggregator class — a tuple of rules plus a four-line loop — is gone. `Engine.__init__` drops the `validator` parameter and keeps only its two genuine ports, `reader` and `executor`.

```python
def validate_plan(
    desired: DesiredTable,
    observed: ObservedTable | None,
    plan: ActionPlan,
    rules: tuple[Rule, ...] = DEFAULT_RULES,
) -> ValidationResult:
    ...
```

## Why

`PlanValidator` was shallow: its interface was as wide as its implementation, and it existed only to be constructor-injected into the engine. That made validation asymmetric with planning (both pure, both backend-free, but one a free function and one an injected object), and it forced the engine tests to fake an **internal** collaborator (`_FakeValidator`) — against the project's classical-testing rule. The fake didn't even subclass `PlanValidator`, so the nominal type enforced nothing.

Collapsing it to a function removes the injection, restores symmetry with `plan_table`, and lets the engine tests drive validation through the **real** rules: a desired spec that adds a NOT NULL column to an existing table trips `NonNullableColumnAdd` for real, so `_FakeValidator` is deleted.

## Kept deliberately

The `Rule` ABC and its subclasses stay. Rules-as-classes is the chosen idiom and the ABC is a greppable extension point; only the redundant *aggregator* is gone. The `rules=` default keeps the rule set swappable for scoped tests without a class. This resolves Q3 in `docs/ousterhout-review.md` (which had proposed going further to bare callables — declined for the rules themselves).

## Scope

- Behaviour unchanged; pure refactor.
- `validation.py` and `engine.py` remain 100% covered.
- Docs updated: architecture diagram and `ousterhout-review.md` Q3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)