### PR TITLE
feat: human-readable __str__ and diff() for report types

### DIFF
--- a/src/delta_engine/application/results.py
+++ b/src/delta_engine/application/results.py
@@ -14,9 +14,26 @@ from collections.abc import Iterator
 from dataclasses import dataclass, field
 from datetime import datetime
 from enum import StrEnum
+import functools
 
 from delta_engine.domain.model import ObservedTable, QualifiedName
-from delta_engine.domain.plan.actions import ActionPlan
+from delta_engine.domain.plan.actions import (
+    Action,
+    ActionPlan,
+    AddColumn,
+    ColumnTypeChange,
+    CreateTable,
+    DropColumn,
+    DropForeignKey,
+    DropPrimaryKey,
+    PartitioningChange,
+    SetColumnComment,
+    SetColumnNullability,
+    SetForeignKey,
+    SetPrimaryKey,
+    SetProperty,
+    SetTableComment,
+)
 
 # ---------- Status enums ----------
 
@@ -258,6 +275,14 @@ class TableRunReport:
             out.extend(self.execution.failures)
         return tuple(out)
 
+    def diff(self) -> str:
+        """Render this table's planned changes as a +/-/~ change list."""
+        return _render_diff_block(self)
+
+    def __str__(self) -> str:
+        """Render this report as the grid header plus its single row."""
+        return _render_grid((self,))
+
 
 @dataclass(frozen=True, slots=True)
 class SyncReport:
@@ -279,3 +304,171 @@ class SyncReport:
 
     def __iter__(self) -> Iterator[TableRunReport]:
         return iter(self.table_reports)
+
+    def diff(self) -> str:
+        """Render every table's planned changes, in report order."""
+        return "\n\n".join(_render_diff_block(report) for report in self.table_reports)
+
+    def __str__(self) -> str:
+        """Render the run as an aligned grid followed by a summary footer."""
+        if not self.table_reports:
+            return "Sync report: 0 tables"
+        return f"{_render_grid(self.table_reports)}\n\n{_run_summary_footer(self)}"
+
+
+# ---------- Display
+
+
+def _type_name(data_type: object) -> str:
+    """Backend-agnostic display name for a domain data type (e.g. 'String')."""
+    return type(data_type).__name__
+
+
+@functools.singledispatch
+def _action_diff_line(action: Action) -> str:
+    """Render one plan action as a single +/-/~ diff line."""
+    raise NotImplementedError(f"No diff line for action {type(action).__name__}")
+
+
+@_action_diff_line.register
+def _(action: CreateTable) -> str:
+    columns = ", ".join(column.name for column in action.table.columns)
+    return f"+ create table (columns: {columns})"
+
+
+@_action_diff_line.register
+def _(action: AddColumn) -> str:
+    nullable = "" if action.column.nullable else " NOT NULL"
+    return f"+ column {action.column.name} {_type_name(action.column.data_type)}{nullable}"
+
+
+@_action_diff_line.register
+def _(action: DropColumn) -> str:
+    return f"- column {action.column_name}"
+
+
+@_action_diff_line.register
+def _(action: SetColumnNullability) -> str:
+    direction = "drop" if action.nullable else "set"
+    return f"~ column {action.column_name} {direction} NOT NULL"
+
+
+@_action_diff_line.register
+def _(action: SetColumnComment) -> str:
+    suffix = "" if action.comment else " (unset)"
+    return f"~ comment on column {action.column_name}{suffix}"
+
+
+@_action_diff_line.register
+def _(action: SetTableComment) -> str:
+    return "~ comment on table"
+
+
+@_action_diff_line.register
+def _(action: SetProperty) -> str:
+    return f"~ property {action.name} = '{action.value}'"
+
+
+@_action_diff_line.register
+def _(action: SetPrimaryKey) -> str:
+    columns = ", ".join(column.name for column in action.columns)
+    return f"+ primary key ({columns})"
+
+
+@_action_diff_line.register
+def _(action: DropPrimaryKey) -> str:
+    return "- primary key"
+
+
+@_action_diff_line.register
+def _(action: SetForeignKey) -> str:
+    return f"+ foreign key {action.constraint_name}"
+
+
+@_action_diff_line.register
+def _(action: DropForeignKey) -> str:
+    return f"- foreign key {action.constraint_name}"
+
+
+@_action_diff_line.register
+def _(action: ColumnTypeChange) -> str:
+    return (
+        f"~ column {action.column_name} type "
+        f"{_type_name(action.from_type)} → {_type_name(action.to_type)}"
+    )
+
+
+@_action_diff_line.register
+def _(action: PartitioningChange) -> str:
+    return f"~ partitioning {action.observed_partitioning} → {action.desired_partitioning}"
+
+
+def _render_diff_block(report: TableRunReport) -> str:
+    """Render one table's change block: its name then one line per planned action."""
+    header = str(report.qualified_name)
+    if isinstance(report.read, ReadFailed):
+        return f"{header}\n  (could not read — no diff)"
+    if not report.plan:
+        return f"{header}\n  (no changes)"
+    lines = [f"  {_action_diff_line(action)}" for action in report.plan]
+    return "\n".join([header, *lines])
+
+
+_DETAIL_MAX_CHARS = 60
+
+_GRID_HEADERS = ("TABLE", "STATUS", "ACTIONS", "DETAIL")
+
+
+def _grid_detail(report: TableRunReport) -> str:
+    """Return the DETAIL cell: first failure summary, action names, or 'no changes'."""
+    if report.has_failures:
+        failures = report.all_failures
+        first = failures[0].format_lines()[0]
+        extra = len(failures) - 1
+        return f"{first} (+{extra} more)" if extra else first
+    if len(report.plan):
+        return ", ".join(type(action).__name__ for action in report.plan)
+    return "no changes"
+
+
+def _truncate(text: str, limit: int = _DETAIL_MAX_CHARS) -> str:
+    """Truncate with an ellipsis when longer than ``limit``."""
+    return text if len(text) <= limit else text[: limit - 1] + "…"
+
+
+def _grid_row_cells(report: TableRunReport) -> tuple[str, str, str, str]:
+    """Return the four grid cells for one report (DETAIL already truncated)."""
+    return (
+        str(report.qualified_name),
+        report.status.value,
+        str(len(report.plan)),
+        _truncate(_grid_detail(report)),
+    )
+
+
+def _render_grid(reports: tuple[TableRunReport, ...]) -> str:
+    """Render an aligned TABLE | STATUS | ACTIONS | DETAIL grid for ``reports``."""
+    rows = [_GRID_HEADERS, *(_grid_row_cells(report) for report in reports)]
+    widths = [max(len(row[col]) for row in rows) for col in range(len(_GRID_HEADERS))]
+    return "\n".join(
+        "  ".join(cell.ljust(widths[col]) for col, cell in enumerate(row)).rstrip()
+        for row in rows
+    )
+
+
+def _run_summary_footer(report: SyncReport) -> str:
+    """One-line summary: table total, changed/unchanged/failed counts, duration."""
+    changed = unchanged = failed = 0
+    for table_report in report.table_reports:
+        if table_report.has_failures:
+            failed += 1
+        elif len(table_report.plan):
+            changed += 1
+        else:
+            unchanged += 1
+    seconds = (report.ended_at - report.started_at).total_seconds()
+    total = len(report.table_reports)
+    return (
+        f"{total} tables: {changed} changed, {unchanged} unchanged, "
+        f"{failed} failed ({seconds:.1f}s)"
+    )


### PR DESCRIPTION
## Summary

Adds two human-readable renderings to `TableRunReport` and `SyncReport`, both derived from data already on the reports (no new engine computation, no new fields):

- **`__str__`** — an aligned `TABLE | STATUS | ACTIONS | DETAIL` grid. A single `TableRunReport` prints the header plus its own row; `SyncReport` prints the full grid plus a `N tables: X changed, Y unchanged, Z failed (D.Ds)` footer (and `Sync report: 0 tables` when empty). The DETAIL cell shows the first failure summary (with `(+N more)`), the action type names for a successful change, or `no changes`; it truncates at 60 chars.
- **`diff()`** — a per-table `+`/`-`/`~` change list rendered from the `ActionPlan` via a `functools.singledispatch` over actions (mirroring the SQL compiler's dispatch pattern). Backend-agnostic: domain type names, no SQL. Empty plans render `(no changes)`; read-failed tables render `(could not read — no diff)`.

This is especially useful alongside `dry_run`, which returns a populated report for inspection.

### Example

```
TABLE              STATUS             ACTIONS  DETAIL
cat.sch.customers  SUCCESS            2        CreateTable, AddColumn
cat.sch.regions    SUCCESS            0        no changes
cat.sch.orders     VALIDATION_FAILED  4        Validation failed: NonNullableColumnAdd - column 'total' ca…

4 tables: 1 changed, 1 unchanged, 2 failed (2.1s)
```

```
cat.sch.orders
  - column legacy
  ~ column email set NOT NULL
  + foreign key orders_region_fk
  ~ column amount type Integer → Double
```

## Design notes

- `SyncFailedError` is intentionally left unchanged; it keeps its own failure formatter.
- All rendering lives in `results.py` alongside the types (a separate display module would force a one-way import back into the types).
- The `ACTIONS` column reflects the **planned** action count, consistent with `diff()` — a validation-failed table with a 2-action plan that never ran still shows its planned count.

## Testing

No automated tests were added (per request — this is cosmetic display logic). Output was verified by a smoke-check against real reports covering created / unchanged / altered / read-failed tables. `mypy` clean (70 files), `ruff` clean, and the existing 222 non-Spark tests pass.

Note: this means there is no regression guard if the rendering format changes later — worth adding tests if the output is ever consumed programmatically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)