### PR TITLE
fix: reject blank names and duplicate partition columns in the domain

### DIFF
--- a/src/delta_engine/domain/model/column.py
+++ b/src/delta_engine/domain/model/column.py
@@ -25,6 +25,8 @@ class Column:
     comment: str = ""
 
     def __post_init__(self) -> None:
-        """Raise if name contains uppercase characters."""
+        """Raise if the name is blank or contains uppercase characters."""
+        if not self.name.strip():
+            raise ValueError(f"Column name must not be blank: {self.name!r}")
         if self.name != self.name.casefold():
             raise ValueError(f"Column name must be lowercase: {self.name!r}")

--- a/src/delta_engine/domain/model/qualified_name.py
+++ b/src/delta_engine/domain/model/qualified_name.py
@@ -22,12 +22,14 @@ class QualifiedName:
     name: str
 
     def __post_init__(self) -> None:
-        """Raise if any part contains uppercase characters."""
+        """Raise if any part is blank or contains uppercase characters."""
         for field_name, value in (
             ("catalog", self.catalog),
             ("schema", self.schema),
             ("name", self.name),
         ):
+            if not value.strip():
+                raise ValueError(f"QualifiedName {field_name} must not be blank: {value!r}")
             if value != value.casefold():
                 raise ValueError(f"QualifiedName {field_name} must be lowercase: {value!r}")
 

--- a/src/delta_engine/domain/model/table.py
+++ b/src/delta_engine/domain/model/table.py
@@ -29,7 +29,7 @@ class TableSnapshot:
     partitioned_by: tuple[str, ...] = ()
 
     def __post_init__(self) -> None:
-        """Validate columns are non-empty, unique, and partition references exist."""
+        """Validate columns are non-empty and unique, and partitions exist and are unique."""
         if not self.columns:
             raise ValueError("Table requires at least one column")
 
@@ -43,6 +43,13 @@ class TableSnapshot:
             missing = [name for name in self.partitioned_by if name.casefold() not in seen_names]
             if missing:
                 raise ValueError(f"Partition column not found: {missing[0]}")
+
+            seen_partitions: set[str] = set()
+            for name in self.partitioned_by:
+                folded = name.casefold()
+                if folded in seen_partitions:
+                    raise ValueError(f"Duplicate partition column: {name}")
+                seen_partitions.add(folded)
 
 
 @dataclass(frozen=True, slots=True)

--- a/tests/adapters/databricks/test_reader.py
+++ b/tests/adapters/databricks/test_reader.py
@@ -2,11 +2,12 @@ from __future__ import annotations
 
 from types import SimpleNamespace
 
+from py4j.protocol import Py4JJavaError
 import pyspark.sql.types as T
 from pyspark.sql.utils import AnalysisException
 import pytest
 
-from delta_engine.adapters.databricks.reader import DatabricksReader
+from delta_engine.adapters.databricks.reader import DatabricksReader, _exc_type_name
 from delta_engine.application.results import ReadFailed, TableAbsent, TablePresent
 from delta_engine.domain.model import QualifiedName
 
@@ -442,3 +443,37 @@ def test_fetch_state_lowercases_mixed_case_column_names_from_catalog():
     assert isinstance(result, TablePresent)
     assert [c.name for c in result.table.columns] == ["eventid", "username"]
     assert result.table.partitioned_by == ("username",)
+
+
+def _py4j_java_error(java_class_name: str) -> Py4JJavaError:
+    """
+    Build a Py4JJavaError whose underlying Java exception reports the given class.
+
+    ``_target_id`` is the only attribute Py4JJavaError.__init__ touches; the
+    ``getClass().getName()`` chain is what ``_exc_type_name`` reads. (Its
+    ``__str__`` would need a live JVM gateway, so the error is never stringified
+    here -- _exc_type_name only inspects the class.)
+    """
+    java_exception = SimpleNamespace(
+        _target_id="o123",
+        getClass=lambda: SimpleNamespace(getName=lambda: java_class_name),
+    )
+    return Py4JJavaError("boom", java_exception)
+
+
+def test_exc_type_name_reports_the_underlying_java_class_for_a_py4j_error():
+    # Given a Py4JJavaError -- the primary failure shape on real Databricks, where
+    # JVM exceptions surface through py4j wrapping the real Spark exception
+    error = _py4j_java_error("org.apache.spark.sql.AnalysisException")
+
+    # When naming the exception type at the adapter boundary
+    name = _exc_type_name(error)
+
+    # Then the underlying Java class is reported, not the "Py4JJavaError" wrapper
+    assert name == "org.apache.spark.sql.AnalysisException"
+
+
+def test_exc_type_name_falls_back_to_python_class_for_a_plain_exception():
+    # Given a plain Python exception (no JVM origin)
+    # Then the Python class name is used
+    assert _exc_type_name(ValueError("nope")) == "ValueError"

--- a/tests/domain/model/test_column.py
+++ b/tests/domain/model/test_column.py
@@ -18,3 +18,12 @@ def test_raises_when_name_is_not_lowercase() -> None:
     # Then: a ValueError is raised
     with pytest.raises(ValueError, match="lowercase"):
         Column("UserId", Integer())
+
+
+@pytest.mark.parametrize("blank", ["", "   ", "\t"], ids=["empty", "spaces", "tab"])
+def test_raises_when_name_is_blank(blank: str) -> None:
+    # Given: a blank or whitespace-only column name (would emit a malformed
+    # `` `` identifier in DDL)
+    # When/Then: constructing a Column fails
+    with pytest.raises(ValueError, match="blank"):
+        Column(blank, Integer())

--- a/tests/domain/model/test_qualified_name.py
+++ b/tests/domain/model/test_qualified_name.py
@@ -21,3 +21,20 @@ def test_raises_when_any_part_is_not_lowercase() -> None:
 
     with pytest.raises(ValueError, match="lowercase"):
         QualifiedName("catalog", "schema", "MyTable")
+
+
+@pytest.mark.parametrize(
+    "catalog, schema, name",
+    [
+        ("", "schema", "table"),
+        ("catalog", "  ", "table"),
+        ("catalog", "schema", "\t"),
+    ],
+    ids=["empty-catalog", "whitespace-schema", "whitespace-name"],
+)
+def test_raises_when_any_part_is_blank(catalog: str, schema: str, name: str) -> None:
+    # Given a blank or whitespace-only part (would render as a malformed
+    # identifier like `.schema.table` or `catalog..table`)
+    # When/Then construction fails rather than producing invalid SQL
+    with pytest.raises(ValueError, match="blank"):
+        QualifiedName(catalog, schema, name)

--- a/tests/domain/model/test_table.py
+++ b/tests/domain/model/test_table.py
@@ -40,3 +40,13 @@ def test_partition_reference_matches_a_column_case_insensitively():
 
     # Then: the reference resolves to the column (the check casefolds) and is preserved
     assert snapshot.partitioned_by == ("VISIT_DATE",)
+
+
+def test_fails_when_partition_columns_are_duplicated():
+    # Given: columns 'visit_date' and 'id'
+    cols = (Column("visit_date", Date()), Column("id", Integer()))
+    # When: the same partition column is listed twice (would emit malformed
+    # PARTITIONED BY (visit_date, visit_date) DDL)
+    # Then: validation fails rather than producing invalid SQL
+    with pytest.raises(ValueError):
+        TableSnapshot(_QUALIFIED_NAME, cols, partitioned_by=("visit_date", "visit_date"))


### PR DESCRIPTION
## What

Three domain-validation gaps from the test-suite review — each silently accepted input that produces **malformed DDL**. All are additive `__post_init__` guards that reject at construction, where the error names the offending value.

| Input | Was | Now |
|---|---|---|
| `Column("", …)` / whitespace name | accepted → malformed `` `` `` identifier | `ValueError` |
| `QualifiedName("", "s", "t")` / whitespace part | accepted → `.s.t` / `c..t` | `ValueError` |
| `partitioned_by=("ds", "ds")` | accepted → `PARTITIONED BY (ds, ds)` | `ValueError` (case-insensitive) |

Same flavour as the CREATE TABLE column-comment bug just fixed: input that only ever produced invalid SQL is now rejected up front.

## Also

Covers the reader's **`Py4JJavaError` branch** in `_exc_type_name` — the primary failure shape on real Databricks (JVM exceptions wrapped by py4j), previously exercised only via plain Python exceptions. Unit-tested directly: its `__str__` needs a live JVM gateway, so the error is never stringified — `_exc_type_name` only reads `getClass().getName()` — plus a fallback assertion for a plain Python exception.

## Scope

- TDD: every guard test written failing first, then the guard added.
- Production change is three small validation guards; behaviour change is limited to **rejecting** previously-malformed input (no valid input changes).
- Full unit suite passes (173, +9). Lint + mypy clean.
- Final chunk of the test-suite review (the only one with production changes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)