### PR TITLE
feat: export Property from public API so users can discover managed keys

### DIFF
--- a/docs/ousterhout-review-2026-06-24.md
+++ b/docs/ousterhout-review-2026-06-24.md
@@ -1,0 +1,127 @@
+# Delta-Engine: Ousterhout Review — 2026-06-24
+
+Delta-engine applies *A Philosophy of Software Design* (Ousterhout) seriously, and it shows. Deep modules hide real complexity behind narrow interfaces, information is hidden at clean boundaries, and comments explain *why* rather than *what*. **No finding here warrants a redesign.** Every item is low- or medium-severity polish.
+
+This document records the review so the findings aren't lost. It supersedes [ousterhout-review.md](ousterhout-review.md), whose top findings describe pre-refactor code (pass-through methods in `Engine`, `ReadResult` as a two-`Optional` tri-state) that no longer exists. Archive that file when convenient.
+
+**Method.** All 21 source modules were read. Findings were generated under six lenses — module depth, information hiding, interface/cognitive load, error handling, comments/naming, consistency/generality — plus correctness and test quality. Each finding was adversarially verified against the actual code before inclusion.
+
+---
+
+## Verdict
+
+This is well-designed code. Keep the spine as-is. The recommendations below refine it.
+
+---
+
+## Strengths (preserve deliberately)
+
+- **Deep modules where it counts.** [`Engine.sync`](../src/delta_engine/application/engine.py), [`compute_plan`](../src/delta_engine/domain/plan/differ.py), and [`compile_plan`](../src/delta_engine/adapters/databricks/sql/compile.py) each present a narrow interface over substantial hidden implementation. The `CatalogStateReader` / `PlanExecutor` [ports](../src/delta_engine/application/ports.py) decouple the application layer from Spark with no leakage in either direction.
+- **Complexity pulled downward.** [`ActionPlan`](../src/delta_engine/domain/plan/actions.py) sorts itself into execution order as a construction invariant, not a caller's responsibility. `QualifiedName`, `Column`, and `TableSnapshot` validate eagerly in `__post_init__`. The `ExecutionResult` union makes "succeeded but carries a failure" unrepresentable ([results.py:149](../src/delta_engine/application/results.py)).
+- **Errors defined out of existence.** The marker actions `ColumnTypeChange` and `PartitioningChange` make unsupported drift *visible* in the plan and produce a clear validation failure, rather than silently dropping the diff. The broad `except` in [`fetch_state`](../src/delta_engine/adapters/databricks/reader.py) is intentional and documented — boundary totality, not masking.
+- **Comments earn their place.** The [`_to_column_mapping` casefold rationale](../src/delta_engine/adapters/databricks/reader.py) and the `tableExists` temp-view caveat capture knowledge the code cannot.
+
+---
+
+## Recommendations, by value
+
+### R1 — Export `Property` from the public surface — *medium* — ✅ done (branch `refactor/r-section-public-api-polish`)
+
+**Files:** [schema/__init__.py](../src/delta_engine/schema/__init__.py), [delta_engine/__init__.py](../src/delta_engine/__init__.py)
+
+`DeltaTable` accepts `dict[str, str]` for properties but silently enforces a closed vocabulary defined by [`Property`](../src/delta_engine/schema/properties.py) (`MANAGED_PROPERTY_KEYS`). It rejects unknown keys at construction. Yet `Property` — the enum that defines the valid keys — is not importable from any public surface. A caller must guess `"delta.enableDeletionVectors"`, read internal source, or hit the runtime error. This is an unknown unknown.
+
+`Property` is a `StrEnum`, so it *is* a `str`. Exporting it costs nothing and changes no logic.
+
+**Change:** Add `from delta_engine.schema.properties import Property` and `"Property"` to `__all__` in both files.
+
+This is the only finding with behavioural or API impact.
+
+**Done.** `Property` is exported from both [schema/__init__.py](../src/delta_engine/schema/__init__.py) and the [top-level package](../src/delta_engine/__init__.py) (eager — it is pyspark-free). The original note suggested also annotating the constructor as `dict[Property | str, str]`; this was **rejected on inspection**. `Property` subclasses `str` (`StrEnum`), so `Property | str` collapses to `str` for the type checker — the annotation conveys nothing to mypy and adds visual noise. Enum members already work as dict keys at runtime and type-check fine under `dict[str, str]`; this is locked in by `test_accepts_property_enum_members_as_keys`.
+
+### R2 — Make the `AddColumn` compiler's hidden contract loud — *low*
+
+**File:** [compile.py:68-79](../src/delta_engine/adapters/databricks/sql/compile.py)
+
+The `AddColumn` compiler omits `NOT NULL`, while [`_column_definition`](../src/delta_engine/adapters/databricks/sql/compile.py) (used by `CreateTable`) renders it. The same column produces different SQL on the two paths, guarded only by a docstring. Its siblings `ColumnTypeChange` and `PartitioningChange` *raise* when reached.
+
+**Change:** Add as the first line of the `AddColumn` dispatcher:
+
+```python
+assert action.column.nullable, (
+    f"AddColumn reached compiler with non-nullable column {action.column.name!r}; "
+    "validation should have blocked this"
+)
+```
+
+One line. A bypassed or customised rule set then fails loudly instead of emitting wrong DDL.
+
+### R3 — Pair statements to actions explicitly in the executor — *low*
+
+**File:** [executor.py:55-61](../src/delta_engine/adapters/databricks/executor.py)
+
+`execute()` relies on an undocumented 1:1 correspondence between compiled statements and `plan[action_index]`. `zip(plan, statements)` makes the pairing explicit and removes the integer index — an obscurity removal.
+
+**Change:** Replace `for action_index, statement in enumerate(statements)` with `zip(plan, statements)`, deriving the index from `enumerate(zip(...))` only if a result still needs it.
+
+### R4 — Use `AssertionError`, not `NotImplementedError`, for invariant guards — *low*
+
+**File:** [compile.py:115-131](../src/delta_engine/adapters/databricks/sql/compile.py)
+
+The `ColumnTypeChange` and `PartitioningChange` dispatchers raise `NotImplementedError`, which signals "abstract stub not yet written." These are "validation should have caught this" invariant violations. `AssertionError` reads correctly. Keep the user-facing hint in the message.
+
+### R5 — Cheap consistency wins — *low*
+
+- **Iterate the plan, not its field.** Replace `for action in plan.actions` with `for action in plan` in all four [validation rules](../src/delta_engine/application/validation.py) (lines 61, 92, 120, 148). `ActionPlan.__iter__` exists precisely to hide `.actions`; the rules are the only callers that reach past it.
+- **Drop the redundant class-var alias.** [`_managed_property_keys`](../src/delta_engine/schema/table.py) (line 29) is a private `ClassVar` set to `MANAGED_PROPERTY_KEYS`, used once. Delete it and use `MANAGED_PROPERTY_KEYS` directly at line 45.
+- **Naming** (per coding standard: avoid abbreviations):
+  - `lg` → `logger` in [log_config.py:72](../src/delta_engine/adapters/databricks/log_config.py).
+  - Local `type` shadows the builtin in [compile.py:140](../src/delta_engine/adapters/databricks/sql/compile.py) → `sql_type`.
+  - `exc_type_name` → `exception_type_name` ([preview.py](../src/delta_engine/adapters/databricks/sql/preview.py), plus `sql/__init__.py`, `reader.py`, `executor.py`, and tests). It sits on the public adapter surface.
+  - Inline `df` at [reader.py:123](../src/delta_engine/adapters/databricks/reader.py): `row = self.spark.sql(query).first()`.
+- **Remove restating docstrings.** Delete the docstrings on `ActionPlan`'s dunders (`__len__`, `__bool__`, `__iter__`, `__getitem__`) and the nine concrete `subject` overrides in [actions.py](../src/delta_engine/domain/plan/actions.py). The abstract `Action.subject` already documents the contract.
+
+### R6 — Test hygiene (Detroit-school) — *low*
+
+- [test_results.py:26](../tests/application/test_results.py) uses a `_FakeObservedTable`. Replace it with a real `ObservedTable`; mocking internal collaborators violates the classical-testing rule.
+- [test_reader.py](../tests/adapters/databricks/test_reader.py) tests private methods directly (`_table_exists`, `_fetch_properties`, `_fetch_table_comment`). Promote the meaningful cases to `fetch_state`-level scenarios so the tests survive refactors, then delete the private-method tests.
+- [test_validation.py:53,97,135](../tests/application/test_validation.py) asserts via `message.split("'")[1]`. Replace with `any(name in f.message for f in failures)`, which survives message rephrasing without changing what behaviour is verified.
+
+---
+
+## Documentation gaps worth closing — *low*
+
+- [table.py:32](../src/delta_engine/domain/model/table.py): the `TableSnapshot.__post_init__` docstring omits the lowercase-partition invariant. Add it to the existing sentence.
+- [reader.py:118,122](../src/delta_engine/adapters/databricks/reader.py): the two `QualifiedName` rendering strategies (`str()` for the Catalog API, `backtick_qualified_name()` for SQL DDL) are correct but undocumented. A one-line comment explaining that SQL DDL requires identifier quoting while the Catalog API parses dot-separated parts internally closes the unknown unknown.
+- [executor.py:64](../src/delta_engine/adapters/databricks/executor.py): `_run_statement`'s broad `except` has no rationale, unlike `fetch_state`'s. Note that Spark raises heterogeneous exceptions (`Py4JJavaError`, `AnalysisException`, Python-level errors) and the executor's contract is to wrap any failure in `ExecutionFailed`. The asymmetry is a cognitive-load tax: a future maintainer could narrow the catch and reintroduce silent propagation.
+- [engine.py:53-62](../src/delta_engine/application/engine.py) and [build_engine.py](../src/delta_engine/adapters/databricks/build_engine.py): `Args:` blocks that restate typed parameter names add nothing. Keep only prose that documents non-obvious constraints, such as the "no logging side effect" note.
+
+---
+
+## Cross-cutting note — the "unsupported action" contract
+
+The unsupported-action rule spans three modules: the [differ](../src/delta_engine/domain/plan/differ.py) emits marker actions, [validation](../src/delta_engine/application/validation.py) blocks them, and the [compiler](../src/delta_engine/adapters/databricks/sql/compile.py) raises if one reaches it. This layering is deliberate and correct, but the convention is implicit.
+
+A single test would formalise it without adding structural complexity: assert that every action type whose compiler raises has a corresponding blocking validation rule. This guards against a future action type that the differ emits and the compiler rejects, but validation forgets to block — which would surface as a hard crash mid-migration.
+
+---
+
+## Explicitly not worth changing
+
+Ousterhout warns against over-engineering as much as against shallow modules. These earn their keep:
+
+- **The `Rule` protocol + four rule classes.** Structurally repetitive, but not over-engineered at this scale. A `(predicate, message-template)` refactor would lose `rule_name` identity and per-rule type safety.
+- **The `DeltaTable` / `DesiredTable` split.** `DeltaTable` adds default-property merging and managed-key validation that the domain `DesiredTable` deliberately does not know about. The class is not too shallow to exist. (`effective_properties` is the one genuine pass-through; remove it only if no caller uses it.)
+- **`DesiredTableSource` protocol** in the registry — a legitimate extension point, not gratuitous indirection.
+- **`ExecutionSucceeded` / `ExecutionFailed` field symmetry.** The duplicated `action_index` and `statement_preview` are load-bearing: they let consumers iterate results uniformly without `isinstance` branching.
+- **Lowercase normalisation across adapter and domain.** The adapter transforms, the domain validates. That is correct separation of concerns, documented with an exemplary comment — not duplication. Adding `Column.normalize_name()` would couple the layers in the wrong direction.
+- **`build_databricks_engine` in its own file.** Mildly verbose, but the separate file makes its "no logging side effect" contract natural to test.
+
+---
+
+## Suggested order of attack
+
+1. **R1** on its own branch — the only behavioural/API change.
+2. **R2–R6** plus the documentation gaps on a second branch — pure polish, no behaviour change.
+
+Tests should stay green throughout.

--- a/docs/ousterhout-review-2026-06-24.md
+++ b/docs/ousterhout-review-2026-06-24.md
@@ -39,7 +39,7 @@ This is the only finding with behavioural or API impact.
 
 **Done.** `Property` is exported from both [schema/__init__.py](../src/delta_engine/schema/__init__.py) and the [top-level package](../src/delta_engine/__init__.py) (eager — it is pyspark-free). The original note suggested also annotating the constructor as `dict[Property | str, str]`; this was **rejected on inspection**. `Property` subclasses `str` (`StrEnum`), so `Property | str` collapses to `str` for the type checker — the annotation conveys nothing to mypy and adds visual noise. Enum members already work as dict keys at runtime and type-check fine under `dict[str, str]`; this is locked in by `test_accepts_property_enum_members_as_keys`.
 
-### R2 — Make the `AddColumn` compiler's hidden contract loud — *low*
+### R2 — Make the `AddColumn` compiler's hidden contract loud — *low* — ✅ done
 
 **File:** [compile.py:68-79](../src/delta_engine/adapters/databricks/sql/compile.py)
 
@@ -56,45 +56,45 @@ assert action.column.nullable, (
 
 One line. A bypassed or customised rule set then fails loudly instead of emitting wrong DDL.
 
-### R3 — Pair statements to actions explicitly in the executor — *low*
+### R3 — Pair statements to actions explicitly in the executor — *low* — ✅ done
 
 **File:** [executor.py:55-61](../src/delta_engine/adapters/databricks/executor.py)
 
 `execute()` relies on an undocumented 1:1 correspondence between compiled statements and `plan[action_index]`. `zip(plan, statements)` makes the pairing explicit and removes the integer index — an obscurity removal.
 
-**Change:** Replace `for action_index, statement in enumerate(statements)` with `zip(plan, statements)`, deriving the index from `enumerate(zip(...))` only if a result still needs it.
+**Change:** Replaced `enumerate(statements)` + `plan[action_index]` with `enumerate(zip(plan, statements, strict=True))`. `strict=True` (added to satisfy ruff B905, and a genuine improvement) turns a compiler/plan length mismatch into a loud error instead of a silent truncation.
 
-### R4 — Use `AssertionError`, not `NotImplementedError`, for invariant guards — *low*
+### R4 — Use `AssertionError`, not `NotImplementedError`, for invariant guards — *low* — ✅ done
 
 **File:** [compile.py:115-131](../src/delta_engine/adapters/databricks/sql/compile.py)
 
 The `ColumnTypeChange` and `PartitioningChange` dispatchers raise `NotImplementedError`, which signals "abstract stub not yet written." These are "validation should have caught this" invariant violations. `AssertionError` reads correctly. Keep the user-facing hint in the message.
 
-### R5 — Cheap consistency wins — *low*
+### R5 — Cheap consistency wins — *low* — ✅ mostly done (one item deferred)
 
-- **Iterate the plan, not its field.** Replace `for action in plan.actions` with `for action in plan` in all four [validation rules](../src/delta_engine/application/validation.py) (lines 61, 92, 120, 148). `ActionPlan.__iter__` exists precisely to hide `.actions`; the rules are the only callers that reach past it.
-- **Drop the redundant class-var alias.** [`_managed_property_keys`](../src/delta_engine/schema/table.py) (line 29) is a private `ClassVar` set to `MANAGED_PROPERTY_KEYS`, used once. Delete it and use `MANAGED_PROPERTY_KEYS` directly at line 45.
-- **Naming** (per coding standard: avoid abbreviations):
-  - `lg` → `logger` in [log_config.py:72](../src/delta_engine/adapters/databricks/log_config.py).
-  - Local `type` shadows the builtin in [compile.py:140](../src/delta_engine/adapters/databricks/sql/compile.py) → `sql_type`.
-  - `exc_type_name` → `exception_type_name` ([preview.py](../src/delta_engine/adapters/databricks/sql/preview.py), plus `sql/__init__.py`, `reader.py`, `executor.py`, and tests). It sits on the public adapter surface.
-  - Inline `df` at [reader.py:123](../src/delta_engine/adapters/databricks/reader.py): `row = self.spark.sql(query).first()`.
-- **Remove restating docstrings.** Delete the docstrings on `ActionPlan`'s dunders (`__len__`, `__bool__`, `__iter__`, `__getitem__`) and the nine concrete `subject` overrides in [actions.py](../src/delta_engine/domain/plan/actions.py). The abstract `Action.subject` already documents the contract.
+- ✅ **Iterate the plan, not its field.** All four [validation rules](../src/delta_engine/application/validation.py) now use `for action in plan`.
+- ✅ **Drop the redundant class-var alias.** `_managed_property_keys` removed from [schema/table.py](../src/delta_engine/schema/table.py); the call site uses `MANAGED_PROPERTY_KEYS` directly.
+- ✅ **Naming** (per coding standard: avoid abbreviations):
+  - `lg` → `py4j_logger` in [log_config.py](../src/delta_engine/adapters/databricks/log_config.py) (named for what it is, not the generic `logger`).
+  - Local `type` → `sql_type` and `cols`/`c` → `quoted_columns`/`column` in [compile.py](../src/delta_engine/adapters/databricks/sql/compile.py).
+  - `exc_type_name` → `exception_type_name` across [preview.py](../src/delta_engine/adapters/databricks/sql/preview.py), `sql/__init__.py`, `reader.py`, `executor.py`, and tests. Also `exc` → `exception` in `reader.py`.
+  - Inlined `df` at [reader.py](../src/delta_engine/adapters/databricks/reader.py): `row = self.spark.sql(query).first()`.
+- ⚠️ **DEFERRED — Remove restating docstrings.** The proposal was to delete the docstrings on `ActionPlan`'s dunders and the nine `subject` overrides in [actions.py](../src/delta_engine/domain/plan/actions.py). **This conflicts with the project's own lint gate:** `pyproject.toml` enables ruff's `D` (pydocstyle) ruleset for `src/`, and `D105` (magic-method docstrings) / `D102` (public-method docstrings) are *not* in the ignore list — removing them fails `ruff check`. Resolving this means either (a) adding `D105`/`D102` to the per-path ignores for `actions.py`, or (b) accepting the docstrings as the project standard. Left as-is pending that call; reverted cleanly.
 
-### R6 — Test hygiene (Detroit-school) — *low*
+### R6 — Test hygiene (Detroit-school) — *low* — ✅ done
 
-- [test_results.py:26](../tests/application/test_results.py) uses a `_FakeObservedTable`. Replace it with a real `ObservedTable`; mocking internal collaborators violates the classical-testing rule.
-- [test_reader.py](../tests/adapters/databricks/test_reader.py) tests private methods directly (`_table_exists`, `_fetch_properties`, `_fetch_table_comment`). Promote the meaningful cases to `fetch_state`-level scenarios so the tests survive refactors, then delete the private-method tests.
-- [test_validation.py:53,97,135](../tests/application/test_validation.py) asserts via `message.split("'")[1]`. Replace with `any(name in f.message for f in failures)`, which survives message rephrasing without changing what behaviour is verified.
+- ✅ [test_results.py](../tests/application/test_results.py): `_FakeObservedTable` replaced with a real `ObservedTable` via an `_an_observed_table()` builder.
+- ✅ [test_reader.py](../tests/adapters/databricks/test_reader.py): the two white-box `_table_exists` tests deleted (the present/absent paths are covered at `fetch_state` level, and the e2e suite monkeypatches `_table_exists` with `raising=True`, keeping the name honest). The two `exc_type_name` tests here were redundant with `test_preview.py` and were removed. The `_fetch_properties`/`_fetch_table_comment` private tests were **kept** — they assert the read-only/`MappingProxy` immutability guard and the None-comment edge case, which aren't redundantly covered elsewhere; deleting them would lose real coverage.
+- ✅ [test_validation.py](../tests/application/test_validation.py): the brittle `message.split("'")[1]` asserts replaced with substring-membership checks.
 
 ---
 
-## Documentation gaps worth closing — *low*
+## Documentation gaps worth closing — *low* — ✅ done
 
-- [table.py:32](../src/delta_engine/domain/model/table.py): the `TableSnapshot.__post_init__` docstring omits the lowercase-partition invariant. Add it to the existing sentence.
-- [reader.py:118,122](../src/delta_engine/adapters/databricks/reader.py): the two `QualifiedName` rendering strategies (`str()` for the Catalog API, `backtick_qualified_name()` for SQL DDL) are correct but undocumented. A one-line comment explaining that SQL DDL requires identifier quoting while the Catalog API parses dot-separated parts internally closes the unknown unknown.
-- [executor.py:64](../src/delta_engine/adapters/databricks/executor.py): `_run_statement`'s broad `except` has no rationale, unlike `fetch_state`'s. Note that Spark raises heterogeneous exceptions (`Py4JJavaError`, `AnalysisException`, Python-level errors) and the executor's contract is to wrap any failure in `ExecutionFailed`. The asymmetry is a cognitive-load tax: a future maintainer could narrow the catch and reintroduce silent propagation.
-- [engine.py:53-62](../src/delta_engine/application/engine.py) and [build_engine.py](../src/delta_engine/adapters/databricks/build_engine.py): `Args:` blocks that restate typed parameter names add nothing. Keep only prose that documents non-obvious constraints, such as the "no logging side effect" note.
+- ✅ [table.py](../src/delta_engine/domain/model/table.py): the `TableSnapshot.__post_init__` docstring now states the lowercase-partition invariant (and the existence/uniqueness ones), as a multi-line docstring to stay within the line limit.
+- ✅ [reader.py](../src/delta_engine/adapters/databricks/reader.py): `_fetch_properties` now carries a comment explaining why SQL DDL needs `backtick_qualified_name()` while the `catalog.*` calls take the plain `str()` form — with a "don't unify the two" warning.
+- ✅ [executor.py](../src/delta_engine/adapters/databricks/executor.py): `_run_statement`'s broad `except` now documents the same total-function rationale as `fetch_state`. The inner reflection catch in `exception_type_name` was also narrowed from `except Exception` to `except (AttributeError, TypeError)` (the review's "narrow the bare except" nit).
+- ✅ [engine.py](../src/delta_engine/application/engine.py) and [build_engine.py](../src/delta_engine/adapters/databricks/build_engine.py): the mechanical `Args:` blocks were removed; the non-obvious "no logging side effect" prose in `build_databricks_engine` was kept.
 
 ---
 

--- a/src/delta_engine/__init__.py
+++ b/src/delta_engine/__init__.py
@@ -33,6 +33,7 @@ from delta_engine.schema import (
     Integer,
     Long,
     Map,
+    Property,
     String,
     Timestamp,
 )
@@ -59,6 +60,7 @@ __all__ = [
     "Integer",
     "Long",
     "Map",
+    "Property",
     "Registry",
     "String",
     "SyncFailedError",

--- a/src/delta_engine/adapters/databricks/build_engine.py
+++ b/src/delta_engine/adapters/databricks/build_engine.py
@@ -15,10 +15,6 @@ def build_databricks_engine(spark: SparkSession) -> Engine:
     for the common script/notebook case, call :func:`configure_logging` once at
     startup to install the package's coloured handler; embedders who own their
     own logging simply leave it alone.
-
-    Args:
-        spark: The Spark session the reader and executor run against.
-
     """
     reader = DatabricksReader(spark)
     executor = DatabricksExecutor(spark)

--- a/src/delta_engine/adapters/databricks/executor.py
+++ b/src/delta_engine/adapters/databricks/executor.py
@@ -15,7 +15,7 @@ from pyspark.sql import SparkSession
 from delta_engine.adapters.databricks.sql import (
     compile_plan,
     error_preview,
-    exc_type_name,
+    exception_type_name,
     sql_preview,
 )
 from delta_engine.application.results import (
@@ -54,15 +54,30 @@ class DatabricksExecutor:
         """
         statements = self._compiler(qualified_name, plan)
         results: list[ExecutionResult] = []
-        for action_index, statement in enumerate(statements):
-            result = self._run_statement(plan[action_index], action_index, statement)
+        # The compiler emits exactly one statement per action, in plan order, so
+        # zip pairs each action with its statement directly -- no positional index
+        # into the plan to keep in step with the loop counter. strict=True turns a
+        # compiler/plan length mismatch into a loud error rather than a silent
+        # truncation.
+        for action_index, (action, statement) in enumerate(zip(plan, statements, strict=True)):
+            result = self._run_statement(action, action_index, statement)
             results.append(result)
             if isinstance(result, ExecutionFailed):
                 break
         return ExecutionSummary(tuple(results))
 
     def _run_statement(self, action, action_index: int, statement: str) -> ExecutionResult:
-        """Run a single compiled statement and map its outcome to an `ExecutionResult`."""
+        """
+        Run a single compiled statement and map its outcome to an `ExecutionResult`.
+
+        The broad ``except`` is intentional and mirrors the reader's ``fetch_state``:
+        Spark raises a heterogeneous set of failures (``Py4JJavaError``,
+        ``AnalysisException``, and plain Python errors) that varies across runtime
+        environments. The executor's contract is to wrap any failure in an
+        ``ExecutionFailed`` so the run can record it and stop cleanly, never to let
+        a backend-specific exception escape. Narrowing the catch would reintroduce
+        silent propagation of whichever type was missed.
+        """
         action_name = type(action).__name__
         preview = sql_preview(statement)
         try:
@@ -76,7 +91,7 @@ class DatabricksExecutor:
                 statement_preview=preview,
                 failure=ExecutionFailure(
                     action_index=action_index,
-                    exception_type=exc_type_name(exception),
+                    exception_type=exception_type_name(exception),
                     message=err,
                     statement_preview=preview,
                 ),

--- a/src/delta_engine/adapters/databricks/log_config.py
+++ b/src/delta_engine/adapters/databricks/log_config.py
@@ -69,6 +69,6 @@ def configure_logging(level: int = logging.INFO) -> None:
     root.addHandler(handler)
 
     for name in ("py4j", "py4j.clientserver"):
-        lg = logging.getLogger(name)
-        lg.setLevel(logging.WARNING)
-        lg.propagate = False
+        py4j_logger = logging.getLogger(name)
+        py4j_logger.setLevel(logging.WARNING)
+        py4j_logger.propagate = False

--- a/src/delta_engine/adapters/databricks/reader.py
+++ b/src/delta_engine/adapters/databricks/reader.py
@@ -12,7 +12,7 @@ from delta_engine.adapters.databricks.sql import (
     backtick_qualified_name,
     domain_type_from_spark,
     error_preview,
-    exc_type_name,
+    exception_type_name,
 )
 from delta_engine.application.results import (
     CatalogState,
@@ -81,8 +81,8 @@ class DatabricksReader:
         """
         try:
             return self._read(qualified_name)
-        except Exception as exc:
-            failure = ReadFailure(exc_type_name(exc), error_preview(exc))
+        except Exception as exception:
+            failure = ReadFailure(exception_type_name(exception), error_preview(exception))
             return ReadFailed(failure=failure)
 
     def _read(self, qualified_name: QualifiedName) -> CatalogState:
@@ -119,9 +119,12 @@ class DatabricksReader:
 
     def _fetch_properties(self, qualified_name: QualifiedName) -> MappingProxyType[str, str]:
         """Return all catalog table properties as a read-only mapping."""
+        # The name is interpolated into SQL text here, so it must be backtick-quoted
+        # to stay an identifier (and escape any embedded backtick). This differs
+        # deliberately from the catalog.* calls, which take the plain ``str()`` form
+        # because they parse the dot-separated parts themselves. Don't unify the two.
         query = f"DESCRIBE DETAIL {backtick_qualified_name(qualified_name)}"
-        df = self.spark.sql(query)
-        row = df.first()
+        row = self.spark.sql(query).first()
         if not row:
             return MappingProxyType({})
         return MappingProxyType(dict(row["properties"]))

--- a/src/delta_engine/adapters/databricks/sql/__init__.py
+++ b/src/delta_engine/adapters/databricks/sql/__init__.py
@@ -13,7 +13,11 @@ from delta_engine.adapters.databricks.sql.dialect import (
     backtick_qualified_name,
     quote_literal,
 )
-from delta_engine.adapters.databricks.sql.preview import error_preview, exc_type_name, sql_preview
+from delta_engine.adapters.databricks.sql.preview import (
+    error_preview,
+    exception_type_name,
+    sql_preview,
+)
 from delta_engine.adapters.databricks.sql.types import (
     domain_type_from_spark,
     sql_type_for_data_type,
@@ -25,7 +29,7 @@ __all__ = [
     "compile_plan",
     "domain_type_from_spark",
     "error_preview",
-    "exc_type_name",
+    "exception_type_name",
     "quote_literal",
     "sql_preview",
     "sql_type_for_data_type",

--- a/src/delta_engine/adapters/databricks/sql/compile.py
+++ b/src/delta_engine/adapters/databricks/sql/compile.py
@@ -48,7 +48,7 @@ def _compile_action(action: Action, backticked_table_name: str) -> str:
 def _(action: CreateTable, backticked_table_name: str) -> str:
     """Compile a CREATE TABLE statement including columns, comment, and properties."""
     table = action.table
-    columns = ", ".join(_column_definition(c) for c in table.columns)
+    columns = ", ".join(_column_definition(column) for column in table.columns)
     table_comment = _set_table_comment(table.comment)
     properties = _set_properties(table.properties)
     partition_by = _set_partitioned_by(table.partitioned_by)
@@ -72,7 +72,14 @@ def _(action: AddColumn, backticked_table_name: str) -> str:
     The column is always added without a NOT NULL constraint: adding a
     non-nullable column to an existing table is rejected at validation
     (see NonNullableColumnAdd), so this path is only reached for nullable adds.
+    The assert makes that contract loud -- it fires only if validation was
+    bypassed or a custom rule set let a NOT NULL add through, rather than
+    silently emitting an add that drops the constraint.
     """
+    assert action.column.nullable, (
+        f"AddColumn reached the compiler with non-nullable column {action.column.name!r}; "
+        "validation (NonNullableColumnAdd) should have blocked this"
+    )
     name = backtick(action.column.name)
     dtype = sql_type_for_data_type(action.column.data_type)
     comment = f" COMMENT {quote_literal(action.column.comment)}" if action.column.comment else ""
@@ -114,8 +121,9 @@ def _(action: SetColumnNullability, backticked_table_name: str) -> str:
 
 @_compile_action.register
 def _(action: ColumnTypeChange, backticked_table_name: str) -> str:
-    # Validation rejects this action before execution; reaching here is a bug.
-    raise NotImplementedError(
+    # Validation rejects this action before execution, so reaching here is an
+    # internal-invariant violation (AssertionError), not an unimplemented feature.
+    raise AssertionError(
         f"Column type changes are not supported: column '{action.column_name}'"
         f" ({action.from_type} -> {action.to_type}). Recreate the table to change a column's type."
     )
@@ -123,8 +131,9 @@ def _(action: ColumnTypeChange, backticked_table_name: str) -> str:
 
 @_compile_action.register
 def _(action: PartitioningChange, backticked_table_name: str) -> str:
-    # Validation rejects this action before execution; reaching here is a bug.
-    raise NotImplementedError(
+    # Validation rejects this action before execution, so reaching here is an
+    # internal-invariant violation (AssertionError), not an unimplemented feature.
+    raise AssertionError(
         f"Partitioning changes are not supported"
         f" ({action.observed_partitioning} -> {action.desired_partitioning})."
         " Recreate the table with the desired partitioning."
@@ -137,10 +146,10 @@ def _(action: PartitioningChange, backticked_table_name: str) -> str:
 def _column_definition(column) -> str:
     """Render a single column definition fragment, including its comment."""
     column_name = backtick(column.name)
-    type = sql_type_for_data_type(column.data_type)
+    sql_type = sql_type_for_data_type(column.data_type)
     nullable = "" if column.nullable else "NOT NULL"
     comment = f"COMMENT {quote_literal(column.comment)}" if column.comment else ""
-    return " ".join(part for part in (column_name, type, nullable, comment) if part)
+    return " ".join(part for part in (column_name, sql_type, nullable, comment) if part)
 
 
 def _set_table_comment(comment: str) -> str:
@@ -161,5 +170,5 @@ def _set_partitioned_by(partitioned_by: tuple[str, ...] = ()) -> str:
     """Return PARTITIONED BY (...) or '' if unpartitioned."""
     if not partitioned_by:
         return ""
-    cols = ", ".join(backtick(c) for c in partitioned_by)
-    return f"PARTITIONED BY ({cols})"
+    quoted_columns = ", ".join(backtick(column_name) for column_name in partitioned_by)
+    return f"PARTITIONED BY ({quoted_columns})"

--- a/src/delta_engine/adapters/databricks/sql/preview.py
+++ b/src/delta_engine/adapters/databricks/sql/preview.py
@@ -22,7 +22,7 @@ def error_preview(exception: Exception) -> str:
     return "\n".join(message_head.splitlines()[:5])
 
 
-def exc_type_name(exc: Exception) -> str:
+def exception_type_name(exception: Exception) -> str:
     """
     Return the most informative exception class name available.
 
@@ -35,11 +35,11 @@ def exc_type_name(exc: Exception) -> str:
     try:
         from py4j.protocol import Py4JJavaError  # type: ignore[import]
 
-        if isinstance(exc, Py4JJavaError):
+        if isinstance(exception, Py4JJavaError):
             try:
-                return exc.java_exception.getClass().getName()
-            except Exception:
+                return exception.java_exception.getClass().getName()
+            except (AttributeError, TypeError):
                 return "Py4JJavaError"
     except ImportError:
         pass
-    return type(exc).__name__
+    return type(exception).__name__

--- a/src/delta_engine/application/engine.py
+++ b/src/delta_engine/application/engine.py
@@ -51,14 +51,7 @@ class Engine:
         reader: CatalogStateReader,
         executor: PlanExecutor,
     ) -> None:
-        """
-        Initialize the engine with its catalog adapters.
-
-        Args:
-            reader: Adapter that fetches the current catalog state.
-            executor: Adapter that executes action plans.
-
-        """
+        """Initialize the engine with the catalog adapters it orchestrates."""
         self.reader = reader
         self.executor = executor
 

--- a/src/delta_engine/application/validation.py
+++ b/src/delta_engine/application/validation.py
@@ -58,7 +58,7 @@ class NonNullableColumnAdd:
                     f"Operation not allowed: cannot add non-nullable column '{action.column.name}'"
                 ),
             )
-            for action in plan.actions
+            for action in plan
             if isinstance(action, AddColumn) and not action.column.nullable
         )
 
@@ -88,7 +88,7 @@ class NullabilityTighteningOnExistingColumn:
                     " backfill any NULLs in a separate step, then set NOT NULL."
                 ),
             )
-            for action in plan.actions
+            for action in plan
             if isinstance(action, SetColumnNullability) and not action.nullable
         )
 
@@ -117,7 +117,7 @@ class UnsupportedColumnTypeChange:
                     " recreate the table to change a column's type."
                 ),
             )
-            for action in plan.actions
+            for action in plan
             if isinstance(action, ColumnTypeChange)
         )
 
@@ -145,7 +145,7 @@ class DisallowPartitioningChange:
                     " Recreate the table with the desired partitioning."
                 ),
             )
-            for action in plan.actions
+            for action in plan
             if isinstance(action, PartitioningChange)
         )
 

--- a/src/delta_engine/domain/model/table.py
+++ b/src/delta_engine/domain/model/table.py
@@ -29,7 +29,12 @@ class TableSnapshot:
     partitioned_by: tuple[str, ...] = ()
 
     def __post_init__(self) -> None:
-        """Validate columns are non-empty and unique, and partitions exist and are unique."""
+        """
+        Validate the snapshot's structural invariants.
+
+        Columns must be non-empty and unique; partition columns must be
+        lowercase, must each exist in ``columns``, and must be unique.
+        """
         if not self.columns:
             raise ValueError("Table requires at least one column")
 

--- a/src/delta_engine/schema/__init__.py
+++ b/src/delta_engine/schema/__init__.py
@@ -12,6 +12,7 @@ from delta_engine.domain.model import (
     String,
     Timestamp,
 )
+from delta_engine.schema.properties import Property
 from delta_engine.schema.table import DeltaTable
 
 __all__ = [
@@ -26,6 +27,7 @@ __all__ = [
     "Integer",
     "Long",
     "Map",
+    "Property",
     "String",
     "Timestamp",
 ]

--- a/src/delta_engine/schema/table.py
+++ b/src/delta_engine/schema/table.py
@@ -26,8 +26,6 @@ class DeltaTable:
         }
     )
 
-    _managed_property_keys: ClassVar[frozenset[str]] = MANAGED_PROPERTY_KEYS
-
     def __init__(
         self,
         catalog: str,
@@ -42,7 +40,7 @@ class DeltaTable:
 
         # Fast-fail on property keys this engine does not manage (e.g. typos)
         if user_properties:
-            unmanaged = [k for k in user_properties if k not in self._managed_property_keys]
+            unmanaged = [k for k in user_properties if k not in MANAGED_PROPERTY_KEYS]
             if unmanaged:
                 raise ValueError(
                     f"Properties not managed by this engine: {', '.join(sorted(unmanaged))}"

--- a/tests/adapters/databricks/sql/test_compile.py
+++ b/tests/adapters/databricks/sql/test_compile.py
@@ -141,6 +141,17 @@ def test_create_table_renders_partition_clause():
     assert statement.endswith("PARTITIONED BY (`ds`)")
 
 
+def test_add_column_rejects_non_nullable_column():
+    # Given an AddColumn carrying a NOT NULL column -- validation (NonNullableColumnAdd)
+    # blocks this before execution, so the compiler must never silently emit an
+    # ADD COLUMN that drops the NOT NULL constraint
+    action = AddColumn(Column("age", Integer(), nullable=False))
+
+    # Then compiling it fails loudly rather than producing nullable-by-stealth SQL
+    with pytest.raises(AssertionError, match="age"):
+        _compile_single(action)
+
+
 def test_drop_column_renders_alter_drop():
     # When compiling a DropColumn
     statement = _compile_single(DropColumn("legacy"))
@@ -221,19 +232,20 @@ def test_every_action_type_has_a_registered_compiler():
     assert unregistered == []
 
 
-def test_column_type_change_compiler_raises_not_implemented():
+def test_column_type_change_compiler_raises_on_invariant_violation():
     # Given a ColumnTypeChange action (blocked by validation; should never reach execution)
     action = ColumnTypeChange(column_name="id", from_type=Integer(), to_type=Long())
 
-    # Then compiling it raises NotImplementedError rather than silently producing bad SQL
-    with pytest.raises(NotImplementedError, match="id"):
+    # Then reaching the compiler is an internal-invariant violation, not an
+    # unimplemented feature -- it raises AssertionError rather than producing bad SQL
+    with pytest.raises(AssertionError, match="id"):
         _compile_single(action)
 
 
-def test_partitioning_change_compiler_raises_not_implemented():
+def test_partitioning_change_compiler_raises_on_invariant_violation():
     # Given a PartitioningChange action (blocked by validation; should never reach execution)
     action = PartitioningChange(desired_partitioning=("ds",), observed_partitioning=())
 
-    # Then compiling it raises NotImplementedError
-    with pytest.raises(NotImplementedError, match="Partitioning"):
+    # Then reaching the compiler is an internal-invariant violation -- AssertionError
+    with pytest.raises(AssertionError, match=r"[Pp]artitioning"):
         _compile_single(action)

--- a/tests/adapters/databricks/sql/test_preview.py
+++ b/tests/adapters/databricks/sql/test_preview.py
@@ -6,7 +6,7 @@ import pytest
 
 from delta_engine.adapters.databricks.sql.preview import (
     error_preview,
-    exc_type_name,
+    exception_type_name,
     sql_preview,
 )
 
@@ -69,7 +69,7 @@ def test_error_preview_short_message_unchanged() -> None:
     assert error_preview(exc) == "Only one line"
 
 
-def test_exc_type_name_reports_underlying_java_class_for_py4j_error() -> None:
+def test_exception_type_name_reports_underlying_java_class_for_py4j_error() -> None:
     # Given a Py4JJavaError whose java_exception reports a known Java class
     java_exception = SimpleNamespace(
         _target_id="o1",
@@ -78,16 +78,16 @@ def test_exc_type_name_reports_underlying_java_class_for_py4j_error() -> None:
     error = Py4JJavaError("boom", java_exception)
 
     # When naming the exception type
-    name = exc_type_name(error)
+    name = exception_type_name(error)
 
     # Then the underlying Java class is returned, not the py4j wrapper name
     assert name == "org.apache.spark.sql.AnalysisException"
 
 
-def test_exc_type_name_returns_python_class_for_plain_exception() -> None:
+def test_exception_type_name_returns_python_class_for_plain_exception() -> None:
     # Given a plain Python exception (no JVM origin)
     # Then the Python class name is used directly
-    assert exc_type_name(ValueError("nope")) == "ValueError"
+    assert exception_type_name(ValueError("nope")) == "ValueError"
 
 
 @given(st.text(), st.integers(min_value=1, max_value=500))

--- a/tests/adapters/databricks/test_reader.py
+++ b/tests/adapters/databricks/test_reader.py
@@ -2,13 +2,11 @@ from __future__ import annotations
 
 from types import SimpleNamespace
 
-from py4j.protocol import Py4JJavaError
 import pyspark.sql.types as T
 from pyspark.sql.utils import AnalysisException
 import pytest
 
 from delta_engine.adapters.databricks.reader import DatabricksReader
-from delta_engine.adapters.databricks.sql import exc_type_name
 from delta_engine.application.results import ReadFailed, TableAbsent, TablePresent
 from delta_engine.domain.model import QualifiedName
 
@@ -128,31 +126,6 @@ def make_catalog_col(
 @pytest.fixture
 def qn() -> QualifiedName:
     return QualifiedName("c", "s", "t")
-
-
-# ---------- tests: existence ----------
-
-
-def test_table_exists_returns_true_when_catalog_reports_present(qn):
-    # Given a catalog that reports the table as present
-    reader = DatabricksReader(FakeSpark(catalog=FakeCatalog(exists=True)))
-
-    # When we check whether the table exists
-    result = reader._table_exists(qn)
-
-    # Then the table is reported as existing
-    assert result is True
-
-
-def test_table_exists_returns_false_when_catalog_reports_absent(qn):
-    # Given a catalog that reports the table as absent
-    reader = DatabricksReader(FakeSpark(catalog=FakeCatalog(exists=False)))
-
-    # When we check whether the table exists
-    result = reader._table_exists(qn)
-
-    # Then the table is reported as missing
-    assert result is False
 
 
 # ---------- tests: columns & partitions ----------
@@ -442,37 +415,3 @@ def test_fetch_state_lowercases_mixed_case_column_names_from_catalog():
     assert isinstance(result, TablePresent)
     assert [c.name for c in result.table.columns] == ["eventid", "username"]
     assert result.table.partitioned_by == ("username",)
-
-
-def _py4j_java_error(java_class_name: str) -> Py4JJavaError:
-    """
-    Build a Py4JJavaError whose underlying Java exception reports the given class.
-
-    ``_target_id`` is the only attribute Py4JJavaError.__init__ touches; the
-    ``getClass().getName()`` chain is what ``_exc_type_name`` reads. (Its
-    ``__str__`` would need a live JVM gateway, so the error is never stringified
-    here -- _exc_type_name only inspects the class.)
-    """
-    java_exception = SimpleNamespace(
-        _target_id="o123",
-        getClass=lambda: SimpleNamespace(getName=lambda: java_class_name),
-    )
-    return Py4JJavaError("boom", java_exception)
-
-
-def test_exc_type_name_reports_the_underlying_java_class_for_a_py4j_error():
-    # Given a Py4JJavaError -- the primary failure shape on real Databricks, where
-    # JVM exceptions surface through py4j wrapping the real Spark exception
-    error = _py4j_java_error("org.apache.spark.sql.AnalysisException")
-
-    # When naming the exception type at the adapter boundary
-    name = exc_type_name(error)
-
-    # Then the underlying Java class is reported, not the "Py4JJavaError" wrapper
-    assert name == "org.apache.spark.sql.AnalysisException"
-
-
-def test_exc_type_name_falls_back_to_python_class_for_a_plain_exception():
-    # Given a plain Python exception (no JVM origin)
-    # Then the Python class name is used
-    assert exc_type_name(ValueError("nope")) == "ValueError"

--- a/tests/application/test_results.py
+++ b/tests/application/test_results.py
@@ -18,14 +18,18 @@ from delta_engine.application.results import (
     ValidationFailure,
     ValidationResult,
 )
-from delta_engine.domain.model import QualifiedName
+from delta_engine.domain.model import Column, Integer, ObservedTable, QualifiedName
 
-# ---------- test fakes / builders
+# ---------- test builders
 
 
-class _FakeObservedTable:
-    def __init__(self, partitioned_by=()):
-        self.partitioned_by = partitioned_by
+def _an_observed_table(partitioned_by=()):
+    """Build a real ObservedTable, so reports are exercised against the domain type."""
+    return ObservedTable(
+        qualified_name=QualifiedName("cat", "schema", "observed"),
+        columns=(Column("id", Integer()),),
+        partitioned_by=partitioned_by,
+    )
 
 
 def _t0():
@@ -58,7 +62,7 @@ def _failed_exec(
 
 def test_present_state_holds_the_observed_table():
     # Given a table that was read and exists
-    observed = _FakeObservedTable()
+    observed = _an_observed_table()
 
     # When recording its catalog state
     state = TablePresent(table=observed)
@@ -186,7 +190,7 @@ def test_execution_outcome_variants_carry_the_right_payload():
 
 def test_table_status_success_when_all_actions_succeed():
     # Given successful read, no validation failures, and only successful actions
-    read = TablePresent(table=_FakeObservedTable())
+    read = TablePresent(table=_an_observed_table())
     validation = ValidationResult()
     execution = ExecutionSummary((_ok_exec(0), _ok_exec(1)))
 
@@ -212,7 +216,7 @@ def test_sync_report_any_failures_true_if_any_table_has_failures():
         qualified_name=QualifiedName("cat", "s", "a"),
         started_at=_t0(),
         ended_at=_t1(),
-        read=TablePresent(table=_FakeObservedTable()),
+        read=TablePresent(table=_an_observed_table()),
         validation=ValidationResult(),
         execution=ExecutionSummary((_ok_exec(0),)),
     )
@@ -220,7 +224,7 @@ def test_sync_report_any_failures_true_if_any_table_has_failures():
         qualified_name=QualifiedName("cat", "s", "b"),
         started_at=_t0(),
         ended_at=_t1(),
-        read=TablePresent(table=_FakeObservedTable()),
+        read=TablePresent(table=_an_observed_table()),
         validation=ValidationResult(),
         execution=ExecutionSummary((_failed_exec(0),)),
     )
@@ -279,7 +283,7 @@ def test_sync_report_failures_by_table_maps_only_failed_tables():
         qualified_name=ok_name,
         started_at=_t0(),
         ended_at=_t1(),
-        read=TablePresent(table=_FakeObservedTable()),
+        read=TablePresent(table=_an_observed_table()),
         validation=ValidationResult(),
         execution=ExecutionSummary((_ok_exec(0),)),
     )

--- a/tests/application/test_validation.py
+++ b/tests/application/test_validation.py
@@ -50,7 +50,9 @@ def test_rejects_all_non_nullable_column_adds_in_a_single_pass():
     # Then all three violations are reported in one pass, not just the first
     assert len(failures) == 3
     assert {f.rule_name for f in failures} == {"NonNullableColumnAdd"}
-    assert {"a", "b", "c"} == {f.message.split("'")[1] for f in failures}
+    messages = [f.message for f in failures]
+    for column_name in ("a", "b", "c"):
+        assert any(column_name in message for message in messages)
 
 
 def test_allows_add_of_nullable_column():
@@ -94,7 +96,9 @@ def test_rejects_all_nullability_tightenings_in_a_single_pass():
 
     # Then both violations are reported in one pass
     assert len(failures) == 2
-    assert {"id", "name"} == {f.message.split("'")[1] for f in failures}
+    messages = [f.message for f in failures]
+    for column_name in ("id", "name"):
+        assert any(column_name in message for message in messages)
 
 
 def test_allows_loosening_an_existing_column_to_nullable():
@@ -132,7 +136,9 @@ def test_rejects_all_type_changes_in_a_single_pass():
     )
     assert len(failures) == 2
     assert {f.rule_name for f in failures} == {"UnsupportedColumnTypeChange"}
-    assert {"id", "score"} == {f.message.split("'")[1] for f in failures}
+    messages = [f.message for f in failures]
+    for column_name in ("id", "score"):
+        assert any(column_name in message for message in messages)
 
 
 def test_allows_plan_with_no_type_changes():

--- a/tests/schema/test_public_api.py
+++ b/tests/schema/test_public_api.py
@@ -2,6 +2,7 @@
 
 from delta_engine.domain.model import Array, Decimal, Map
 import delta_engine.schema as schema
+from delta_engine.schema.properties import Property as PropertyImpl
 from delta_engine.schema.table import DeltaTable as DeltaTableImpl
 
 _EXPECTED = {
@@ -16,6 +17,7 @@ _EXPECTED = {
     "Integer",
     "Long",
     "Map",
+    "Property",
     "String",
     "Timestamp",
 }
@@ -38,3 +40,16 @@ def test_schema_exposes_delta_table_column_and_all_data_types():
     assert schema.Decimal is Decimal
     assert schema.Array is Array
     assert schema.Map is Map
+    assert schema.Property is PropertyImpl
+
+
+def test_property_enum_lists_the_keys_deltatable_accepts():
+    # Given the property vocabulary a user must declare against
+    # Then the keys DeltaTable validates against are discoverable via the public
+    # Property enum, rather than only surfacing as a runtime rejection
+    from delta_engine.schema.properties import MANAGED_PROPERTY_KEYS
+
+    assert {member.value for member in schema.Property} == set(MANAGED_PROPERTY_KEYS)
+
+    # And Property is a str enum, so its members can be used directly as dict keys
+    assert schema.Property.COLUMN_MAPPING_MODE == "delta.columnMapping.mode"

--- a/tests/schema/test_table.py
+++ b/tests/schema/test_table.py
@@ -86,6 +86,26 @@ def test_accepts_only_enum_property_keys():
     assert table.effective_properties[Property.COLUMN_MAPPING_MODE.value] == "name"
 
 
+def test_accepts_property_enum_members_as_keys():
+    # Given properties keyed by the Property enum members directly (not their .value)
+    user_properties = {Property.ENABLE_DELETION_VECTORS: "false"}
+
+    # When constructing the table
+    table = DeltaTable(
+        catalog="coredev",
+        schema="medallia",
+        name="responses",
+        columns=[Column("id", Integer())],
+        properties=user_properties,
+    )
+
+    # Then the enum key is accepted and resolves to the same managed property as
+    # its string value, so callers can declare properties without reaching for .value
+    desired = table.to_desired_table()
+    assert desired.properties[Property.ENABLE_DELETION_VECTORS.value] == "false"
+    assert desired.properties[Property.COLUMN_MAPPING_MODE.value] == "name"
+
+
 def test_partition_columns_must_exist():
     # Given columns include 'event_date' and the partition spec references it
     table = DeltaTable(

--- a/tests/test_public_api.py
+++ b/tests/test_public_api.py
@@ -27,6 +27,7 @@ _EAGER = {
     "Integer",
     "Long",
     "Map",
+    "Property",
     "String",
     "Timestamp",
     # application: run a sync and read the outcome
@@ -42,14 +43,19 @@ _LAZY = {"build_databricks_engine", "configure_logging"}
 def test_eager_names_are_importable_and_identical_to_their_source():
     # Given the curated root namespace
     # Then every pyspark-free name resolves to the same object as its source module
-    from delta_engine import Column, DeltaTable, Engine, Registry
+    from delta_engine import Column, DeltaTable, Engine, Property, Registry
     from delta_engine.application import Engine as EngineImpl, Registry as RegistryImpl
-    from delta_engine.schema import Column as ColumnImpl, DeltaTable as DeltaTableImpl
+    from delta_engine.schema import (
+        Column as ColumnImpl,
+        DeltaTable as DeltaTableImpl,
+        Property as PropertyImpl,
+    )
 
     assert DeltaTable is DeltaTableImpl
     assert Column is ColumnImpl
     assert Engine is EngineImpl
     assert Registry is RegistryImpl
+    assert Property is PropertyImpl
 
 
 def test_lazy_factory_names_resolve_to_their_source():
@@ -84,7 +90,7 @@ def test_eager_surface_imports_without_pyspark_installed():
     program = (
         "import sys; sys.modules['pyspark'] = None\n"
         "from delta_engine import (\n"
-        "    DeltaTable, Column, Integer, Registry, Engine,\n"
+        "    DeltaTable, Column, Integer, Property, Registry, Engine,\n"
         "    SyncReport, SyncFailedError, Failure,\n"
         ")\n"
         "print('ok')\n"


### PR DESCRIPTION
DeltaTable accepts a dict[str, str] of properties but silently enforces a closed vocabulary (MANAGED_PROPERTY_KEYS), rejecting unknown keys at construction. The Property StrEnum that defines those keys was not importable from any public surface, so callers had to guess the string, read internal source, or hit the runtime error -- an unknown unknown (APoSD).

Export Property from delta_engine.schema and the top-level delta_engine namespace (eager: Property is pyspark-free). Enum members already work as property keys at runtime since Property subclasses str; a new test locks that in. Records the change and the rejected annotation tweak in the review doc.