### PR TITLE
fix: use exc_type_name in executor to surface Java class for Py4J errors

### DIFF
--- a/src/delta_engine/adapters/databricks/executor.py
+++ b/src/delta_engine/adapters/databricks/executor.py
@@ -12,7 +12,12 @@ import logging
 
 from pyspark.sql import SparkSession
 
-from delta_engine.adapters.databricks.sql import compile_plan, error_preview, sql_preview
+from delta_engine.adapters.databricks.sql import (
+    compile_plan,
+    error_preview,
+    exc_type_name,
+    sql_preview,
+)
 from delta_engine.application.results import (
     ExecutionFailed,
     ExecutionFailure,
@@ -75,7 +80,7 @@ class DatabricksExecutor:
                 statement_preview=preview,
                 failure=ExecutionFailure(
                     action_index=action_index,
-                    exception_type=type(exception).__name__,
+                    exception_type=exc_type_name(exception),
                     message=error_preview(exception),
                 ),
             )

--- a/src/delta_engine/adapters/databricks/reader.py
+++ b/src/delta_engine/adapters/databricks/reader.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 from types import MappingProxyType
 
-from py4j.protocol import Py4JJavaError  # type: ignore[import]
 from pyspark.sql import SparkSession
 from pyspark.sql.catalog import Column as SparkColumn
 
@@ -12,6 +11,7 @@ from delta_engine.adapters.databricks.sql import (
     backtick_qualified_name,
     domain_type_from_spark,
     error_preview,
+    exc_type_name,
 )
 from delta_engine.application.results import (
     CatalogState,
@@ -21,18 +21,6 @@ from delta_engine.application.results import (
     TablePresent,
 )
 from delta_engine.domain.model import Column as DomainColumn, ObservedTable, QualifiedName
-
-
-def _exc_type_name(exc: Exception) -> str:
-    """Prefer the underlying Java class for Py4J errors; else the Python class."""
-    if isinstance(exc, Py4JJavaError):
-        try:
-            return (
-                exc.java_exception.getClass().getName()
-            )  # e.g. 'org.apache.spark.sql.AnalysisException'
-        except Exception:
-            return "Py4JJavaError"
-    return type(exc).__name__
 
 
 def _to_domain_column(column: SparkColumn, type_mapper=domain_type_from_spark) -> DomainColumn:
@@ -80,7 +68,7 @@ class DatabricksReader:
         try:
             return self._read(qualified_name)
         except Exception as exc:
-            failure = ReadFailure(_exc_type_name(exc), error_preview(exc))
+            failure = ReadFailure(exc_type_name(exc), error_preview(exc))
             return ReadFailed(failure=failure)
 
     def _read(self, qualified_name: QualifiedName) -> CatalogState:

--- a/src/delta_engine/adapters/databricks/sql/__init__.py
+++ b/src/delta_engine/adapters/databricks/sql/__init__.py
@@ -13,7 +13,7 @@ from delta_engine.adapters.databricks.sql.dialect import (
     backtick_qualified_name,
     quote_literal,
 )
-from delta_engine.adapters.databricks.sql.preview import error_preview, sql_preview
+from delta_engine.adapters.databricks.sql.preview import error_preview, exc_type_name, sql_preview
 from delta_engine.adapters.databricks.sql.types import (
     domain_type_from_spark,
     sql_type_for_data_type,
@@ -25,6 +25,7 @@ __all__ = [
     "compile_plan",
     "domain_type_from_spark",
     "error_preview",
+    "exc_type_name",
     "quote_literal",
     "sql_preview",
     "sql_type_for_data_type",

--- a/src/delta_engine/adapters/databricks/sql/preview.py
+++ b/src/delta_engine/adapters/databricks/sql/preview.py
@@ -20,3 +20,26 @@ def error_preview(exception: Exception) -> str:
     """Return a short, single-string preview of an exception message body."""
     message_head = str(exception)
     return "\n".join(message_head.splitlines()[:5])
+
+
+def exc_type_name(exc: Exception) -> str:
+    """
+    Return the most informative exception class name available.
+
+    For Py4JJavaError (the primary failure shape on Databricks, where JVM
+    exceptions surface through py4j), the underlying Java class is preferred
+    over the py4j wrapper — e.g. 'org.apache.spark.sql.AnalysisException'
+    rather than 'Py4JJavaError'. Falls back to the Python class name for all
+    other exceptions.
+    """
+    try:
+        from py4j.protocol import Py4JJavaError  # type: ignore[import]
+
+        if isinstance(exc, Py4JJavaError):
+            try:
+                return exc.java_exception.getClass().getName()
+            except Exception:
+                return "Py4JJavaError"
+    except ImportError:
+        pass
+    return type(exc).__name__

--- a/tests/adapters/databricks/sql/test_preview.py
+++ b/tests/adapters/databricks/sql/test_preview.py
@@ -1,8 +1,13 @@
 from hypothesis import given, strategies as st
 import pytest
 
+from types import SimpleNamespace
+
+from py4j.protocol import Py4JJavaError
+
 from delta_engine.adapters.databricks.sql.preview import (
     error_preview,
+    exc_type_name,
     sql_preview,
 )
 
@@ -63,6 +68,27 @@ def test_error_preview_returns_first_5_lines() -> None:
 def test_error_preview_short_message_unchanged() -> None:
     exc = Exception("Only one line")
     assert error_preview(exc) == "Only one line"
+
+
+def test_exc_type_name_reports_underlying_java_class_for_py4j_error() -> None:
+    # Given a Py4JJavaError whose java_exception reports a known Java class
+    java_exception = SimpleNamespace(
+        _target_id="o1",
+        getClass=lambda: SimpleNamespace(getName=lambda: "org.apache.spark.sql.AnalysisException"),
+    )
+    error = Py4JJavaError("boom", java_exception)
+
+    # When naming the exception type
+    name = exc_type_name(error)
+
+    # Then the underlying Java class is returned, not the py4j wrapper name
+    assert name == "org.apache.spark.sql.AnalysisException"
+
+
+def test_exc_type_name_returns_python_class_for_plain_exception() -> None:
+    # Given a plain Python exception (no JVM origin)
+    # Then the Python class name is used directly
+    assert exc_type_name(ValueError("nope")) == "ValueError"
 
 
 @given(st.text(), st.integers(min_value=1, max_value=500))

--- a/tests/adapters/databricks/test_executor.py
+++ b/tests/adapters/databricks/test_executor.py
@@ -108,6 +108,7 @@ def test_execute_stops_at_first_failure_to_avoid_half_migrating():
     assert [r.action_index for r in results] == [0, 1]
 
 
+
 def test_execute_returns_empty_summary_for_empty_plan():
     # Given an empty plan
     plan = ActionPlan(actions=())

--- a/tests/adapters/databricks/test_reader.py
+++ b/tests/adapters/databricks/test_reader.py
@@ -7,7 +7,8 @@ import pyspark.sql.types as T
 from pyspark.sql.utils import AnalysisException
 import pytest
 
-from delta_engine.adapters.databricks.reader import DatabricksReader, _exc_type_name
+from delta_engine.adapters.databricks.reader import DatabricksReader
+from delta_engine.adapters.databricks.sql import exc_type_name
 from delta_engine.application.results import ReadFailed, TableAbsent, TablePresent
 from delta_engine.domain.model import QualifiedName
 
@@ -465,7 +466,7 @@ def test_exc_type_name_reports_the_underlying_java_class_for_a_py4j_error():
     error = _py4j_java_error("org.apache.spark.sql.AnalysisException")
 
     # When naming the exception type at the adapter boundary
-    name = _exc_type_name(error)
+    name = exc_type_name(error)
 
     # Then the underlying Java class is reported, not the "Py4JJavaError" wrapper
     assert name == "org.apache.spark.sql.AnalysisException"
@@ -474,4 +475,4 @@ def test_exc_type_name_reports_the_underlying_java_class_for_a_py4j_error():
 def test_exc_type_name_falls_back_to_python_class_for_a_plain_exception():
     # Given a plain Python exception (no JVM origin)
     # Then the Python class name is used
-    assert _exc_type_name(ValueError("nope")) == "ValueError"
+    assert exc_type_name(ValueError("nope")) == "ValueError"


### PR DESCRIPTION
## Summary

- Moves `exc_type_name` (previously `_exc_type_name` in `reader.py`) into `sql/preview.py` alongside `error_preview` — both are exception presentation utilities — and re-exports it from the `sql` package
- The executor now calls `exc_type_name(exception)` instead of `type(exception).__name__`, so `ExecutionFailure.exception_type` reports the underlying Java class (e.g. `org.apache.spark.sql.AnalysisException`) rather than the py4j wrapper (`Py4JJavaError`)
- The py4j import inside `exc_type_name` is lazy so the `sql` package remains importable without pyspark installed

## Motivation

`ReadFailure` and `ExecutionFailure` both have an `exception_type` field intended for error classification. On Databricks, almost every Spark SQL error surfaces as a `Py4JJavaError` wrapping a Java exception. The reader correctly unwrapped this via a private helper; the executor did not, so the same root cause (e.g. `AnalysisException`) was described differently depending on which phase caught it. Any consumer filtering on `exception_type` — alerting rules, retry logic, dashboards — would silently fail to match execution-phase Spark errors.

## Test plan

- [ ] `tests/adapters/databricks/sql/test_preview.py` — two new unit tests for `exc_type_name` (Py4J unwrapping and plain exception fallback)
- [ ] `tests/adapters/databricks/test_reader.py` — existing `_exc_type_name` tests updated to import from `sql` package
- [ ] All 180 non-Spark tests pass at 95% coverage

🤖 Generated with [Claude Code](https://claude.com/claude-code)