### PR TITLE
fix: validation rules report all violations in a single pass

### DIFF
--- a/src/delta_engine/application/validation.py
+++ b/src/delta_engine/application/validation.py
@@ -15,7 +15,7 @@ class Rule(ABC):
     @abstractmethod
     def evaluate(
         self, desired: DesiredTable, observed: ObservedTable | None, plan: ActionPlan
-    ) -> ValidationFailure | None:
+    ) -> tuple[ValidationFailure, ...]:
         """
         Evaluate the rule against a planned change.
 
@@ -26,7 +26,9 @@ class Rule(ABC):
             plan: The action plan to reach ``desired``.
 
         Returns:
-            A failure description if the rule is violated, otherwise ``None``.
+            A tuple of failures — one per violation found. Empty when the rule
+            passes. Returning all violations in one call lets the caller report
+            the full set rather than requiring a fix-and-rerun cycle per failure.
 
         """
         ...
@@ -42,20 +44,21 @@ class NonNullableColumnAdd(Rule):
 
     def evaluate(
         self, desired: DesiredTable, observed: ObservedTable | None, plan: ActionPlan
-    ) -> ValidationFailure | None:
-        """Flag the plan if it adds a NOT NULL column to an existing table."""
+    ) -> tuple[ValidationFailure, ...]:
+        """Flag every NOT NULL column addition to an existing table."""
         if observed is None:
-            return None
-        for action in plan.actions:
-            if isinstance(action, AddColumn) and (not action.column.nullable):
-                return ValidationFailure(
-                    rule_name=self.__class__.__name__,
-                    message=(
-                        "Operation not allowed: cannot add non-nullable"
-                        f" column '{action.column.name}'"
-                    ),
-                )
-        return None
+            return ()
+        return tuple(
+            ValidationFailure(
+                rule_name=self.__class__.__name__,
+                message=(
+                    "Operation not allowed: cannot add non-nullable"
+                    f" column '{action.column.name}'"
+                ),
+            )
+            for action in plan.actions
+            if isinstance(action, AddColumn) and not action.column.nullable
+        )
 
 
 class NullabilityTighteningOnExistingColumn(Rule):
@@ -72,21 +75,22 @@ class NullabilityTighteningOnExistingColumn(Rule):
 
     def evaluate(
         self, desired: DesiredTable, observed: ObservedTable | None, plan: ActionPlan
-    ) -> ValidationFailure | None:
-        """Flag the plan if it tightens any existing column to NOT NULL."""
+    ) -> tuple[ValidationFailure, ...]:
+        """Flag every action that tightens an existing column to NOT NULL."""
         if observed is None:
-            return None
-        for action in plan.actions:
-            if isinstance(action, SetColumnNullability) and (not action.nullable):
-                return ValidationFailure(
-                    rule_name=self.__class__.__name__,
-                    message=(
-                        "Operation not allowed: cannot tighten existing column"
-                        f" '{action.column_name}' to NOT NULL. Keep it nullable,"
-                        " backfill any NULLs in a separate step, then set NOT NULL."
-                    ),
-                )
-        return None
+            return ()
+        return tuple(
+            ValidationFailure(
+                rule_name=self.__class__.__name__,
+                message=(
+                    "Operation not allowed: cannot tighten existing column"
+                    f" '{action.column_name}' to NOT NULL. Keep it nullable,"
+                    " backfill any NULLs in a separate step, then set NOT NULL."
+                ),
+            )
+            for action in plan.actions
+            if isinstance(action, SetColumnNullability) and not action.nullable
+        )
 
 
 class UnsupportedColumnTypeChange(Rule):
@@ -102,24 +106,25 @@ class UnsupportedColumnTypeChange(Rule):
 
     def evaluate(
         self, desired: DesiredTable, observed: ObservedTable | None, plan: ActionPlan
-    ) -> ValidationFailure | None:
-        """Flag any common column whose desired data type differs from observed."""
+    ) -> tuple[ValidationFailure, ...]:
+        """Flag every common column whose desired data type differs from observed."""
         if observed is None:
-            return None
+            return ()
         observed_types = {column.name: column.data_type for column in observed.columns}
-        for desired_column in desired.columns:
-            observed_type = observed_types.get(desired_column.name)
-            if observed_type is not None and observed_type != desired_column.data_type:
-                return ValidationFailure(
-                    rule_name=self.__class__.__name__,
-                    message=(
-                        "Operation not allowed: cannot change the type of existing"
-                        f" column '{desired_column.name}' from {observed_type} to"
-                        f" {desired_column.data_type}. Type migrations are not supported;"
-                        " recreate the table to change a column's type."
-                    ),
-                )
-        return None
+        return tuple(
+            ValidationFailure(
+                rule_name=self.__class__.__name__,
+                message=(
+                    "Operation not allowed: cannot change the type of existing"
+                    f" column '{desired_column.name}' from {observed_types[desired_column.name]} to"
+                    f" {desired_column.data_type}. Type migrations are not supported;"
+                    " recreate the table to change a column's type."
+                ),
+            )
+            for desired_column in desired.columns
+            if desired_column.name in observed_types
+            and observed_types[desired_column.name] != desired_column.data_type
+        )
 
 
 class DisallowPartitioningChange(Rule):
@@ -131,21 +136,23 @@ class DisallowPartitioningChange(Rule):
 
     def evaluate(
         self, desired: DesiredTable, observed: ObservedTable | None, plan: ActionPlan
-    ) -> ValidationFailure | None:
+    ) -> tuple[ValidationFailure, ...]:
         """Flag the plan if desired and observed partition columns differ."""
         if observed is None:
-            return None
+            return ()
         if desired.partitioned_by != observed.partitioned_by:
-            return ValidationFailure(
-                rule_name=self.__class__.__name__,
-                message=(
-                    "Operation not allowed: partitioning changes are not supported."
-                    f" Current partition columns: {observed.partitioned_by}"
-                    f" - Requested partition columns: {desired.partitioned_by}."
-                    " Recreate the table with the desired partitioning."
+            return (
+                ValidationFailure(
+                    rule_name=self.__class__.__name__,
+                    message=(
+                        "Operation not allowed: partitioning changes are not supported."
+                        f" Current partition columns: {observed.partitioned_by}"
+                        f" - Requested partition columns: {desired.partitioned_by}."
+                        " Recreate the table with the desired partitioning."
+                    ),
                 ),
             )
-        return None
+        return ()
 
 
 DEFAULT_RULES: tuple[Rule, ...] = (
@@ -181,6 +188,8 @@ def validate_plan(
 
     """
     failures = tuple(
-        failure for rule in rules if (failure := rule.evaluate(desired, observed, plan)) is not None
+        failure
+        for rule in rules
+        for failure in rule.evaluate(desired, observed, plan)
     )
     return ValidationResult(failures=failures)

--- a/tests/application/test_validation.py
+++ b/tests/application/test_validation.py
@@ -55,11 +55,32 @@ def test_rejects_add_of_non_nullable_column_on_existing_table():
     rule = NonNullableColumnAdd()
 
     # Then the rule flags the operation as invalid
-    failure = rule.evaluate(
+    failures = rule.evaluate(
         _desired(), _observed(), _plan(AddColumn(Column("order_id", Integer(), nullable=False)))
     )
-    assert failure is not None
-    assert failure.rule_name == "NonNullableColumnAdd"
+    assert len(failures) == 1
+    assert failures[0].rule_name == "NonNullableColumnAdd"
+
+
+def test_rejects_all_non_nullable_column_adds_in_a_single_pass():
+    # Given an existing table and a plan adding three NOT NULL columns at once
+    rule = NonNullableColumnAdd()
+
+    # When evaluating the plan
+    failures = rule.evaluate(
+        _desired(),
+        _observed(),
+        _plan(
+            AddColumn(Column("a", Integer(), nullable=False)),
+            AddColumn(Column("b", String(), nullable=False)),
+            AddColumn(Column("c", Integer(), nullable=False)),
+        ),
+    )
+
+    # Then all three violations are reported in one pass, not just the first
+    assert len(failures) == 3
+    assert {f.rule_name for f in failures} == {"NonNullableColumnAdd"}
+    assert {"a", "b", "c"} == {f.message.split("'")[1] for f in failures}
 
 
 def test_allows_add_of_nullable_column_on_existing_table():
@@ -67,10 +88,10 @@ def test_allows_add_of_nullable_column_on_existing_table():
     rule = NonNullableColumnAdd()
 
     # Then the rule allows it
-    failure = rule.evaluate(
+    failures = rule.evaluate(
         _desired(), _observed(), _plan(AddColumn(Column("notes", String(), nullable=True)))
     )
-    assert failure is None
+    assert failures == ()
 
 
 def test_allows_non_nullable_column_when_creating_new_table():
@@ -78,10 +99,10 @@ def test_allows_non_nullable_column_when_creating_new_table():
     rule = NonNullableColumnAdd()
 
     # Then the rule does not block creation-time constraints
-    failure = rule.evaluate(
+    failures = rule.evaluate(
         _desired(), None, _plan(AddColumn(Column("id", Integer(), nullable=False)))
     )
-    assert failure is None
+    assert failures == ()
 
 
 # ---- DisallowPartitioningChange
@@ -92,7 +113,7 @@ def test_rejects_partitioning_change_on_existing_table():
     rule = DisallowPartitioningChange()
 
     # Then the rule flags the operation as invalid
-    failure = rule.evaluate(
+    failures = rule.evaluate(
         _desired(
             columns=(Column("id", Integer()), Column("country", String())),
             partitioned_by=("country",),
@@ -103,8 +124,8 @@ def test_rejects_partitioning_change_on_existing_table():
         ),
         _plan(),
     )
-    assert failure is not None
-    assert failure.rule_name == "DisallowPartitioningChange"
+    assert len(failures) == 1
+    assert failures[0].rule_name == "DisallowPartitioningChange"
 
 
 def test_allows_partitioning_on_new_table():
@@ -112,7 +133,7 @@ def test_allows_partitioning_on_new_table():
     rule = DisallowPartitioningChange()
 
     # Then the rule allows it for table creation
-    failure = rule.evaluate(
+    failures = rule.evaluate(
         _desired(
             columns=(Column("id", Integer()), Column("ds", String())),
             partitioned_by=("ds",),
@@ -120,7 +141,7 @@ def test_allows_partitioning_on_new_table():
         None,
         _plan(),
     )
-    assert failure is None
+    assert failures == ()
 
 
 def test_allows_when_partition_spec_unchanged_on_existing_table():
@@ -129,12 +150,12 @@ def test_allows_when_partition_spec_unchanged_on_existing_table():
 
     # Then there is no failure from this rule
     columns = (Column("id", Integer()), Column("ds", String()))
-    failure = rule.evaluate(
+    failures = rule.evaluate(
         _desired(columns=columns, partitioned_by=("ds",)),
         _observed(columns=columns, partitioned_by=("ds",)),
         _plan(),
     )
-    assert failure is None
+    assert failures == ()
 
 
 # ---- NullabilityTighteningOnExistingColumn
@@ -145,11 +166,31 @@ def test_rejects_tightening_an_existing_column_to_not_null():
     rule = NullabilityTighteningOnExistingColumn()
 
     # Then the rule flags it: tightening can fail at runtime if NULLs already exist
-    failure = rule.evaluate(
+    failures = rule.evaluate(
         _desired(), _observed(), _plan(SetColumnNullability(column_name="id", nullable=False))
     )
-    assert failure is not None
-    assert "id" in failure.message
+    assert len(failures) == 1
+    assert "id" in failures[0].message
+
+
+def test_rejects_all_nullability_tightenings_in_a_single_pass():
+    # Given an existing table and a plan tightening two columns to NOT NULL at once
+    rule = NullabilityTighteningOnExistingColumn()
+    cols = (Column("id", Integer()), Column("name", String()))
+
+    # When evaluating the plan
+    failures = rule.evaluate(
+        _desired(columns=cols),
+        _observed(columns=cols),
+        _plan(
+            SetColumnNullability(column_name="id", nullable=False),
+            SetColumnNullability(column_name="name", nullable=False),
+        ),
+    )
+
+    # Then both violations are reported in one pass
+    assert len(failures) == 2
+    assert {"id", "name"} == {f.message.split("'")[1] for f in failures}
 
 
 def test_allows_loosening_an_existing_column_to_nullable():
@@ -157,10 +198,10 @@ def test_allows_loosening_an_existing_column_to_nullable():
     rule = NullabilityTighteningOnExistingColumn()
 
     # Then the rule allows it
-    failure = rule.evaluate(
+    failures = rule.evaluate(
         _desired(), _observed(), _plan(SetColumnNullability(column_name="id", nullable=True))
     )
-    assert failure is None
+    assert failures == ()
 
 
 def test_allows_tightening_when_creating_a_new_table():
@@ -168,10 +209,10 @@ def test_allows_tightening_when_creating_a_new_table():
     rule = NullabilityTighteningOnExistingColumn()
 
     # Then creation-time constraints are not this rule's concern
-    failure = rule.evaluate(
+    failures = rule.evaluate(
         _desired(), None, _plan(SetColumnNullability(column_name="id", nullable=False))
     )
-    assert failure is None
+    assert failures == ()
 
 
 # ---- UnsupportedColumnTypeChange
@@ -182,14 +223,31 @@ def test_rejects_changing_the_type_of_an_existing_column():
     rule = UnsupportedColumnTypeChange()
 
     # Then the drift is flagged rather than silently ignored
-    failure = rule.evaluate(
+    failures = rule.evaluate(
         _desired(columns=(Column("id", Long()),)),
         _observed(columns=(Column("id", Integer()),)),
         _plan(),
     )
-    assert failure is not None
-    assert failure.rule_name == "UnsupportedColumnTypeChange"
-    assert "id" in failure.message
+    assert len(failures) == 1
+    assert failures[0].rule_name == "UnsupportedColumnTypeChange"
+    assert "id" in failures[0].message
+
+
+def test_rejects_all_type_changes_in_a_single_pass():
+    # Given two columns that both have changed type at once
+    rule = UnsupportedColumnTypeChange()
+
+    # When evaluating the plan
+    failures = rule.evaluate(
+        _desired(columns=(Column("id", Long()), Column("score", String()))),
+        _observed(columns=(Column("id", Integer()), Column("score", Integer()))),
+        _plan(),
+    )
+
+    # Then both type mismatches are reported in one pass
+    assert len(failures) == 2
+    assert {f.rule_name for f in failures} == {"UnsupportedColumnTypeChange"}
+    assert {"id", "score"} == {f.message.split("'")[1] for f in failures}
 
 
 def test_allows_columns_whose_type_is_unchanged():
@@ -197,28 +255,28 @@ def test_allows_columns_whose_type_is_unchanged():
     rule = UnsupportedColumnTypeChange()
 
     columns = (Column("id", Integer()), Column("name", String()))
-    failure = rule.evaluate(_desired(columns=columns), _observed(columns=columns), _plan())
-    assert failure is None
+    failures = rule.evaluate(_desired(columns=columns), _observed(columns=columns), _plan())
+    assert failures == ()
 
 
 def test_ignores_added_and_dropped_columns_for_type_change():
     # Given a column only in desired (add) and one only in observed (drop)
     rule = UnsupportedColumnTypeChange()
 
-    failure = rule.evaluate(
+    failures = rule.evaluate(
         _desired(columns=(Column("id", Integer()), Column("added", String()))),
         _observed(columns=(Column("id", Integer()), Column("dropped", String()))),
         _plan(),
     )
-    assert failure is None
+    assert failures == ()
 
 
 def test_allows_type_specification_when_creating_a_new_table():
     # Given a new table creation (no observed table)
     rule = UnsupportedColumnTypeChange()
 
-    failure = rule.evaluate(_desired(columns=(Column("id", Long()),)), None, _plan())
-    assert failure is None
+    failures = rule.evaluate(_desired(columns=(Column("id", Long()),)), None, _plan())
+    assert failures == ()
 
 
 # ---- validate_plan


### PR DESCRIPTION
## Summary

- Changes `Rule.evaluate()` return type from `ValidationFailure | None` to `tuple[ValidationFailure, ...]`
- All four rules (`NonNullableColumnAdd`, `NullabilityTighteningOnExistingColumn`, `UnsupportedColumnTypeChange`, `DisallowPartitioningChange`) now collect every violation before returning
- `validate_plan` flattens per-rule tuples into a single `failures` tuple on `ValidationResult`
- Adds multi-violation tests for three of the four rules (partitioning change is inherently a single failure)

## Test plan

- [ ] `uv run pytest --ignore=tests/e2e -q` passes (183 passed, 95% coverage)
- [ ] Multi-violation tests confirm all failures are reported in one call
- [ ] Existing single-violation and passing-path tests remain green

🤖 Generated with [Claude Code](https://claude.com/claude-code)