### PR TITLE
fix: remove logging.raiseExceptions = False from configure_logging

### DIFF
--- a/src/delta_engine/adapters/databricks/log_config.py
+++ b/src/delta_engine/adapters/databricks/log_config.py
@@ -53,8 +53,6 @@ def configure_logging(level: int = logging.INFO) -> None:
     Uses sys.__stderr__ to avoid pytest's captured stream and installs a
     shutdown-safe handler. Also quiets noisy third-party loggers.
     """
-    logging.raiseExceptions = False
-
     root = logging.getLogger()
 
     if root.handlers:


### PR DESCRIPTION
## Summary

- Removes `logging.raiseExceptions = False` from `configure_logging`
- `SafeStreamHandler.emit` already catches `ValueError` (the closed-stream error that occurs during interpreter/pytest teardown), which was the only failure mode this flag was protecting against

## Motivation

`logging.raiseExceptions = False` is a process-wide mutation on the `logging` module. It silences all unhandled exceptions from any handler's `emit()`, any `Formatter.format()`, and any `Handler.handleError()` call — across every logger in the process, including third-party libraries. This goes well beyond the `ValueError` that `SafeStreamHandler` already handles, and makes broken file handlers, network log handler timeouts, and formatter errors completely invisible.

## Test plan

- [ ] No test changes required — no tests relied on this flag
- [ ] 180 non-Spark tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)