### PR TITLE
test: apply Priority 3 APoSD test strengthening

### DIFF
--- a/tests/application/test_engine.py
+++ b/tests/application/test_engine.py
@@ -191,8 +191,12 @@ def test_engine_reads_all_tables_then_raises_on_any_read_failure():
         engine.sync(reg)
 
     # Then both tables appear in the report; one READ_FAILED, one SUCCESS
-    statuses = [tr.status for tr in err.value.report]
-    assert statuses == [TableRunStatus.READ_FAILED, TableRunStatus.SUCCESS]
+    [tr_a, tr_b] = list(err.value.report)
+    assert tr_a.status is TableRunStatus.READ_FAILED
+    assert tr_b.status is TableRunStatus.SUCCESS
+    # And the surviving table was actually executed, not just reported as success
+    # with an empty (never-run) execution summary
+    assert tr_b.execution.results != ()
 
 
 def test_engine_validates_all_tables_executes_only_the_passing_ones_then_raises():

--- a/tests/e2e/test_engine_e2e.py
+++ b/tests/e2e/test_engine_e2e.py
@@ -184,12 +184,12 @@ def test_engine_idempotent_when_already_in_desired_state(spark, monkeypatch, tem
     engine = Engine(DatabricksReader(spark), DatabricksExecutor(spark))
 
     engine.sync(reg)
-    first = spark.table(fq).schema.jsonValue()
 
-    engine.sync(reg)
-    second = spark.table(fq).schema.jsonValue()
+    # When syncing a second time against an already-correct table
+    second_report = engine.sync(reg)
 
-    assert first == second
+    # Then no actions were executed (true no-op, not just a schema-equal re-apply)
+    assert all(len(t.execution.results) == 0 for t in second_report.table_reports)
     assert spark.catalog.getTable(fq).description == "idempotency test"
 
 


### PR DESCRIPTION
## Summary

Applies the two actionable Priority 3 items from the APoSD design review in `docs/design-review.md`. The third item (e2e patch) is deferred pending Delta session access.

- **Idempotency test now proves a true no-op** — previously asserted `first_schema == second_schema`, which passes even if properties are re-set every sync (because `SET TBLPROPERTIES` is idempotent at the DDL level). Now captures the second `SyncReport` and asserts `len(t.execution.results) == 0` for all tables.

- **Read-failure isolation now proves the survivor ran** — previously checked only `TableRunStatus.SUCCESS` for the surviving table, which is consistent with an empty never-run `ExecutionSummary`. Now also asserts `tr_b.execution.results != ()` to prove the engine actually executed the surviving table.

## Not included

`_patch_table_exists_for_local` (Priority 3 item 2) — this monkey-patch replaces `DatabricksReader._table_exists` to use a two-part name (`schema.table`) instead of the three-part name the production code emits (`spark_catalog.schema.table`). The fix is to verify whether `spark.catalog.tableExists("spark_catalog.schema.table")` resolves correctly under the local `DeltaCatalog` config, and if so, delete the patch. This needs the e2e suite to run against a real Delta session, which is blocked locally by the Delta JAR SSL issue. Left for a follow-up.

## Test plan

- [ ] `uv run pytest tests/application/test_engine.py -q` — 9 passed
- [ ] e2e tests remain unchanged in behaviour; idempotency test is strictly stronger

🤖 Generated with [Claude Code](https://claude.com/claude-code)