### PR TITLE
test: harden e2e (fail-loud monkeypatch, drop dead seed loop)

### DIFF
--- a/tests/e2e/test_engine_e2e.py
+++ b/tests/e2e/test_engine_e2e.py
@@ -17,7 +17,9 @@ def _patch_table_exists_for_local(monkeypatch):
         # Local Spark fallback for existence checks
         return self.spark.catalog.tableExists(f"{qualified_name.schema}.{qualified_name.name}")
 
-    monkeypatch.setattr(DatabricksReader, "_table_exists", _table_exists, raising=False)
+    # raising=True so a rename of _table_exists fails loudly here rather than
+    # silently leaving every e2e test running against the unpatched method.
+    monkeypatch.setattr(DatabricksReader, "_table_exists", _table_exists, raising=True)
 
 
 @pytest.fixture
@@ -288,7 +290,7 @@ def test_engine_creates_partitioned_table_with_expected_partitions(spark, monkey
 
 
 def test_engine_isolates_failures_and_applies_successful_tables(
-    spark, monkeypatch, temp_schema, make_temp_table
+    spark, monkeypatch, temp_schema
 ):
     _patch_table_exists_for_local(monkeypatch)
 
@@ -297,13 +299,7 @@ def test_engine_isolates_failures_and_applies_successful_tables(
     fq_ok = f"{TEST_CATALOG}.{temp_schema}.{ok}"
     fq_bad = f"{TEST_CATALOG}.{temp_schema}.{bad}"
 
-    # seed both tables
-    for _ in (fq_ok, fq_bad):
-        make_temp_table(
-            "seed_ignored",
-            "id INT NOT NULL, name STRING",
-            tblprops={"delta.columnMapping.mode": "name"},
-        )  # created and auto-dropped; we need specific names instead:
+    # seed both tables with specific names the registry will target
     spark.sql(
         f"CREATE TABLE {fq_ok} (id INT NOT NULL, name STRING)"
         " USING DELTA TBLPROPERTIES ('delta.columnMapping.mode'='name')"


### PR DESCRIPTION
## What

Two e2e test cleanups from the test-suite review (`tests/e2e/test_engine_e2e.py`).

### 1. Fail-loud monkeypatch
`_patch_table_exists_for_local` used `monkeypatch.setattr(..., raising=False)`. A future rename of `DatabricksReader._table_exists` would then **silently** leave all seven e2e tests running against the unpatched production method — passing or failing for the wrong reason. Switched to `raising=True` so the patch target is verified to exist.

### 2. Dead seed loop removed
`test_engine_isolates_failures_and_applies_successful_tables` opened with a loop that created two uuid-named tables via `make_temp_table` and let them auto-drop **unused**, with a comment admitting *"we need specific names instead"*. It then created the real `fq_ok`/`fq_bad` tables via raw SQL. Deleted the dead loop and its now-unused `make_temp_table` parameter.

## Scope

- Test-only; no production change. CI (live Spark) is the real check — these tests are CI-only.
- First of several small chunks working through the test-suite review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)