### PR TITLE
refactor: CatalogState read sum + ExecutionSummary

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -77,12 +77,12 @@ sequenceDiagram
 
     loop per table
         E->>CR: fetch_state(qualified_name)
-        CR-->>E: ReadResult
+        CR-->>E: CatalogState
         E->>E: diff(desired, observed) → ActionPlan
         E->>V: validate_plan(desired, observed, plan)
         V-->>E: ValidationResult
         E->>X: execute(ActionPlan)
-        X-->>E: ExecutionResults
+        X-->>E: ExecutionSummary
     end
 
     E-->>U: Final report

--- a/docs/ousterhout-review.md
+++ b/docs/ousterhout-review.md
@@ -75,48 +75,47 @@ This is Ousterhout's "define errors out of existence." Replace with a real sum
 type and the illegal state, the classmethods, and the two-step decode all
 vanish (the project targets 3.12, so `match` is idiomatic).
 
-**Decision (deviation from the original three-variant sketch below):** the
-implemented shape is **two variants** — `ReadSucceeded(observed: ObservedTable |
-None) | ReadFailed(failure)`. Rationale: the engine treats *present* and
-*absent* identically — both flow into `make_plan_context(desired, observed)`
-(the differ already reads `observed is None` as "create the table"), and the
-only place that distinguishes them is a log string. A three-way split would
-force the engine to re-derive `observed | None` for the shared planning path,
-re-introducing a decode step. Two variants eliminate the illegal
-`(observed=X, failure=X)` state — the whole point of the finding — while
-collapsing the engine to a clean 2-way `match`. Present/absent remains an
-`observed is not None` check at the one log site that cares.
+**Decision — RESOLVED (PR phase-result-types).** First shipped as **two
+variants** (`ReadSucceeded(observed: ObservedTable | None) | ReadFailed`),
+reasoning that the engine treats present and absent identically so a third arm
+would only force it to re-derive `observed | None`. That held until the owner
+revisited the engine and found the surviving `observed is None` sentinel still
+unintuitive: `ReadSucceeded(observed=None)` reads as "a successful read of
+nothing," and every construction site had to spell out the `None`. The
+**three-variant** shape originally sketched below was adopted after all, renamed
+to read like the question it answers — *what is the catalog's state for this
+table?*
 
 ```python
 @dataclass(frozen=True, slots=True)
-class ReadSucceeded:
-    observed: ObservedTable | None   # None = table absent
-
+class TablePresent:
+    table: ObservedTable
+@dataclass(frozen=True, slots=True)
+class TableAbsent:
+    pass
 @dataclass(frozen=True, slots=True)
 class ReadFailed:
-    failure: ReadFailure
+    failure: ReadFailure   # unchanged; consistent with ReadFailure / READ_FAILED
 
-ReadResult = ReadSucceeded | ReadFailed
+CatalogState = TablePresent | TableAbsent | ReadFailed
 ```
 
-Original three-variant sketch (superseded by the decision above):
+The earlier worry (re-deriving `observed | None`) was answered by collapsing the
+present/absent distinction in **one** line at the engine's read branch —
+`observed = catalog_state.table if isinstance(catalog_state, TablePresent) else None`
+— so the shared planning body still runs once. `ReadFailed` was kept untouched,
+so every `isinstance(self.read, ReadFailed)` in `TableRunReport`/`errors.py`
+needed no edit. Net: the illegal `(observed=X, failure=X)` state *and* the
+`observed is None` sentinel are both gone.
 
-```python
-@dataclass(frozen=True, slots=True)
-class ReadPresent:  observed: ObservedTable
-@dataclass(frozen=True, slots=True)
-class ReadAbsent:   pass
-@dataclass(frozen=True, slots=True)
-class ReadFailed:   failure: ReadFailure
-
-ReadResult = ReadPresent | ReadAbsent | ReadFailed
-```
-
-**`ExecutionResult.__post_init__`**
-(`results.py:128-133`) is the same smell (`FAILED` requires a `failure`; the
-others forbid it) and splits the same way into
-`ExecutionOk | ExecutionNoop | ExecutionFailed` — lower priority since the
-runtime guard at least prevents silent misuse.
+**`ExecutionResult` — RESOLVED.** Was the same smell (a `__post_init__` guard:
+`FAILED` requires a `failure`, the others forbid it). Now a sum type
+`ExecutionSucceeded | ExecutionFailed`, so the illegal combinations are
+unrepresentable and the guard is gone. The per-plan aggregate later gained a
+home too: `ExecutionSummary` wraps `tuple[ExecutionResult, ...]` and owns the
+`failed` / `failures` / `failed_count` queries (mirroring `ValidationResult`),
+collapsing the `isinstance(..., ExecutionFailed)` filter that had been
+duplicated across the engine and the report.
 
 ### A3 — Push failure formatting onto the failure types — *medium*
 
@@ -472,14 +471,19 @@ missing `fetch_state`-level test for the null-comment case. No production
 behaviour changes; this is a tests + naming pass. Worth doing opportunistically,
 not urgent.
 
-**Rejected (recorded so they're not re-litigated):** `TableRunReport._any_action_failed`
-(same-object); `engine` reading `read_result.failure.{exception_type,message}` for
-logging (frozen data record; and `format_line()` would double-prefix the log line);
+**Rejected (recorded so they're not re-litigated):** `engine` reading
+`catalog_state.failure.{exception_type,message}` for logging (frozen data record;
+and `format_line()` would double-prefix the log line);
 `spark.catalog.getTable(...).description` (external API); `compile.py`
 `action.column.name`/`data_type` (data records); `errors._format_failure_detail`
-(uses public surface correctly); `errors` reading `execution_results` for SQL
-previews (public field of a data record; a `failed_execution_previews` accessor
-would be a shallow wrapper coupling a result value object to error-formatting).
+(uses public surface correctly); `errors` reading `execution.results` for SQL
+previews (public field of a result aggregate; the one surviving
+`isinstance(..., ExecutionFailed)` there is structural — `statement_preview`
+lives on the result arm, not on `ExecutionFailure`, so it cannot be reached
+through `execution.failures`).
+
+*Note: `TableRunReport._any_action_failed` (previously listed here) no longer
+exists — `ExecutionSummary.failed` subsumed it.*
 
 ### C2 — Deep-simplification pass: question the core abstractions — *complete*
 

--- a/src/delta_engine/adapters/databricks/catalog/executor.py
+++ b/src/delta_engine/adapters/databricks/catalog/executor.py
@@ -19,6 +19,7 @@ from delta_engine.application.results import (
     ExecutionFailure,
     ExecutionResult,
     ExecutionSucceeded,
+    ExecutionSummary,
 )
 from delta_engine.domain.model import QualifiedName
 from delta_engine.domain.plan.actions import ActionPlan
@@ -37,17 +38,15 @@ class DatabricksExecutor:
         self.spark = spark
         self._compiler = compiler
 
-    def execute(
-        self, target: QualifiedName, plan: ActionPlan
-    ) -> tuple[ExecutionResult, ...]:
+    def execute(self, target: QualifiedName, plan: ActionPlan) -> ExecutionSummary:
         """
-        Execute the plan's actions against ``target``, returning a per-action result.
+        Execute the plan's actions against ``target`` and summarize the outcome.
 
         Execution stops at the first failure: the actions form a dependency
         chain, and the engine is not transactional, so continuing past a failure
-        risks compounding a half-migrated table. The returned results cover the
-        actions attempted, ending at the one that failed; actions after it are
-        left unattempted rather than run against an inconsistent table.
+        risks compounding a half-migrated table. The summary covers the actions
+        attempted, ending at the one that failed; actions after it are left
+        unattempted rather than run against an inconsistent table.
         """
         statements = self._compiler(target, plan)
         results: list[ExecutionResult] = []
@@ -56,7 +55,7 @@ class DatabricksExecutor:
             results.append(result)
             if isinstance(result, ExecutionFailed):
                 break
-        return tuple(results)
+        return ExecutionSummary(tuple(results))
 
     def _run_statement(self, action, action_index: int, statement: str) -> ExecutionResult:
         """Run a single compiled statement and map its outcome to an `ExecutionResult`."""

--- a/src/delta_engine/adapters/databricks/catalog/reader.py
+++ b/src/delta_engine/adapters/databricks/catalog/reader.py
@@ -11,7 +11,13 @@ from pyspark.sql.catalog import Column as SparkColumn
 from delta_engine.adapters.databricks.sql.preview import error_preview
 from delta_engine.adapters.databricks.sql.read import query_describe_detail, query_table_existence
 from delta_engine.adapters.databricks.sql.types import domain_type_from_spark
-from delta_engine.application.results import ReadFailed, ReadFailure, ReadResult, ReadSucceeded
+from delta_engine.application.results import (
+    CatalogState,
+    ReadFailed,
+    ReadFailure,
+    TableAbsent,
+    TablePresent,
+)
 from delta_engine.domain.model import Column as DomainColumn, ObservedTable, QualifiedName
 
 
@@ -55,19 +61,19 @@ class DatabricksReader:
         """Initialize the reader with a `SparkSession`."""
         self.spark = spark
 
-    def fetch_state(self, qualified_name: QualifiedName) -> ReadResult:
+    def fetch_state(self, qualified_name: QualifiedName) -> CatalogState:
         """
-        Fetch observed table schema or absence for a qualified name.
+        Fetch the current state of a table: present, absent, or unreadable.
 
-        Returns ``ReadSucceeded`` carrying the current columns, properties, and
-        table comment; ``ReadSucceeded`` with ``observed=None`` when the table
-        doesn't exist; or ``ReadFailed`` if catalog access raised an exception.
+        Returns ``TablePresent`` carrying the current columns, properties, and
+        table comment; ``TableAbsent`` when the table doesn't exist; or
+        ``ReadFailed`` if catalog access raised an exception.
 
         Every failure mode is contained: anything that goes wrong reading this
         table -- a failing existence probe, an unsupported column type, a Spark
         error mid-read -- becomes a ``ReadFailed`` for this table rather than an
         exception that aborts the whole sync. The ``CatalogStateReader`` contract
-        promises a ``ReadResult``, so the boundary must be total.
+        promises a ``CatalogState``, so the boundary must be total.
         """
         try:
             return self._read(qualified_name)
@@ -75,10 +81,10 @@ class DatabricksReader:
             failure = ReadFailure(_exc_type_name(exc), error_preview(exc))
             return ReadFailed(failure=failure)
 
-    def _read(self, qualified_name: QualifiedName) -> ReadResult:
+    def _read(self, qualified_name: QualifiedName) -> CatalogState:
         """Read current state, letting any failure propagate to ``fetch_state``."""
         if not self._table_exists(qualified_name):
-            return ReadSucceeded(observed=None)
+            return TableAbsent()
 
         catalog_columns = self.spark.catalog.listColumns(str(qualified_name))
         columns = tuple(_to_domain_column(c) for c in catalog_columns)
@@ -92,7 +98,7 @@ class DatabricksReader:
             properties=self._fetch_properties(qualified_name),
             partitioned_by=partition_columns,
         )
-        return ReadSucceeded(observed=observed)
+        return TablePresent(table=observed)
 
     def _table_exists(self, qualified_name: QualifiedName) -> bool:
         """Return `True` if the table exists, else `False`."""

--- a/src/delta_engine/application/__init__.py
+++ b/src/delta_engine/application/__init__.py
@@ -4,8 +4,8 @@ Application layer: the engine and the public outcome types.
 These are the names a library consumer depends on -- register tables in a
 `Registry`, construct an `Engine`, call `sync`, and handle the `SyncReport` it
 returns or the `SyncFailedError` it raises (whose failures render via
-`Failure.format_line`). The per-phase result types (`ReadResult`,
-`ExecutionResult`, `TableRunReport`, ...) remain internal.
+`Failure.format_line`). The per-phase result types (`CatalogState`,
+`ExecutionSummary`, `TableRunReport`, ...) remain internal.
 """
 
 from delta_engine.application.engine import Engine

--- a/src/delta_engine/application/engine.py
+++ b/src/delta_engine/application/engine.py
@@ -19,10 +19,10 @@ from delta_engine.application.plan import plan_table
 from delta_engine.application.ports import CatalogStateReader, PlanExecutor
 from delta_engine.application.registry import Registry
 from delta_engine.application.results import (
-    ExecutionFailed,
-    ExecutionResult,
+    ExecutionSummary,
     ReadFailed,
     SyncReport,
+    TablePresent,
     TableRunReport,
     ValidationResult,
 )
@@ -107,23 +107,23 @@ class Engine:
         logger.info("Processing table %s", fully_qualified_name)
 
         validation = ValidationResult()
-        executions: tuple[ExecutionResult, ...] = ()
+        execution = ExecutionSummary()
 
-        read_result = self.reader.fetch_state(desired.qualified_name)
-        if isinstance(read_result, ReadFailed):
+        catalog_state = self.reader.fetch_state(desired.qualified_name)
+        if isinstance(catalog_state, ReadFailed):
             logger.error(
                 "Read failed for %s: %s - %s",
                 fully_qualified_name,
-                read_result.failure.exception_type,
-                read_result.failure.message,
+                catalog_state.failure.exception_type,
+                catalog_state.failure.message,
             )
         else:
+            observed = catalog_state.table if isinstance(catalog_state, TablePresent) else None
             logger.info(
                 "Read state for %s: %s",
                 fully_qualified_name,
-                "present" if read_result.observed is not None else "absent",
+                "present" if observed is not None else "absent",
             )
-            observed = read_result.observed
             plan = plan_table(desired, observed)
             logger.info("Planned %d action(s) for %s", len(plan), fully_qualified_name)
             validation = validate_plan(desired, observed, plan)
@@ -135,20 +135,19 @@ class Engine:
                 )
             else:
                 logger.info("Validation passed for %s", fully_qualified_name)
-                executions = self.executor.execute(desired.qualified_name, plan)
-                failed_count = sum(1 for e in executions if isinstance(e, ExecutionFailed))
+                execution = self.executor.execute(desired.qualified_name, plan)
                 logger.info(
                     "Executed %d action(s) for %s (%d failed)",
-                    len(executions),
+                    len(execution.results),
                     fully_qualified_name,
-                    failed_count,
+                    execution.failed_count,
                 )
 
         return TableRunReport(
             fully_qualified_name=fully_qualified_name,
             started_at=started,
             ended_at=_utc_now(),
-            read=read_result,
+            read=catalog_state,
             validation=validation,
-            execution_results=executions,
+            execution=execution,
         )

--- a/src/delta_engine/application/errors.py
+++ b/src/delta_engine/application/errors.py
@@ -40,7 +40,10 @@ def _format_failure_detail(table_report: TableRunReport) -> list[str]:
     for failure in table_report.all_failures:
         lines.append(f"    {failure.format_line()}")
 
-    for result in table_report.execution_results:
+    # The surviving isinstance is structural: statement_preview lives on the
+    # ExecutionFailed result arm, not on ExecutionFailure, so it cannot be
+    # reached through execution.failures.
+    for result in table_report.execution.results:
         if isinstance(result, ExecutionFailed):
             lines.append(f"    Failed SQL preview (action {result.action_index}):")
             lines.append(f"        {result.statement_preview}")

--- a/src/delta_engine/application/ports.py
+++ b/src/delta_engine/application/ports.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from typing import Protocol, runtime_checkable
 
-from delta_engine.application.results import ExecutionResult, ReadResult
+from delta_engine.application.results import CatalogState, ExecutionSummary
 from delta_engine.domain.model import QualifiedName
 from delta_engine.domain.plan.actions import ActionPlan
 
@@ -13,9 +13,9 @@ from delta_engine.domain.plan.actions import ActionPlan
 class CatalogStateReader(Protocol):
     """Reads current catalog state."""
 
-    def fetch_state(self, qualified_name: QualifiedName) -> ReadResult:
+    def fetch_state(self, qualified_name: QualifiedName) -> CatalogState:
         """
-        Return the result of an attempted catalog read against a table.
+        Return the table's current state: present, absent, or unreadable.
 
         Args:
             qualified_name: Fully qualified object name to look up.
@@ -28,8 +28,6 @@ class CatalogStateReader(Protocol):
 class PlanExecutor(Protocol):
     """Executes an action plan against a backing engine."""
 
-    def execute(
-        self, target: QualifiedName, plan: ActionPlan
-    ) -> tuple[ExecutionResult, ...]:
+    def execute(self, target: QualifiedName, plan: ActionPlan) -> ExecutionSummary:
         """Run the plan against ``target`` and return the execution outcome."""
         ...

--- a/src/delta_engine/application/results.py
+++ b/src/delta_engine/application/results.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 
 from abc import ABC, abstractmethod
 from collections.abc import Iterator
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from datetime import datetime
 from enum import StrEnum
 
@@ -80,20 +80,19 @@ class ExecutionFailure(Failure):
         )
 
 
-# ---------- ReadResult ----------
+# ---------- CatalogState ----------
 
 
 @dataclass(frozen=True, slots=True)
-class ReadSucceeded:
-    """
-    A catalog read that completed without error.
+class TablePresent:
+    """The catalog holds a live table; ``table`` is its observed schema."""
 
-    ``observed`` carries the table's current schema, or ``None`` when the table
-    does not exist. Both outcomes are successful reads: the engine plans against
-    either, treating a missing table as "create it".
-    """
+    table: ObservedTable
 
-    observed: ObservedTable | None
+
+@dataclass(frozen=True, slots=True)
+class TableAbsent:
+    """The catalog confirmed the table does not exist; the engine will create it."""
 
 
 @dataclass(frozen=True, slots=True)
@@ -103,9 +102,9 @@ class ReadFailed:
     failure: ReadFailure
 
 
-# A read either succeeds (with or without an existing table) or fails. The split
-# makes the "succeeded but errored" state unrepresentable.
-ReadResult = ReadSucceeded | ReadFailed
+# The three answers a catalog can give about a table: it is there, it is not
+# there, or it could not be read.
+CatalogState = TablePresent | TableAbsent | ReadFailed
 
 
 # ---------- ValidationResult ----------
@@ -151,6 +150,37 @@ class ExecutionFailed:
 ExecutionResult = ExecutionSucceeded | ExecutionFailed
 
 
+@dataclass(frozen=True, slots=True)
+class ExecutionSummary:
+    """
+    The outcome of running a whole action plan.
+
+    Mirrors :class:`ValidationResult`: a frozen container over the phase's raw
+    results that answers ``failed`` and exposes its ``failures``. It owns the
+    single pass that separates failed actions from successful ones, so callers
+    read a property instead of re-deriving the split with ``isinstance``.
+    """
+
+    results: tuple[ExecutionResult, ...] = ()
+
+    @property
+    def failed(self) -> bool:
+        """True when any action in the plan failed."""
+        return any(isinstance(result, ExecutionFailed) for result in self.results)
+
+    @property
+    def failures(self) -> tuple[ExecutionFailure, ...]:
+        """The failure detail from each failed action, in execution order."""
+        return tuple(
+            result.failure for result in self.results if isinstance(result, ExecutionFailed)
+        )
+
+    @property
+    def failed_count(self) -> int:
+        """How many of the plan's actions failed."""
+        return len(self.failures)
+
+
 # ---------- Reports ----------
 
 
@@ -161,14 +191,9 @@ class TableRunReport:
     fully_qualified_name: str
     started_at: datetime
     ended_at: datetime
-    read: ReadResult
+    read: CatalogState
     validation: ValidationResult
-    execution_results: tuple[ExecutionResult, ...] = ()
-
-    @property
-    def _any_action_failed(self) -> bool:
-        """True if any executed action failed."""
-        return any(isinstance(e, ExecutionFailed) for e in self.execution_results)
+    execution: ExecutionSummary = field(default_factory=ExecutionSummary)
 
     @property
     def status(self) -> TableRunStatus:
@@ -177,7 +202,7 @@ class TableRunReport:
             return TableRunStatus.READ_FAILED
         if self.validation.failed:
             return TableRunStatus.VALIDATION_FAILED
-        if self._any_action_failed:
+        if self.execution.failed:
             return TableRunStatus.EXECUTION_FAILED
         return TableRunStatus.SUCCESS
 
@@ -187,19 +212,13 @@ class TableRunReport:
         return self.status is not TableRunStatus.SUCCESS
 
     @property
-    def action_failures(self) -> tuple[ExecutionFailure, ...]:
-        """Failures captured from action execution results only."""
-        return tuple(e.failure for e in self.execution_results if isinstance(e, ExecutionFailed))
-
-    @property
     def all_failures(self) -> tuple[Failure, ...]:
         """All failures for this table (read, validation, execution)."""
         out: list[Failure] = []
         if isinstance(self.read, ReadFailed):
             out.append(self.read.failure)
-        if self.validation.failed:
-            out.extend(self.validation.failures)
-        out.extend(self.action_failures)
+        out.extend(self.validation.failures)
+        out.extend(self.execution.failures)
         return tuple(out)
 
 

--- a/tests/adapters/databricks/catalog/test_executor.py
+++ b/tests/adapters/databricks/catalog/test_executor.py
@@ -85,11 +85,12 @@ def test_execute_maps_success_and_failure_without_leakage():
         return ["SELECT 1", "SELECT * FROM __nope__"]  # OK, then FAIL
 
     # When we execute
-    results = DatabricksExecutor(_FakeSpark(), compiler=_fake_compiler).execute(
+    summary = DatabricksExecutor(_FakeSpark(), compiler=_fake_compiler).execute(
         _dummy_target(), plan
     )
 
     # Then the success and failure are mapped with correct metadata and no leakage
+    results = summary.results
     assert [r.action for r in results] == ["AddColumn", "DropColumn"]
     assert [r.action_index for r in results] == [0, 1]
     assert isinstance(results[0], ExecutionSucceeded)
@@ -116,25 +117,27 @@ def test_execute_stops_at_first_failure_to_avoid_half_migrating():
         ]
 
     # When we execute
-    results = DatabricksExecutor(spark, compiler=_fake_compiler).execute(_dummy_target(), plan)
+    summary = DatabricksExecutor(spark, compiler=_fake_compiler).execute(_dummy_target(), plan)
 
     # Then execution stops at the failure: the third statement never runs
     assert spark.executed == ["SELECT 1", "SELECT * FROM __nope__"]
 
     # And the report covers only the attempted actions, ending at the failure
+    results = summary.results
     assert [type(r) for r in results] == [ExecutionSucceeded, ExecutionFailed]
     assert [r.action_index for r in results] == [0, 1]
 
 
-def test_execute_returns_empty_tuple_for_empty_plan():
+def test_execute_returns_empty_summary_for_empty_plan():
     # Given an empty plan
     plan = ActionPlan(actions=())
 
     # When we execute the plan
-    results = DatabricksExecutor(_FakeSpark()).execute(_dummy_target(), plan)
+    summary = DatabricksExecutor(_FakeSpark()).execute(_dummy_target(), plan)
 
-    # Then no results are returned
-    assert results == ()
+    # Then nothing ran and the summary is empty and non-failing
+    assert summary.results == ()
+    assert summary.failed is False
 
 
 def test_createtable_action_creates_table_with_correct_schema(spark, test_table):

--- a/tests/adapters/databricks/catalog/test_reader.py
+++ b/tests/adapters/databricks/catalog/test_reader.py
@@ -7,7 +7,7 @@ from pyspark.sql.utils import AnalysisException
 import pytest
 
 from delta_engine.adapters.databricks.catalog.reader import DatabricksReader
-from delta_engine.application.results import ReadFailed, ReadSucceeded
+from delta_engine.application.results import ReadFailed, TableAbsent, TablePresent
 from delta_engine.domain.model import QualifiedName
 
 # ---------- fakes & helpers ----------
@@ -179,7 +179,8 @@ def test_columns_maps_name_nullability_and_comment(qn):
     result = DatabricksReader(spark).fetch_state(qn)
 
     # Then names, nullability, and comments are mapped correctly
-    cols = result.observed.columns
+    assert isinstance(result, TablePresent)
+    cols = result.table.columns
     assert [c.name for c in cols] == ["id", "p_date"]
     assert [c.nullable for c in cols] == [False, True]
     assert [c.comment for c in cols] == ["identifier", ""]
@@ -202,7 +203,8 @@ def test_partition_columns_returns_only_partition_names_in_order(qn):
     result = DatabricksReader(spark).fetch_state(qn)
 
     # Then only partition columns are returned and ordering is preserved
-    assert result.observed.partitioned_by == ("p_store", "p_date")
+    assert isinstance(result, TablePresent)
+    assert result.table.partitioned_by == ("p_store", "p_date")
 
 
 def test_partition_columns_ignores_missing_or_false_flags():
@@ -225,7 +227,8 @@ def test_partition_columns_ignores_missing_or_false_flags():
     result = DatabricksReader(spark).fetch_state(qn)
 
     # Then no partitions are reported
-    assert result.observed.partitioned_by == ()
+    assert isinstance(result, TablePresent)
+    assert result.table.partitioned_by == ()
 
 
 # ---------- tests: properties ----------
@@ -296,9 +299,8 @@ def test_fetch_state_returns_absent_when_table_does_not_exist(qn):
     # When we fetch state
     result = reader.fetch_state(qn)
 
-    # Then the read succeeded with no observed table (absence)
-    assert isinstance(result, ReadSucceeded)
-    assert result.observed is None
+    # Then the catalog reports the table as absent
+    assert isinstance(result, TableAbsent)
 
 
 def test_fetch_state_returns_present_with_columns_partitions_comment_and_properties():
@@ -334,9 +336,8 @@ def test_fetch_state_returns_present_with_columns_partitions_comment_and_propert
     result = reader.fetch_state(qn)
 
     # Then the observed payload contains correct columns, partitions, comment, and properties
-    assert isinstance(result, ReadSucceeded)
-    assert result.observed is not None
-    observed = result.observed
+    assert isinstance(result, TablePresent)
+    observed = result.table
     assert [c.name for c in observed.columns] == ["id", "p_date"]
     assert observed.partitioned_by == ("p_date",)
     assert observed.comment == "orders table"
@@ -363,10 +364,9 @@ def test_fetch_state_returns_present_with_empty_properties_when_describe_has_no_
     result = reader.fetch_state(qn)
 
     # Then the table is present with empty properties and the expected comment
-    assert isinstance(result, ReadSucceeded)
-    assert result.observed is not None
-    assert dict(result.observed.properties) == {}
-    assert result.observed.comment == ""
+    assert isinstance(result, TablePresent)
+    assert dict(result.table.properties) == {}
+    assert result.table.comment == ""
 
 
 def test_fetch_state_returns_failed_when_spark_raises_analysis_exception():
@@ -446,6 +446,6 @@ def test_fetch_state_lowercases_mixed_case_column_names_from_catalog():
     result = reader.fetch_state(qn)
 
     # Then names are normalised to lowercase at the adapter boundary (no crash)
-    assert isinstance(result, ReadSucceeded)
-    assert [c.name for c in result.observed.columns] == ["eventid", "username"]
-    assert result.observed.partitioned_by == ("username",)
+    assert isinstance(result, TablePresent)
+    assert [c.name for c in result.table.columns] == ["eventid", "username"]
+    assert result.table.partitioned_by == ("username",)

--- a/tests/application/test_engine.py
+++ b/tests/application/test_engine.py
@@ -5,15 +5,17 @@ from delta_engine.application.engine import Engine
 from delta_engine.application.errors import SyncFailedError
 from delta_engine.application.registry import Registry
 from delta_engine.application.results import (
+    CatalogState,
     ExecutionFailed,
     ExecutionFailure,
     ExecutionResult,
     ExecutionSucceeded,
+    ExecutionSummary,
     ReadFailed,
     ReadFailure,
-    ReadResult,
-    ReadSucceeded,
     SyncReport,
+    TableAbsent,
+    TablePresent,
     TableRunStatus,
 )
 from delta_engine.domain.model import ObservedTable, QualifiedName
@@ -45,11 +47,11 @@ def _spec_adding_not_null(fqn: str) -> DeltaTable:
     )
 
 
-def _existing_id_table(fqn: str) -> ReadSucceeded:
-    """Build a successful read of an existing table with a single 'id' column."""
+def _existing_id_table(fqn: str) -> TablePresent:
+    """Build the present-state read of an existing table with a single 'id' column."""
     catalog, schema, name = fqn.split(".")
-    return ReadSucceeded(
-        observed=ObservedTable(
+    return TablePresent(
+        table=ObservedTable(
             qualified_name=QualifiedName(catalog, schema, name),
             columns=(Column("id", String()),),
         )
@@ -57,21 +59,19 @@ def _existing_id_table(fqn: str) -> ReadSucceeded:
 
 
 class _FakeReader:
-    def __init__(self, mapping: dict[str, ReadResult]) -> None:
+    def __init__(self, mapping: dict[str, CatalogState]) -> None:
         self.mapping = mapping
 
-    def fetch_state(self, qualified_name: QualifiedName) -> ReadResult:
-        return self.mapping.get(str(qualified_name), ReadSucceeded(observed=None))
+    def fetch_state(self, qualified_name: QualifiedName) -> CatalogState:
+        return self.mapping.get(str(qualified_name), TableAbsent())
 
 
 class _FakeExecutor:
     def __init__(self, results: tuple[ExecutionResult, ...]) -> None:
         self.results = results
 
-    def execute(
-        self, target: QualifiedName, plan: ActionPlan
-    ) -> tuple[ExecutionResult, ...]:
-        return self.results
+    def execute(self, target: QualifiedName, plan: ActionPlan) -> ExecutionSummary:
+        return ExecutionSummary(self.results)
 
 
 def _ok_exec(idx: int = 0) -> ExecutionResult:
@@ -93,10 +93,8 @@ class _SeqExecutor:
     def __init__(self, per_call_results: list[tuple[ExecutionResult, ...]]) -> None:
         self._seq = list(per_call_results)
 
-    def execute(
-        self, target: QualifiedName, plan: ActionPlan
-    ) -> tuple[ExecutionResult, ...]:
-        return self._seq.pop(0)
+    def execute(self, target: QualifiedName, plan: ActionPlan) -> ExecutionSummary:
+        return ExecutionSummary(self._seq.pop(0))
 
 
 # ---------- Tests
@@ -137,7 +135,7 @@ def test_raises_when_execution_contains_any_failure():
     # Given a table that reads & validates successfully, but execution has a failed action
     reg = Registry()
     reg.register(_spec("c.s.exec_fail"))
-    reader = _FakeReader({"c.s.exec_fail": ReadSucceeded(observed=None)})
+    reader = _FakeReader({"c.s.exec_fail": TableAbsent()})
     executor = _FakeExecutor(results=(_ok_exec(0), _failed_exec(1), _ok_exec(2)))
 
     # When syncing
@@ -155,8 +153,8 @@ def test_returns_report_when_all_tables_succeed():
     )  # registry will yield in name-sorted order
     reader = _FakeReader(
         {
-            "c.a.users": ReadSucceeded(observed=None),
-            "c.b.orders": ReadSucceeded(observed=None),
+            "c.a.users": TableAbsent(),
+            "c.b.orders": TableAbsent(),
         }
     )
     executor = _FakeExecutor(results=(_ok_exec(0), _ok_exec(1)))
@@ -181,7 +179,7 @@ def test_engine_reads_all_tables_then_raises_on_any_read_failure():
     reader = _FakeReader(
         {
             "c.s.a": ReadFailed(ReadFailure("IOError", "cannot read")),
-            "c.s.b": ReadSucceeded(observed=None),
+            "c.s.b": TableAbsent(),
         }
     )
     executor = _FakeExecutor(results=(_ok_exec(0),))  # irrelevant for a; used for b
@@ -204,7 +202,7 @@ def test_engine_validates_all_tables_executes_only_the_passing_ones_then_raises(
     reader = _FakeReader(
         {
             "c.s.a": _existing_id_table("c.s.a"),  # existing -> add NOT NULL is rejected
-            "c.s.b": ReadSucceeded(observed=None),  # absent -> clean create
+            "c.s.b": TableAbsent(),  # absent -> clean create
         }
     )
     executor = _FakeExecutor(results=(_ok_exec(0), _ok_exec(1)))  # used only for b
@@ -217,9 +215,9 @@ def test_engine_validates_all_tables_executes_only_the_passing_ones_then_raises(
     # Then the report shows a VALIDATION_FAILED and a SUCCESS
     [tr_a, tr_b] = list(err.value.report)
     assert tr_a.status is TableRunStatus.VALIDATION_FAILED
-    assert tr_a.execution_results == ()  # a was not executed
+    assert tr_a.execution.results == ()  # a was not executed
     assert tr_b.status is TableRunStatus.SUCCESS
-    assert tr_b.execution_results != ()  # b was executed
+    assert tr_b.execution.results != ()  # b was executed
 
 
 def test_engine_executes_all_tables_then_raises_if_any_execution_failed():
@@ -228,8 +226,8 @@ def test_engine_executes_all_tables_then_raises_if_any_execution_failed():
     reg.register(_spec("c.s.a"), _spec("c.s.b"))
     reader = _FakeReader(
         {
-            "c.s.a": ReadSucceeded(observed=None),
-            "c.s.b": ReadSucceeded(observed=None),
+            "c.s.a": TableAbsent(),
+            "c.s.b": TableAbsent(),
         }
     )
     executor = _SeqExecutor(
@@ -255,8 +253,8 @@ def test_engine_executes_remaining_tables_even_if_first_execution_fails():
     reg.register(_spec("c.s.a"), _spec("c.s.b"))
     reader = _FakeReader(
         {
-            "c.s.a": ReadSucceeded(observed=None),
-            "c.s.b": ReadSucceeded(observed=None),
+            "c.s.a": TableAbsent(),
+            "c.s.b": TableAbsent(),
         }
     )
     executor = _SeqExecutor(
@@ -275,4 +273,4 @@ def test_engine_executes_remaining_tables_even_if_first_execution_fails():
     [tr_a, tr_b] = list(err.value.report)
     assert tr_a.status is TableRunStatus.EXECUTION_FAILED
     assert tr_b.status is TableRunStatus.SUCCESS
-    assert tr_b.execution_results != ()  # proves 'b' actually executed
+    assert tr_b.execution.results != ()  # proves 'b' actually executed

--- a/tests/application/test_errors.py
+++ b/tests/application/test_errors.py
@@ -2,14 +2,14 @@ from datetime import UTC, datetime
 
 from delta_engine.application.errors import SyncFailedError
 from delta_engine.application.results import (
+    CatalogState,
     ExecutionFailed,
     ExecutionFailure,
-    ExecutionResult,
+    ExecutionSummary,
     ReadFailed,
     ReadFailure,
-    ReadResult,
-    ReadSucceeded,
     SyncReport,
+    TableAbsent,
     TableRunReport,
     ValidationFailure,
     ValidationResult,
@@ -17,13 +17,14 @@ from delta_engine.application.results import (
 
 _AT = datetime(2026, 1, 1, tzinfo=UTC)
 _NO_VALIDATION_FAILURES = ValidationResult()
+_NO_EXECUTION = ExecutionSummary()
 
 
 def _table_report(
     *,
-    read: ReadResult,
+    read: CatalogState,
     validation: ValidationResult = _NO_VALIDATION_FAILURES,
-    execution_results: tuple[ExecutionResult, ...] = (),
+    execution: ExecutionSummary = _NO_EXECUTION,
 ) -> TableRunReport:
     return TableRunReport(
         fully_qualified_name="cat.sch.tbl",
@@ -31,7 +32,7 @@ def _table_report(
         ended_at=_AT,
         read=read,
         validation=validation,
-        execution_results=execution_results,
+        execution=execution,
     )
 
 
@@ -67,7 +68,7 @@ def test_message_renders_read_failure_detail():
 def test_message_renders_validation_failure_detail():
     # Given a table whose validation phase failed
     report = _table_report(
-        read=ReadSucceeded(observed=None),
+        read=TableAbsent(),
         validation=ValidationResult(
             failures=(ValidationFailure("DisallowPartitioningChange", "cannot repartition"),)
         ),
@@ -89,7 +90,7 @@ def test_message_renders_execution_failure_detail_with_sql_preview():
         statement_preview="ALTER TABLE cat.sch.tbl ADD COLUMN x INT",
         failure=ExecutionFailure(action_index=2, exception_type="SparkException", message="boom"),
     )
-    report = _table_report(read=ReadSucceeded(observed=None), execution_results=(failed_result,))
+    report = _table_report(read=TableAbsent(), execution=ExecutionSummary((failed_result,)))
 
     # When building the error message
     message = _message_for(report)

--- a/tests/application/test_results.py
+++ b/tests/application/test_results.py
@@ -4,10 +4,12 @@ from delta_engine.application.results import (
     ExecutionFailed,
     ExecutionFailure,
     ExecutionSucceeded,
+    ExecutionSummary,
     ReadFailed,
     ReadFailure,
-    ReadSucceeded,
     SyncReport,
+    TableAbsent,
+    TablePresent,
     TableRunReport,
     TableRunStatus,
     ValidationFailure,
@@ -49,27 +51,26 @@ def _failed_exec(
 # ---------- Tests
 
 
-def test_read_succeeded_present_holds_the_observed_table():
+def test_present_state_holds_the_observed_table():
     # Given a table that was read and exists
     observed = _FakeObservedTable()
 
-    # When recording a successful read
-    result = ReadSucceeded(observed=observed)
+    # When recording its catalog state
+    state = TablePresent(table=observed)
 
     # Then it carries the observed table and is not a failure
-    assert result.observed is observed
-    assert not isinstance(result, ReadFailed)
+    assert state.table is observed
+    assert not isinstance(state, ReadFailed)
 
 
-def test_read_succeeded_absent_carries_no_observed_table():
+def test_absent_state_is_distinct_from_a_failure():
     # Given a table that was read but does not exist
 
-    # When recording a successful read with no table
-    result = ReadSucceeded(observed=None)
+    # When recording its catalog state
+    state = TableAbsent()
 
-    # Then absence is represented by a null observed table, still not a failure
-    assert result.observed is None
-    assert not isinstance(result, ReadFailed)
+    # Then absence is its own state, not a failure
+    assert not isinstance(state, ReadFailed)
 
 
 def test_read_failed_carries_the_failure():
@@ -125,6 +126,36 @@ def test_validation_result_failed_property_reflects_presence_of_failures():
     assert ok_result.failed is False
 
 
+def test_execution_summary_reports_no_failure_when_every_action_succeeds():
+    # Given a plan whose actions all executed
+    summary = ExecutionSummary((_ok_exec(0), _ok_exec(1)))
+
+    # Then the summary reports success with no failures
+    assert summary.failed is False
+    assert summary.failures == ()
+    assert summary.failed_count == 0
+
+
+def test_execution_summary_exposes_the_failures_among_mixed_results():
+    # Given a plan that ran two actions, the second of which failed
+    summary = ExecutionSummary((_ok_exec(0), _failed_exec(1, msg="bang")))
+
+    # Then the summary surfaces the single failure and its count
+    assert summary.failed is True
+    assert summary.failed_count == 1
+    assert tuple(f.message for f in summary.failures) == ("bang",)
+
+
+def test_execution_summary_defaults_to_an_empty_unattempted_run():
+    # Given no execution happened (e.g. an earlier phase short-circuited)
+    summary = ExecutionSummary()
+
+    # Then it is an empty, non-failing summary
+    assert summary.results == ()
+    assert summary.failed is False
+    assert summary.failed_count == 0
+
+
 def test_execution_outcome_variants_carry_the_right_payload():
     # Given the two execution outcomes
     succeeded = ExecutionSucceeded(action="AddColumn", action_index=0, statement_preview="SQL")
@@ -142,9 +173,9 @@ def test_execution_outcome_variants_carry_the_right_payload():
 
 def test_table_status_success_when_all_actions_succeed():
     # Given successful read, no validation failures, and only successful actions
-    read = ReadSucceeded(observed=_FakeObservedTable())
+    read = TablePresent(table=_FakeObservedTable())
     validation = ValidationResult()
-    execution_results = (_ok_exec(0), _ok_exec(1))
+    execution = ExecutionSummary((_ok_exec(0), _ok_exec(1)))
 
     # When aggregating
     report = TableRunReport(
@@ -153,13 +184,13 @@ def test_table_status_success_when_all_actions_succeed():
         ended_at=_t1(),
         read=read,
         validation=validation,
-        execution_results=execution_results,
+        execution=execution,
     )
 
     # Then everything is SUCCESS and has_failures is False
     assert report.status is TableRunStatus.SUCCESS
     assert report.has_failures is False
-    assert report.action_failures == ()
+    assert report.execution.failures == ()
 
 
 def test_sync_report_any_failures_true_if_any_table_has_failures():
@@ -168,17 +199,17 @@ def test_sync_report_any_failures_true_if_any_table_has_failures():
         fully_qualified_name="a",
         started_at=_t0(),
         ended_at=_t1(),
-        read=ReadSucceeded(observed=_FakeObservedTable()),
+        read=TablePresent(table=_FakeObservedTable()),
         validation=ValidationResult(),
-        execution_results=(_ok_exec(0),),
+        execution=ExecutionSummary((_ok_exec(0),)),
     )
     t_bad = TableRunReport(
         fully_qualified_name="b",
         started_at=_t0(),
         ended_at=_t1(),
-        read=ReadSucceeded(observed=_FakeObservedTable()),
+        read=TablePresent(table=_FakeObservedTable()),
         validation=ValidationResult(),
-        execution_results=(_failed_exec(0),),
+        execution=ExecutionSummary((_failed_exec(0),)),
     )
 
     # When aggregating the sync
@@ -194,17 +225,17 @@ def test_sync_report_failures_by_table_maps_only_failed_tables():
         fully_qualified_name="x",
         started_at=_t0(),
         ended_at=_t1(),
-        read=ReadSucceeded(observed=_FakeObservedTable()),
+        read=TablePresent(table=_FakeObservedTable()),
         validation=ValidationResult(),
-        execution_results=(_ok_exec(0),),
+        execution=ExecutionSummary((_ok_exec(0),)),
     )
     t_bad = TableRunReport(
         fully_qualified_name="y",
         started_at=_t0(),
         ended_at=_t1(),
-        read=ReadSucceeded(observed=_FakeObservedTable()),
+        read=TableAbsent(),
         validation=ValidationResult(failures=(ValidationFailure("R", "v"),)),
-        execution_results=(),
+        execution=ExecutionSummary(),
     )
 
     # When


### PR DESCRIPTION
## What

Reshapes the read and execute phase-result types so the engine reads as intent instead of decoding sentinels.

### Read → `CatalogState` (three-arm sum)

```python
CatalogState = TablePresent | TableAbsent | ReadFailed
```

`ReadSucceeded(observed: ObservedTable | None)` folded *present* and *absent* into one type behind an `observed is None` sentinel — so "a successful read of nothing" was constructible, and every call site had to spell out the `None`. The three arms model the catalog's actual answers and make "present-but-empty" unrepresentable. The engine's read branch now reads as a question about state:

```python
catalog_state = self.reader.fetch_state(desired.qualified_name)
if isinstance(catalog_state, ReadFailed):
    ...
else:
    observed = catalog_state.table if isinstance(catalog_state, TablePresent) else None
    plan = plan_table(desired, observed)
    ...
```

The shared planning path still runs once — present/absent collapses to one local in a single line at the seam. `ReadFailed` is unchanged, so every `isinstance(read, ReadFailed)` in the report/error formatter needed no edit.

### Execute → `ExecutionSummary` (mirrors `ValidationResult`)

```python
execution = self.executor.execute(target, plan)
logger.info("Executed ... (failed=%s)", execution.failed_count)   # owned by the type
```

`failed_count` was derived inline in the engine, and the same `isinstance(_, ExecutionFailed)` filter was duplicated in the engine, `TableRunReport._any_action_failed`, and `TableRunReport.action_failures`. `ExecutionSummary` owns `failed` / `failures` / `failed_count` in one place; the report delegates and `_any_action_failed`/`action_failures` are gone.

One `isinstance` survives in `errors.py` — `statement_preview` lives on the `ExecutionFailed` arm, not on `ExecutionFailure`, so it can't be reached through `execution.failures`. Pulling it into the summary would drag SQL-formatting into a domain type; left as-is, with a comment.

## Why

Both came from the owner reviewing the engine: `read_result = self.reader.fetch_state(...)` should read as "the state of what's there," and `failed_count` should live *on* the execution result, not be re-derived by the orchestrator. Design was chosen via a propose → adversarial-critique → synthesize pass; the read change scored highest, the execution wrapper was adopted as the seam-consistent counterpart to `ValidationResult`.

## Scope

- Behaviour unchanged; pure refactor.
- `results.py`, `engine.py`, `ports.py`, `errors.py` stay **100%** covered.
- Both Databricks adapters and all affected tests follow the new types.
- Resolves review findings **A2** (read sum) and the `ExecutionResult` aggregate note; `docs/architecture.md` and `docs/ousterhout-review.md` updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
