### PR TITLE
test: real domain values in builders; fix mislabeled partition test

### DIFF
--- a/tests/domain/model/test_table.py
+++ b/tests/domain/model/test_table.py
@@ -22,10 +22,21 @@ def test_fails_when_column_names_duplicate():
         TableSnapshot(_QUALIFIED_NAME, cols)
 
 
-def test_fails_when_partition_references_missing_column_case_insensitive():
+def test_fails_when_partition_references_undefined_column():
     # Given: columns 'visit_date' and 'id'
     cols = (Column("visit_date", Date()), Column("id", Integer()))
-    # When: declaring a partition on a non-existent column name (case-insensitive check)
-    # Then: validation fails because the partition column is not defined
+    # When: declaring a partition on a column that is not defined
+    # Then: validation fails because the partition column does not exist
     with pytest.raises(ValueError):
         TableSnapshot(_QUALIFIED_NAME, cols, partitioned_by=("date",))
+
+
+def test_partition_reference_matches_a_column_case_insensitively():
+    # Given: a column 'visit_date' and a partition spec naming it in upper case
+    cols = (Column("visit_date", Date()), Column("id", Integer()))
+
+    # When: constructing the snapshot with a differently-cased partition reference
+    snapshot = TableSnapshot(_QUALIFIED_NAME, cols, partitioned_by=("VISIT_DATE",))
+
+    # Then: the reference resolves to the column (the check casefolds) and is preserved
+    assert snapshot.partitioned_by == ("VISIT_DATE",)

--- a/tests/domain/plan/test_actions.py
+++ b/tests/domain/plan/test_actions.py
@@ -1,6 +1,6 @@
 import pytest
 
-from delta_engine.domain.model import Column, DesiredTable, QualifiedName
+from delta_engine.domain.model import Column, DesiredTable, Integer, QualifiedName
 from delta_engine.domain.plan.actions import (
     ActionPlan,
     AddColumn,
@@ -16,16 +16,13 @@ from delta_engine.domain.plan.actions import (
 
 
 def _column(name: str) -> Column:
-    return Column(name=name, data_type="string", nullable=True, comment=None)
+    return Column(name=name, data_type=Integer())
 
 
 def _create_table_action() -> CreateTable:
     table = DesiredTable(
         qualified_name=QualifiedName("c", "s", "t"),
         columns=(_column("id"),),
-        comment=None,
-        properties={},
-        partitioned_by=(),
     )
     return CreateTable(table=table)
 


### PR DESCRIPTION
## What

Two domain-test hygiene fixes from the test-suite review.

### 1. `test_actions.py` `_column` built an invalid `Column`
It passed `data_type="string"` (a raw `str` where a `DataType` is required) and `comment=None` (where a `str` is required). Dataclasses don't enforce annotations, so these invalid objects were silently accepted — the tests passed only because they read `.subject` and never touched `data_type`.

Now builds a real `Column(name, Integer())`, and `_create_table_action` drops the explicit `comment=None` / `properties={}` / `partitioned_by=()` (they're the defaults). If `Column` ever gains a validator, these tests exercise a valid object instead of breaking for the wrong reason.

### 2. `test_table.py` mislabeled partition test
`test_fails_when_partition_references_missing_column_case_insensitive` tested a partition on `"date"` against columns `("visit_date","id")` — that's just a **missing** column, not a case mismatch. Renamed to `test_fails_when_partition_references_undefined_column`, and added the genuinely-missing positive case: `partitioned_by=("VISIT_DATE",)` resolves to column `visit_date` (the invariant casefolds) and the original casing is preserved.

## Scope

- Test-only; no production change. Full unit suite passes (158, +1 new partition case).
- Chunk 2 of the test-suite-review cleanups.

🤖 Generated with [Claude Code](https://claude.com/claude-code)