### PR TITLE
test: tighten public-surface contract tests

### DIFF
--- a/tests/adapters/databricks/test_build_engine.py
+++ b/tests/adapters/databricks/test_build_engine.py
@@ -1,6 +1,7 @@
 import logging
 
 from delta_engine.adapters.databricks import build_databricks_engine, configure_logging
+from delta_engine.adapters.databricks.log_config import LevelColorFormatter
 from delta_engine.application.engine import Engine
 
 
@@ -32,7 +33,21 @@ def test_build_databricks_engine_does_not_touch_root_logging():
         root.removeHandler(sentinel)
 
 
-def test_configure_logging_is_publicly_available_for_opt_in():
-    # Given the opt-in logging escape hatch the factory docstring advertises
-    # Then it is reachable from the package's public surface
-    assert callable(configure_logging)
+def test_configure_logging_installs_the_coloured_handler_at_the_requested_level():
+    # Given the root logger's current state (restored afterwards so this opt-in
+    # global mutation does not leak into other tests)
+    root = logging.getLogger()
+    saved_handlers = root.handlers[:]
+    saved_level = root.level
+    try:
+        # When the caller opts in to the package's logging
+        configure_logging(level=logging.DEBUG)
+
+        # Then the root logger carries exactly the package's coloured handler at
+        # the requested level -- the escape hatch actually configures logging
+        assert root.level == logging.DEBUG
+        colour_handlers = [h for h in root.handlers if isinstance(h.formatter, LevelColorFormatter)]
+        assert len(colour_handlers) == 1
+    finally:
+        root.handlers[:] = saved_handlers
+        root.setLevel(saved_level)

--- a/tests/schema/test_public_api.py
+++ b/tests/schema/test_public_api.py
@@ -2,8 +2,10 @@
 
 from delta_engine.domain.model import Array, Decimal, Map
 import delta_engine.schema as schema
+from delta_engine.schema.table import DeltaTable as DeltaTableImpl
 
 _EXPECTED = {
+    "DeltaTable",
     "Array",
     "Boolean",
     "Column",
@@ -19,18 +21,20 @@ _EXPECTED = {
 }
 
 
-def test_schema_exposes_column_and_all_data_types():
+def test_schema_exposes_delta_table_column_and_all_data_types():
     # Given the schema package a user imports to define a table
-    # Then Column and every data type -- scalar and parameterised -- are importable
-    # from it directly, so a Decimal/Array/Map column needs no reach into the
+    # Then DeltaTable, Column, and every data type -- scalar and parameterised --
+    # are importable from it directly, so defining a table never reaches into the
     # internal domain layer
     for name in _EXPECTED:
         assert hasattr(schema, name), f"{name} not importable from delta_engine.schema"
 
-    # And the declared surface advertises them
-    assert _EXPECTED <= set(schema.__all__)
+    # And the declared surface is EXACTLY this set -- so dropping or adding a name
+    # to __all__ fails here rather than slipping through a subset check
+    assert set(schema.__all__) == _EXPECTED
 
-    # And the parameterised re-exports resolve to the real domain types (single identity)
+    # And the re-exports resolve to the real types (single identity, not a shadow)
+    assert schema.DeltaTable is DeltaTableImpl
     assert schema.Decimal is Decimal
     assert schema.Array is Array
     assert schema.Map is Map

--- a/tests/test_public_api.py
+++ b/tests/test_public_api.py
@@ -83,7 +83,10 @@ def test_eager_surface_imports_without_pyspark_installed():
     # pyspark is a dev-only dependency)
     program = (
         "import sys; sys.modules['pyspark'] = None\n"
-        "from delta_engine import DeltaTable, Column, Integer, Registry, Engine\n"
+        "from delta_engine import (\n"
+        "    DeltaTable, Column, Integer, Registry, Engine,\n"
+        "    SyncReport, SyncFailedError, Failure,\n"
+        ")\n"
         "print('ok')\n"
     )
 


### PR DESCRIPTION
## What

Section F hardening from the test-suite review — three contract tests that were weaker than they looked.

### 1. `schema/test_public_api.py` — exact surface, with `DeltaTable`
`_EXPECTED` omitted `DeltaTable` (the headline export) and the check was a **subset** (`_EXPECTED <= __all__`), so dropping a name from `schema.__all__` would pass silently. Added `DeltaTable`, switched to set **equality** (`==`), and asserted `DeltaTable` resolves to the real implementation.

### 2. `tests/test_public_api.py` — broaden the pyspark-free guarantee
The subprocess test (import with `pyspark` blocked) covered only five names. Extended it to `SyncReport`, `SyncFailedError`, and `Failure` — the result types a user **reads/catches** must also be importable without a Spark install, not just the define-and-run names.

### 3. `test_build_engine.py` — real contract for `configure_logging`
`assert callable(configure_logging)` was trivially true for any imported function (the file wouldn't even collect if it were missing). Replaced with a behavioural contract: `configure_logging(level=DEBUG)` installs exactly one coloured handler on the root logger at the requested level. The test saves and restores the root logger so this global mutation doesn't leak into others.

## Scope

- Test-only; no production change. Full unit suite passes (164).
- Chunk 5 of the test-suite-review cleanups. One chunk left (domain-validation gaps — the only one with production changes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)