### PR TITLE
docs: trim restate-the-code docstrings, thicken port contracts, document CREATE race

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,3 +115,9 @@ cover, and the following are known boundaries to be aware of:
   left untouched, never unset.
 - **No support for views, constraints, generated/identity columns, or liquid
   clustering** — these are out of scope for the current DDL-only model.
+- **Table creation is not race-safe against concurrent writers.** Creation is
+  compiled as `CREATE TABLE IF NOT EXISTS`, so if another process creates the
+  table between the engine's read and its execution, the statement no-ops and the
+  run reports success without reconciling that table's schema. The next sync
+  re-reads the live state and plans any drift. Run a single writer per table if
+  you need create-time schema guarantees.

--- a/docs/design-review.md
+++ b/docs/design-review.md
@@ -123,6 +123,8 @@ The reader reports `TableAbsent`, the differ emits `CreateTable`, and the compil
 
 **Recommendation:** Add a comment in the compiler stating the intent, and a note in the README's non-goals section.
 
+**Status: ✅ Done (`docs/aposd-comments-and-docs`).** The compiler now carries a comment on the `CREATE TABLE IF NOT EXISTS` clause explaining the read-then-create race and the resilience trade-off, and the README non-goals section documents that creation is not race-safe against concurrent writers. The `ColumnTypeChange`/`PartitioningChange`-as-`Action` decision above is left as recommended.
+
 ## Comments and documentation
 
 The codebase has excellent comments where they matter. The `zip(strict=True)` comment captures the cross-module one-statement-per-action contract ([executor.py:57](../src/delta_engine/adapters/databricks/executor.py#L57)). The `_fetch_properties` comment explains why two quoting paths must stay separate ([reader.py:122](../src/delta_engine/adapters/databricks/reader.py#L122)). The `ActionPhase` docstring explains the ordering invariant, not just the enum.
@@ -131,6 +133,8 @@ Two adjustments:
 
 - **Trim restate-the-code docstrings.** The `D` (pydocstyle) ruleset forces low-value docstrings: nine near-identical `subject()` docstrings, trivial `__len__`/`__bool__`/`__iter__` docstrings, and `format_lines` docstrings that name the method. APoSD treats these as noise.
 - **Thicken the port docstrings.** `CatalogStateReader` and `PlanExecutor` are the extension points every future adapter implements ([ports.py:13](../src/delta_engine/application/ports.py#L13)). The totality contract — "always returns a `CatalogState`, never raises" — currently lives on the concrete `DatabricksReader`. Lift it to the Protocol.
+
+**Status: ✅ Done (`docs/aposd-comments-and-docs`).** The restate-the-code docstrings were removed (the nine `subject()` overrides, the trivial `__len__`/`__bool__`/`__iter__` dunders, and the three concrete `format_lines` overrides), keeping the contract-bearing docstrings on the abstract `Action.subject` and `Failure.format_lines`. Because the `D` ruleset forced these, `D105` is now ignored project-wide (magic methods are documented by the protocol they implement) and `D102` is ignored for the two value-object modules (`actions.py`, `results.py`); `D102` stays enforced everywhere else. The totality contract is lifted onto both `CatalogStateReader` and `PlanExecutor` Protocol docstrings.
 
 ## Summary
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,6 +61,7 @@ ignore = [
   "E203", # slice spacing (compatible with ruff-format/black)
   "E266", # allow long inline comments
   "D104", # don't require package docstrings in __init__.py
+  "D105", # magic methods implement named protocols (len/iter/bool); the protocol documents them
   "D107", # don't require docstrings on __init__ methods
   "D212", # don't require multi-line docstring summary to start at the first line
   "D203", # no blank line before docstring
@@ -91,6 +92,11 @@ ban-relative-imports = "all" # enforce absolute imports (TID252)
   "N815", # allow variables in class scope to be mixedCase
   "N812", # allow uppercase variable names
 ]
+# Value-object modules: each class is documented and the contract lives on the
+# abstract method (Action.subject, Failure.format_lines). Concrete overrides
+# only restate it, so we don't require a docstring on every override.
+"src/delta_engine/domain/plan/actions.py" = ["D102"]
+"src/delta_engine/application/results.py" = ["D102"]
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]

--- a/src/delta_engine/adapters/databricks/sql/compile.py
+++ b/src/delta_engine/adapters/databricks/sql/compile.py
@@ -53,6 +53,13 @@ def _(action: CreateTable, backticked_table_name: str) -> str:
     properties = _set_properties(table.properties)
     partition_by = _set_partitioned_by(table.partitioned_by)
 
+    # IF NOT EXISTS, even though CreateTable is only emitted after the reader
+    # reports the table absent. It guards the read-then-create race: if another
+    # process creates the table in that window, the statement no-ops rather than
+    # erroring. The trade-off is that such a table is reported created without
+    # reconciling its schema; the next sync re-reads and plans any drift. This
+    # favours a resilient run over failing loud on a rare race -- see the README
+    # non-goals.
     parts = [
         f"CREATE TABLE IF NOT EXISTS {backticked_table_name}",
         f"({columns})",

--- a/src/delta_engine/application/ports.py
+++ b/src/delta_engine/application/ports.py
@@ -11,11 +11,23 @@ from delta_engine.domain.plan.actions import ActionPlan
 
 @runtime_checkable
 class CatalogStateReader(Protocol):
-    """Reads current catalog state."""
+    """
+    Reads the current catalog state for a single table.
+
+    The boundary every adapter must honour: ``fetch_state`` is **total**. A read
+    that cannot determine state -- a backend error, an unmappable schema, a
+    permissions failure -- is returned as ``ReadFailed``, never raised. The
+    engine reads many tables in one run and branches on the returned state rather
+    than guarding each call, so an exception escaping here would abort the whole
+    sync instead of failing the one table. Implementations contain their own
+    failure modes.
+    """
 
     def fetch_state(self, qualified_name: QualifiedName) -> CatalogState:
         """
         Return the table's current state: present, absent, or unreadable.
+
+        Total: returns ``ReadFailed`` on any error rather than raising.
 
         Args:
             qualified_name: Fully qualified object name to look up.
@@ -26,8 +38,21 @@ class CatalogStateReader(Protocol):
 
 @runtime_checkable
 class PlanExecutor(Protocol):
-    """Executes an action plan against a backing engine."""
+    """
+    Executes an action plan against a backing engine.
+
+    Like :class:`CatalogStateReader`, the boundary is **total**: a statement that
+    fails is captured in the returned ``ExecutionSummary`` (which records both the
+    actions that succeeded and the one that failed), not raised. The engine
+    records the summary on the table's report and moves on, so a failure executing
+    one table does not abort the others.
+    """
 
     def execute(self, qualified_name: QualifiedName, plan: ActionPlan) -> ExecutionSummary:
-        """Run the plan against ``qualified_name`` and return the execution outcome."""
+        """
+        Run the plan against ``qualified_name`` and return the execution outcome.
+
+        Total: failures are captured in the returned ``ExecutionSummary`` rather
+        than raised.
+        """
         ...

--- a/src/delta_engine/application/registry.py
+++ b/src/delta_engine/application/registry.py
@@ -64,5 +64,4 @@ class Registry:
         yield from (self._tables[name] for name in sorted(self._tables, key=str))
 
     def __len__(self) -> int:
-        """Return the number of registered tables."""
         return len(self._tables)

--- a/src/delta_engine/application/results.py
+++ b/src/delta_engine/application/results.py
@@ -48,7 +48,6 @@ class ReadFailure(Failure):
     message: str
 
     def format_lines(self) -> tuple[str, ...]:
-        """Render the read failure as a display line."""
         return (f"Read error: {self.exception_type} - {self.message}",)
 
 
@@ -60,7 +59,6 @@ class ValidationFailure(Failure):
     message: str
 
     def format_lines(self) -> tuple[str, ...]:
-        """Render the validation failure as a display line."""
         return (f"Validation failed: {self.rule_name} - {self.message}",)
 
 
@@ -74,7 +72,6 @@ class ExecutionFailure(Failure):
     statement_preview: str
 
     def format_lines(self) -> tuple[str, ...]:
-        """Render the execution failure and its SQL preview as display lines."""
         return (
             f"Execution failed at action {self.action_index}: "
             f"{self.exception_type} - {self.message}",
@@ -242,5 +239,4 @@ class SyncReport:
         return {t.qualified_name: t.all_failures for t in self.table_reports if t.has_failures}
 
     def __iter__(self) -> Iterator[TableRunReport]:
-        """Iterate over per-table reports in the sync run."""
         return iter(self.table_reports)

--- a/src/delta_engine/domain/plan/actions.py
+++ b/src/delta_engine/domain/plan/actions.py
@@ -70,7 +70,6 @@ class CreateTable(Action):
 
     @property
     def subject(self) -> str:
-        """Targets the table as a whole."""
         return ""
 
 
@@ -84,7 +83,6 @@ class AddColumn(Action):
 
     @property
     def subject(self) -> str:
-        """The added column's name."""
         return self.column.name
 
 
@@ -98,7 +96,6 @@ class DropColumn(Action):
 
     @property
     def subject(self) -> str:
-        """The dropped column's name."""
         return self.column_name
 
 
@@ -113,7 +110,6 @@ class SetProperty(Action):
 
     @property
     def subject(self) -> str:
-        """The property name being set."""
         return self.name
 
 
@@ -128,7 +124,6 @@ class SetColumnComment(Action):
 
     @property
     def subject(self) -> str:
-        """The commented column's name."""
         return self.column_name
 
 
@@ -142,7 +137,6 @@ class SetTableComment(Action):
 
     @property
     def subject(self) -> str:
-        """Targets the table as a whole."""
         return ""
 
 
@@ -157,7 +151,6 @@ class SetColumnNullability(Action):
 
     @property
     def subject(self) -> str:
-        """The column whose nullability changes."""
         return self.column_name
 
 
@@ -180,7 +173,6 @@ class ColumnTypeChange(Action):
 
     @property
     def subject(self) -> str:
-        """The column whose type changed."""
         return self.column_name
 
 
@@ -201,7 +193,6 @@ class PartitioningChange(Action):
 
     @property
     def subject(self) -> str:
-        """Targets the table as a whole."""
         return ""
 
 
@@ -229,13 +220,10 @@ class ActionPlan:
         object.__setattr__(self, "actions", tuple(sorted(self.actions, key=_execution_order)))
 
     def __len__(self) -> int:
-        """Return the number of actions in the plan."""
         return len(self.actions)
 
     def __bool__(self) -> bool:
-        """Return ``True`` if the plan contains any actions."""
         return bool(self.actions)
 
     def __iter__(self) -> Iterator[Action]:
-        """Iterate over actions in plan order."""
         return iter(self.actions)


### PR DESCRIPTION
## Summary

Implements two documentation-focused sections of the APoSD design review (`docs/design-review.md`): **Comments and documentation**, and the **`CREATE TABLE IF NOT EXISTS`** decision-to-weigh. No runtime behaviour changes — code-file edits are docstring/comment-only (verified: no executable line changed).

### Comments and documentation
- **Trimmed restate-the-code docstrings:** the nine `subject()` property overrides, the trivial `__len__`/`__bool__`/`__iter__` dunders, and the three concrete `format_lines` overrides. The contract-bearing docstrings on the abstract `Action.subject` and `Failure.format_lines` are kept, as are behavioural ones (e.g. `Registry.__iter__`'s "qualified-name order").
- **Lint config:** these docstrings were *forced* by the `D` ruleset, so it's relaxed to match — `D105` ignored project-wide (magic methods are documented by the protocol they implement; already ignored in tests), and `D102` ignored for the two value-object modules `actions.py`/`results.py`. `D102` stays enforced everywhere else; `D101` (class docstrings) untouched.
- **Thickened the port docstrings:** lifted the totality contract ("never raises; failures come back as `ReadFailed` / inside `ExecutionSummary`") onto the `CatalogStateReader` and `PlanExecutor` Protocols. This is load-bearing — the engine calls both without a guard, so the guarantee belongs on the interface every adapter implements, not only on the Databricks concrete class.

### CREATE TABLE IF NOT EXISTS
- Compiler comment explaining the read-then-create race and the resilience-over-fail-loud trade-off.
- README non-goals bullet documenting that creation is not race-safe against concurrent writers.

## Deviation flagged
Relaxing `D102`/`D105` steps back from the org Python standard's "MUST document public APIs". Justification: these are trivial overrides of *already-documented* abstract methods — exactly the redundant-comment noise APoSD (and this review) calls out. Enforcement is narrowed surgically, not removed.

## Test plan
- [ ] `ruff check src/ tests/` — clean
- [ ] `mypy src/` — clean
- [ ] 165 non-e2e tests pass (the 9 errors are the pre-existing Spark/Java-gateway env failures documented in the review; no test depends on the removed docstrings)

🤖 Generated with [Claude Code](https://claude.com/claude-code)