### PR TITLE
refactor: apply Priority 2 APoSD quick wins

### DIFF
--- a/docs/design-review.md
+++ b/docs/design-review.md
@@ -1,0 +1,149 @@
+# Design Review
+
+A deep review of delta-engine against John Ousterhout's *A Philosophy of Software Design* (APoSD), conducted 2026-06-25 against commit `25bacd0`.
+
+## Verdict
+
+delta-engine is a strong example of the philosophy it set out to follow. The domain layer is pure and Spark-free. Ports are narrow. `compute_plan` and `validate_plan` are deep functions: a simple signature over real logic. The `ExecutionSucceeded | ExecutionFailed` union makes "succeeded but carries a failure" unrepresentable — defining errors out of existence, done right.
+
+The findings below are refinements, not rework. Two are correctness hazards worth acting on. The rest are mechanical cleanups and documentation balance. The architecture should stay as it is.
+
+Method: nine reviewers each applied a distinct APoSD lens. Every finding was then re-checked against the source by a separate pass. Of roughly 78 raised findings, 49 survived; 29 were rejected as taste, documented intent, or worse-if-changed.
+
+## Priority 1 — Correctness hazards
+
+### One unmappable column type makes the whole table unmanageable
+
+`DatabricksReader._read` wraps the entire read in a single `try/except` ([reader.py:83](../src/delta_engine/adapters/databricks/reader.py#L83)). `domain_type_from_spark` raises `TypeError` for any type outside its match arms ([types.py:109](../src/delta_engine/adapters/databricks/sql/types.py#L109)). A single `STRUCT`, `TimestampNTZType`, `BinaryType`, or `VariantType` column therefore turns the table into `ReadFailed`. The engine then cannot manage any other column or any property on that table.
+
+These types are common in PySpark 4.0 production tables. A table with one nested column and ten simple ones the user wants to manage becomes wholly unmanageable.
+
+**Fix:** Catch `TypeError` per column in `_to_column_mapping` and skip the unmappable column instead of failing the table. Log a warning naming the column and its Spark type. This matches the existing "properties are a declared subset" design: manage what you understand, ignore the rest. Document the supported type set in the README. Do not add an `Unsupported` sentinel to the domain — that would pollute the pure layer.
+
+### Properties may never reach a no-op on adopted tables
+
+`DeltaTable.default_properties` injects `delta.enableDeletionVectors=true` and `delta.columnMapping.mode=name` into every desired state ([table.py:22](../src/delta_engine/schema/table.py#L22)). `_fetch_properties` reads the `properties` column of `DESCRIBE DETAIL` ([reader.py:126](../src/delta_engine/adapters/databricks/reader.py#L126)). If a `delta.*` key is enabled by a workspace or catalog default but absent from the table's own `TBLPROPERTIES`, `_diff_properties` sees a mismatch and emits `SetProperty` on every sync. The table never reaches a true no-op.
+
+Tables created by the engine are safe — it always sets these properties at creation. The risk applies to pre-existing tables adopted into management.
+
+**Status:** Unconfirmed. Local verification was blocked by an environment issue: the dev machine cannot resolve Delta jars from Maven (SSL trust), and the installed pyspark (4.1.1) mismatches the cached Delta build (4.2.0 for Spark 4.0). The Delta docs describe the field only as "all the properties set for this table." Confirm against a real Databricks Unity Catalog cluster.
+
+**Fix, regardless of the runtime answer:** Strengthen the idempotency test (see Priority 3). The current test cannot catch this because `SET TBLPROPERTIES` is idempotent at the DDL level, so the schema stays equal even when properties are re-set every run.
+
+## Priority 2 — Quick wins
+
+Low-risk, behaviour-preserving, high-clarity.
+
+### `assert` is disabled under `python -O`
+
+The `AddColumn` compiler guards a contract with `assert action.column.nullable` ([compile.py:79](../src/delta_engine/adapters/databricks/sql/compile.py#L79)). Python strips `assert` under the `-O` flag. If validation is bypassed and the flag is set, a `NOT NULL` column compiles to a plain `ADD COLUMN` — the constraint is dropped, the column is created nullable, and execution reports success. The same file uses `raise AssertionError(...)` for the same purpose 45 lines later ([compile.py:126](../src/delta_engine/adapters/databricks/sql/compile.py#L126)), so the guard is also inconsistent.
+
+**Fix:** Replace the `assert` with `if not action.column.nullable: raise AssertionError(...)` to match lines 126 and 136.
+
+### Clearing a comment writes an empty string, not NULL
+
+The `SetColumnComment` compiler always emits `COMMENT '...'`, even when the comment is empty ([compile.py:103](../src/delta_engine/adapters/databricks/sql/compile.py#L103)). `_column_definition` guards the same fragment with `if column.comment` ([compile.py:151](../src/delta_engine/adapters/databricks/sql/compile.py#L151)). The two paths handle the empty-string sentinel differently. Clearing a comment stores a literal `''` in the catalog rather than removing it.
+
+**Fix:** When the comment is empty, emit `ALTER COLUMN ... UNSET COMMENT` instead of `COMMENT ''`. This makes all compiler paths consistent.
+
+### `statement_preview` is stored twice
+
+`ExecutionFailed` carries `statement_preview`, and its nested `ExecutionFailure` carries the same value ([results.py:131-147](../src/delta_engine/application/results.py#L131)). The executor passes the same string to both constructors ([executor.py:88](../src/delta_engine/adapters/databricks/executor.py#L88)). Production code never reads `ExecutionFailed.statement_preview` independently — every consumer reaches it through `result.failure`.
+
+**Fix:** Remove `statement_preview` from `ExecutionFailed`. Read it via `result.failure.statement_preview`. This drops a duplicated field that two call sites must keep in sync.
+
+### Two test-only seams sit in production signatures
+
+`DatabricksExecutor.__init__` accepts a `compiler` parameter ([executor.py:37](../src/delta_engine/adapters/databricks/executor.py#L37)). `_to_column_mapping` accepts a `type_mapper` parameter ([reader.py:33](../src/delta_engine/adapters/databricks/reader.py#L33)). Both exist for test injection. No production code overrides either default. No test even injects `type_mapper`. APoSD's guidance: make the real code testable rather than widen the boundary for tests.
+
+**Fix:** Remove `type_mapper` outright; the unsupported-type path is already covered with `BinaryType` against the real mapper. Extract the executor's stop-on-first-failure loop into a module-private function the tests call directly, then drop the `compiler` parameter.
+
+### Type-hint gaps
+
+Type hints on all signatures are a project standard. These are missing them:
+
+| Location | Gap |
+| --- | --- |
+| [executor.py:69](../src/delta_engine/adapters/databricks/executor.py#L69) | `action` parameter on `_run_statement` |
+| [compile.py:146](../src/delta_engine/adapters/databricks/sql/compile.py#L146) | `column` parameter on `_column_definition` |
+| [engine.py:35](../src/delta_engine/application/engine.py#L35) | return type on `_utc_now` |
+| [actions.py:238](../src/delta_engine/domain/plan/actions.py#L238) | `ActionPlan.__iter__` / `__getitem__` |
+| [registry.py:61](../src/delta_engine/application/registry.py#L61) | `Registry.__iter__` / `__len__` |
+| [reader.py:33](../src/delta_engine/adapters/databricks/reader.py#L33) | `type_mapper` parameter (removed by the fix above) |
+| [\_\_init\_\_.py:74](../src/delta_engine/__init__.py#L74) | return type on `__getattr__` |
+
+`mypy` passes today but does not flag these.
+
+### `ActionPlan.__getitem__` is dead interface
+
+`ActionPlan.__getitem__` supports indexing and slicing ([actions.py:242](../src/delta_engine/domain/plan/actions.py#L242)). No caller in `src/` or `tests/` uses it. Tests inspect `plan.actions` directly. A narrow interface is a virtue; every unused member is complexity to carry.
+
+**Fix:** Remove it. Re-add with proper type hints if indexed access is ever needed.
+
+## Priority 3 — Tests
+
+### Idempotency test cannot prove a no-op
+
+`test_engine_idempotent_when_already_in_desired_state` syncs twice and asserts the schemas match ([test_engine_e2e.py:168](../tests/e2e/test_engine_e2e.py#L168)). It does not assert that the second sync planned zero actions. `SET TBLPROPERTIES` is idempotent at the DDL level, so the schema stays equal even if the differ re-emits property actions every run. The test cannot catch the Priority 1 property hazard.
+
+**Fix:** Capture the second `SyncReport` and assert a true no-op:
+
+```python
+second_report = engine.sync(reg)
+assert all(len(t.execution.results) == 0 for t in second_report)
+```
+
+### E2E tests patch a private method of the class under test
+
+Every e2e test calls `_patch_table_exists_for_local`, which monkey-patches `DatabricksReader._table_exists` ([test_engine_e2e.py:15](../tests/e2e/test_engine_e2e.py#L15)). This couples the suite to a private implementation detail and changes the method's semantics (three-part name versus two-part). The e2e tests no longer exercise the real existence-check path. It also breaks the project's own rule against mocking internal collaborators.
+
+**Fix:** Check whether `spark.catalog.tableExists("spark_catalog.schema.table")` resolves under the local DeltaCatalog. If it does, delete the patch. If three-part resolution genuinely fails locally, fix it at the data level in the fixture rather than patching the adapter.
+
+### Read-failure isolation is under-tested
+
+`test_engine_reads_all_tables_then_raises_on_any_read_failure` checks that both tables appear in the report when one read fails ([test_engine.py:177](../tests/application/test_engine.py#L177)). It does not assert that the surviving table was executed. `TableRunStatus.SUCCESS` is consistent with an empty, never-run `ExecutionSummary`, so the status check alone does not prove the engine honoured "failures in individual tables do not halt the sync of others."
+
+**Fix:** Assert `tr_b.execution.results != ()` for the surviving table.
+
+## Decisions to weigh, not fix
+
+These are judgement calls. The current design is defensible.
+
+### Unsupported-change actions flow through the executable pipeline
+
+`ColumnTypeChange` and `PartitioningChange` are `Action` subclasses that can never execute ([actions.py:163](../src/delta_engine/domain/plan/actions.py#L163), [actions.py:186](../src/delta_engine/domain/plan/actions.py#L186)). They occupy `ActionPhase` slots, need compiler handlers that only raise, and need validation rules to intercept them. This overloads "action" to also mean "detected drift."
+
+The docstrings document the intent clearly, which is why the finding survived only as a decision rather than a fix. The APoSD-purist alternative: have `compute_plan` return `(ActionPlan, tuple[DriftConflict, ...])`, where `DriftConflict` is not an `Action`. That removes two enum members, two raising compiler handlers, and simplifies the mental model. It is also a real change.
+
+**Recommendation:** Leave it. Revisit if a third unsupported-change category appears.
+
+### `CREATE TABLE IF NOT EXISTS` after an absence check
+
+The reader reports `TableAbsent`, the differ emits `CreateTable`, and the compiler renders `CREATE TABLE IF NOT EXISTS` ([compile.py:57](../src/delta_engine/adapters/databricks/sql/compile.py#L57)). If another process creates the table between read and execution, the clause silently no-ops and the run reports success despite a possibly divergent schema. Either choice — keep `IF NOT EXISTS` for resilience, or use plain `CREATE TABLE` to fail loud — is reasonable. The gap is that the behaviour is undocumented.
+
+**Recommendation:** Add a comment in the compiler stating the intent, and a note in the README's non-goals section.
+
+## Comments and documentation
+
+The codebase has excellent comments where they matter. The `zip(strict=True)` comment captures the cross-module one-statement-per-action contract ([executor.py:57](../src/delta_engine/adapters/databricks/executor.py#L57)). The `_fetch_properties` comment explains why two quoting paths must stay separate ([reader.py:122](../src/delta_engine/adapters/databricks/reader.py#L122)). The `ActionPhase` docstring explains the ordering invariant, not just the enum.
+
+Two adjustments:
+
+- **Trim restate-the-code docstrings.** The `D` (pydocstyle) ruleset forces low-value docstrings: nine near-identical `subject()` docstrings, trivial `__len__`/`__bool__`/`__iter__` docstrings, and `format_lines` docstrings that name the method. APoSD treats these as noise.
+- **Thicken the port docstrings.** `CatalogStateReader` and `PlanExecutor` are the extension points every future adapter implements ([ports.py:13](../src/delta_engine/application/ports.py#L13)). The totality contract — "always returns a `CatalogState`, never raises" — currently lives on the concrete `DatabricksReader`. Lift it to the Protocol.
+
+## Summary
+
+| Priority | Item | Action |
+| --- | --- | --- |
+| 1 | Unmappable column fails whole table | Skip column, log, document |
+| 1 | Property idempotency on adopted tables | Verify on UC; strengthen test |
+| 2 | `assert` disabled under `-O` | Use `raise AssertionError` |
+| 2 | Comment cleared as `''` not NULL | Emit `UNSET COMMENT` |
+| 2 | `statement_preview` duplicated | Drop from `ExecutionFailed` |
+| 2 | Test-only seams in production | Remove `type_mapper`; extract loop |
+| 2 | Missing type hints | Add them |
+| 2 | Dead `__getitem__` | Remove |
+| 3 | Idempotency test | Assert empty second plan |
+| 3 | E2E patches private method | Remove patch |
+| 3 | Read-failure isolation | Assert survivor executed |

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -2,6 +2,7 @@ site_name: delta-engine
 nav:
   - Home: index.md
   - Architecture: architecture.md
+  - Design Review: design-review.md
 
 markdown_extensions:
   - admonition

--- a/src/delta_engine/__init__.py
+++ b/src/delta_engine/__init__.py
@@ -71,7 +71,7 @@ __all__ = [
 ]
 
 
-def __getattr__(name: str):
+def __getattr__(name: str) -> object:
     """Resolve the pyspark-bound exports on first access (PEP 562)."""
     if name in _LAZY_EXPORTS:
         from delta_engine.adapters import databricks

--- a/src/delta_engine/adapters/databricks/executor.py
+++ b/src/delta_engine/adapters/databricks/executor.py
@@ -7,7 +7,7 @@ returns `ExecutionResult` entries including SQL previews and failure details.
 
 from __future__ import annotations
 
-from collections.abc import Callable, Iterable
+from collections.abc import Iterable
 import logging
 
 from pyspark.sql import SparkSession
@@ -26,7 +26,7 @@ from delta_engine.application.results import (
     ExecutionSummary,
 )
 from delta_engine.domain.model import QualifiedName
-from delta_engine.domain.plan.actions import ActionPlan
+from delta_engine.domain.plan.actions import Action, ActionPlan
 
 logger = logging.getLogger(__name__)
 
@@ -34,13 +34,9 @@ logger = logging.getLogger(__name__)
 class DatabricksExecutor:
     """Plan executor that runs compiled statements via a Spark session."""
 
-    def __init__(
-        self,
-        spark: SparkSession,
-        compiler: Callable[[QualifiedName, ActionPlan], Iterable[str]] = compile_plan,
-    ) -> None:
+    def __init__(self, spark: SparkSession) -> None:
+        """Initialize the executor with the Spark session it runs statements on."""
         self.spark = spark
-        self._compiler = compiler
 
     def execute(self, qualified_name: QualifiedName, plan: ActionPlan) -> ExecutionSummary:
         """
@@ -52,54 +48,69 @@ class DatabricksExecutor:
         attempted, ending at the one that failed; actions after it are left
         unattempted rather than run against an inconsistent table.
         """
-        statements = self._compiler(qualified_name, plan)
-        results: list[ExecutionResult] = []
-        # The compiler emits exactly one statement per action, in plan order, so
-        # zip pairs each action with its statement directly -- no positional index
-        # into the plan to keep in step with the loop counter. strict=True turns a
-        # compiler/plan length mismatch into a loud error rather than a silent
-        # truncation.
-        for action_index, (action, statement) in enumerate(zip(plan, statements, strict=True)):
-            result = self._run_statement(action, action_index, statement)
-            results.append(result)
-            if isinstance(result, ExecutionFailed):
-                break
-        return ExecutionSummary(tuple(results))
+        statements = compile_plan(qualified_name, plan)
+        return _execute_statements(self.spark, plan, statements)
 
-    def _run_statement(self, action, action_index: int, statement: str) -> ExecutionResult:
-        """
-        Run a single compiled statement and map its outcome to an `ExecutionResult`.
 
-        The broad ``except`` is intentional and mirrors the reader's ``fetch_state``:
-        Spark raises a heterogeneous set of failures (``Py4JJavaError``,
-        ``AnalysisException``, and plain Python errors) that varies across runtime
-        environments. The executor's contract is to wrap any failure in an
-        ``ExecutionFailed`` so the run can record it and stop cleanly, never to let
-        a backend-specific exception escape. Narrowing the catch would reintroduce
-        silent propagation of whichever type was missed.
-        """
-        action_name = type(action).__name__
-        preview = sql_preview(statement)
-        try:
-            self.spark.sql(statement)
-        except Exception as exception:
-            err = error_preview(exception)
-            logger.warning("%s failed: %s\nSQL: %s", action_name, err, preview)
-            return ExecutionFailed(
-                action=action_name,
-                action_index=action_index,
-                statement_preview=preview,
-                failure=ExecutionFailure(
-                    action_index=action_index,
-                    exception_type=exception_type_name(exception),
-                    message=err,
-                    statement_preview=preview,
-                ),
-            )
+def _execute_statements(
+    spark: SparkSession, plan: ActionPlan, statements: Iterable[str]
+) -> ExecutionSummary:
+    """
+    Run each compiled statement in plan order, stopping at the first failure.
 
-        logger.info("Executed: %s", action_name)
-        return ExecutionSucceeded(
+    Holds the stop-on-first-failure loop as a free function so it is testable
+    without a Spark session: a unit test passes a fake ``spark`` and a pre-canned
+    ``statements`` list, with no need to inject a compiler.
+
+    The compiler emits exactly one statement per action, in plan order, so zip
+    pairs each action with its statement directly -- no positional index into the
+    plan to keep in step with the loop counter. strict=True turns a compiler/plan
+    length mismatch into a loud error rather than a silent truncation.
+    """
+    results: list[ExecutionResult] = []
+    for action_index, (action, statement) in enumerate(zip(plan, statements, strict=True)):
+        result = _run_statement(spark, action, action_index, statement)
+        results.append(result)
+        if isinstance(result, ExecutionFailed):
+            break
+    return ExecutionSummary(tuple(results))
+
+
+def _run_statement(
+    spark: SparkSession, action: Action, action_index: int, statement: str
+) -> ExecutionResult:
+    """
+    Run a single compiled statement and map its outcome to an `ExecutionResult`.
+
+    The broad ``except`` is intentional and mirrors the reader's ``fetch_state``:
+    Spark raises a heterogeneous set of failures (``Py4JJavaError``,
+    ``AnalysisException``, and plain Python errors) that varies across runtime
+    environments. The executor's contract is to wrap any failure in an
+    ``ExecutionFailed`` so the run can record it and stop cleanly, never to let
+    a backend-specific exception escape. Narrowing the catch would reintroduce
+    silent propagation of whichever type was missed.
+    """
+    action_name = type(action).__name__
+    preview = sql_preview(statement)
+    try:
+        spark.sql(statement)
+    except Exception as exception:
+        error_message = error_preview(exception)
+        logger.warning("%s failed: %s\nSQL: %s", action_name, error_message, preview)
+        return ExecutionFailed(
             action=action_name,
             action_index=action_index,
-            statement_preview=preview,
+            failure=ExecutionFailure(
+                action_index=action_index,
+                exception_type=exception_type_name(exception),
+                message=error_message,
+                statement_preview=preview,
+            ),
         )
+
+    logger.info("Executed: %s", action_name)
+    return ExecutionSucceeded(
+        action=action_name,
+        action_index=action_index,
+        statement_preview=preview,
+    )

--- a/src/delta_engine/adapters/databricks/reader.py
+++ b/src/delta_engine/adapters/databricks/reader.py
@@ -30,9 +30,7 @@ class _ColumnMapping:
     is_partition: bool
 
 
-def _to_column_mapping(
-    spark_column: SparkColumn, type_mapper=domain_type_from_spark
-) -> _ColumnMapping:
+def _to_column_mapping(spark_column: SparkColumn) -> _ColumnMapping:
     """
     Convert a Spark catalog column into a domain ``Column`` and its partition flag.
 
@@ -43,7 +41,7 @@ def _to_column_mapping(
     therefore derived from the already-normalised domain column name, not from
     the raw Spark object.
     """
-    domain_data_type = type_mapper(spark_column.dataType)
+    domain_data_type = domain_type_from_spark(spark_column.dataType)
     nullable = bool(getattr(spark_column, "nullable", True))
     comment = spark_column.description if spark_column.description else ""
 

--- a/src/delta_engine/adapters/databricks/sql/compile.py
+++ b/src/delta_engine/adapters/databricks/sql/compile.py
@@ -107,7 +107,8 @@ def _(action: SetColumnComment, backticked_table_name: str) -> str:
     column_name = backtick(action.column_name)
     if not action.comment:
         return f"ALTER TABLE {backticked_table_name} ALTER COLUMN {column_name} UNSET COMMENT"
-    return f"ALTER TABLE {backticked_table_name} ALTER COLUMN {column_name} COMMENT {quote_literal(action.comment)}"
+    comment = quote_literal(action.comment)
+    return f"ALTER TABLE {backticked_table_name} ALTER COLUMN {column_name} COMMENT {comment}"
 
 
 @_compile_action.register

--- a/src/delta_engine/adapters/databricks/sql/compile.py
+++ b/src/delta_engine/adapters/databricks/sql/compile.py
@@ -16,7 +16,7 @@ from delta_engine.adapters.databricks.sql.dialect import (
     quote_literal,
 )
 from delta_engine.adapters.databricks.sql.types import sql_type_for_data_type
-from delta_engine.domain.model import QualifiedName
+from delta_engine.domain.model import Column, QualifiedName
 from delta_engine.domain.plan.actions import (
     Action,
     ActionPlan,
@@ -72,14 +72,17 @@ def _(action: AddColumn, backticked_table_name: str) -> str:
     The column is always added without a NOT NULL constraint: adding a
     non-nullable column to an existing table is rejected at validation
     (see NonNullableColumnAdd), so this path is only reached for nullable adds.
-    The assert makes that contract loud -- it fires only if validation was
+    The guard makes that contract loud -- it fires only if validation was
     bypassed or a custom rule set let a NOT NULL add through, rather than
-    silently emitting an add that drops the constraint.
+    silently emitting an add that drops the constraint. It is an unconditional
+    ``raise`` (not ``assert``) so the invariant survives ``python -O``, matching
+    the ColumnTypeChange/PartitioningChange guards below.
     """
-    assert action.column.nullable, (
-        f"AddColumn reached the compiler with non-nullable column {action.column.name!r}; "
-        "validation (NonNullableColumnAdd) should have blocked this"
-    )
+    if not action.column.nullable:
+        raise AssertionError(
+            f"AddColumn reached the compiler with non-nullable column {action.column.name!r}; "
+            "validation (NonNullableColumnAdd) should have blocked this"
+        )
     name = backtick(action.column.name)
     dtype = sql_type_for_data_type(action.column.data_type)
     comment = f" COMMENT {quote_literal(action.column.comment)}" if action.column.comment else ""
@@ -102,8 +105,9 @@ def _(action: SetProperty, backticked_table_name: str) -> str:
 @_compile_action.register
 def _(action: SetColumnComment, backticked_table_name: str) -> str:
     column_name = backtick(action.column_name)
-    comment = quote_literal(action.comment)
-    return f"ALTER TABLE {backticked_table_name} ALTER COLUMN {column_name} COMMENT {comment}"
+    if not action.comment:
+        return f"ALTER TABLE {backticked_table_name} ALTER COLUMN {column_name} UNSET COMMENT"
+    return f"ALTER TABLE {backticked_table_name} ALTER COLUMN {column_name} COMMENT {quote_literal(action.comment)}"
 
 
 @_compile_action.register
@@ -143,7 +147,7 @@ def _(action: PartitioningChange, backticked_table_name: str) -> str:
 # ----------- helpers ------------
 
 
-def _column_definition(column) -> str:
+def _column_definition(column: Column) -> str:
     """Render a single column definition fragment, including its comment."""
     column_name = backtick(column.name)
     sql_type = sql_type_for_data_type(column.data_type)

--- a/src/delta_engine/application/engine.py
+++ b/src/delta_engine/application/engine.py
@@ -32,7 +32,7 @@ from delta_engine.domain.plan.differ import compute_plan
 logger = logging.getLogger(__name__)
 
 
-def _utc_now():
+def _utc_now() -> datetime:
     """Return current UTC time as a timezone-aware datetime."""
     return datetime.now(UTC)
 

--- a/src/delta_engine/application/registry.py
+++ b/src/delta_engine/application/registry.py
@@ -6,6 +6,7 @@ duplicate names, and iterates in qualified-name order to produce deterministic
 planning input for the engine.
 """
 
+from collections.abc import Iterator
 from typing import Protocol, runtime_checkable
 
 from delta_engine.domain.model import DesiredTable, QualifiedName
@@ -58,10 +59,10 @@ class Registry:
 
         self._tables.update(new_tables)
 
-    def __iter__(self):
+    def __iter__(self) -> Iterator[DesiredTable]:
         """Iterate over desired tables in qualified-name order."""
         yield from (self._tables[name] for name in sorted(self._tables, key=str))
 
-    def __len__(self):
+    def __len__(self) -> int:
         """Return the number of registered tables."""
         return len(self._tables)

--- a/src/delta_engine/application/results.py
+++ b/src/delta_engine/application/results.py
@@ -142,7 +142,6 @@ class ExecutionFailed:
 
     action: str
     action_index: int
-    statement_preview: str
     failure: ExecutionFailure
 
 

--- a/src/delta_engine/domain/plan/actions.py
+++ b/src/delta_engine/domain/plan/actions.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
+from collections.abc import Iterator
 from dataclasses import dataclass
 from enum import IntEnum, auto
 from typing import ClassVar
@@ -235,10 +236,6 @@ class ActionPlan:
         """Return ``True`` if the plan contains any actions."""
         return bool(self.actions)
 
-    def __iter__(self):
+    def __iter__(self) -> Iterator[Action]:
         """Iterate over actions in plan order."""
         return iter(self.actions)
-
-    def __getitem__(self, index):
-        """Return the action at ``index`` (supports slicing)."""
-        return self.actions[index]

--- a/tests/adapters/databricks/sql/test_compile.py
+++ b/tests/adapters/databricks/sql/test_compile.py
@@ -194,6 +194,14 @@ def test_set_column_comment_escapes_single_quotes_end_to_end():
     assert statement == ("ALTER TABLE `cat`.`sch`.`tbl` ALTER COLUMN `id` COMMENT 'it''s the key'")
 
 
+def test_set_column_comment_emits_unset_when_comment_is_empty():
+    # Given a SetColumnComment with an empty comment (clearing the comment)
+    statement = _compile_single(SetColumnComment(column_name="id", comment=""))
+
+    # Then it emits UNSET COMMENT rather than COMMENT '' to avoid storing an empty string
+    assert statement == "ALTER TABLE `cat`.`sch`.`tbl` ALTER COLUMN `id` UNSET COMMENT"
+
+
 def test_set_table_comment_renders_comment_on_table():
     # When compiling a SetTableComment
     statement = _compile_single(SetTableComment(comment="core table"))

--- a/tests/adapters/databricks/test_executor.py
+++ b/tests/adapters/databricks/test_executor.py
@@ -1,6 +1,6 @@
 import pyspark.sql.types as T
 
-from delta_engine.adapters.databricks.executor import DatabricksExecutor
+from delta_engine.adapters.databricks.executor import DatabricksExecutor, _execute_statements
 from delta_engine.application.results import ExecutionFailed, ExecutionSucceeded
 from delta_engine.domain.model import Column, DesiredTable, QualifiedName
 from delta_engine.domain.model.data_type import Integer
@@ -57,16 +57,12 @@ class _FakeSpark:
 
 
 def test_execute_maps_success_and_failure_without_leakage():
-    # Given a 2-action plan whose statements run OK → FAIL
+    # Given a 2-action plan and the statements it compiles to (OK → FAIL)
     plan = ActionPlan(actions=(AddColumn(Column("a", Integer())), DropColumn("b")))
+    statements = ["SELECT 1", "SELECT * FROM __nope__"]
 
-    def _fake_compiler(_target, _plan):
-        return ["SELECT 1", "SELECT * FROM __nope__"]  # OK, then FAIL
-
-    # When we execute
-    summary = DatabricksExecutor(_FakeSpark(), compiler=_fake_compiler).execute(
-        _dummy_qualified_name(), plan
-    )
+    # When we execute the statements against the plan
+    summary = _execute_statements(_FakeSpark(), plan, statements)
 
     # Then the success and failure are mapped with correct metadata and no leakage
     results = summary.results
@@ -87,17 +83,14 @@ def test_execute_stops_at_first_failure_to_avoid_half_migrating():
             AddColumn(Column("c", Integer())),
         ),
     )
+    statements = [
+        "SELECT 1",  # OK
+        "SELECT * FROM __nope__",  # FAIL
+        "SELECT 2",  # must NOT run -- the plan stops at the failure
+    ]
 
-    def _fake_compiler(_target, _plan):
-        return [
-            "SELECT 1",  # OK
-            "SELECT * FROM __nope__",  # FAIL
-            "SELECT 2",  # must NOT run -- the plan stops at the failure
-        ]
-
-    # When we execute
-    executor = DatabricksExecutor(spark, compiler=_fake_compiler)
-    summary = executor.execute(_dummy_qualified_name(), plan)
+    # When we execute the statements against the plan
+    summary = _execute_statements(spark, plan, statements)
 
     # Then execution stops at the failure: the third statement never runs
     assert spark.executed == ["SELECT 1", "SELECT * FROM __nope__"]

--- a/tests/application/test_engine.py
+++ b/tests/application/test_engine.py
@@ -82,7 +82,6 @@ def _failed_exec(idx: int = 0, exc="AnalysisException", msg="boom") -> Execution
     return ExecutionFailed(
         action="X",
         action_index=idx,
-        statement_preview="-- bad sql",
         failure=ExecutionFailure(
             action_index=idx, exception_type=exc, message=msg, statement_preview="-- bad sql"
         ),

--- a/tests/application/test_errors.py
+++ b/tests/application/test_errors.py
@@ -108,7 +108,6 @@ def test_message_renders_execution_failure_detail_with_sql_preview():
     failed_result = ExecutionFailed(
         action="AddColumn",
         action_index=2,
-        statement_preview="ALTER TABLE cat.sch.tbl ADD COLUMN x INT",
         failure=ExecutionFailure(
             action_index=2,
             exception_type="SparkException",

--- a/tests/application/test_results.py
+++ b/tests/application/test_results.py
@@ -50,7 +50,6 @@ def _failed_exec(
     return ExecutionFailed(
         action=action,
         action_index=idx,
-        statement_preview=preview,
         failure=ExecutionFailure(
             action_index=idx, exception_type=exc, message=msg, statement_preview=preview
         ),
@@ -177,7 +176,6 @@ def test_execution_outcome_variants_carry_the_right_payload():
     failed = ExecutionFailed(
         action="AddColumn",
         action_index=1,
-        statement_preview="SQL",
         failure=ExecutionFailure(
             action_index=1, exception_type="E", message="m", statement_preview="SQL"
         ),
@@ -250,7 +248,6 @@ _EXECUTION_RESULT = st.one_of(
         ExecutionFailed,
         action=st.just("AddColumn"),
         action_index=st.integers(min_value=0, max_value=100),
-        statement_preview=st.just("ALTER TABLE ..."),
         failure=st.builds(
             ExecutionFailure,
             action_index=st.integers(min_value=0, max_value=100),


### PR DESCRIPTION
## Summary

Applies the Priority 2 (quick wins) items from the APoSD design review in `docs/design-review.md`. All changes are behaviour-preserving except the `UNSET COMMENT` fix, which corrects a semantic bug.

- **`assert` → `raise AssertionError`** in `AddColumn` compiler — invariant now survives `python -O`, consistent with the `ColumnTypeChange`/`PartitioningChange` guards
- **`UNSET COMMENT` on empty string** — `SetColumnComment` with `comment=""` now emits `ALTER COLUMN ... UNSET COMMENT` instead of `COMMENT ''`, matching how `_column_definition` handles the same case; new test added
- **Drop `statement_preview` from `ExecutionFailed`** — it duplicated `result.failure.statement_preview`; all consumers updated
- **Remove test-only seams** — `compiler` param removed from `DatabricksExecutor.__init__` (loop extracted to `_execute_statements` module-private function, tests call it directly); `type_mapper` param removed from `_to_column_mapping`
- **Missing type hints** — `_column_definition(column: Column)`, `ActionPlan.__iter__ -> Iterator[Action]`, `Registry.__iter__/__len__`, `_utc_now -> datetime`, `__getattr__ -> object`
- **Dead `ActionPlan.__getitem__`** — removed; no caller in src or tests

## Test plan

- [ ] `uv run pytest tests/ --ignore=tests/e2e --ignore=tests/adapters/databricks/sql/test_types.py` — 181 passed (the ignored tests require Delta JARs which cannot resolve locally due to SSL; this is a pre-existing env issue documented in the design review)
- [ ] New `test_set_column_comment_emits_unset_when_comment_is_empty` covers the UNSET COMMENT path
- [ ] Executor unit tests now call `_execute_statements` directly without a compiler seam

🤖 Generated with [Claude Code](https://claude.com/claude-code)