### PR TITLE
feat(notebooks): add display tables for schema, tags, and properties

### DIFF
--- a/notebooks/catalog_inspector.py
+++ b/notebooks/catalog_inspector.py
@@ -90,9 +90,11 @@ class CatalogInspector:
     def display_tags(self, table: str) -> None:
         """Display the live Unity Catalog tags as a table: tag, value."""
         rows = [Row(tag=k, value=v) for k, v in self.tags_of(table).items()]
-        display(spark.createDataFrame(rows) if rows else spark.createDataFrame([], "tag string, value string"))
+        empty = spark.createDataFrame([], "tag string, value string")
+        display(spark.createDataFrame(rows) if rows else empty)
 
     def display_properties(self, table: str) -> None:
         """Display the live Delta table properties as a table: property, value."""
         rows = [Row(property=k, value=v) for k, v in self.properties_of(table).items()]
-        display(spark.createDataFrame(rows) if rows else spark.createDataFrame([], "property string, value string"))
+        empty = spark.createDataFrame([], "property string, value string")
+        display(spark.createDataFrame(rows) if rows else empty)

--- a/notebooks/catalog_inspector.py
+++ b/notebooks/catalog_inspector.py
@@ -9,7 +9,8 @@ Keep this file in the same workspace folder as the notebook so the import
 resolves.
 """
 
-from databricks.sdk.runtime import spark
+from databricks.sdk.runtime import display, spark
+from pyspark.sql import Row
 from pyspark.sql.types import StructField
 
 
@@ -72,3 +73,26 @@ class CatalogInspector:
     def column_comment(self, table: str, column: str) -> str:
         """Return the live comment on one column, or empty string."""
         return self.fields_of(table)[column].metadata.get("comment", "")
+
+    def display_schema(self, table: str) -> None:
+        """Display the live column schema as a table: column, type, nullable, comment."""
+        rows = [
+            Row(
+                column=field.name,
+                type=field.dataType.simpleString(),
+                nullable=field.nullable,
+                comment=field.metadata.get("comment", ""),
+            )
+            for field in self.fields_of(table).values()
+        ]
+        display(spark.createDataFrame(rows))
+
+    def display_tags(self, table: str) -> None:
+        """Display the live Unity Catalog tags as a table: tag, value."""
+        rows = [Row(tag=k, value=v) for k, v in self.tags_of(table).items()]
+        display(spark.createDataFrame(rows) if rows else spark.createDataFrame([], "tag string, value string"))
+
+    def display_properties(self, table: str) -> None:
+        """Display the live Delta table properties as a table: property, value."""
+        rows = [Row(property=k, value=v) for k, v in self.properties_of(table).items()]
+        display(spark.createDataFrame(rows) if rows else spark.createDataFrame([], "property string, value string"))

--- a/notebooks/delta_engine_walkthrough.py
+++ b/notebooks/delta_engine_walkthrough.py
@@ -156,6 +156,8 @@ assert inspector.has_primary_key("orders")
 assert inspector.has_foreign_key("orders")
 
 print("Act 1 verified: both tables created with expected schema and constraints.")
+inspector.display_schema("customers")
+inspector.display_schema("orders")
 
 # COMMAND ----------
 
@@ -246,6 +248,9 @@ assert inspector.properties_of("customers").get("delta.enableChangeDataFeed") ==
 assert inspector.table_comment("customers") == "Customer master table (with contact details)"
 assert inspector.column_comment("customers", "name") == "Full legal name"
 print("Act 3a verified: batched add/drop/tags/property/comments applied together.")
+inspector.display_schema("customers")
+inspector.display_tags("customers")
+inspector.display_properties("customers")
 
 # COMMAND ----------
 
@@ -288,6 +293,7 @@ print(report.diff())
 assert report.any_failures is False
 assert inspector.fields_of("customers")["status"].nullable is True
 print("Act 3b verified: nullability loosened (NOT NULL dropped).")
+inspector.display_schema("customers")
 
 # COMMAND ----------
 
@@ -331,6 +337,7 @@ print(report.diff())
 assert report.any_failures is False
 assert inspector.tags_of("customers") == {"domain": "sales"}
 print("Act 3c verified: undeclared tag removed by full-state reconciliation.")
+inspector.display_tags("customers")
 
 # COMMAND ----------
 
@@ -405,6 +412,7 @@ customer_fields = inspector.fields_of("customers")
 assert "region_id" in customer_fields and customer_fields["region_id"].nullable is True
 assert inspector.has_foreign_key("customers")
 print("Act 3d verified: foreign key added to an existing table.")
+inspector.display_schema("customers")
 
 # COMMAND ----------
 
@@ -462,6 +470,7 @@ print(report.diff())
 assert report.any_failures is False
 assert inspector.properties_of("customers").get("delta.logRetentionDuration") == "interval 7 days"
 print("Act 3e verified: undeclared property left untouched (declared-subset).")
+inspector.display_properties("customers")
 
 # COMMAND ----------
 
@@ -746,6 +755,7 @@ print(report.diff())
 assert report.any_failures is False
 assert "phone" in inspector.fields_of("customers")
 print("Act 6 verified: previewed change committed.")
+inspector.display_schema("customers")
 
 # COMMAND ----------
 


### PR DESCRIPTION
## Summary

- Adds `display_schema`, `display_tags`, and `display_properties` methods to `CatalogInspector` — each builds a Spark DataFrame from live catalog state and calls `display()`
- Appends the relevant display calls after each verify block in the walkthrough notebook so the reader can see the actual catalog state that the assertions just confirmed

## Test plan

- [ ] Run the walkthrough notebook end-to-end on a Databricks cluster with Unity Catalog enabled
- [ ] Confirm each verify block shows a rendered table beneath the print confirmation
- [ ] Confirm Act 3c shows only `domain: sales` after the `owner` tag is dropped
- [ ] Confirm Act 3e shows both `delta.enableChangeDataFeed` and `delta.logRetentionDuration` (the out-of-band property)
- [ ] Confirm all existing assertions still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)