### PR TITLE
refactor: one canonical name for the qualified-name concept

### DIFF
--- a/src/delta_engine/adapters/databricks/catalog/executor.py
+++ b/src/delta_engine/adapters/databricks/catalog/executor.py
@@ -38,9 +38,9 @@ class DatabricksExecutor:
         self.spark = spark
         self._compiler = compiler
 
-    def execute(self, target: QualifiedName, plan: ActionPlan) -> ExecutionSummary:
+    def execute(self, qualified_name: QualifiedName, plan: ActionPlan) -> ExecutionSummary:
         """
-        Execute the plan's actions against ``target`` and summarize the outcome.
+        Execute the plan's actions against ``qualified_name`` and summarize the outcome.
 
         Execution stops at the first failure: the actions form a dependency
         chain, and the engine is not transactional, so continuing past a failure
@@ -48,7 +48,7 @@ class DatabricksExecutor:
         attempted, ending at the one that failed; actions after it are left
         unattempted rather than run against an inconsistent table.
         """
-        statements = self._compiler(target, plan)
+        statements = self._compiler(qualified_name, plan)
         results: list[ExecutionResult] = []
         for action_index, statement in enumerate(statements):
             result = self._run_statement(plan[action_index], action_index, statement)

--- a/src/delta_engine/adapters/databricks/sql/compile.py
+++ b/src/delta_engine/adapters/databricks/sql/compile.py
@@ -30,9 +30,9 @@ from delta_engine.domain.plan.actions import (
 )
 
 
-def compile_plan(target: QualifiedName, plan: ActionPlan) -> tuple[str, ...]:
-    """Compile an :class:`ActionPlan` for ``target`` into Spark SQL statements."""
-    backticked_table_name = backtick_qualified_name(target)
+def compile_plan(qualified_name: QualifiedName, plan: ActionPlan) -> tuple[str, ...]:
+    """Compile an :class:`ActionPlan` for ``qualified_name`` into Spark SQL statements."""
+    backticked_table_name = backtick_qualified_name(qualified_name)
     return tuple(_compile_action(action, backticked_table_name) for action in plan)
 
 

--- a/src/delta_engine/application/engine.py
+++ b/src/delta_engine/application/engine.py
@@ -103,17 +103,17 @@ class Engine:
         produced.
         """
         started = _utc_now()
-        fully_qualified_name = str(desired.qualified_name)
-        logger.info("Processing table %s", fully_qualified_name)
+        qualified_name = desired.qualified_name
+        logger.info("Processing table %s", qualified_name)
 
         validation = ValidationResult()
         execution = ExecutionSummary()
 
-        catalog_state = self.reader.fetch_state(desired.qualified_name)
+        catalog_state = self.reader.fetch_state(qualified_name)
         if isinstance(catalog_state, ReadFailed):
             logger.error(
                 "Read failed for %s: %s - %s",
-                fully_qualified_name,
+                qualified_name,
                 catalog_state.failure.exception_type,
                 catalog_state.failure.message,
             )
@@ -121,30 +121,30 @@ class Engine:
             observed = catalog_state.table if isinstance(catalog_state, TablePresent) else None
             logger.info(
                 "Read state for %s: %s",
-                fully_qualified_name,
+                qualified_name,
                 "present" if observed is not None else "absent",
             )
             plan = plan_table(desired, observed)
-            logger.info("Planned %d action(s) for %s", len(plan), fully_qualified_name)
+            logger.info("Planned %d action(s) for %s", len(plan), qualified_name)
             validation = validate_plan(desired, observed, plan)
             if validation.failed:
                 logger.error(
                     "Validation failed for %s (%d failure(s))",
-                    fully_qualified_name,
+                    qualified_name,
                     len(validation.failures),
                 )
             else:
-                logger.info("Validation passed for %s", fully_qualified_name)
-                execution = self.executor.execute(desired.qualified_name, plan)
+                logger.info("Validation passed for %s", qualified_name)
+                execution = self.executor.execute(qualified_name, plan)
                 logger.info(
                     "Executed %d action(s) for %s (%d failed)",
                     len(execution.results),
-                    fully_qualified_name,
+                    qualified_name,
                     execution.failed_count,
                 )
 
         return TableRunReport(
-            fully_qualified_name=fully_qualified_name,
+            qualified_name=qualified_name,
             started_at=started,
             ended_at=_utc_now(),
             read=catalog_state,

--- a/src/delta_engine/application/errors.py
+++ b/src/delta_engine/application/errors.py
@@ -35,7 +35,7 @@ def _format_failure_detail(table_report: TableRunReport) -> list[str]:
     Covers the table headline, each top-level failure (read, validation,
     execution), and SQL previews for any failed actions.
     """
-    lines = [f"\n❌ {table_report.fully_qualified_name} [{table_report.status.value}]"]
+    lines = [f"\n❌ {table_report.qualified_name} [{table_report.status.value}]"]
 
     for failure in table_report.all_failures:
         lines.append(f"    {failure.format_line()}")

--- a/src/delta_engine/application/ports.py
+++ b/src/delta_engine/application/ports.py
@@ -28,6 +28,6 @@ class CatalogStateReader(Protocol):
 class PlanExecutor(Protocol):
     """Executes an action plan against a backing engine."""
 
-    def execute(self, target: QualifiedName, plan: ActionPlan) -> ExecutionSummary:
-        """Run the plan against ``target`` and return the execution outcome."""
+    def execute(self, qualified_name: QualifiedName, plan: ActionPlan) -> ExecutionSummary:
+        """Run the plan against ``qualified_name`` and return the execution outcome."""
         ...

--- a/src/delta_engine/application/registry.py
+++ b/src/delta_engine/application/registry.py
@@ -2,13 +2,13 @@
 In-memory registry of desired table definitions for planning.
 
 Accepts table specifications that convert themselves to domain models, rejects
-duplicate names, and iterates in fully qualified name order to produce
-deterministic planning input for the engine.
+duplicate names, and iterates in qualified-name order to produce deterministic
+planning input for the engine.
 """
 
 from typing import Protocol, runtime_checkable
 
-from delta_engine.domain.model import DesiredTable
+from delta_engine.domain.model import DesiredTable, QualifiedName
 
 
 @runtime_checkable
@@ -24,14 +24,14 @@ class Registry:
     """
     In-memory registry of desired table definitions.
 
-    Tables are keyed by fully qualified name, which gives duplicate detection
-    and uniqueness for free. Iteration yields tables in deterministic
+    Tables are keyed by their :class:`QualifiedName`, which gives duplicate
+    detection and uniqueness for free. Iteration yields tables in deterministic
     (name-sorted) order.
     """
 
     def __init__(self) -> None:
         """Create an empty registry."""
-        self._tables_by_name: dict[str, DesiredTable] = {}
+        self._tables: dict[QualifiedName, DesiredTable] = {}
 
     def register(self, *tables: DesiredTableSource) -> None:
         """
@@ -42,26 +42,26 @@ class Registry:
                 domain :class:`DesiredTable` via ``to_desired_table()``.
 
         Raises:
-            ValueError: If the same fully qualified name is registered twice
+            ValueError: If the same qualified name is registered twice
                 (either within this call or across previous calls).
 
         """
         # Convert and check every table before mutating, so a duplicate in the
         # batch leaves the registry unchanged rather than half-applied.
-        new_tables: dict[str, DesiredTable] = {}
+        new_tables: dict[QualifiedName, DesiredTable] = {}
         for table in tables:
             desired = table.to_desired_table()
-            fqn = str(desired.qualified_name)
-            if fqn in self._tables_by_name or fqn in new_tables:
-                raise ValueError(f"Duplicate table registration: {fqn}")
-            new_tables[fqn] = desired
+            qualified_name = desired.qualified_name
+            if qualified_name in self._tables or qualified_name in new_tables:
+                raise ValueError(f"Duplicate table registration: {qualified_name}")
+            new_tables[qualified_name] = desired
 
-        self._tables_by_name.update(new_tables)
+        self._tables.update(new_tables)
 
     def __iter__(self):
-        """Iterate over desired tables in fully-qualified-name order."""
-        yield from (self._tables_by_name[fqn] for fqn in sorted(self._tables_by_name))
+        """Iterate over desired tables in qualified-name order."""
+        yield from (self._tables[name] for name in sorted(self._tables, key=str))
 
     def __len__(self):
         """Return the number of registered tables."""
-        return len(self._tables_by_name)
+        return len(self._tables)

--- a/src/delta_engine/application/results.py
+++ b/src/delta_engine/application/results.py
@@ -14,7 +14,7 @@ from dataclasses import dataclass, field
 from datetime import datetime
 from enum import StrEnum
 
-from delta_engine.domain.model import ObservedTable
+from delta_engine.domain.model import ObservedTable, QualifiedName
 
 # ---------- Status enums ----------
 
@@ -188,7 +188,7 @@ class ExecutionSummary:
 class TableRunReport:
     """Per-table report with timings, outcomes, and failures."""
 
-    fully_qualified_name: str
+    qualified_name: QualifiedName
     started_at: datetime
     ended_at: datetime
     read: CatalogState
@@ -236,10 +236,10 @@ class SyncReport:
         return any(t.has_failures for t in self.table_reports)
 
     @property
-    def failures_by_table(self) -> dict[str, tuple[Failure, ...]]:
-        """Mapping of fully qualified table name to its failures (if any)."""
+    def failures_by_table(self) -> dict[QualifiedName, tuple[Failure, ...]]:
+        """Mapping of qualified table name to its failures (if any)."""
         return {
-            t.fully_qualified_name: t.all_failures for t in self.table_reports if t.has_failures
+            t.qualified_name: t.all_failures for t in self.table_reports if t.has_failures
         }
 
     def __iter__(self) -> Iterator[TableRunReport]:

--- a/tests/adapters/databricks/catalog/test_executor.py
+++ b/tests/adapters/databricks/catalog/test_executor.py
@@ -57,7 +57,7 @@ def _get_field(spark, full_table_name: str, column_name: str):
     return next(f for f in spark.table(full_table_name).schema.fields if f.name == column_name)
 
 
-def _dummy_target() -> QualifiedName:
+def _dummy_qualified_name() -> QualifiedName:
     return QualifiedName("cat", "sch", "tbl")
 
 
@@ -86,7 +86,7 @@ def test_execute_maps_success_and_failure_without_leakage():
 
     # When we execute
     summary = DatabricksExecutor(_FakeSpark(), compiler=_fake_compiler).execute(
-        _dummy_target(), plan
+        _dummy_qualified_name(), plan
     )
 
     # Then the success and failure are mapped with correct metadata and no leakage
@@ -117,7 +117,8 @@ def test_execute_stops_at_first_failure_to_avoid_half_migrating():
         ]
 
     # When we execute
-    summary = DatabricksExecutor(spark, compiler=_fake_compiler).execute(_dummy_target(), plan)
+    executor = DatabricksExecutor(spark, compiler=_fake_compiler)
+    summary = executor.execute(_dummy_qualified_name(), plan)
 
     # Then execution stops at the failure: the third statement never runs
     assert spark.executed == ["SELECT 1", "SELECT * FROM __nope__"]
@@ -133,7 +134,7 @@ def test_execute_returns_empty_summary_for_empty_plan():
     plan = ActionPlan(actions=())
 
     # When we execute the plan
-    summary = DatabricksExecutor(_FakeSpark()).execute(_dummy_target(), plan)
+    summary = DatabricksExecutor(_FakeSpark()).execute(_dummy_qualified_name(), plan)
 
     # Then nothing ran and the summary is empty and non-failing
     assert summary.results == ()

--- a/tests/application/test_engine.py
+++ b/tests/application/test_engine.py
@@ -70,7 +70,7 @@ class _FakeExecutor:
     def __init__(self, results: tuple[ExecutionResult, ...]) -> None:
         self.results = results
 
-    def execute(self, target: QualifiedName, plan: ActionPlan) -> ExecutionSummary:
+    def execute(self, qualified_name: QualifiedName, plan: ActionPlan) -> ExecutionSummary:
         return ExecutionSummary(self.results)
 
 
@@ -93,7 +93,7 @@ class _SeqExecutor:
     def __init__(self, per_call_results: list[tuple[ExecutionResult, ...]]) -> None:
         self._seq = list(per_call_results)
 
-    def execute(self, target: QualifiedName, plan: ActionPlan) -> ExecutionSummary:
+    def execute(self, qualified_name: QualifiedName, plan: ActionPlan) -> ExecutionSummary:
         return ExecutionSummary(self._seq.pop(0))
 
 

--- a/tests/application/test_errors.py
+++ b/tests/application/test_errors.py
@@ -14,6 +14,7 @@ from delta_engine.application.results import (
     ValidationFailure,
     ValidationResult,
 )
+from delta_engine.domain.model import QualifiedName
 
 _AT = datetime(2026, 1, 1, tzinfo=UTC)
 _NO_VALIDATION_FAILURES = ValidationResult()
@@ -27,7 +28,7 @@ def _table_report(
     execution: ExecutionSummary = _NO_EXECUTION,
 ) -> TableRunReport:
     return TableRunReport(
-        fully_qualified_name="cat.sch.tbl",
+        qualified_name=QualifiedName("cat", "sch", "tbl"),
         started_at=_AT,
         ended_at=_AT,
         read=read,

--- a/tests/application/test_registry.py
+++ b/tests/application/test_registry.py
@@ -18,8 +18,8 @@ def _tbl(fqn: str, **kwargs) -> DeltaTable:
     return DeltaTable(catalog=catalog, schema=schema, name=name, **defaults)
 
 
-def test_register_rejects_duplicate_fqn_within_same_call():
-    # Given an empty registry and two specs with same FQN
+def test_register_rejects_duplicate_qualified_name_within_same_call():
+    # Given an empty registry and two specs with the same qualified name
     reg = Registry()
     t1 = _tbl("cat.a.users")
     t2 = _tbl("cat.a.users")  # duplicate in same call
@@ -29,18 +29,18 @@ def test_register_rejects_duplicate_fqn_within_same_call():
         reg.register(t1, t2)
 
 
-def test_register_rejects_duplicate_fqn_across_calls():
+def test_register_rejects_duplicate_qualified_name_across_calls():
     # Given a registry with one table already registered
     reg = Registry()
     reg.register(_tbl("cat.a.users"))
 
-    # When attempting to register the same FQN again (separate call)
+    # When attempting to register the same qualified name again (separate call)
     # Then a clear duplicate error is raised
     with pytest.raises(ValueError):
         reg.register(_tbl("cat.a.users"))
 
 
-def test_iteration_is_sorted_by_fully_qualified_name():
+def test_iteration_is_sorted_by_qualified_name():
     # Given tables registered out of order
     reg = Registry()
     reg.register(

--- a/tests/application/test_results.py
+++ b/tests/application/test_results.py
@@ -15,13 +15,13 @@ from delta_engine.application.results import (
     ValidationFailure,
     ValidationResult,
 )
+from delta_engine.domain.model import QualifiedName
 
 # ---------- test fakes / builders
 
 
 class _FakeObservedTable:
-    def __init__(self, name="dummy", partitioned_by=()):
-        self.fully_qualified_name = name  # not used here, kept for parity
+    def __init__(self, partitioned_by=()):
         self.partitioned_by = partitioned_by
 
 
@@ -179,7 +179,7 @@ def test_table_status_success_when_all_actions_succeed():
 
     # When aggregating
     report = TableRunReport(
-        fully_qualified_name="cat.schema.tbl",
+        qualified_name=QualifiedName("cat", "schema", "tbl"),
         started_at=_t0(),
         ended_at=_t1(),
         read=read,
@@ -196,7 +196,7 @@ def test_table_status_success_when_all_actions_succeed():
 def test_sync_report_any_failures_true_if_any_table_has_failures():
     # Given two tables: one success, one with execution failure
     t_ok = TableRunReport(
-        fully_qualified_name="a",
+        qualified_name=QualifiedName("cat", "s", "a"),
         started_at=_t0(),
         ended_at=_t1(),
         read=TablePresent(table=_FakeObservedTable()),
@@ -204,7 +204,7 @@ def test_sync_report_any_failures_true_if_any_table_has_failures():
         execution=ExecutionSummary((_ok_exec(0),)),
     )
     t_bad = TableRunReport(
-        fully_qualified_name="b",
+        qualified_name=QualifiedName("cat", "s", "b"),
         started_at=_t0(),
         ended_at=_t1(),
         read=TablePresent(table=_FakeObservedTable()),
@@ -221,8 +221,10 @@ def test_sync_report_any_failures_true_if_any_table_has_failures():
 
 def test_sync_report_failures_by_table_maps_only_failed_tables():
     # Given one failed and one successful table
+    ok_name = QualifiedName("cat", "s", "x")
+    failed_name = QualifiedName("cat", "s", "y")
     t_ok = TableRunReport(
-        fully_qualified_name="x",
+        qualified_name=ok_name,
         started_at=_t0(),
         ended_at=_t1(),
         read=TablePresent(table=_FakeObservedTable()),
@@ -230,7 +232,7 @@ def test_sync_report_failures_by_table_maps_only_failed_tables():
         execution=ExecutionSummary((_ok_exec(0),)),
     )
     t_bad = TableRunReport(
-        fully_qualified_name="y",
+        qualified_name=failed_name,
         started_at=_t0(),
         ended_at=_t1(),
         read=TableAbsent(),
@@ -241,9 +243,10 @@ def test_sync_report_failures_by_table_maps_only_failed_tables():
     # When
     sr = SyncReport(started_at=_t0(), ended_at=_t1(), table_reports=(t_ok, t_bad))
 
-    # Then only the failed table appears, with its failures
+    # Then only the failed table appears, keyed by its QualifiedName, with its failures
     mapping = sr.failures_by_table
-    assert list(mapping.keys()) == ["y"]
+    assert list(mapping.keys()) == [failed_name]
     assert all(
-        isinstance(f, ValidationFailure | ReadFailure | ExecutionFailure) for f in mapping["y"]
+        isinstance(f, ValidationFailure | ReadFailure | ExecutionFailure)
+        for f in mapping[failed_name]
     )


### PR DESCRIPTION
## What

One concept — the `catalog.schema.table` identifier — was wearing **four** names depending on where you looked:

| Name | Where | Type |
|---|---|---|
| `qualified_name` | `TableSnapshot`, reader, ports | `QualifiedName` object |
| `target` | executor / compiler only | `QualifiedName` object |
| `fqn` | registry | `str` |
| `fully_qualified_name` | engine local + `TableRunReport` field | `str` |

Same concept, four names, plus a smeared object/string boundary — the value was re-stringified independently in the engine, the registry key, and the report field. That's Ousterhout's consistency rule (Ch. 17) broken four ways.

This standardizes on **one name — `qualified_name`** — and **one rule**: thread the `QualifiedName` *object* through every layer; stringify only at the true edges (Spark's `str`-taking catalog calls, already correct; and display, where `%s`/f-strings call `__str__` for free). After this, `str(…qualified_name)` appears nowhere in `application/` or `domain/`.

## Changes

- **engine `_sync_table`** — drop the `fully_qualified_name = str(…)` local; log `qualified_name` directly (7 sites) and hand the object to the report.
- **`TableRunReport.fully_qualified_name: str` → `qualified_name: QualifiedName`** — the report no longer discards the object; consumers keep `catalog`/`schema`/`name` instead of re-parsing a string.
- **`SyncReport.failures_by_table`: `dict[str, …]` → `dict[QualifiedName, …]`.** ⚠️ **Public API change** — callers doing `report.failures_by_table["c.s.t"]` must key by the `QualifiedName`. `str(key)` / f-strings still render the dotted name. No in-repo callers; no known published string-key consumers.
- **registry** — key by `QualifiedName` (frozen + hashable), `_tables_by_name` → `_tables`, kill the `fqn` local, sort via `key=str` (identical order; `QualifiedName` has no `order=True`).
- **`PlanExecutor.execute` / `DatabricksExecutor.execute` / `compile_plan`** — `target` → `qualified_name`.

## Kept deliberately

- `QualifiedName` (class) and `TableSnapshot.qualified_name` (attribute) — "fully" is load-bearing on the class; every shorter attribute name is more ambiguous than the mild type-name stutter.
- Test helpers `_spec(fqn: str)` / `_tbl(fqn: str)` — these `.split(".")` a dotted **string**; it genuinely is a string, not the object.
- `FakeCatalog`/Spark params keep the names PySpark's real `str`-based API uses.

## Scope

- Behaviour unchanged; pure rename + object-threading.
- `results` / `engine` / `registry` / `ports` / `errors` stay **100%** covered.
- Decided via a propose → adversarial-critique → synthesize review pass; all four facets scored 4–5 on Ousterhout/consistency.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
