### PR TITLE
chore: make the two cluster-blocked review items runnable

### DIFF
--- a/docs/design-review.md
+++ b/docs/design-review.md
@@ -28,6 +28,8 @@ Tables created by the engine are safe — it always sets these properties at cre
 
 **Status:** Unconfirmed. Local verification was blocked by an environment issue: the dev machine cannot resolve Delta jars from Maven (SSL trust), and the installed pyspark (4.1.1) mismatches the cached Delta build (4.2.0 for Spark 4.0). The Delta docs describe the field only as "all the properties set for this table." Confirm against a real Databricks Unity Catalog cluster.
 
+**Ready to verify:** [`scripts/verify_property_idempotency.py`](../scripts/verify_property_idempotency.py) settles this on a live session. It creates a plain Delta table (no managed properties — the adopted-table condition), registers it with the engine, and syncs three times: it exits 0 if syncs 2 and 3 are true no-ops, or 1 (with the confirmed finding and fix direction) if the engine re-emits `SetProperty` every run. Run it as `python scripts/verify_property_idempotency.py --catalog <cat> --schema <schema>`.
+
 **Fix, regardless of the runtime answer:** Strengthen the idempotency test (see Priority 3). The current test cannot catch this because `SET TBLPROPERTIES` is idempotent at the DDL level, so the schema stays equal even when properties are re-set every run.
 
 ## Priority 2 — Quick wins
@@ -98,6 +100,8 @@ assert all(len(t.execution.results) == 0 for t in second_report)
 Every e2e test calls `_patch_table_exists_for_local`, which monkey-patches `DatabricksReader._table_exists` ([test_engine_e2e.py:15](../tests/e2e/test_engine_e2e.py#L15)). This couples the suite to a private implementation detail and changes the method's semantics (three-part name versus two-part). The e2e tests no longer exercise the real existence-check path. It also breaks the project's own rule against mocking internal collaborators.
 
 **Fix:** Check whether `spark.catalog.tableExists("spark_catalog.schema.table")` resolves under the local DeltaCatalog. If it does, delete the patch. If three-part resolution genuinely fails locally, fix it at the data level in the fixture rather than patching the adapter.
+
+**Ready to verify:** `_patch_table_exists_for_local` now carries an in-code `TODO` and is gated behind an env var. Set `DELTA_ENGINE_E2E_REAL_TABLE_EXISTS=1` to skip the patch and run the e2e suite against the real `DatabricksReader._table_exists`. If it passes on a session that can run e2e, delete the helper and its call sites; the env var made the experiment a one-line change rather than a code edit per run.
 
 ### Read-failure isolation is under-tested
 

--- a/scripts/verify_property_idempotency.py
+++ b/scripts/verify_property_idempotency.py
@@ -1,0 +1,148 @@
+"""
+Verify whether adopted tables reach a true property no-op on a real cluster.
+
+Run this against a live Databricks Unity Catalog session to settle the
+"Unconfirmed" Priority 1 finding in ``docs/design-review.md`` ("Properties may
+never reach a no-op on adopted tables").
+
+The hypothesis under test
+--------------------------
+``DeltaTable`` injects ``delta.enableDeletionVectors=true`` and
+``delta.columnMapping.mode=name`` into every desired state. ``_diff_properties``
+emits a ``SetProperty`` whenever ``observed.get(name) != value`` for a declared
+key, reading ``observed`` from the ``properties`` column of ``DESCRIBE DETAIL``.
+
+The open question is whether, once the engine issues ``SET TBLPROPERTIES`` for a
+managed key on a pre-existing (adopted) table, the next ``DESCRIBE DETAIL`` reads
+that key back with the same value:
+
+* If yes -> the second sync sees a match and reaches a true no-op. The table
+  self-heals after one corrective sync; the finding is a non-issue.
+* If no (the value is reported differently, or not at all, even after being set)
+  -> the differ re-emits ``SetProperty`` on every run and the table never reaches
+  a no-op. The finding is confirmed and the engine must reconcile against
+  effective, DESCRIBE-reported properties rather than declared keys.
+
+This cannot be reproduced on the local in-memory Delta catalog used by the test
+suite, which is why it is a standalone script rather than an e2e test.
+
+Usage
+-----
+On a cluster (or Databricks Connect session) where ``spark`` is available::
+
+    python scripts/verify_property_idempotency.py --catalog <cat> --schema <schema>
+
+It creates a *plain* Delta table directly via SQL -- with none of the managed
+properties set -- to mimic a table created outside the engine, then registers
+that table with the engine and syncs three times. The first sync applies the
+managed properties; the second and third reveal whether the table has reached a
+steady-state no-op. The temp table is dropped on exit.
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from uuid import uuid4
+
+from delta_engine import (
+    Column,
+    DeltaTable,
+    Integer,
+    Registry,
+    String,
+    build_databricks_engine,
+)
+from delta_engine.schema.properties import Property
+
+
+def _get_spark():  # type: ignore[no-untyped-def]
+    """Return the ambient SparkSession, or exit with guidance if there is none."""
+    try:
+        from pyspark.sql import SparkSession
+    except ImportError:
+        sys.exit("pyspark is not installed in this environment.")
+
+    spark = SparkSession.getActiveSession()
+    if spark is None:
+        sys.exit(
+            "No active SparkSession. Run this on a Databricks cluster or in a "
+            "Databricks Connect session where `spark` is available."
+        )
+    return spark
+
+
+def _describe_managed_properties(spark, fully_qualified_name: str) -> dict[str, str]:  # type: ignore[no-untyped-def]
+    """Return the engine-managed property keys as reported by DESCRIBE DETAIL."""
+    described = spark.sql(f"DESCRIBE DETAIL {fully_qualified_name}").first()
+    properties = dict(described["properties"]) if described else {}
+    managed = {Property.ENABLE_DELETION_VECTORS.value, Property.COLUMN_MAPPING_MODE.value}
+    return {key: properties[key] for key in managed if key in properties}
+
+
+def _actions_executed(report) -> int:  # type: ignore[no-untyped-def]
+    """Total number of execution results across all tables in a SyncReport."""
+    return sum(len(table.execution.results) for table in report.table_reports)
+
+
+def main() -> int:
+    """Run the idempotency probe and return a process exit code (0 = no-op reached)."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--catalog", required=True, help="Unity Catalog catalog name")
+    parser.add_argument("--schema", required=True, help="Schema to create the temp table in")
+    args = parser.parse_args()
+
+    spark = _get_spark()
+    engine = build_databricks_engine(spark)
+
+    table_name = f"verify_prop_idem_{uuid4().hex[:8]}"
+    fully_qualified_name = f"{args.catalog}.{args.schema}.{table_name}"
+
+    desired = DeltaTable(
+        args.catalog,
+        args.schema,
+        table_name,
+        columns=(Column("id", Integer(), nullable=False), Column("name", String())),
+        comment="property idempotency probe",
+    )
+    registry = Registry()
+    registry.register(desired)
+
+    try:
+        # Create a plain Delta table with NO managed properties: this is the
+        # adopted-table condition the finding is about (a table created outside
+        # the engine, so the managed keys live only in catalog defaults, if at all).
+        spark.sql(
+            f"CREATE TABLE {fully_qualified_name} (id INT NOT NULL, name STRING) USING DELTA"
+        )
+        print("Managed properties before any sync (adopted table):")
+        print(f"  {_describe_managed_properties(spark, fully_qualified_name) or '<none reported>'}")
+
+        first = engine.sync(registry)
+        print(f"\nSync 1 executed {_actions_executed(first)} action(s) (expected > 0: sets props).")
+        print("Managed properties after sync 1:")
+        print(f"  {_describe_managed_properties(spark, fully_qualified_name) or '<none reported>'}")
+
+        second = engine.sync(registry)
+        third = engine.sync(registry)
+        second_actions = _actions_executed(second)
+        third_actions = _actions_executed(third)
+        print(f"\nSync 2 executed {second_actions} action(s).")
+        print(f"Sync 3 executed {third_actions} action(s).")
+
+        if second_actions == 0 and third_actions == 0:
+            print("\nRESULT: steady-state no-op reached. Finding NOT reproduced.")
+            print("Adopted tables self-heal after one sync; the declared-subset diff is safe.")
+            return 0
+
+        print("\nRESULT: the table never reaches a no-op. Finding CONFIRMED.")
+        print("SET TBLPROPERTIES does not round-trip through DESCRIBE DETAIL for a managed key,")
+        print("so the engine re-emits SetProperty every run. Fix: reconcile against effective,")
+        print("DESCRIBE-reported properties rather than declared keys.")
+        return 1
+    finally:
+        spark.sql(f"DROP TABLE IF EXISTS {fully_qualified_name}")
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/e2e/test_engine_e2e.py
+++ b/tests/e2e/test_engine_e2e.py
@@ -1,3 +1,4 @@
+import os
 from uuid import uuid4
 
 import pyspark.sql.types as T
@@ -11,8 +12,24 @@ from delta_engine.application.registry import Registry
 from delta_engine.schema import Column, Date, DeltaTable, Integer, String
 from tests.config import TEST_CATALOG
 
+# TODO(design-review Priority 3): remove this patch once confirmed unnecessary.
+# The patch rewrites the three-part `catalog.schema.table` name to a two-part
+# `schema.table` because three-part resolution under the local in-memory
+# DeltaCatalog is unverified. It mocks a private method of the class under test,
+# which violates the project's "no mocking internal collaborators" rule and means
+# the e2e suite never exercises the real existence-check path. TEST_CATALOG is
+# already "spark_catalog" (the local catalog id), so the three-part name likely
+# resolves as-is. To settle it on a cluster (or any session that can run e2e),
+# set DELTA_ENGINE_E2E_REAL_TABLE_EXISTS=1 to skip the patch and run against the
+# real DatabricksReader._table_exists; if the suite passes, delete this helper
+# and every call to it.
+_USE_REAL_TABLE_EXISTS = os.environ.get("DELTA_ENGINE_E2E_REAL_TABLE_EXISTS") == "1"
+
 
 def _patch_table_exists_for_local(monkeypatch):
+    if _USE_REAL_TABLE_EXISTS:
+        return
+
     def _table_exists(self, qualified_name):
         # Local Spark fallback for existence checks
         return self.spark.catalog.tableExists(f"{qualified_name.schema}.{qualified_name.name}")


### PR DESCRIPTION
## Summary

The two remaining APoSD design-review items can't be completed without a live Databricks/Spark session. This PR makes both **runnable the moment you're on a cluster**, without leaving them as stale prose in the tracker. No production code changes; default behaviour is unchanged.

### 1. Property idempotency (Priority 1, "Unconfirmed")
Adds `scripts/verify_property_idempotency.py`. On a live Unity Catalog session it:
- creates a *plain* Delta table via SQL with **no** managed properties — the adopted-table condition the finding is about (a table created outside the engine),
- registers it with the engine and syncs three times,
- exits `0` if syncs 2 and 3 are true no-ops (finding **not** reproduced — adopted tables self-heal), or `1` with the confirmed finding and fix direction if the engine re-emits `SetProperty` every run.

Run: `python scripts/verify_property_idempotency.py --catalog <cat> --schema <schema>`

I deliberately create-then-adopt rather than create-then-`UNSET`, because Delta can reject unsetting `columnMapping.mode` once enabled — the SQL-create path is a faithful, non-fragile reproduction.

### 2. E2E monkeypatch removal (Priority 3, deferred)
`_patch_table_exists_for_local` mocks a private method of the class under test (against the project's no-mocking-internal-collaborators rule). It was deferred because three-part `tableExists` resolution under the local in-memory DeltaCatalog is unverified. This PR:
- adds the in-code `TODO` the review asked for (the deferral reason previously lived only in a commit message),
- gates the patch behind `DELTA_ENGINE_E2E_REAL_TABLE_EXISTS=1` so you can run the e2e suite against the **real** `DatabricksReader._table_exists` with one env var, no code edit. If it passes, delete the helper and its call sites.

## Test plan
- [ ] `ruff check .` — clean
- [ ] `mypy .` — clean (66 files; the script is type-checked as part of the repo)
- [ ] 165 non-e2e tests pass (the 9 errors are the pre-existing Spark/Java-gateway env failures)
- [ ] On a cluster: run the script, and run e2e with `DELTA_ENGINE_E2E_REAL_TABLE_EXISTS=1`

🤖 Generated with [Claude Code](https://claude.com/claude-code)