### PR TITLE
feat: add primary key constraint support

### DIFF
--- a/.superpowers/sdd/task-2-report.md
+++ b/.superpowers/sdd/task-2-report.md
@@ -2,17 +2,50 @@
 DONE_WITH_CONCERNS
 
 ## Commits
-c61b8d9 docs: add getting-started tutorial
+ac5b219 feat: add DropPrimaryKey and SetPrimaryKey action types with DROP_PRIMARY_KEY and SET_PRIMARY_KEY phases
 
-## Tests / build
-Sphinx build succeeded (0 errors, 0 warnings after suppression).
+## Tests
+191 passed (7 new in test_actions.py, 2 new in test_compile.py). Pre-existing coverage threshold failure at 89.82% vs 90% — was 89.58% before this task; the gap is in unrelated pre-existing files (executor.py, log_config.py, preview.py, types.py).
 
 ## Concerns
-Two warnings appeared that `-W` would have turned into errors:
-1. `toc.not_included` — file not yet in any toctree (expected; nav wired in Task 13).
-2. `myst.xref_missing` — forward reference to `how-to-handle-sync-failures.md` (specified verbatim in the brief; that doc is a later task).
+**Out-of-brief scope addition:** The brief specified changes to `actions.py`, `__init__.py`, and `test_actions.py` only. However, `test_every_action_type_has_a_registered_compiler` in `test_compile.py` is a hard guard that immediately fails when any new `Action` subclass lacks a registered SQL compiler. Without also registering compilers, the full suite had 1 failure.
 
-Both were added to `suppress_warnings` in `docs/conf.py` so the `-W` build stays green until the nav and the cross-referenced how-to are added. The suppressions are broad (any file, not scoped to the tutorial), so once Task 13 wires the toctree and the how-to doc is created, the entries should be removed.
+To keep the suite green, I added:
+- SQL compilers for `DropPrimaryKey` and `SetPrimaryKey` to `src/delta_engine/adapters/databricks/sql/compile.py`
+- Corresponding tests to `tests/adapters/databricks/sql/test_compile.py`
 
-## Fix applied
-Changed `coloured` to `colored`. Sphinx build passes.
+SQL emitted:
+- `DropPrimaryKey` → `ALTER TABLE <tbl> DROP PRIMARY KEY`
+- `SetPrimaryKey` → `ALTER TABLE <tbl> ADD CONSTRAINT <name> PRIMARY KEY (<col1>, <col2>, ...)`
+
+If a follow-on task was intended to own SQL compilation for these types, those files will need revision. The implementations are correct Databricks SQL syntax and consistent with the rest of the compiler module.
+
+---
+
+## Bug Fix (follow-on)
+
+### What changed
+**Fix 1 — `DropPrimaryKey` compiler** (`compile.py` line 139):
+- `DROP PRIMARY KEY` → `DROP PRIMARY KEY IF EXISTS` (idempotent; avoids error when no PK exists)
+
+**Fix 2 — `SetPrimaryKey` compiler** (`compile.py` line 146):
+- Removed `backtick()` wrapping from `constraint_name`; constraint names are named identifiers, not column names, and should not be backtick-quoted.
+
+**Fix 3 — `test_drop_primary_key_renders_alter_drop_primary_key`** (`test_compile.py` line 269):
+- Assertion updated to expect `DROP PRIMARY KEY IF EXISTS`
+
+**Fix 4 — `test_set_primary_key_renders_add_constraint_primary_key`** (`test_compile.py` line 288):
+- Assertion updated: `orders_pk` (unquoted) instead of `` `orders_pk` ``
+
+### Test command run
+```
+uv run pytest tests/adapters/databricks/sql/test_compile.py -v -k "primary_key"
+```
+
+### Test output
+```
+tests/adapters/databricks/sql/test_compile.py::test_drop_primary_key_renders_alter_drop_primary_key PASSED
+tests/adapters/databricks/sql/test_compile.py::test_set_primary_key_renders_add_constraint_primary_key PASSED
+2 passed, 19 deselected
+```
+(Coverage failure is a pre-existing issue from running only 2/21 tests via `-k` filter, not introduced by this fix.)

--- a/docs/explanation-architecture.md
+++ b/docs/explanation-architecture.md
@@ -44,7 +44,7 @@ The `delta_engine.adapters.databricks` package implements both ports for Databri
 
 ## Planning and determinism
 
-`compute_plan(desired, observed)` diffs the desired declaration against the observed catalog state and returns an `ActionPlan`. Actions are sorted by `ActionPhase` (an `IntEnum`) then alphabetically by subject, producing a stable, predictable sequence regardless of declaration order: creates run before adds, adds before drops.
+`compute_plan(desired, observed)` diffs the desired declaration against the observed catalog state and returns an `ActionPlan`. Actions are sorted by `ActionPhase` (an `IntEnum`) then alphabetically by subject, producing a stable, predictable sequence regardless of declaration order. The phase ordering encodes dependency constraints: primary key drops run before column mutations (so no constraint references a column being dropped), and primary key sets run after nullability changes (so columns are guaranteed non-nullable before the constraint is applied).
 
 ## Sentinel actions
 

--- a/docs/how-to-add-action-type.md
+++ b/docs/how-to-add-action-type.md
@@ -37,11 +37,13 @@ If the action belongs to a new execution phase, add it to the `ActionPhase` enum
 class ActionPhase(IntEnum):
     CREATE_TABLE = auto()
     SET_PROPERTY = auto()
+    DROP_PRIMARY_KEY = auto()
     ADD_COLUMN = auto()
     DROP_COLUMN = auto()
     SET_COLUMN_COMMENT = auto()
     SET_TABLE_COMMENT = auto()
     SET_COLUMN_NULLABILITY = auto()
+    SET_PRIMARY_KEY = auto()
     COLUMN_TYPE_CHANGE = auto()
     PARTITIONING_CHANGE = auto()
     # ADD_YOUR_NEW_PHASE = auto()

--- a/docs/how-to-declare-primary-keys.md
+++ b/docs/how-to-declare-primary-keys.md
@@ -1,0 +1,61 @@
+---
+tags:
+  - how-to
+---
+
+# How to declare a primary key
+
+Declare a primary key by setting `primary_key=True` on one or more `Column` objects. All primary key columns must be `NOT NULL`.
+
+```python
+from delta_engine import Column, DeltaTable, Integer, String
+
+orders = DeltaTable(
+    catalog="dev",
+    schema="silver",
+    name="orders",
+    columns=[
+        Column("order_id", Integer(), nullable=False, primary_key=True),
+        Column("customer_id", Integer(), nullable=False),
+        Column("status", String()),
+    ],
+)
+```
+
+The engine derives the constraint name as `{table_name}_pk` — `orders_pk` in the example above. You can read it back from `orders.primary_key_constraint_name`.
+
+## Composite primary keys
+
+Set `primary_key=True` on multiple columns. The constraint covers them in declaration order.
+
+```python
+order_items = DeltaTable(
+    catalog="dev",
+    schema="silver",
+    name="order_items",
+    columns=[
+        Column("order_id", Integer(), nullable=False, primary_key=True),
+        Column("line_number", Integer(), nullable=False, primary_key=True),
+        Column("product_id", Integer(), nullable=False),
+    ],
+)
+```
+
+## Drift management
+
+The engine manages primary key drift on existing tables:
+
+| Change | Actions emitted |
+|---|---|
+| Primary key added | `SetPrimaryKey` |
+| Primary key removed | `DropPrimaryKey` |
+| Primary key columns changed | `DropPrimaryKey` then `SetPrimaryKey` |
+| No change | nothing |
+
+Column order within the key is ignored when detecting drift — `(a, b)` and `(b, a)` are treated as equal.
+
+## Constraints
+
+Databricks primary key constraints are informational, not enforced. They do not prevent duplicate or null values at write time, but they enable query optimizations in Unity Catalog.
+
+Because Databricks rejects a primary key on a nullable column at execution time, the engine validates this before running any SQL. If any primary key column is nullable, `sync` raises `SyncFailedError` with a `PrimaryKeyColumnsNullable` failure. See [reference-safe-change-rules.md](reference-safe-change-rules.md) for all validation rules.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -15,6 +15,7 @@ Declarative schema management for Delta Lake tables on Databricks.
 
    how-to-handle-sync-failures
    how-to-declare-partitioned-tables
+   how-to-declare-primary-keys
    how-to-configure-properties
 
 .. toctree::

--- a/docs/reference-safe-change-rules.md
+++ b/docs/reference-safe-change-rules.md
@@ -5,7 +5,7 @@ tags:
 
 # Safe-change rules
 
-The engine validates a computed plan before executing any SQL. These four rules block changes that cannot be made safely in place. Each fires a `VALIDATION_FAILED` status with a message naming the rule and the affected column or table.
+The engine validates a computed plan before executing any SQL. These five rules block changes that cannot be made safely in place. Each fires a `VALIDATION_FAILED` status with a message naming the rule and the affected column or table.
 
 | Rule | What it blocks | How to resolve |
 |---|---|---|
@@ -13,5 +13,6 @@ The engine validates a computed plan before executing any SQL. These four rules 
 | `NullabilityTighteningOnExistingColumn` | Changing an existing nullable column to `NOT NULL` | Backfill existing NULLs first, then update the declaration |
 | `UnsupportedColumnTypeChange` | Changing a column's declared data type | Drop and recreate the table out of band, then re-sync |
 | `DisallowPartitioningChange` | Changing `partitioned_by` on an existing table | Drop and recreate the table out of band, then re-sync |
+| `PrimaryKeyColumnsNullable` | Declaring a primary key on a nullable column | Set `nullable=False` on every primary key column |
 
 Validation runs before any SQL executes. A failed validation means the table is unchanged.

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -4,3 +4,13 @@
 - [ ] Determine whether Delta table properties and/or liquid clustering need to be tied to specific Delta / DBR versions (compatibility matrix)
 - [ ] Decide whether to create an enum for `Property` values as well as keys (currently only keys are enumerated)
 - [ ] Figure out how to add existing tables (tables that already exist in the catalog but are not yet declared in the registry)
+- [ ] Add support for foreign keys
+- [ ] Add support for tags
+- [ ] Add support for clustering
+- [ ] make partitioned_by a Column-level thing
+- [ ] add unique columns: ALTER TABLE U ADD CONSTRAINT u_uq_email UNIQUE(email);
+- [ ] add scripts/example.ipynb for example notebook
+- [ ] where does backticked_table_name belong? Should it be constructed inside the compiler dispatches?
+- [ ] should all of the sql statements live in a dedicated file and be imported into reader/exeecutor?
+- [ ] should databricks rules live in validator?
+- [ ] add clarifying comments to differ functions

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -14,3 +14,6 @@
 - [ ] should all of the sql statements live in a dedicated file and be imported into reader/exeecutor?
 - [ ] should databricks rules live in validator?
 - [ ] add clarifying comments to differ functions
+- [ ] add clarifying comments to validation rules
+- [ ] make each CI step independently in parallel
+- [ ] review except AnalysisException in reader's _fetch_primary_key()

--- a/src/delta_engine/__init__.py
+++ b/src/delta_engine/__init__.py
@@ -14,14 +14,6 @@ planned without a Spark install.
 
 from typing import TYPE_CHECKING
 
-from delta_engine.application import (
-    Engine,
-    Failure,
-    Registry,
-    SyncFailedError,
-    SyncReport,
-    TableRunStatus,
-)
 from delta_engine.api import (
     Array,
     Boolean,
@@ -37,6 +29,14 @@ from delta_engine.api import (
     Property,
     String,
     Timestamp,
+)
+from delta_engine.application import (
+    Engine,
+    Failure,
+    Registry,
+    SyncFailedError,
+    SyncReport,
+    TableRunStatus,
 )
 
 # Lazily-exposed names. These live in the Databricks adapter, which imports

--- a/src/delta_engine/adapters/databricks/reader.py
+++ b/src/delta_engine/adapters/databricks/reader.py
@@ -14,6 +14,7 @@ from delta_engine.adapters.databricks.sql import (
     domain_type_from_spark,
     error_preview,
     exception_type_name,
+    quote_literal,
 )
 from delta_engine.application.results import (
     CatalogState,
@@ -119,6 +120,7 @@ class DatabricksReader:
             comment=self._fetch_table_comment(qualified_name),
             properties=self._fetch_properties(qualified_name),
             partitioned_by=partition_columns,
+            primary_key=self._fetch_primary_key(qualified_name),
         )
         return TablePresent(table=observed)
 
@@ -146,6 +148,24 @@ class DatabricksReader:
         if not row:
             return MappingProxyType({})
         return MappingProxyType(dict(row["properties"]))
+
+    def _fetch_primary_key(self, qualified_name: QualifiedName) -> tuple[str, ...]:
+        """Return the primary key column names from Unity Catalog information_schema.
+
+        Returns an empty tuple when no primary key is defined. Column names are
+        normalised to lowercase at the adapter boundary.
+        """
+        query = (
+            f"SELECT ccu.column_name"
+            f" FROM `{qualified_name.catalog}`.information_schema.constraint_column_usage AS ccu"
+            f" JOIN `{qualified_name.catalog}`.information_schema.table_constraints AS tc"
+            f" USING (constraint_catalog, constraint_schema, constraint_name)"
+            f" WHERE ccu.table_schema = {quote_literal(qualified_name.schema)}"
+            f" AND ccu.table_name = {quote_literal(qualified_name.name)}"
+            f" AND tc.constraint_type = 'PRIMARY KEY'"
+        )
+        rows = self.spark.sql(query).collect()
+        return tuple(row["column_name"].casefold() for row in rows)
 
     def _fetch_table_comment(self, qualified_name: QualifiedName) -> str:
         """Return the table comment (empty string when not set)."""

--- a/src/delta_engine/adapters/databricks/reader.py
+++ b/src/delta_engine/adapters/databricks/reader.py
@@ -10,6 +10,7 @@ from pyspark.sql import SparkSession
 from pyspark.sql.catalog import Column as SparkColumn
 
 from delta_engine.adapters.databricks.sql import (
+    backtick,
     backtick_qualified_name,
     domain_type_from_spark,
     error_preview,
@@ -156,13 +157,13 @@ class DatabricksReader:
         normalised to lowercase at the adapter boundary.
         """
         query = (
-            f"SELECT ccu.column_name"
-            f" FROM `{qualified_name.catalog}`.information_schema.constraint_column_usage AS ccu"
-            f" JOIN `{qualified_name.catalog}`.information_schema.table_constraints AS tc"
+            f"SELECT constraint_columns.column_name"
+            f" FROM {backtick(qualified_name.catalog)}.information_schema.constraint_column_usage AS constraint_columns"
+            f" JOIN {backtick(qualified_name.catalog)}.information_schema.table_constraints AS table_constraints_info"
             f" USING (constraint_catalog, constraint_schema, constraint_name)"
-            f" WHERE ccu.table_schema = {quote_literal(qualified_name.schema)}"
-            f" AND ccu.table_name = {quote_literal(qualified_name.name)}"
-            f" AND tc.constraint_type = 'PRIMARY KEY'"
+            f" WHERE constraint_columns.table_schema = {quote_literal(qualified_name.schema)}"
+            f" AND constraint_columns.table_name = {quote_literal(qualified_name.name)}"
+            f" AND table_constraints_info.constraint_type = 'PRIMARY KEY'"
         )
         rows = self.spark.sql(query).collect()
         return tuple(row["column_name"].casefold() for row in rows)

--- a/src/delta_engine/adapters/databricks/reader.py
+++ b/src/delta_engine/adapters/databricks/reader.py
@@ -151,18 +151,24 @@ class DatabricksReader:
         return MappingProxyType(dict(row["properties"]))
 
     def _fetch_primary_key(self, qualified_name: QualifiedName) -> tuple[str, ...]:
-        """Return the primary key column names from Unity Catalog information_schema.
+        """
+        Return the primary key column names from Unity Catalog information_schema.
 
         Returns an empty tuple when no primary key is defined. Column names are
         normalised to lowercase at the adapter boundary.
         """
+        catalog = backtick(qualified_name.catalog)
         query = (
             f"SELECT constraint_columns.column_name"
-            f" FROM {backtick(qualified_name.catalog)}.information_schema.constraint_column_usage AS constraint_columns"
-            f" JOIN {backtick(qualified_name.catalog)}.information_schema.table_constraints AS table_constraints_info"
+            f" FROM {catalog}.information_schema.constraint_column_usage"
+            f" AS constraint_columns"
+            f" JOIN {catalog}.information_schema.table_constraints"
+            f" AS table_constraints_info"
             f" USING (constraint_catalog, constraint_schema, constraint_name)"
-            f" WHERE constraint_columns.table_schema = {quote_literal(qualified_name.schema)}"
-            f" AND constraint_columns.table_name = {quote_literal(qualified_name.name)}"
+            f" WHERE constraint_columns.table_schema ="
+            f" {quote_literal(qualified_name.schema)}"
+            f" AND constraint_columns.table_name ="
+            f" {quote_literal(qualified_name.name)}"
             f" AND table_constraints_info.constraint_type = 'PRIMARY KEY'"
         )
         rows = self.spark.sql(query).collect()

--- a/src/delta_engine/adapters/databricks/reader.py
+++ b/src/delta_engine/adapters/databricks/reader.py
@@ -8,6 +8,7 @@ from types import MappingProxyType
 
 from pyspark.sql import SparkSession
 from pyspark.sql.catalog import Column as SparkColumn
+from pyspark.errors.exceptions.base import AnalysisException
 
 from delta_engine.adapters.databricks.sql import (
     backtick,
@@ -171,7 +172,13 @@ class DatabricksReader:
             f" {quote_literal(qualified_name.name)}"
             f" AND table_constraints_info.constraint_type = 'PRIMARY KEY'"
         )
-        rows = self.spark.sql(query).collect()
+        try:
+            rows = self.spark.sql(query).collect()
+        except AnalysisException:
+            # information_schema is only available in Unity Catalog. On plain
+            # Spark (e.g. local tests), the table does not exist and there are
+            # no PK constraints to observe.
+            return ()
         return tuple(row["column_name"].casefold() for row in rows)
 
     def _fetch_table_comment(self, qualified_name: QualifiedName) -> str:

--- a/src/delta_engine/adapters/databricks/sql/compile.py
+++ b/src/delta_engine/adapters/databricks/sql/compile.py
@@ -54,7 +54,7 @@ def _(action: CreateTable, backticked_table_name: str) -> str:
 
     if table.primary_key and table.primary_key_constraint_name:
         pk_cols = ", ".join(backtick(name) for name in table.primary_key)
-        column_defs.append(f"CONSTRAINT {table.primary_key_constraint_name} PRIMARY KEY ({pk_cols})")
+        column_defs.append(f"CONSTRAINT {backtick(table.primary_key_constraint_name)} PRIMARY KEY ({pk_cols})")
 
     columns_clause = ", ".join(column_defs)
     table_comment = _set_table_comment(table.comment)
@@ -149,8 +149,7 @@ def _(action: DropPrimaryKey, backticked_table_name: str) -> str:
 def _(action: SetPrimaryKey, backticked_table_name: str) -> str:
     """Compile an ALTER TABLE ... ADD CONSTRAINT ... PRIMARY KEY statement."""
     column_list = ", ".join(backtick(column.name) for column in action.columns)
-    constraint_name = action.constraint_name
-    return f"ALTER TABLE {backticked_table_name} ADD CONSTRAINT {constraint_name} PRIMARY KEY ({column_list})"
+    return f"ALTER TABLE {backticked_table_name} ADD CONSTRAINT {backtick(action.constraint_name)} PRIMARY KEY ({column_list})"
 
 
 @_compile_action.register

--- a/src/delta_engine/adapters/databricks/sql/compile.py
+++ b/src/delta_engine/adapters/databricks/sql/compile.py
@@ -54,7 +54,9 @@ def _(action: CreateTable, backticked_table_name: str) -> str:
 
     if table.primary_key and table.primary_key_constraint_name:
         pk_cols = ", ".join(backtick(name) for name in table.primary_key)
-        column_defs.append(f"CONSTRAINT {backtick(table.primary_key_constraint_name)} PRIMARY KEY ({pk_cols})")
+        column_defs.append(
+            f"CONSTRAINT {backtick(table.primary_key_constraint_name)} PRIMARY KEY ({pk_cols})"
+        )
 
     columns_clause = ", ".join(column_defs)
     table_comment = _set_table_comment(table.comment)
@@ -149,7 +151,11 @@ def _(action: DropPrimaryKey, backticked_table_name: str) -> str:
 def _(action: SetPrimaryKey, backticked_table_name: str) -> str:
     """Compile an ALTER TABLE ... ADD CONSTRAINT ... PRIMARY KEY statement."""
     column_list = ", ".join(backtick(column.name) for column in action.columns)
-    return f"ALTER TABLE {backticked_table_name} ADD CONSTRAINT {backtick(action.constraint_name)} PRIMARY KEY ({column_list})"
+    constraint = backtick(action.constraint_name)
+    return (
+        f"ALTER TABLE {backticked_table_name}"
+        f" ADD CONSTRAINT {constraint} PRIMARY KEY ({column_list})"
+    )
 
 
 @_compile_action.register

--- a/src/delta_engine/adapters/databricks/sql/compile.py
+++ b/src/delta_engine/adapters/databricks/sql/compile.py
@@ -24,9 +24,11 @@ from delta_engine.domain.plan.actions import (
     ColumnTypeChange,
     CreateTable,
     DropColumn,
+    DropPrimaryKey,
     PartitioningChange,
     SetColumnComment,
     SetColumnNullability,
+    SetPrimaryKey,
     SetProperty,
     SetTableComment,
 )
@@ -129,6 +131,20 @@ def _(action: SetColumnNullability, backticked_table_name: str) -> str:
     column_name = backtick(action.column_name)
     sign = "DROP" if action.nullable else "SET"
     return f"ALTER TABLE {backticked_table_name} ALTER COLUMN {column_name} {sign} NOT NULL"
+
+
+@_compile_action.register
+def _(action: DropPrimaryKey, backticked_table_name: str) -> str:
+    """Compile an ALTER TABLE ... DROP PRIMARY KEY statement."""
+    return f"ALTER TABLE {backticked_table_name} DROP PRIMARY KEY"
+
+
+@_compile_action.register
+def _(action: SetPrimaryKey, backticked_table_name: str) -> str:
+    """Compile an ALTER TABLE ... ADD CONSTRAINT ... PRIMARY KEY statement."""
+    column_list = ", ".join(backtick(column.name) for column in action.columns)
+    constraint_name = backtick(action.constraint_name)
+    return f"ALTER TABLE {backticked_table_name} ADD CONSTRAINT {constraint_name} PRIMARY KEY ({column_list})"
 
 
 @_compile_action.register

--- a/src/delta_engine/adapters/databricks/sql/compile.py
+++ b/src/delta_engine/adapters/databricks/sql/compile.py
@@ -135,15 +135,15 @@ def _(action: SetColumnNullability, backticked_table_name: str) -> str:
 
 @_compile_action.register
 def _(action: DropPrimaryKey, backticked_table_name: str) -> str:
-    """Compile an ALTER TABLE ... DROP PRIMARY KEY statement."""
-    return f"ALTER TABLE {backticked_table_name} DROP PRIMARY KEY"
+    """Compile an ALTER TABLE ... DROP PRIMARY KEY IF EXISTS statement."""
+    return f"ALTER TABLE {backticked_table_name} DROP PRIMARY KEY IF EXISTS"
 
 
 @_compile_action.register
 def _(action: SetPrimaryKey, backticked_table_name: str) -> str:
     """Compile an ALTER TABLE ... ADD CONSTRAINT ... PRIMARY KEY statement."""
     column_list = ", ".join(backtick(column.name) for column in action.columns)
-    constraint_name = backtick(action.constraint_name)
+    constraint_name = action.constraint_name
     return f"ALTER TABLE {backticked_table_name} ADD CONSTRAINT {constraint_name} PRIMARY KEY ({column_list})"
 
 

--- a/src/delta_engine/adapters/databricks/sql/compile.py
+++ b/src/delta_engine/adapters/databricks/sql/compile.py
@@ -48,9 +48,15 @@ def _compile_action(action: Action, backticked_table_name: str) -> str:
 
 @_compile_action.register
 def _(action: CreateTable, backticked_table_name: str) -> str:
-    """Compile a CREATE TABLE statement including columns, comment, and properties."""
+    """Compile a CREATE TABLE statement including columns, comment, properties, and optional PK."""
     table = action.table
-    columns = ", ".join(_column_definition(column) for column in table.columns)
+    column_defs = [_column_definition(column) for column in table.columns]
+
+    if table.primary_key and table.primary_key_constraint_name:
+        pk_cols = ", ".join(backtick(name) for name in table.primary_key)
+        column_defs.append(f"CONSTRAINT {table.primary_key_constraint_name} PRIMARY KEY ({pk_cols})")
+
+    columns_clause = ", ".join(column_defs)
     table_comment = _set_table_comment(table.comment)
     properties = _set_properties(table.properties)
     partition_by = _set_partitioned_by(table.partitioned_by)
@@ -64,7 +70,7 @@ def _(action: CreateTable, backticked_table_name: str) -> str:
     # non-goals.
     parts = [
         f"CREATE TABLE IF NOT EXISTS {backticked_table_name}",
-        f"({columns})",
+        f"({columns_clause})",
         "USING delta",
         table_comment,
         properties,

--- a/src/delta_engine/api/__init__.py
+++ b/src/delta_engine/api/__init__.py
@@ -1,3 +1,5 @@
+from delta_engine.api.properties import Property
+from delta_engine.api.table import DeltaTable
 from delta_engine.domain.model import (
     Array,
     Boolean,
@@ -12,8 +14,6 @@ from delta_engine.domain.model import (
     String,
     Timestamp,
 )
-from delta_engine.api.properties import Property
-from delta_engine.api.table import DeltaTable
 
 __all__ = [
     "Array",

--- a/src/delta_engine/api/table.py
+++ b/src/delta_engine/api/table.py
@@ -48,21 +48,35 @@ class DeltaTable:
 
         effective = {**self.default_properties, **user_properties}
 
+        columns_tuple = tuple(columns)
+        primary_key = tuple(col.name for col in columns_tuple if col.primary_key)
+
         # Building DesiredTable here enforces all domain invariants (non-empty
         # columns, unique names, partition columns must exist) at construction
         # time rather than deferring them to to_desired_table().
         self._desired_table = DesiredTable(
             qualified_name=QualifiedName(catalog, schema, name),
-            columns=tuple(columns),
+            columns=columns_tuple,
             comment=comment,
             properties=effective,
             partitioned_by=tuple(partitioned_by) if partitioned_by is not None else (),
+            primary_key=primary_key,
         )
 
     @property
     def effective_properties(self) -> Mapping[str, str]:
         """Defaults overlaid by user properties (user wins)."""
         return self._desired_table.properties
+
+    @property
+    def primary_key(self) -> tuple[str, ...]:
+        """Column names declared as the primary key, in declaration order."""
+        return self._desired_table.primary_key
+
+    @property
+    def primary_key_constraint_name(self) -> str | None:
+        """The constraint name for this table's primary key, or None if no PK is defined."""
+        return self._desired_table.primary_key_constraint_name
 
     def to_desired_table(self) -> DesiredTable:
         """Return the domain :class:`DesiredTable` for this table definition."""

--- a/src/delta_engine/api/table.py
+++ b/src/delta_engine/api/table.py
@@ -4,8 +4,8 @@ from collections.abc import Iterable, Mapping
 from types import MappingProxyType
 from typing import ClassVar
 
-from delta_engine.domain.model import Column, DesiredTable, QualifiedName
 from delta_engine.api.properties import MANAGED_PROPERTY_KEYS, Property
+from delta_engine.domain.model import Column, DesiredTable, QualifiedName
 
 
 class DeltaTable:

--- a/src/delta_engine/application/validation.py
+++ b/src/delta_engine/application/validation.py
@@ -10,7 +10,6 @@ from delta_engine.domain.plan import (
     AddColumn,
     ColumnTypeChange,
     CreateTable,
-    DropPrimaryKey,
     PartitioningChange,
     SetColumnNullability,
     SetPrimaryKey,

--- a/src/delta_engine/application/validation.py
+++ b/src/delta_engine/application/validation.py
@@ -9,8 +9,11 @@ from delta_engine.domain.plan import (
     ActionPlan,
     AddColumn,
     ColumnTypeChange,
+    CreateTable,
+    DropPrimaryKey,
     PartitioningChange,
     SetColumnNullability,
+    SetPrimaryKey,
 )
 
 
@@ -150,11 +153,60 @@ class DisallowPartitioningChange:
         )
 
 
+class PrimaryKeyColumnsNullable:
+    """
+    Disallow primary key constraints on nullable columns.
+
+    Databricks rejects primary key constraints on nullable columns at execution
+    time. This rule surfaces the violation at validation time — before any SQL
+    is executed — with a clear message. Fires on both ``SetPrimaryKey`` actions
+    (for existing tables) and ``CreateTable`` actions (for new tables with a
+    declared primary key).
+    """
+
+    name: ClassVar[str] = "PrimaryKeyColumnsNullable"
+
+    def evaluate(self, plan: ActionPlan) -> tuple[ValidationFailure, ...]:
+        """Flag every nullable column declared as a primary key member."""
+        failures = []
+        for action in plan:
+            if isinstance(action, SetPrimaryKey):
+                for column in action.columns:
+                    if column.nullable:
+                        failures.append(
+                            ValidationFailure(
+                                rule_name=self.name,
+                                message=(
+                                    f"Operation not allowed: primary key column '{column.name}'"
+                                    " must be NOT NULL. Set nullable=False on the column before"
+                                    " declaring it as a primary key."
+                                ),
+                            )
+                        )
+            elif isinstance(action, CreateTable):
+                if action.table.primary_key:
+                    pk_set = frozenset(action.table.primary_key)
+                    for column in action.table.columns:
+                        if column.name in pk_set and column.nullable:
+                            failures.append(
+                                ValidationFailure(
+                                    rule_name=self.name,
+                                    message=(
+                                        f"Operation not allowed: primary key column '{column.name}'"
+                                        " must be NOT NULL. Set nullable=False on the column before"
+                                        " declaring it as a primary key."
+                                    ),
+                                )
+                            )
+        return tuple(failures)
+
+
 DEFAULT_RULES: tuple[Rule, ...] = (
     NonNullableColumnAdd(),
     NullabilityTighteningOnExistingColumn(),
     UnsupportedColumnTypeChange(),
     DisallowPartitioningChange(),
+    PrimaryKeyColumnsNullable(),
 )
 
 

--- a/src/delta_engine/domain/model/column.py
+++ b/src/delta_engine/domain/model/column.py
@@ -16,6 +16,9 @@ class Column:
         name: Column name (normalized to lowercase).
         data_type: Logical data type of the column.
         nullable: Whether the column accepts ``NULL`` values.
+        comment: Optional column comment.
+        primary_key: Whether this column is part of the table's primary key.
+            Used by the API layer to derive the table-level primary key tuple.
 
     """
 
@@ -23,6 +26,7 @@ class Column:
     data_type: DataType
     nullable: bool = True
     comment: str = ""
+    primary_key: bool = False
 
     def __post_init__(self) -> None:
         """Raise if the name is blank or contains uppercase characters."""

--- a/src/delta_engine/domain/model/table.py
+++ b/src/delta_engine/domain/model/table.py
@@ -68,6 +68,12 @@ class TableSnapshot:
             if missing_pk:
                 raise ValueError(f"Primary key column not found in columns: {missing_pk[0]}")
 
+            seen_pk: set[str] = set()
+            for name in self.primary_key:
+                if name in seen_pk:
+                    raise ValueError(f"Duplicate primary key column: {name}")
+                seen_pk.add(name)
+
 
 @dataclass(frozen=True, slots=True)
 class DesiredTable(TableSnapshot):

--- a/src/delta_engine/domain/model/table.py
+++ b/src/delta_engine/domain/model/table.py
@@ -19,6 +19,8 @@ class TableSnapshot:
         columns: Ordered tuple of ``Column`` definitions.
         comment: Optional table-level comment (empty string when unset).
         properties: Read-only mapping of table properties.
+        partitioned_by: Ordered tuple of partition column names.
+        primary_key: Ordered tuple of primary key column names (empty when none).
 
     """
 
@@ -27,6 +29,7 @@ class TableSnapshot:
     comment: str = ""
     properties: Mapping[str, str] = field(default_factory=dict)
     partitioned_by: tuple[str, ...] = ()
+    primary_key: tuple[str, ...] = ()
 
     def __post_init__(self) -> None:
         """
@@ -34,6 +37,7 @@ class TableSnapshot:
 
         Columns must be non-empty and unique; partition columns must be
         lowercase, must each exist in ``columns``, and must be unique.
+        Primary key columns must each exist in ``columns``.
         """
         if not self.columns:
             raise ValueError("Table requires at least one column")
@@ -59,10 +63,22 @@ class TableSnapshot:
                     raise ValueError(f"Duplicate partition column: {name}")
                 seen_partitions.add(name)
 
+        if self.primary_key:
+            missing_pk = [name for name in self.primary_key if name not in seen_names]
+            if missing_pk:
+                raise ValueError(f"Primary key column not found in columns: {missing_pk[0]}")
+
 
 @dataclass(frozen=True, slots=True)
 class DesiredTable(TableSnapshot):
     """Desired definition authored by users (target state)."""
+
+    @property
+    def primary_key_constraint_name(self) -> str | None:
+        """Return the constraint name for this table's primary key, or None if no PK is defined."""
+        if not self.primary_key:
+            return None
+        return f"{self.qualified_name.name}_pk"
 
 
 @dataclass(frozen=True, slots=True)

--- a/src/delta_engine/domain/plan/__init__.py
+++ b/src/delta_engine/domain/plan/__init__.py
@@ -10,8 +10,8 @@ from delta_engine.domain.plan.actions import (
     PartitioningChange,
     SetColumnComment,
     SetColumnNullability,
-    SetProperty,
     SetPrimaryKey,
+    SetProperty,
     SetTableComment,
 )
 
@@ -27,7 +27,7 @@ __all__ = [
     "PartitioningChange",
     "SetColumnComment",
     "SetColumnNullability",
-    "SetProperty",
     "SetPrimaryKey",
+    "SetProperty",
     "SetTableComment",
 ]

--- a/src/delta_engine/domain/plan/__init__.py
+++ b/src/delta_engine/domain/plan/__init__.py
@@ -6,10 +6,12 @@ from delta_engine.domain.plan.actions import (
     ColumnTypeChange,
     CreateTable,
     DropColumn,
+    DropPrimaryKey,
     PartitioningChange,
     SetColumnComment,
     SetColumnNullability,
     SetProperty,
+    SetPrimaryKey,
     SetTableComment,
 )
 
@@ -21,9 +23,11 @@ __all__ = [
     "ColumnTypeChange",
     "CreateTable",
     "DropColumn",
+    "DropPrimaryKey",
     "PartitioningChange",
     "SetColumnComment",
     "SetColumnNullability",
     "SetProperty",
+    "SetPrimaryKey",
     "SetTableComment",
 ]

--- a/src/delta_engine/domain/plan/actions.py
+++ b/src/delta_engine/domain/plan/actions.py
@@ -169,7 +169,8 @@ class DropPrimaryKey(Action):
 
 @dataclass(frozen=True, slots=True)
 class SetPrimaryKey(Action):
-    """Add a primary key constraint to a table.
+    """
+    Add a primary key constraint to a table.
 
     Carries the full Column objects so the validation rule can check
     nullability without requiring a DesiredTable reference.

--- a/src/delta_engine/domain/plan/actions.py
+++ b/src/delta_engine/domain/plan/actions.py
@@ -25,11 +25,13 @@ class ActionPhase(IntEnum):
 
     CREATE_TABLE = auto()
     SET_PROPERTY = auto()
+    DROP_PRIMARY_KEY = auto()
     ADD_COLUMN = auto()
     DROP_COLUMN = auto()
     SET_COLUMN_COMMENT = auto()
     SET_TABLE_COMMENT = auto()
     SET_COLUMN_NULLABILITY = auto()
+    SET_PRIMARY_KEY = auto()
     COLUMN_TYPE_CHANGE = auto()
     PARTITIONING_CHANGE = auto()
 
@@ -152,6 +154,35 @@ class SetColumnNullability(Action):
     @property
     def subject(self) -> str:
         return self.column_name
+
+
+@dataclass(frozen=True, slots=True)
+class DropPrimaryKey(Action):
+    """Drop the existing primary key constraint from a table."""
+
+    phase: ClassVar[ActionPhase] = ActionPhase.DROP_PRIMARY_KEY
+
+    @property
+    def subject(self) -> str:
+        return ""
+
+
+@dataclass(frozen=True, slots=True)
+class SetPrimaryKey(Action):
+    """Add a primary key constraint to a table.
+
+    Carries the full Column objects so the validation rule can check
+    nullability without requiring a DesiredTable reference.
+    """
+
+    columns: tuple[Column, ...]
+    constraint_name: str
+
+    phase: ClassVar[ActionPhase] = ActionPhase.SET_PRIMARY_KEY
+
+    @property
+    def subject(self) -> str:
+        return ""
 
 
 @dataclass(frozen=True, slots=True)

--- a/src/delta_engine/domain/plan/differ.py
+++ b/src/delta_engine/domain/plan/differ.py
@@ -125,10 +125,9 @@ def _diff_table_comment(desired: str, observed: str) -> tuple[SetTableComment, .
     return (SetTableComment(comment=desired),)
 
 
-def _diff_primary_key(
-    desired: DesiredTable, observed: ObservedTable
-) -> tuple[Action, ...]:
-    """Return the primary key actions to align observed with desired.
+def _diff_primary_key(desired: DesiredTable, observed: ObservedTable) -> tuple[Action, ...]:
+    """
+    Return the primary key actions to align observed with desired.
 
     Uses frozenset comparison so column order does not trigger spurious changes.
     Declaration order from desired is preserved in SetPrimaryKey.columns.
@@ -145,9 +144,7 @@ def _diff_primary_key(
         actions.append(DropPrimaryKey())
 
     if desired_set:
-        pk_columns = tuple(
-            column for column in desired.columns if column.name in desired_set
-        )
+        pk_columns = tuple(column for column in desired.columns if column.name in desired_set)
         constraint_name = desired.primary_key_constraint_name
         assert constraint_name is not None  # guaranteed: desired_set is non-empty
         actions.append(

--- a/src/delta_engine/domain/plan/differ.py
+++ b/src/delta_engine/domain/plan/differ.py
@@ -20,9 +20,11 @@ from delta_engine.domain.plan.actions import (
     ColumnTypeChange,
     CreateTable,
     DropColumn,
+    DropPrimaryKey,
     PartitioningChange,
     SetColumnComment,
     SetColumnNullability,
+    SetPrimaryKey,
     SetProperty,
     SetTableComment,
 )
@@ -48,6 +50,7 @@ def compute_plan(desired: DesiredTable, observed: ObservedTable | None) -> Actio
             + _diff_properties(desired.properties, observed.properties)
             + _diff_table_comment(desired.comment, observed.comment)
             + _diff_partitioning(desired.partitioned_by, observed.partitioned_by)
+            + _diff_primary_key(desired, observed)
         )
     return ActionPlan(actions)
 
@@ -120,3 +123,36 @@ def _diff_table_comment(desired: str, observed: str) -> tuple[SetTableComment, .
     if desired == observed:
         return ()
     return (SetTableComment(comment=desired),)
+
+
+def _diff_primary_key(
+    desired: DesiredTable, observed: ObservedTable
+) -> tuple[Action, ...]:
+    """Return the primary key actions to align observed with desired.
+
+    Uses frozenset comparison so column order does not trigger spurious changes.
+    Declaration order from desired is preserved in SetPrimaryKey.columns.
+    """
+    desired_set = frozenset(desired.primary_key)
+    observed_set = frozenset(observed.primary_key)
+
+    if desired_set == observed_set:
+        return ()
+
+    actions: list[Action] = []
+
+    if observed_set:
+        actions.append(DropPrimaryKey())
+
+    if desired_set:
+        pk_columns = tuple(
+            column for column in desired.columns if column.name in desired_set
+        )
+        actions.append(
+            SetPrimaryKey(
+                columns=pk_columns,
+                constraint_name=desired.primary_key_constraint_name,  # type: ignore[arg-type]
+            )
+        )
+
+    return tuple(actions)

--- a/src/delta_engine/domain/plan/differ.py
+++ b/src/delta_engine/domain/plan/differ.py
@@ -148,10 +148,12 @@ def _diff_primary_key(
         pk_columns = tuple(
             column for column in desired.columns if column.name in desired_set
         )
+        constraint_name = desired.primary_key_constraint_name
+        assert constraint_name is not None  # guaranteed: desired_set is non-empty
         actions.append(
             SetPrimaryKey(
                 columns=pk_columns,
-                constraint_name=desired.primary_key_constraint_name,  # type: ignore[arg-type]
+                constraint_name=constraint_name,
             )
         )
 

--- a/tests/adapters/databricks/sql/test_compile.py
+++ b/tests/adapters/databricks/sql/test_compile.py
@@ -12,9 +12,11 @@ from delta_engine.domain.plan.actions import (
     ColumnTypeChange,
     CreateTable,
     DropColumn,
+    DropPrimaryKey,
     PartitioningChange,
     SetColumnComment,
     SetColumnNullability,
+    SetPrimaryKey,
     SetProperty,
     SetTableComment,
 )
@@ -257,3 +259,31 @@ def test_partitioning_change_compiler_raises_on_invariant_violation():
     # Then reaching the compiler is an internal-invariant violation -- AssertionError
     with pytest.raises(AssertionError, match=r"[Pp]artitioning"):
         _compile_single(action)
+
+
+def test_drop_primary_key_renders_alter_drop_primary_key():
+    # When compiling a DropPrimaryKey action
+    statement = _compile_single(DropPrimaryKey())
+
+    # Then it renders ALTER TABLE ... DROP PRIMARY KEY
+    assert statement == "ALTER TABLE `cat`.`sch`.`tbl` DROP PRIMARY KEY"
+
+
+def test_set_primary_key_renders_add_constraint_primary_key():
+    # Given a SetPrimaryKey with two columns and a constraint name
+    action = SetPrimaryKey(
+        columns=(
+            Column(name="tenant_id", data_type=Integer(), nullable=False),
+            Column(name="order_id", data_type=Integer(), nullable=False),
+        ),
+        constraint_name="orders_pk",
+    )
+
+    # When compiling the action
+    statement = _compile_single(action)
+
+    # Then it renders ALTER TABLE ... ADD CONSTRAINT ... PRIMARY KEY (...)
+    assert statement == (
+        "ALTER TABLE `cat`.`sch`.`tbl`"
+        " ADD CONSTRAINT `orders_pk` PRIMARY KEY (`tenant_id`, `order_id`)"
+    )

--- a/tests/adapters/databricks/sql/test_compile.py
+++ b/tests/adapters/databricks/sql/test_compile.py
@@ -265,8 +265,8 @@ def test_drop_primary_key_renders_alter_drop_primary_key():
     # When compiling a DropPrimaryKey action
     statement = _compile_single(DropPrimaryKey())
 
-    # Then it renders ALTER TABLE ... DROP PRIMARY KEY
-    assert statement == "ALTER TABLE `cat`.`sch`.`tbl` DROP PRIMARY KEY"
+    # Then it renders ALTER TABLE ... DROP PRIMARY KEY IF EXISTS
+    assert statement == "ALTER TABLE `cat`.`sch`.`tbl` DROP PRIMARY KEY IF EXISTS"
 
 
 def test_set_primary_key_renders_add_constraint_primary_key():
@@ -285,5 +285,5 @@ def test_set_primary_key_renders_add_constraint_primary_key():
     # Then it renders ALTER TABLE ... ADD CONSTRAINT ... PRIMARY KEY (...)
     assert statement == (
         "ALTER TABLE `cat`.`sch`.`tbl`"
-        " ADD CONSTRAINT `orders_pk` PRIMARY KEY (`tenant_id`, `order_id`)"
+        " ADD CONSTRAINT orders_pk PRIMARY KEY (`tenant_id`, `order_id`)"
     )

--- a/tests/adapters/databricks/sql/test_compile.py
+++ b/tests/adapters/databricks/sql/test_compile.py
@@ -24,7 +24,9 @@ from delta_engine.domain.plan.actions import (
 _TARGET = QualifiedName("cat", "sch", "tbl")
 
 
-def _create_table(*columns: Column, comment: str = "", properties=None, partitioned_by=(), primary_key=()):
+def _create_table(
+    *columns: Column, comment: str = "", properties=None, partitioned_by=(), primary_key=()
+):
     """Wrap columns in a CreateTable action for the target table."""
     return CreateTable(
         table=DesiredTable(
@@ -299,9 +301,7 @@ def test_set_primary_key_renders_alter_add_constraint():
     statement = _compile_single(action)
 
     # Then it renders ALTER TABLE ... ADD CONSTRAINT ... PRIMARY KEY (...)
-    assert statement == (
-        "ALTER TABLE `cat`.`sch`.`tbl` ADD CONSTRAINT `tbl_pk` PRIMARY KEY (`id`)"
-    )
+    assert statement == ("ALTER TABLE `cat`.`sch`.`tbl` ADD CONSTRAINT `tbl_pk` PRIMARY KEY (`id`)")
 
 
 def test_set_primary_key_renders_multiple_columns():

--- a/tests/adapters/databricks/sql/test_compile.py
+++ b/tests/adapters/databricks/sql/test_compile.py
@@ -286,7 +286,7 @@ def test_set_primary_key_renders_add_constraint_primary_key():
     # Then it renders ALTER TABLE ... ADD CONSTRAINT ... PRIMARY KEY (...)
     assert statement == (
         "ALTER TABLE `cat`.`sch`.`tbl`"
-        " ADD CONSTRAINT orders_pk PRIMARY KEY (`tenant_id`, `order_id`)"
+        " ADD CONSTRAINT `orders_pk` PRIMARY KEY (`tenant_id`, `order_id`)"
     )
 
 
@@ -300,7 +300,7 @@ def test_set_primary_key_renders_alter_add_constraint():
 
     # Then it renders ALTER TABLE ... ADD CONSTRAINT ... PRIMARY KEY (...)
     assert statement == (
-        "ALTER TABLE `cat`.`sch`.`tbl` ADD CONSTRAINT tbl_pk PRIMARY KEY (`id`)"
+        "ALTER TABLE `cat`.`sch`.`tbl` ADD CONSTRAINT `tbl_pk` PRIMARY KEY (`id`)"
     )
 
 
@@ -317,7 +317,7 @@ def test_set_primary_key_renders_multiple_columns():
 
     # Then both columns appear in the PRIMARY KEY clause
     assert statement == (
-        "ALTER TABLE `cat`.`sch`.`tbl` ADD CONSTRAINT tbl_pk PRIMARY KEY (`id`, `tenant_id`)"
+        "ALTER TABLE `cat`.`sch`.`tbl` ADD CONSTRAINT `tbl_pk` PRIMARY KEY (`id`, `tenant_id`)"
     )
 
 
@@ -331,7 +331,7 @@ def test_create_table_inlines_primary_key_constraint():
     statement = _compile_single(action)
 
     # Then the constraint is inlined in the column list
-    assert "CONSTRAINT tbl_pk PRIMARY KEY (`id`)" in statement
+    assert "CONSTRAINT `tbl_pk` PRIMARY KEY (`id`)" in statement
     # And it appears after the column definitions, inside the parentheses
     assert statement.startswith("CREATE TABLE IF NOT EXISTS `cat`.`sch`.`tbl` (")
 

--- a/tests/adapters/databricks/sql/test_compile.py
+++ b/tests/adapters/databricks/sql/test_compile.py
@@ -24,7 +24,7 @@ from delta_engine.domain.plan.actions import (
 _TARGET = QualifiedName("cat", "sch", "tbl")
 
 
-def _create_table(*columns: Column, comment: str = "", properties=None, partitioned_by=()):
+def _create_table(*columns: Column, comment: str = "", properties=None, partitioned_by=(), primary_key=()):
     """Wrap columns in a CreateTable action for the target table."""
     return CreateTable(
         table=DesiredTable(
@@ -33,6 +33,7 @@ def _create_table(*columns: Column, comment: str = "", properties=None, partitio
             comment=comment,
             properties=properties or {},
             partitioned_by=partitioned_by,
+            primary_key=primary_key,
         )
     )
 
@@ -287,3 +288,59 @@ def test_set_primary_key_renders_add_constraint_primary_key():
         "ALTER TABLE `cat`.`sch`.`tbl`"
         " ADD CONSTRAINT orders_pk PRIMARY KEY (`tenant_id`, `order_id`)"
     )
+
+
+def test_set_primary_key_renders_alter_add_constraint():
+    # When compiling a SetPrimaryKey with one column
+    action = SetPrimaryKey(
+        columns=(Column("id", Integer(), nullable=False),),
+        constraint_name="tbl_pk",
+    )
+    statement = _compile_single(action)
+
+    # Then it renders ALTER TABLE ... ADD CONSTRAINT ... PRIMARY KEY (...)
+    assert statement == (
+        "ALTER TABLE `cat`.`sch`.`tbl` ADD CONSTRAINT tbl_pk PRIMARY KEY (`id`)"
+    )
+
+
+def test_set_primary_key_renders_multiple_columns():
+    # When compiling a SetPrimaryKey with two columns
+    action = SetPrimaryKey(
+        columns=(
+            Column("id", Integer(), nullable=False),
+            Column("tenant_id", Integer(), nullable=False),
+        ),
+        constraint_name="tbl_pk",
+    )
+    statement = _compile_single(action)
+
+    # Then both columns appear in the PRIMARY KEY clause
+    assert statement == (
+        "ALTER TABLE `cat`.`sch`.`tbl` ADD CONSTRAINT tbl_pk PRIMARY KEY (`id`, `tenant_id`)"
+    )
+
+
+def test_create_table_inlines_primary_key_constraint():
+    # Given a CREATE TABLE with a primary key column
+    action = _create_table(
+        Column("id", Integer(), nullable=False),
+        Column("name", String()),
+        primary_key=("id",),
+    )
+    statement = _compile_single(action)
+
+    # Then the constraint is inlined in the column list
+    assert "CONSTRAINT tbl_pk PRIMARY KEY (`id`)" in statement
+    # And it appears after the column definitions, inside the parentheses
+    assert statement.startswith("CREATE TABLE IF NOT EXISTS `cat`.`sch`.`tbl` (")
+
+
+def test_create_table_without_pk_omits_constraint_clause():
+    # Given a CREATE TABLE with no primary key
+    action = _create_table(Column("id", Integer()))
+    statement = _compile_single(action)
+
+    # Then no CONSTRAINT clause appears
+    assert "PRIMARY KEY" not in statement
+    assert "CONSTRAINT" not in statement

--- a/tests/adapters/databricks/test_reader.py
+++ b/tests/adapters/databricks/test_reader.py
@@ -23,6 +23,9 @@ class FakeDataFrame:
     def first(self):
         return self._rows[0] if self._rows else None
 
+    def collect(self):
+        return list(self._rows)
+
 
 class FakeCatalog:
     def __init__(
@@ -102,6 +105,36 @@ class FakeSparkForFetchState:
         return FakeDataFrame(self._describe_rows or [])
 
 
+class FakeSparkWithPrimaryKey:
+    """
+    Spark fake that handles both DESCRIBE DETAIL (properties) and the
+    INFORMATION_SCHEMA primary key query.
+
+    sql() is called for both queries; this fake distinguishes them by
+    the presence of 'information_schema' in the query string.
+    """
+
+    def __init__(
+        self,
+        *,
+        catalog: FakeCatalog,
+        describe_rows=None,
+        pk_column_rows=None,
+    ):
+        self._catalog = catalog
+        self._describe_rows = describe_rows or [{"properties": {}}]
+        self._pk_column_rows = pk_column_rows or []
+
+    @property
+    def catalog(self):
+        return self._catalog
+
+    def sql(self, query: str):
+        if "information_schema" in query.lower():
+            return FakeDataFrame(self._pk_column_rows)
+        return FakeDataFrame(self._describe_rows)
+
+
 def make_catalog_col(
     name: str,
     *,
@@ -143,7 +176,7 @@ def test_columns_maps_name_nullability_and_comment(qn):
             ]
         }
     )
-    spark = FakeSparkForFetchState(catalog=catalog, describe_rows=[{"properties": {}}])
+    spark = FakeSparkWithPrimaryKey(catalog=catalog, describe_rows=[{"properties": {}}])
 
     # When we fetch state for the table
     result = DatabricksReader(spark).fetch_state(qn)
@@ -167,7 +200,7 @@ def test_partition_columns_returns_only_partition_names_in_order(qn):
             ]
         }
     )
-    spark = FakeSparkForFetchState(catalog=catalog, describe_rows=[{"properties": {}}])
+    spark = FakeSparkWithPrimaryKey(catalog=catalog, describe_rows=[{"properties": {}}])
 
     # When we fetch state for the table
     result = DatabricksReader(spark).fetch_state(qn)
@@ -191,7 +224,7 @@ def test_partition_columns_ignores_missing_or_false_flags():
             ]
         }
     )
-    spark = FakeSparkForFetchState(catalog=catalog, describe_rows=[{"properties": {}}])
+    spark = FakeSparkWithPrimaryKey(catalog=catalog, describe_rows=[{"properties": {}}])
 
     # When we fetch state for the table
     result = DatabricksReader(spark).fetch_state(qn)
@@ -299,7 +332,7 @@ def test_fetch_state_returns_present_with_columns_partitions_comment_and_propert
     ]
 
     reader = DatabricksReader(
-        FakeSparkForFetchState(catalog=catalog, describe_rows=describe_rows),
+        FakeSparkWithPrimaryKey(catalog=catalog, describe_rows=describe_rows),
     )
 
     # When we fetch state
@@ -327,7 +360,7 @@ def test_fetch_state_returns_present_with_empty_properties_when_describe_has_no_
         table_comments={fq: ""},
     )
     reader = DatabricksReader(
-        FakeSparkForFetchState(catalog=catalog, describe_rows=[]),
+        FakeSparkWithPrimaryKey(catalog=catalog, describe_rows=[]),
     )
 
     # When we fetch state
@@ -381,7 +414,7 @@ def test_fetch_state_returns_failed_when_all_columns_are_unsupported():
         table_comments={str(qn): ""},
     )
     reader = DatabricksReader(
-        FakeSparkForFetchState(catalog=catalog, describe_rows=[{"properties": {}}])
+        FakeSparkWithPrimaryKey(catalog=catalog, describe_rows=[{"properties": {}}])
     )
 
     # When we fetch state
@@ -406,7 +439,7 @@ def test_fetch_state_skips_unsupported_column_leaves_mappable_columns_intact():
         table_comments={str(qn): ""},
     )
     reader = DatabricksReader(
-        FakeSparkForFetchState(catalog=catalog, describe_rows=[{"properties": {}}])
+        FakeSparkWithPrimaryKey(catalog=catalog, describe_rows=[{"properties": {}}])
     )
 
     # When we fetch state
@@ -430,7 +463,7 @@ def test_fetch_state_lowercases_mixed_case_column_names_from_catalog():
         table_comments={str(qn): ""},
     )
     reader = DatabricksReader(
-        FakeSparkForFetchState(catalog=catalog, describe_rows=[{"properties": {}}])
+        FakeSparkWithPrimaryKey(catalog=catalog, describe_rows=[{"properties": {}}])
     )
 
     # When we fetch state
@@ -440,3 +473,102 @@ def test_fetch_state_lowercases_mixed_case_column_names_from_catalog():
     assert isinstance(result, TablePresent)
     assert [c.name for c in result.table.columns] == ["eventid", "username"]
     assert result.table.partitioned_by == ("username",)
+
+
+# ---------- tests: primary key ----------
+
+
+def test_fetch_primary_key_returns_column_names_from_information_schema():
+    # Given: information_schema returns one column name for the PK
+    qn = QualifiedName("c", "s", "t")
+    spark = FakeSparkWithPrimaryKey(
+        catalog=FakeCatalog(),
+        pk_column_rows=[{"column_name": "id"}],
+    )
+
+    # When
+    reader = DatabricksReader(spark)
+    pk = reader._fetch_primary_key(qn)
+
+    # Then: the primary key column names are returned
+    assert pk == ("id",)
+
+
+def test_fetch_primary_key_returns_empty_when_no_pk_defined():
+    # Given: information_schema returns no rows (no PK)
+    qn = QualifiedName("c", "s", "t")
+    spark = FakeSparkWithPrimaryKey(
+        catalog=FakeCatalog(),
+        pk_column_rows=[],
+    )
+
+    # When
+    reader = DatabricksReader(spark)
+    pk = reader._fetch_primary_key(qn)
+
+    # Then: empty tuple
+    assert pk == ()
+
+
+def test_fetch_primary_key_lowercases_column_names():
+    # Given: information_schema returns a mixed-case column name
+    qn = QualifiedName("c", "s", "t")
+    spark = FakeSparkWithPrimaryKey(
+        catalog=FakeCatalog(),
+        pk_column_rows=[{"column_name": "OrderID"}],
+    )
+
+    # When
+    reader = DatabricksReader(spark)
+    pk = reader._fetch_primary_key(qn)
+
+    # Then: name is normalised to lowercase
+    assert pk == ("orderid",)
+
+
+def test_fetch_state_includes_primary_key_in_observed_table():
+    # Given: a table with a PK
+    qn = QualifiedName("c", "s", "t")
+    fq = str(qn)
+    catalog = FakeCatalog(
+        columns_by_table={
+            fq: [make_catalog_col("id", dataType=T.IntegerType(), nullable=False)],
+        },
+        table_comments={fq: ""},
+    )
+    spark = FakeSparkWithPrimaryKey(
+        catalog=catalog,
+        describe_rows=[{"properties": {}}],
+        pk_column_rows=[{"column_name": "id"}],
+    )
+
+    # When
+    result = DatabricksReader(spark).fetch_state(qn)
+
+    # Then: primary_key is populated on the ObservedTable
+    assert isinstance(result, TablePresent)
+    assert result.table.primary_key == ("id",)
+
+
+def test_fetch_state_primary_key_is_empty_when_none_defined():
+    # Given: a table with no PK
+    qn = QualifiedName("c", "s", "t")
+    fq = str(qn)
+    catalog = FakeCatalog(
+        columns_by_table={
+            fq: [make_catalog_col("id", dataType=T.IntegerType())],
+        },
+        table_comments={fq: ""},
+    )
+    spark = FakeSparkWithPrimaryKey(
+        catalog=catalog,
+        describe_rows=[{"properties": {}}],
+        pk_column_rows=[],
+    )
+
+    # When
+    result = DatabricksReader(spark).fetch_state(qn)
+
+    # Then: primary_key is empty
+    assert isinstance(result, TablePresent)
+    assert result.table.primary_key == ()

--- a/tests/adapters/databricks/test_reader.py
+++ b/tests/adapters/databricks/test_reader.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from types import SimpleNamespace
 
 import pyspark.sql.types as T
-from pyspark.sql.utils import AnalysisException
+from pyspark.errors.exceptions.base import AnalysisException
 import pytest
 
 from delta_engine.adapters.databricks.reader import DatabricksReader
@@ -120,10 +120,12 @@ class FakeSparkWithPrimaryKey:
         catalog: FakeCatalog,
         describe_rows=None,
         pk_column_rows=None,
+        pk_exc: Exception | None = None,
     ):
         self._catalog = catalog
         self._describe_rows = describe_rows or [{"properties": {}}]
         self._pk_column_rows = pk_column_rows or []
+        self._pk_exc = pk_exc
 
     @property
     def catalog(self):
@@ -131,6 +133,8 @@ class FakeSparkWithPrimaryKey:
 
     def sql(self, query: str):
         if "information_schema" in query.lower():
+            if self._pk_exc is not None:
+                raise self._pk_exc
             return FakeDataFrame(self._pk_column_rows)
         return FakeDataFrame(self._describe_rows)
 
@@ -570,5 +574,27 @@ def test_fetch_state_primary_key_is_empty_when_none_defined():
     result = DatabricksReader(spark).fetch_state(qn)
 
     # Then: primary_key is empty
+    assert isinstance(result, TablePresent)
+    assert result.table.primary_key == ()
+
+
+def test_fetch_primary_key_returns_empty_when_information_schema_unavailable():
+    # Given: information_schema raises AnalysisException (non-Unity Catalog Spark)
+    qn = QualifiedName("c", "s", "t")
+    fq = str(qn)
+    catalog = FakeCatalog(
+        columns_by_table={fq: [make_catalog_col("id", dataType=T.IntegerType())]},
+        table_comments={fq: ""},
+    )
+    spark = FakeSparkWithPrimaryKey(
+        catalog=catalog,
+        describe_rows=[{"properties": {}}],
+        pk_exc=AnalysisException("TABLE_OR_VIEW_NOT_FOUND"),
+    )
+
+    # When
+    result = DatabricksReader(spark).fetch_state(qn)
+
+    # Then: the read succeeds and primary_key is empty (no UC = no PK constraints)
     assert isinstance(result, TablePresent)
     assert result.table.primary_key == ()

--- a/tests/api/test_public_api.py
+++ b/tests/api/test_public_api.py
@@ -1,9 +1,9 @@
 """The user-facing api package re-exports the names needed to define a table."""
 
-from delta_engine.domain.model import Array, Decimal, Map
 import delta_engine.api as api
 from delta_engine.api.properties import Property as PropertyImpl
 from delta_engine.api.table import DeltaTable as DeltaTableImpl
+from delta_engine.domain.model import Array, Decimal, Map
 
 _EXPECTED = {
     "DeltaTable",

--- a/tests/api/test_table.py
+++ b/tests/api/test_table.py
@@ -195,3 +195,110 @@ def test_to_desired_table_defaults_partitioning_to_empty_tuple():
 
     # Then partitioned_by is a stable empty tuple, never None
     assert desired.partitioned_by == ()
+
+
+def test_column_with_primary_key_flag():
+    # Given a Column with primary_key=True
+    col = Column("id", Integer(), nullable=False, primary_key=True)
+
+    # Then the flag is readable
+    assert col.primary_key is True
+
+
+def test_column_primary_key_defaults_to_false():
+    # Given a Column without the primary_key flag
+    col = Column("id", Integer())
+
+    # Then it defaults to False
+    assert col.primary_key is False
+
+
+def test_delta_table_primary_key_returns_pk_column_names():
+    # Given a DeltaTable with one PK column
+    table = DeltaTable(
+        catalog="c",
+        schema="s",
+        name="orders",
+        columns=[
+            Column("id", Integer(), nullable=False, primary_key=True),
+            Column("name", String()),
+        ],
+    )
+
+    # Then primary_key returns the PK column names in declaration order
+    assert table.primary_key == ("id",)
+
+
+def test_delta_table_primary_key_returns_empty_when_no_pk_declared():
+    # Given a DeltaTable with no PK columns
+    table = DeltaTable(
+        catalog="c",
+        schema="s",
+        name="orders",
+        columns=[Column("id", Integer())],
+    )
+
+    # Then primary_key is an empty tuple
+    assert table.primary_key == ()
+
+
+def test_delta_table_primary_key_constraint_name_returns_table_name_pk():
+    # Given a DeltaTable with a PK column
+    table = DeltaTable(
+        catalog="c",
+        schema="s",
+        name="orders",
+        columns=[Column("id", Integer(), nullable=False, primary_key=True)],
+    )
+
+    # Then the constraint name is {table_name}_pk
+    assert table.primary_key_constraint_name == "orders_pk"
+
+
+def test_delta_table_primary_key_constraint_name_returns_none_when_no_pk():
+    # Given a DeltaTable with no PK
+    table = DeltaTable(
+        catalog="c",
+        schema="s",
+        name="orders",
+        columns=[Column("id", Integer())],
+    )
+
+    # Then the constraint name is None
+    assert table.primary_key_constraint_name is None
+
+
+def test_delta_table_passes_pk_to_desired_table():
+    # Given a DeltaTable where "id" is PK
+    table = DeltaTable(
+        catalog="c",
+        schema="s",
+        name="orders",
+        columns=[
+            Column("id", Integer(), nullable=False, primary_key=True),
+            Column("ds", String()),
+        ],
+    )
+
+    # When converting to domain
+    desired = table.to_desired_table()
+
+    # Then primary_key is set on the domain DesiredTable
+    assert desired.primary_key == ("id",)
+
+
+def test_delta_table_pk_column_order_matches_declaration_order():
+    # Given two PK columns declared in a specific order
+    table = DeltaTable(
+        catalog="c",
+        schema="s",
+        name="orders",
+        columns=[
+            Column("tenant_id", Integer(), nullable=False, primary_key=True),
+            Column("order_id", Integer(), nullable=False, primary_key=True),
+            Column("ds", String()),
+        ],
+    )
+
+    # Then the order in primary_key matches declaration order
+    assert table.primary_key == ("tenant_id", "order_id")

--- a/tests/api/test_table.py
+++ b/tests/api/test_table.py
@@ -1,8 +1,8 @@
 import pytest
 
-from delta_engine.domain.model import Column as DomainColumn
 from delta_engine.api import Column, DeltaTable, Integer, String
 from delta_engine.api.properties import Property
+from delta_engine.domain.model import Column as DomainColumn
 
 
 def test_user_overrides_take_precedence_over_defaults():

--- a/tests/application/test_engine.py
+++ b/tests/application/test_engine.py
@@ -1,5 +1,6 @@
 import pytest
 
+from delta_engine.api import Column, DeltaTable, String
 from delta_engine.application.engine import Engine
 from delta_engine.application.errors import SyncFailedError
 from delta_engine.application.registry import Registry
@@ -19,7 +20,6 @@ from delta_engine.application.results import (
 )
 from delta_engine.domain.model import ObservedTable, QualifiedName
 from delta_engine.domain.plan import ActionPlan
-from delta_engine.api import Column, DeltaTable, String
 
 # --------- helpers/fakes
 

--- a/tests/application/test_registry.py
+++ b/tests/application/test_registry.py
@@ -1,9 +1,9 @@
 from hypothesis import given, strategies as st
 import pytest
 
+from delta_engine.api import DeltaTable, String
 from delta_engine.application.registry import Registry
 from delta_engine.domain.model import Column, DesiredTable, Integer, QualifiedName
-from delta_engine.api import DeltaTable, String
 
 
 @st.composite

--- a/tests/application/test_validation.py
+++ b/tests/application/test_validation.py
@@ -6,8 +6,7 @@ from delta_engine.application.validation import (
     UnsupportedColumnTypeChange,
     validate_plan,
 )
-from delta_engine.domain.model import Column, Integer, Long, String
-from delta_engine.domain.model import DesiredTable, QualifiedName
+from delta_engine.domain.model import Column, DesiredTable, Integer, Long, QualifiedName, String
 from delta_engine.domain.plan.actions import (
     ActionPlan,
     AddColumn,
@@ -291,9 +290,7 @@ def test_allows_set_primary_key_with_all_non_nullable_columns():
     # Given a SetPrimaryKey where every column is NOT NULL
     rule = PrimaryKeyColumnsNullable()
 
-    failures = rule.evaluate(
-        _plan(_set_pk(Column("id", Integer(), nullable=False)))
-    )
+    failures = rule.evaluate(_plan(_set_pk(Column("id", Integer(), nullable=False))))
 
     assert failures == ()
 
@@ -353,8 +350,6 @@ def test_pk_nullable_rule_ignores_non_pk_actions():
     # Given a plan with only column-level actions
     rule = PrimaryKeyColumnsNullable()
 
-    failures = rule.evaluate(
-        _plan(AddColumn(Column("x", Integer())), DropPrimaryKey())
-    )
+    failures = rule.evaluate(_plan(AddColumn(Column("x", Integer())), DropPrimaryKey()))
 
     assert failures == ()

--- a/tests/application/test_validation.py
+++ b/tests/application/test_validation.py
@@ -2,16 +2,21 @@ from delta_engine.application.validation import (
     DisallowPartitioningChange,
     NonNullableColumnAdd,
     NullabilityTighteningOnExistingColumn,
+    PrimaryKeyColumnsNullable,
     UnsupportedColumnTypeChange,
     validate_plan,
 )
 from delta_engine.domain.model import Column, Integer, Long, String
+from delta_engine.domain.model import DesiredTable, QualifiedName
 from delta_engine.domain.plan.actions import (
     ActionPlan,
     AddColumn,
     ColumnTypeChange,
+    CreateTable,
+    DropPrimaryKey,
     PartitioningChange,
     SetColumnNullability,
+    SetPrimaryKey,
 )
 
 
@@ -230,3 +235,126 @@ def test_validation_passes_when_empty_rule_set_is_supplied():
 
     assert not result.failed
     assert result.failures == ()
+
+
+_QN = QualifiedName("c", "s", "t")
+
+
+def _set_pk(*columns: Column) -> SetPrimaryKey:
+    return SetPrimaryKey(columns=columns, constraint_name="t_pk")
+
+
+def _create_table_with_pk(*columns: Column) -> CreateTable:
+    return CreateTable(
+        table=DesiredTable(
+            qualified_name=_QN,
+            columns=columns,
+            primary_key=tuple(c.name for c in columns if not c.nullable),
+        )
+    )
+
+
+# ---- PrimaryKeyColumnsNullable
+
+
+def test_rejects_set_primary_key_with_nullable_column():
+    # Given a SetPrimaryKey carrying a nullable column
+    rule = PrimaryKeyColumnsNullable()
+
+    failures = rule.evaluate(_plan(_set_pk(Column("id", Integer(), nullable=True))))
+
+    assert len(failures) == 1
+    assert "id" in failures[0].message
+    assert failures[0].rule_name == "PrimaryKeyColumnsNullable"
+
+
+def test_rejects_all_nullable_pk_columns_in_a_single_pass():
+    # Given a SetPrimaryKey carrying two nullable columns
+    rule = PrimaryKeyColumnsNullable()
+
+    failures = rule.evaluate(
+        _plan(
+            _set_pk(
+                Column("id", Integer(), nullable=True),
+                Column("tenant_id", Integer(), nullable=True),
+            )
+        )
+    )
+
+    assert len(failures) == 2
+    messages = [f.message for f in failures]
+    for name in ("id", "tenant_id"):
+        assert any(name in m for m in messages)
+
+
+def test_allows_set_primary_key_with_all_non_nullable_columns():
+    # Given a SetPrimaryKey where every column is NOT NULL
+    rule = PrimaryKeyColumnsNullable()
+
+    failures = rule.evaluate(
+        _plan(_set_pk(Column("id", Integer(), nullable=False)))
+    )
+
+    assert failures == ()
+
+
+def test_rejects_create_table_with_nullable_pk_column():
+    # Given a CreateTable whose PK column is nullable
+    rule = PrimaryKeyColumnsNullable()
+
+    action = CreateTable(
+        table=DesiredTable(
+            qualified_name=_QN,
+            columns=(Column("id", Integer(), nullable=True),),
+            primary_key=("id",),
+        )
+    )
+
+    failures = rule.evaluate(_plan(action))
+
+    assert len(failures) == 1
+    assert "id" in failures[0].message
+
+
+def test_allows_create_table_with_no_primary_key():
+    # Given a CreateTable with no primary key defined
+    rule = PrimaryKeyColumnsNullable()
+
+    action = CreateTable(
+        table=DesiredTable(
+            qualified_name=_QN,
+            columns=(Column("id", Integer()),),
+        )
+    )
+
+    failures = rule.evaluate(_plan(action))
+
+    assert failures == ()
+
+
+def test_allows_create_table_with_non_nullable_pk_column():
+    # Given a CreateTable with a NOT NULL PK column
+    rule = PrimaryKeyColumnsNullable()
+
+    action = CreateTable(
+        table=DesiredTable(
+            qualified_name=_QN,
+            columns=(Column("id", Integer(), nullable=False),),
+            primary_key=("id",),
+        )
+    )
+
+    failures = rule.evaluate(_plan(action))
+
+    assert failures == ()
+
+
+def test_pk_nullable_rule_ignores_non_pk_actions():
+    # Given a plan with only column-level actions
+    rule = PrimaryKeyColumnsNullable()
+
+    failures = rule.evaluate(
+        _plan(AddColumn(Column("x", Integer())), DropPrimaryKey())
+    )
+
+    assert failures == ()

--- a/tests/domain/model/test_table.py
+++ b/tests/domain/model/test_table.py
@@ -1,8 +1,10 @@
 import pytest
 
-from delta_engine.domain.model import Column, Date, Integer, QualifiedName, String, TableSnapshot
+from delta_engine.domain.model import Column, Date, DesiredTable, Integer, ObservedTable, QualifiedName, String, TableSnapshot
 
 _QUALIFIED_NAME = QualifiedName("dev", "silver", "orders")
+_QN = QualifiedName("c", "s", "orders")
+_COL = Column("id", Integer(), nullable=False)
 
 
 def test_fails_when_no_columns_defined():
@@ -50,3 +52,42 @@ def test_fails_when_partition_columns_are_duplicated():
     # Then: validation fails rather than producing invalid SQL
     with pytest.raises(ValueError):
         TableSnapshot(_QUALIFIED_NAME, cols, partitioned_by=("visit_date", "visit_date"))
+
+
+def test_desired_table_primary_key_constraint_name_returns_table_name_pk():
+    # Given a DesiredTable with a primary key
+    table = DesiredTable(qualified_name=_QN, columns=(_COL,), primary_key=("id",))
+
+    # Then the constraint name is {table_name}_pk
+    assert table.primary_key_constraint_name == "orders_pk"
+
+
+def test_desired_table_primary_key_constraint_name_returns_none_when_no_pk():
+    # Given a DesiredTable with no primary key
+    table = DesiredTable(qualified_name=_QN, columns=(_COL,))
+
+    # Then the constraint name is None
+    assert table.primary_key_constraint_name is None
+
+
+def test_table_snapshot_primary_key_defaults_to_empty():
+    # Given a DesiredTable constructed without primary_key
+    table = DesiredTable(qualified_name=_QN, columns=(_COL,))
+
+    # Then primary_key is an empty tuple
+    assert table.primary_key == ()
+
+
+def test_table_snapshot_rejects_pk_column_not_in_columns():
+    # Given a primary_key naming a column that does not exist
+    # Then construction raises ValueError
+    with pytest.raises(ValueError, match="missing_col"):
+        DesiredTable(qualified_name=_QN, columns=(_COL,), primary_key=("missing_col",))
+
+
+def test_observed_table_has_primary_key_field():
+    # Given an ObservedTable constructed with a primary key
+    table = ObservedTable(qualified_name=_QN, columns=(_COL,), primary_key=("id",))
+
+    # Then the field is readable
+    assert table.primary_key == ("id",)

--- a/tests/domain/model/test_table.py
+++ b/tests/domain/model/test_table.py
@@ -1,6 +1,15 @@
 import pytest
 
-from delta_engine.domain.model import Column, Date, DesiredTable, Integer, ObservedTable, QualifiedName, String, TableSnapshot
+from delta_engine.domain.model import (
+    Column,
+    Date,
+    DesiredTable,
+    Integer,
+    ObservedTable,
+    QualifiedName,
+    String,
+    TableSnapshot,
+)
 
 _QUALIFIED_NAME = QualifiedName("dev", "silver", "orders")
 _QN = QualifiedName("c", "s", "orders")

--- a/tests/domain/model/test_table.py
+++ b/tests/domain/model/test_table.py
@@ -91,3 +91,14 @@ def test_observed_table_has_primary_key_field():
 
     # Then the field is readable
     assert table.primary_key == ("id",)
+
+
+def test_table_snapshot_rejects_duplicate_pk_column_names():
+    # Given a primary_key with the same column name twice
+    # Then construction raises ValueError
+    with pytest.raises(ValueError, match="id"):
+        DesiredTable(
+            qualified_name=_QN,
+            columns=(Column("id", Integer(), nullable=False),),
+            primary_key=("id", "id"),
+        )

--- a/tests/domain/plan/test_actions.py
+++ b/tests/domain/plan/test_actions.py
@@ -8,8 +8,10 @@ from delta_engine.domain.plan.actions import (
     AddColumn,
     CreateTable,
     DropColumn,
+    DropPrimaryKey,
     SetColumnComment,
     SetColumnNullability,
+    SetPrimaryKey,
     SetProperty,
     SetTableComment,
 )
@@ -156,3 +158,87 @@ def test_actionplan_order_is_independent_of_input_permutation(
 
     # Then: both plans hold the same actions in the same execution order
     assert tuple(result) == tuple(canonical)
+
+
+# ----- DropPrimaryKey / SetPrimaryKey
+
+
+def test_drop_primary_key_has_no_subject():
+    # Given a DropPrimaryKey action (whole-table operation)
+    action = DropPrimaryKey()
+
+    # Then it has no within-phase subject
+    assert action.subject == ""
+
+
+def test_set_primary_key_has_no_subject():
+    # Given a SetPrimaryKey action
+    action = SetPrimaryKey(
+        columns=(Column(name="id", data_type=Integer(), nullable=False),),
+        constraint_name="orders_pk",
+    )
+
+    # Then it has no within-phase subject
+    assert action.subject == ""
+
+
+def test_plan_orders_drop_primary_key_before_add_column():
+    # Given a DropPrimaryKey and an AddColumn in the same plan
+    plan = ActionPlan(
+        (
+            AddColumn(column=_column("new_col")),
+            DropPrimaryKey(),
+        )
+    )
+
+    # Then DropPrimaryKey runs first
+    assert [type(a) for a in plan] == [DropPrimaryKey, AddColumn]
+
+
+def test_plan_orders_set_primary_key_after_set_column_nullability():
+    # Given a SetPrimaryKey and a SetColumnNullability in the same plan
+    plan = ActionPlan(
+        (
+            SetPrimaryKey(
+                columns=(Column(name="id", data_type=Integer(), nullable=False),),
+                constraint_name="t_pk",
+            ),
+            SetColumnNullability(column_name="id", nullable=False),
+        )
+    )
+
+    # Then SetColumnNullability runs first
+    assert [type(a) for a in plan] == [SetColumnNullability, SetPrimaryKey]
+
+
+def test_plan_full_phase_order_with_all_action_types():
+    # Given one action from each phase, handed to the plan in scrambled order
+    plan = ActionPlan(
+        (
+            SetPrimaryKey(
+                columns=(Column(name="id", data_type=Integer(), nullable=False),),
+                constraint_name="t_pk",
+            ),
+            SetTableComment(comment="tbl comment"),
+            AddColumn(column=_column("a_col")),
+            SetProperty(name="p_set", value="1"),
+            SetColumnNullability(column_name="nn_col", nullable=False),
+            DropPrimaryKey(),
+            DropColumn(column_name="d_col"),
+            SetColumnComment(column_name="c_col", comment="c"),
+            _create_table_action(),
+        )
+    )
+
+    # Then the plan holds them in the documented phase precedence
+    assert [type(a) for a in plan] == [
+        CreateTable,
+        SetProperty,
+        DropPrimaryKey,
+        AddColumn,
+        DropColumn,
+        SetColumnComment,
+        SetTableComment,
+        SetColumnNullability,
+        SetPrimaryKey,
+    ]

--- a/tests/domain/plan/test_differ.py
+++ b/tests/domain/plan/test_differ.py
@@ -21,9 +21,11 @@ from delta_engine.domain.plan.actions import (
     ColumnTypeChange,
     CreateTable,
     DropColumn,
+    DropPrimaryKey,
     PartitioningChange,
     SetColumnComment,
     SetColumnNullability,
+    SetPrimaryKey,
     SetProperty,
     SetTableComment,
 )
@@ -87,12 +89,18 @@ def _desired_table(draw: st.DrawFn) -> DesiredTable:
             st.sampled_from(column_names), max_size=min(2, len(column_names)), unique=True
         ).map(tuple)
     )
+    primary_key = draw(
+        st.lists(
+            st.sampled_from(column_names), max_size=min(2, len(column_names)), unique=True
+        ).map(tuple)
+    )
     return DesiredTable(
         qualified_name=_QUALIFIED_NAME,
         columns=tuple(columns),
         comment=draw(st.text(max_size=40)),
         properties=draw(_PROPERTIES),
         partitioned_by=partitioned_by,
+        primary_key=primary_key,
     )
 
 
@@ -106,6 +114,7 @@ def _desired(
     comment="",
     properties=None,
     partitioned_by=(),
+    primary_key=(),
 ) -> DesiredTable:
     """Build a DesiredTable, defaulting every dimension to a no-op baseline."""
     return DesiredTable(
@@ -114,6 +123,7 @@ def _desired(
         comment=comment,
         properties=properties or {},
         partitioned_by=partitioned_by,
+        primary_key=primary_key,
     )
 
 
@@ -123,6 +133,7 @@ def _observed(
     comment="",
     properties=None,
     partitioned_by=(),
+    primary_key=(),
 ) -> ObservedTable:
     """Build an ObservedTable matching `_desired`'s baseline so a single dimension can vary."""
     return ObservedTable(
@@ -131,6 +142,7 @@ def _observed(
         comment=comment,
         properties=properties or {},
         partitioned_by=partitioned_by,
+        primary_key=primary_key,
     )
 
 
@@ -476,6 +488,7 @@ def test_compute_plan_produces_no_actions_when_desired_equals_observed(
         comment=desired.comment,
         properties=desired.properties,
         partitioned_by=desired.partitioned_by,
+        primary_key=desired.primary_key,
     )
 
     # When: computing the plan
@@ -483,3 +496,153 @@ def test_compute_plan_produces_no_actions_when_desired_equals_observed(
 
     # Then: there is nothing to do — the differ is reflexive
     assert plan.actions == ()
+
+
+# ---------- primary key diffs ----------
+
+
+def _desired_with_pk(pk_columns: list[str]) -> DesiredTable:
+    """Build a DesiredTable whose listed columns are NOT NULL and in the primary key."""
+    all_columns = tuple(
+        Column(name, Integer(), nullable=name not in pk_columns)
+        for name in (["id", "name"] if not pk_columns else pk_columns + ["name"])
+    )
+    return DesiredTable(
+        qualified_name=_QUALIFIED_NAME,
+        columns=all_columns,
+        primary_key=tuple(pk_columns),
+    )
+
+
+def _observed_with_pk(pk_columns: list[str]) -> ObservedTable:
+    """Build an ObservedTable with a given primary key (columns default to nullable=True)."""
+    all_columns = (Column("id", Integer()), Column("name", String()))
+    return ObservedTable(
+        qualified_name=_QUALIFIED_NAME,
+        columns=all_columns,
+        primary_key=tuple(pk_columns),
+    )
+
+
+def test_no_pk_actions_when_both_desired_and_observed_have_no_pk():
+    # Given: no primary key on either side
+    plan = compute_plan(_desired(columns=(Column("id", Integer()),)), _observed())
+
+    # Then: no PK actions
+    assert not any(isinstance(a, (DropPrimaryKey, SetPrimaryKey)) for a in plan.actions)
+
+
+def test_emits_set_primary_key_when_desired_has_pk_and_observed_has_none():
+    # Given: desired declares a PK; observed has none
+    desired = _desired_with_pk(["id"])
+    observed = _observed_with_pk([])
+
+    # When
+    plan = compute_plan(desired, observed)
+
+    # Then: a SetPrimaryKey is emitted; no DropPrimaryKey
+    pk_actions = [a for a in plan.actions if isinstance(a, SetPrimaryKey)]
+    assert len(pk_actions) == 1
+    assert pk_actions[0].columns == (Column("id", Integer(), nullable=False),)
+    assert pk_actions[0].constraint_name == "test_pk"
+    assert not any(isinstance(a, DropPrimaryKey) for a in plan.actions)
+
+
+def test_emits_drop_primary_key_when_desired_has_no_pk_and_observed_has_one():
+    # Given: desired removes the PK; observed had one
+    desired = _desired(columns=(Column("id", Integer()),))
+    observed = _observed_with_pk(["id"])
+
+    # When
+    plan = compute_plan(desired, observed)
+
+    # Then: a DropPrimaryKey is emitted; no SetPrimaryKey
+    assert any(isinstance(a, DropPrimaryKey) for a in plan.actions)
+    assert not any(isinstance(a, SetPrimaryKey) for a in plan.actions)
+
+
+def test_emits_drop_and_set_when_pk_columns_change():
+    # Given: desired changes the PK columns
+    desired = _desired_with_pk(["id"])
+    observed = _observed_with_pk(["name"])
+
+    # When
+    plan = compute_plan(desired, observed)
+
+    # Then: both DropPrimaryKey and SetPrimaryKey are emitted
+    assert any(isinstance(a, DropPrimaryKey) for a in plan.actions)
+    assert any(isinstance(a, SetPrimaryKey) for a in plan.actions)
+
+
+def test_no_pk_actions_when_pk_columns_match_regardless_of_order():
+    # Given: desired and observed have the same PK columns in different order
+    desired = DesiredTable(
+        qualified_name=_QUALIFIED_NAME,
+        columns=(
+            Column("id", Integer(), nullable=False),
+            Column("tenant_id", Integer(), nullable=False),
+        ),
+        primary_key=("id", "tenant_id"),
+    )
+    observed = ObservedTable(
+        qualified_name=_QUALIFIED_NAME,
+        columns=(
+            Column("id", Integer(), nullable=False),
+            Column("tenant_id", Integer(), nullable=False),
+        ),
+        primary_key=("tenant_id", "id"),
+    )
+
+    # When
+    plan = compute_plan(desired, observed)
+
+    # Then: order difference alone does not trigger a PK change
+    assert not any(isinstance(a, (DropPrimaryKey, SetPrimaryKey)) for a in plan.actions)
+
+
+def test_drop_primary_key_runs_before_add_column_in_plan():
+    # Given: a plan that both drops the PK and adds a column
+    desired = DesiredTable(
+        qualified_name=_QUALIFIED_NAME,
+        columns=(Column("id", Integer(), nullable=False), Column("new_col", String())),
+        primary_key=(),
+    )
+    observed = ObservedTable(
+        qualified_name=_QUALIFIED_NAME,
+        columns=(Column("id", Integer(), nullable=False),),
+        primary_key=("id",),
+    )
+
+    # When
+    plan = compute_plan(desired, observed)
+
+    types = [type(a) for a in plan.actions]
+    drop_idx = types.index(DropPrimaryKey)
+    add_idx = types.index(AddColumn)
+
+    # Then: DropPrimaryKey comes before AddColumn
+    assert drop_idx < add_idx
+
+
+def test_set_primary_key_runs_after_set_column_nullability_in_plan():
+    # Given: a plan that sets nullability and adds a PK in the same sync
+    desired = DesiredTable(
+        qualified_name=_QUALIFIED_NAME,
+        columns=(Column("id", Integer(), nullable=False),),
+        primary_key=("id",),
+    )
+    observed = ObservedTable(
+        qualified_name=_QUALIFIED_NAME,
+        columns=(Column("id", Integer(), nullable=True),),
+        primary_key=(),
+    )
+
+    # When
+    plan = compute_plan(desired, observed)
+
+    types = [type(a) for a in plan.actions]
+    null_idx = types.index(SetColumnNullability)
+    pk_idx = types.index(SetPrimaryKey)
+
+    # Then: SetColumnNullability runs before SetPrimaryKey
+    assert null_idx < pk_idx

--- a/tests/domain/plan/test_differ.py
+++ b/tests/domain/plan/test_differ.py
@@ -503,9 +503,11 @@ def test_compute_plan_produces_no_actions_when_desired_equals_observed(
 
 def _desired_with_pk(pk_columns: list[str]) -> DesiredTable:
     """Build a DesiredTable whose listed columns are NOT NULL and in the primary key."""
+    extra_columns = [] if "name" in pk_columns else ["name"]
+    all_column_names = pk_columns + extra_columns
     all_columns = tuple(
         Column(name, Integer(), nullable=name not in pk_columns)
-        for name in (["id", "name"] if not pk_columns else pk_columns + ["name"])
+        for name in all_column_names
     )
     return DesiredTable(
         qualified_name=_QUALIFIED_NAME,

--- a/tests/domain/plan/test_differ.py
+++ b/tests/domain/plan/test_differ.py
@@ -506,8 +506,7 @@ def _desired_with_pk(pk_columns: list[str]) -> DesiredTable:
     extra_columns = [] if "name" in pk_columns else ["name"]
     all_column_names = pk_columns + extra_columns
     all_columns = tuple(
-        Column(name, Integer(), nullable=name not in pk_columns)
-        for name in all_column_names
+        Column(name, Integer(), nullable=name not in pk_columns) for name in all_column_names
     )
     return DesiredTable(
         qualified_name=_QUALIFIED_NAME,

--- a/tests/e2e/test_engine_e2e.py
+++ b/tests/e2e/test_engine_e2e.py
@@ -5,10 +5,10 @@ import pytest
 
 from delta_engine.adapters.databricks.executor import DatabricksExecutor
 from delta_engine.adapters.databricks.reader import DatabricksReader
+from delta_engine.api import Column, Date, DeltaTable, Integer, String
 from delta_engine.application.engine import Engine
 from delta_engine.application.errors import SyncFailedError
 from delta_engine.application.registry import Registry
-from delta_engine.api import Column, Date, DeltaTable, Integer, String
 from tests.config import TEST_CATALOG
 
 

--- a/tests/test_public_api.py
+++ b/tests/test_public_api.py
@@ -45,12 +45,12 @@ def test_eager_names_are_importable_and_identical_to_their_source():
     # Given the curated root namespace
     # Then every pyspark-free name resolves to the same object as its source module
     from delta_engine import Column, DeltaTable, Engine, Property, Registry
-    from delta_engine.application import Engine as EngineImpl, Registry as RegistryImpl
     from delta_engine.api import (
         Column as ColumnImpl,
         DeltaTable as DeltaTableImpl,
         Property as PropertyImpl,
     )
+    from delta_engine.application import Engine as EngineImpl, Registry as RegistryImpl
 
     assert DeltaTable is DeltaTableImpl
     assert Column is ColumnImpl


### PR DESCRIPTION
## Summary

- Adds informational primary key constraint support (Databricks Unity Catalog GA feature) to delta-engine
- Users declare `primary_key=True` on `Column` objects; the engine manages full drift lifecycle (add, change, drop)
- New `DeltaTable.primary_key` and `DeltaTable.primary_key_constraint_name` properties expose the declared key

## What changed

**API layer**
- `Column` gains `primary_key: bool = False`
- `DeltaTable.primary_key: tuple[str, ...]` — names of PK columns in declaration order
- `DeltaTable.primary_key_constraint_name: str | None` — returns `{table_name}_pk` or `None`

**Domain model**
- `TableSnapshot.primary_key: tuple[str, ...]` (default `()`)
- `DesiredTable.primary_key_constraint_name: str | None` — single derivation point for the constraint name

**Actions**
- `DropPrimaryKey` — phase `DROP_PRIMARY_KEY` (before `ADD_COLUMN`)
- `SetPrimaryKey(columns, constraint_name)` — phase `SET_PRIMARY_KEY` (after `SET_COLUMN_NULLABILITY`)

**Differ**
- `_diff_primary_key` uses frozenset comparison (order-insensitive); emits drop/set/both/neither

**Validation**
- `PrimaryKeyColumnsNullable` rule — blocks nullable PK columns on `SetPrimaryKey` and `CREATE TABLE`

**SQL compiler**
- `ALTER TABLE t DROP PRIMARY KEY IF EXISTS`
- `ALTER TABLE t ADD CONSTRAINT \`t_pk\` PRIMARY KEY (\`col\`)`
- `CREATE TABLE` inlines `CONSTRAINT \`t_pk\` PRIMARY KEY (...)` when PK is declared

**Reader**
- `DatabricksReader._fetch_primary_key` queries `information_schema` to read observed PK state

## Test plan

- [ ] 223 unit tests pass (`uv run pytest tests/ -q --ignore=tests/adapters/databricks/sql/test_types.py --ignore=tests/e2e --ignore=tests/adapters/databricks/test_executor.py`)
- [ ] Coverage 90.55% (threshold 90%)
- [ ] Verify end-to-end on a real Databricks cluster with a Unity Catalog table

🤖 Generated with [Claude Code](https://claude.com/claude-code)