### PR TITLE
refactor: rename diff_tables to compute_plan

### DIFF
--- a/docs/ousterhout-review.md
+++ b/docs/ousterhout-review.md
@@ -566,7 +566,7 @@ prerequisite question (`NOOP`) that must be answered before a tempting change.
 - **Resolution (PR #44): dissolved `PlanValidator` into a module function**
   `validate_plan(desired, observed, plan, rules=DEFAULT_RULES) -> ValidationResult`.
   The engine now calls it directly, exactly as it calls the planning phase
-  (`diff_tables`) — two pure phases, one shape. The validator injection is gone
+  (`compute_plan`) — two pure phases, one shape. The validator injection is gone
   from `Engine.__init__` (which
   now takes only its two genuine ports, reader and executor), the engine tests
   drive validation through the *real* default rules, and `_FakeValidator` is

--- a/src/delta_engine/application/engine.py
+++ b/src/delta_engine/application/engine.py
@@ -27,7 +27,7 @@ from delta_engine.application.results import (
 )
 from delta_engine.application.validation import validate_plan
 from delta_engine.domain.model.table import DesiredTable
-from delta_engine.domain.plan.differ import diff_tables
+from delta_engine.domain.plan.differ import compute_plan
 
 logger = logging.getLogger(__name__)
 
@@ -124,7 +124,7 @@ class Engine:
                 qualified_name,
                 "present" if observed is not None else "absent",
             )
-            plan = diff_tables(desired=desired, observed=observed)
+            plan = compute_plan(desired=desired, observed=observed)
             logger.info("Planned %d action(s) for %s", len(plan), qualified_name)
             validation = validate_plan(desired, observed, plan)
             if validation.failed:

--- a/src/delta_engine/application/validation.py
+++ b/src/delta_engine/application/validation.py
@@ -165,7 +165,7 @@ def validate_plan(
     """
     Evaluate every rule against a planned change and return the verdict.
 
-    A pure phase alongside :func:`~delta_engine.domain.plan.differ.diff_tables`:
+    A pure phase alongside :func:`~delta_engine.domain.plan.differ.compute_plan`:
     the same inputs always yield the same result. The caller reads
     ``ValidationResult.failed`` to gate execution; it does not assemble the verdict.
 

--- a/src/delta_engine/domain/plan/differ.py
+++ b/src/delta_engine/domain/plan/differ.py
@@ -1,11 +1,11 @@
 """
 Compute the actions required to reconcile a table to its desired schema.
 
-`diff_tables` is the single public entry point: given the desired definition and
+`compute_plan` is the single public entry point: given the desired definition and
 the currently observed one (or ``None`` when the table is missing), it returns
 the `ActionPlan` that closes the gap. The per-dimension diffs (columns,
 properties, table comment) are private helpers — they exist only to keep
-`diff_tables` readable and have no meaning outside it.
+`compute_plan` readable and have no meaning outside it.
 """
 
 from __future__ import annotations
@@ -26,7 +26,7 @@ from delta_engine.domain.plan.actions import (
 )
 
 
-def diff_tables(desired: DesiredTable, observed: ObservedTable | None) -> ActionPlan:
+def compute_plan(desired: DesiredTable, observed: ObservedTable | None) -> ActionPlan:
     """
     Compute the actions required to reach the desired schema.
 

--- a/tests/domain/plan/test_differ.py
+++ b/tests/domain/plan/test_differ.py
@@ -17,7 +17,7 @@ from delta_engine.domain.plan.actions import (
     SetProperty,
     SetTableComment,
 )
-from delta_engine.domain.plan.differ import diff_tables
+from delta_engine.domain.plan.differ import compute_plan
 
 _QUALIFIED_NAME = QualifiedName("dev", "silver", "test")
 _BASELINE_COLUMNS = (Column("id", Integer()),)
@@ -69,7 +69,7 @@ def test_creates_table_when_observed_is_missing():
     )
 
     # When: diffing desired vs None
-    plan = diff_tables(desired, observed=None)
+    plan = compute_plan(desired, observed=None)
 
     # Then: we get a CreateTable wrapped in an ActionPlan
     assert plan.actions == (CreateTable(desired),)
@@ -96,7 +96,7 @@ def test_no_actions_when_desired_equals_observed():
     )
 
     # When
-    plan = diff_tables(desired, observed)
+    plan = compute_plan(desired, observed)
 
     # Then: nothing to do
     assert plan.actions == ()
@@ -129,7 +129,7 @@ def test_combines_column_property_comment_and_partition_diffs():
     )
 
     # When
-    plan = diff_tables(desired, observed)
+    plan = compute_plan(desired, observed)
 
     # Then: the plan contains the expected representative actions
     assert isinstance(plan, ActionPlan)
@@ -151,7 +151,7 @@ def test_no_column_actions_when_columns_are_identical():
     columns = (Column("id", Integer()), Column("name", String(), comment="customer name"))
 
     # When
-    plan = diff_tables(_desired(columns=columns), _observed(columns=columns))
+    plan = compute_plan(_desired(columns=columns), _observed(columns=columns))
 
     # Then: nothing to do
     assert plan.actions == ()
@@ -163,7 +163,7 @@ def test_adds_columns_present_only_in_desired():
     observed = _observed(columns=(Column("id", Integer()),))
 
     # When
-    plan = diff_tables(desired, observed)
+    plan = compute_plan(desired, observed)
 
     # Then: an AddColumn for "age" is produced
     assert AddColumn(column=Column("age", Integer())) in plan.actions
@@ -175,7 +175,7 @@ def test_drops_columns_present_only_in_observed():
     observed = _observed(columns=(Column("id", Integer()), Column("legacy", String())))
 
     # When
-    plan = diff_tables(desired, observed)
+    plan = compute_plan(desired, observed)
 
     # Then: a DropColumn for "legacy" is produced
     assert plan.actions == (DropColumn("legacy"),)
@@ -187,7 +187,7 @@ def test_sets_column_comment_when_desired_differs_from_observed():
     observed = _observed(columns=(Column("name", String(), comment=""),))
 
     # When
-    plan = diff_tables(desired, observed)
+    plan = compute_plan(desired, observed)
 
     # Then: a SetColumnComment aligns the comment
     assert plan.actions == (SetColumnComment("name", "customer"),)
@@ -199,7 +199,7 @@ def test_clears_column_comment_when_desired_is_empty_and_observed_is_not():
     observed = _observed(columns=(Column("name", String(), comment="customer"),))
 
     # When
-    plan = diff_tables(desired, observed)
+    plan = compute_plan(desired, observed)
 
     # Then: a SetColumnComment clears it to empty
     assert plan.actions == (SetColumnComment("name", ""),)
@@ -211,7 +211,7 @@ def test_sets_column_nullability_when_flag_differs():
     observed = _observed(columns=(Column("active", String(), nullable=True),))
 
     # When
-    plan = diff_tables(desired, observed)
+    plan = compute_plan(desired, observed)
 
     # Then: a SetColumnNullability aligns the flag
     assert plan.actions == (SetColumnNullability(column_name="active", nullable=False),)
@@ -230,7 +230,7 @@ def test_combines_column_add_drop_and_updates_without_duplicates():
     )
 
     # When
-    plan = diff_tables(desired, observed)
+    plan = compute_plan(desired, observed)
 
     # Then: exactly three actions — no redundant comment/nullability for the added column
     assert plan.actions == (
@@ -251,7 +251,7 @@ def test_adding_column_to_existing_table_emits_only_add_column():
     observed = _observed(columns=(Column("id", Integer()),))
 
     # When
-    plan = diff_tables(desired, observed)
+    plan = compute_plan(desired, observed)
 
     # Then: only one AddColumn; no redundant SetColumnComment or SetColumnNullability
     assert plan.actions == (
@@ -265,7 +265,7 @@ def test_ignores_column_type_changes_until_type_migrations_supported():
     observed = _observed(columns=(Column("id", Integer()),))
 
     # When
-    plan = diff_tables(desired, observed)
+    plan = compute_plan(desired, observed)
 
     # Then: no action emitted for type change (explicitly unsupported for now)
     assert plan.actions == ()
@@ -279,7 +279,7 @@ def test_no_property_actions_when_mappings_are_identical():
     props = {"delta.appendOnly": "true", "owner": "cdm"}
 
     # When
-    plan = diff_tables(_desired(properties=props), _observed(properties=props))
+    plan = compute_plan(_desired(properties=props), _observed(properties=props))
 
     # Then: nothing to do
     assert plan.actions == ()
@@ -291,7 +291,7 @@ def test_sets_property_when_missing_in_observed():
     observed = _observed(properties={})
 
     # When
-    plan = diff_tables(desired, observed)
+    plan = compute_plan(desired, observed)
 
     # Then: a SetProperty is emitted with the desired value
     assert plan.actions == (SetProperty(name="delta.appendOnly", value="true"),)
@@ -303,7 +303,7 @@ def test_updates_property_when_value_differs():
     observed = _observed(properties={"delta.appendOnly": "true"})
 
     # When
-    plan = diff_tables(desired, observed)
+    plan = compute_plan(desired, observed)
 
     # Then: a single SetProperty updates the value
     assert plan.actions == (SetProperty(name="delta.appendOnly", value="false"),)
@@ -316,7 +316,7 @@ def test_ignores_observed_only_properties():
     observed = _observed(properties={"owner": "cdm", "delta.minReaderVersion": "2"})
 
     # When
-    plan = diff_tables(desired, observed)
+    plan = compute_plan(desired, observed)
 
     # Then: the undeclared property is left untouched — no unset is emitted
     assert plan.actions == ()
@@ -327,7 +327,7 @@ def test_ignores_observed_only_properties():
 
 def test_no_comment_action_when_comments_match():
     # Given: same comment on desired and observed
-    plan = diff_tables(_desired(comment="core table"), _observed(comment="core table"))
+    plan = compute_plan(_desired(comment="core table"), _observed(comment="core table"))
 
     # Then
     assert plan.actions == ()
@@ -335,7 +335,7 @@ def test_no_comment_action_when_comments_match():
 
 def test_sets_table_comment_when_comment_differs():
     # Given: desired has a different comment than observed
-    plan = diff_tables(_desired(comment="core table"), _observed(comment=""))
+    plan = compute_plan(_desired(comment="core table"), _observed(comment=""))
 
     # Then: a single SetTableComment is emitted with the desired text
     assert plan.actions == (SetTableComment(comment="core table"),)
@@ -343,7 +343,7 @@ def test_sets_table_comment_when_comment_differs():
 
 def test_clears_table_comment_when_desired_is_empty():
     # Given: observed has a comment; desired clears it
-    plan = diff_tables(_desired(comment=""), _observed(comment="legacy"))
+    plan = compute_plan(_desired(comment=""), _observed(comment="legacy"))
 
     # Then: a single SetTableComment clears to empty
     assert plan.actions == (SetTableComment(comment=""),)


### PR DESCRIPTION
> **Stacked on #48** (`refactor/inline-plan-wrapper`). Base will retarget to `main` automatically once #48 merges; review/merge #48 first.

## What

Renames the public planning function `diff_tables` → `compute_plan`.

```python
# engine.py
plan = compute_plan(desired=desired, observed=observed)
```

The module file stays `differ.py`; the private helpers stay `_diff_columns` / `_diff_properties` / `_diff_table_comment`.

## Why

`diff_tables` named the **mechanism** (it diffs two table definitions), but the function lives in `domain/plan/`, returns an `ActionPlan`, and every caller binds it to `plan = …`. The name leaked the HOW (diffing) instead of the WHAT (a computed plan) — an Ousterhout precision smell — and was at odds with the module's own docstring, which already says *"Compute the actions required to reconcile a table to its desired schema."*

Keeping `differ.py` + the `_diff_*` helpers is deliberate: `diff` is the right word for the internal mechanism. The public name speaks **outcome**, the internals speak **mechanism** — the deep-module split.

## Why `compute_plan` over the alternatives

Chosen via a propose → adversarial-critique → synthesize naming pass:
- **`reconcile_tables`** — sharper on the domain operation, but would force a module rename too and carries an *execution* connotation (K8s/Terraform reconcilers) this pure, side-effect-free function doesn't have.
- **`plan_changes`** — stutters against the `plan = …` binding at ~25 call sites and drops "table", so it's less precise.
- **keep `diff_tables`** — defensible (coherent with the `_diff_*` helpers) but mechanism-flavored; the module docstring already frames the outcome as "compute".

## Scope

- Pure rename; no behaviour change.
- Function def + 1 engine call site + ~20 test calls + 2 docstring references.
- Lint + mypy clean; full unit suite passes unchanged (146).

🤖 Generated with [Claude Code](https://claude.com/claude-code)