### PR TITLE
fix: enforce lowercase validation on partition column names

### DIFF
--- a/src/delta_engine/domain/model/table.py
+++ b/src/delta_engine/domain/model/table.py
@@ -40,16 +40,19 @@ class TableSnapshot:
             seen_names.add(column.name)
 
         if self.partitioned_by:
-            missing = [name for name in self.partitioned_by if name.casefold() not in seen_names]
+            for name in self.partitioned_by:
+                if name != name.casefold():
+                    raise ValueError(f"Partition column name must be lowercase: {name!r}")
+
+            missing = [name for name in self.partitioned_by if name not in seen_names]
             if missing:
                 raise ValueError(f"Partition column not found: {missing[0]}")
 
             seen_partitions: set[str] = set()
             for name in self.partitioned_by:
-                folded = name.casefold()
-                if folded in seen_partitions:
+                if name in seen_partitions:
                     raise ValueError(f"Duplicate partition column: {name}")
-                seen_partitions.add(folded)
+                seen_partitions.add(name)
 
 
 @dataclass(frozen=True, slots=True)

--- a/src/delta_engine/schema/table.py
+++ b/src/delta_engine/schema/table.py
@@ -45,7 +45,7 @@ class DeltaTable:
         self.columns = tuple(columns)
         self.comment = comment
         self.properties = dict(properties or {})
-        self.partitioned_by = partitioned_by
+        self.partitioned_by = tuple(partitioned_by) if partitioned_by is not None else ()
 
         # Fast-fail on property keys this engine does not manage (e.g. typos)
         if self.properties:
@@ -79,5 +79,5 @@ class DeltaTable:
             columns=tuple(self.columns),
             comment=self.comment,
             properties=self.effective_properties,
-            partitioned_by=tuple(self.partitioned_by) if self.partitioned_by else (),
+            partitioned_by=self.partitioned_by,
         )

--- a/tests/domain/model/test_table.py
+++ b/tests/domain/model/test_table.py
@@ -31,15 +31,15 @@ def test_fails_when_partition_references_undefined_column():
         TableSnapshot(_QUALIFIED_NAME, cols, partitioned_by=("date",))
 
 
-def test_partition_reference_matches_a_column_case_insensitively():
+def test_fails_when_partition_column_name_is_not_lowercase():
     # Given: a column 'visit_date' and a partition spec naming it in upper case
     cols = (Column("visit_date", Date()), Column("id", Integer()))
 
-    # When: constructing the snapshot with a differently-cased partition reference
-    snapshot = TableSnapshot(_QUALIFIED_NAME, cols, partitioned_by=("VISIT_DATE",))
-
-    # Then: the reference resolves to the column (the check casefolds) and is preserved
-    assert snapshot.partitioned_by == ("VISIT_DATE",)
+    # When: constructing the snapshot with a mixed-case partition reference
+    # Then: validation fails — partition column names must be lowercase, consistent
+    # with Column and QualifiedName which reject non-lowercase identifiers at construction
+    with pytest.raises(ValueError, match="lowercase"):
+        TableSnapshot(_QUALIFIED_NAME, cols, partitioned_by=("VISIT_DATE",))
 
 
 def test_fails_when_partition_columns_are_duplicated():


### PR DESCRIPTION
## Summary

- `TableSnapshot.__post_init__` now validates that partition column names are lowercase and raises `ValueError` if not — consistent with `Column` and `QualifiedName` which already apply the same validate-and-reject pattern
- The existence lookup for partition columns is now an exact match rather than a casefolded lookup, which is correct now that lowercase is enforced
- `DeltaTable.partitioned_by` is materialised to a `tuple` at construction time, matching the existing `columns` field and preventing silent generator exhaustion on repeated calls to `to_desired_table()`

## Motivation

Mixed-case partition names (e.g. `partitioned_by=['Event_Date']`) were silently accepted by `TableSnapshot.__post_init__` because the existence check used `casefold()`. The value was stored as-is, but the reader always returns partition column names lowercased. `DisallowPartitioningChange` uses exact tuple equality, so `('Event_Date',) != ('event_date',)` caused a spurious `ValidationFailure` on every sync against an already-correctly-partitioned table — the table was permanently stuck in `VALIDATION_FAILED` with no way to recover without changing the declared schema.

## Test plan

- [ ] `tests/domain/model/test_table.py` — replaced `test_partition_reference_matches_a_column_case_insensitively` with `test_fails_when_partition_column_name_is_not_lowercase` asserting the new behaviour
- [ ] All 120 non-Spark tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)