### PR TITLE
refactor: replace double-pass column scan in reader with single _ColumnMapping pass

### DIFF
--- a/src/delta_engine/adapters/databricks/reader.py
+++ b/src/delta_engine/adapters/databricks/reader.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from dataclasses import dataclass
 from types import MappingProxyType
 
 from pyspark.sql import SparkSession
@@ -23,24 +24,37 @@ from delta_engine.application.results import (
 from delta_engine.domain.model import Column as DomainColumn, ObservedTable, QualifiedName
 
 
-def _to_domain_column(column: SparkColumn, type_mapper=domain_type_from_spark) -> DomainColumn:
+@dataclass(frozen=True, slots=True)
+class _ColumnMapping:
+    column: DomainColumn
+    is_partition: bool
+
+
+def _to_column_mapping(
+    spark_column: SparkColumn, type_mapper=domain_type_from_spark
+) -> _ColumnMapping:
     """
-    Convert a spark Column object into a domain `Column`.
+    Convert a Spark catalog column into a domain ``Column`` and its partition flag.
 
     The column name is lowercased here: the domain model requires lowercase
     identifiers, and case-preserving catalogs (e.g. Hive Metastore) can return
     mixed-case names. Normalising at the adapter boundary keeps that impedance
-    mismatch out of the domain.
+    mismatch out of the domain. The partition name in ``_ColumnMapping`` is
+    therefore derived from the already-normalised domain column name, not from
+    the raw Spark object.
     """
-    domain_data_type = type_mapper(column.dataType)
-    nullable = bool(getattr(column, "nullable", True))
-    comment = column.description if column.description else ""
+    domain_data_type = type_mapper(spark_column.dataType)
+    nullable = bool(getattr(spark_column, "nullable", True))
+    comment = spark_column.description if spark_column.description else ""
 
-    return DomainColumn(
-        name=column.name.casefold(),
-        data_type=domain_data_type,
-        nullable=nullable,
-        comment=comment,
+    return _ColumnMapping(
+        column=DomainColumn(
+            name=spark_column.name.casefold(),
+            data_type=domain_data_type,
+            nullable=nullable,
+            comment=comment,
+        ),
+        is_partition=bool(getattr(spark_column, "isPartition", False)),
     )
 
 
@@ -76,11 +90,9 @@ class DatabricksReader:
         if not self._table_exists(qualified_name):
             return TableAbsent()
 
-        catalog_columns = self.spark.catalog.listColumns(str(qualified_name))
-        columns = tuple(_to_domain_column(c) for c in catalog_columns)
-        partition_columns = tuple(
-            c.name.casefold() for c in catalog_columns if bool(getattr(c, "isPartition", False))
-        )
+        mappings = tuple(_to_column_mapping(c) for c in self.spark.catalog.listColumns(str(qualified_name)))
+        columns = tuple(m.column for m in mappings)
+        partition_columns = tuple(m.column.name for m in mappings if m.is_partition)
         observed = ObservedTable(
             qualified_name=qualified_name,
             columns=columns,

--- a/src/delta_engine/adapters/databricks/reader.py
+++ b/src/delta_engine/adapters/databricks/reader.py
@@ -90,7 +90,9 @@ class DatabricksReader:
         if not self._table_exists(qualified_name):
             return TableAbsent()
 
-        mappings = tuple(_to_column_mapping(c) for c in self.spark.catalog.listColumns(str(qualified_name)))
+        mappings = tuple(
+            _to_column_mapping(c) for c in self.spark.catalog.listColumns(str(qualified_name))
+        )
         columns = tuple(m.column for m in mappings)
         partition_columns = tuple(m.column.name for m in mappings if m.is_partition)
         observed = ObservedTable(


### PR DESCRIPTION
## Summary

- Introduces `_ColumnMapping(column: DomainColumn, is_partition: bool)` — a private pair that carries both pieces of information available from a single Spark catalog column
- Replaces `_to_domain_column` with `_to_column_mapping`, which converts the Spark column and captures `isPartition` in one call
- `_read` now does a single pass over `listColumns` results; partition names are derived from the already-normalised domain column names rather than re-extracted from raw Spark objects

## Why

`_read` previously iterated `catalog_columns` twice: once through `_to_domain_column` (which normalised the name via `.casefold()`) and a second time to extract partition names (which also called `.casefold()` independently). The converter discarded `isPartition` even though it was available, forcing the caller to go back to the raw Spark objects to recover it. Two normalisation calls, two sources of truth for the same name.

## Test plan

- [ ] `uv run pytest --ignore=tests/e2e -q` — 183 passed, 95% coverage
- [ ] `test_partition_columns_returns_only_partition_names_in_order` — verifies partition extraction still works
- [ ] `test_fetch_state_lowercases_mixed_case_column_names_from_catalog` — verifies normalisation still happens at the adapter boundary

🤖 Generated with [Claude Code](https://claude.com/claude-code)