### PR TITLE
feat: add Unity Catalog column tags

### DIFF
--- a/docs/how-to-configure-tags.md
+++ b/docs/how-to-configure-tags.md
@@ -45,3 +45,41 @@ This means a tag applied outside delta-engine (in the Databricks UI, by another 
 Tags require Unity Catalog on Databricks Runtime 13.3 LTS or later, and the `APPLY TAG` privilege on the table (plus `USE SCHEMA` / `USE CATALOG`). On non-Unity-Catalog environments the engine observes no tags and emits no tag changes.
 
 Databricks limits: up to 50 tags per table; keys and values up to 256 characters; tag keys cannot contain `. , - = / :` or leading/trailing spaces.
+
+## Column tags
+
+Tags can also be declared on individual columns. Pass a `tags` dict to a
+`Column`:
+
+```python
+from delta_engine import Column, DeltaTable, String
+
+table = DeltaTable(
+    catalog="dev",
+    schema="silver",
+    name="events",
+    columns=[
+        Column("id", String()),
+        Column(
+            "email",
+            String(),
+            tags={"pii": "true", "classification": "restricted"},
+        ),
+    ],
+)
+```
+
+Column tags follow the **same full-state reconciliation** as table tags: on each
+sync the engine sets any declared tag that is missing or has a different value,
+and unsets any tag found on the column that is not declared. A column tag applied
+out-of-band (Databricks UI, another job, an automated classifier) is removed on
+the next sync unless it is also declared.
+
+As with table tags, keys are **case-sensitive** (`PII` and `pii` are distinct).
+
+### Requirements and limits
+
+Column tags require Unity Catalog on Databricks Runtime 13.3 LTS or later and the
+`APPLY TAG` privilege. Databricks limits: up to 50 tags per column, at most 1,000
+column tags per table across all columns, keys and values up to 256 characters,
+and tag keys cannot contain `. , - = / :` or leading/trailing spaces.

--- a/notebooks/catalog_inspector.py
+++ b/notebooks/catalog_inspector.py
@@ -46,6 +46,15 @@ class CatalogInspector:
         ).collect()
         return {row.tag_name: row.tag_value for row in rows}
 
+    def column_tags_of(self, table: str) -> dict[tuple[str, str], str]:
+        """Return {(column, tag): value} for the live table, from information_schema."""
+        rows = spark.sql(
+            f"SELECT column_name, tag_name, tag_value"
+            f" FROM {self.catalog}.information_schema.column_tags"
+            f" WHERE schema_name = '{self.schema}' AND table_name = '{table}'"
+        ).collect()
+        return {(row.column_name, row.tag_name): row.tag_value for row in rows}
+
     def has_primary_key(self, table: str) -> bool:
         """Return True if the live table has a primary key constraint."""
         rows = spark.sql(

--- a/notebooks/delta_engine_walkthrough.py
+++ b/notebooks/delta_engine_walkthrough.py
@@ -335,7 +335,71 @@ print("Act 3c verified: undeclared tag removed by full-state reconciliation.")
 # COMMAND ----------
 
 # MAGIC %md
-# MAGIC ### Act 3d — Foreign-key drift on an existing table (own sync)
+# MAGIC ### Act 3d — Column tags — set then unset (full-state)
+# MAGIC
+# MAGIC Add a column tag to `email` (`pii=true`), sync, and assert it landed. Then
+# MAGIC re-declare without the tag and resync — column-tag reconciliation is
+# MAGIC **full-state**, so the absent declaration removes the tag. This is the
+# MAGIC column-level analogue of Act 3c.
+
+# COMMAND ----------
+
+customers = DeltaTable(
+    catalog=CATALOG,
+    schema=SCHEMA,
+    name="customers",
+    columns=[
+        Column("id", Long(), nullable=False, primary_key=True),
+        Column("name", String(), comment="Full legal name"),
+        Column("email", String(), tags={"pii": "true"}),
+        Column("status", String()),
+    ],
+    comment="Customer master table (with contact details)",
+    tags={"domain": "sales"},
+    properties={Property.CHANGE_DATA_FEED: "true"},
+)
+
+registry = Registry()
+registry.register(customers, orders)
+report = engine.sync(registry)
+print(report)
+print(report.diff())
+
+assert report.any_failures is False
+assert inspector.column_tags_of("customers")[("email", "pii")] == "true"
+print("Column tag set: customers.email pii=true")
+
+# COMMAND ----------
+
+customers = DeltaTable(
+    catalog=CATALOG,
+    schema=SCHEMA,
+    name="customers",
+    columns=[
+        Column("id", Long(), nullable=False, primary_key=True),
+        Column("name", String(), comment="Full legal name"),
+        Column("email", String()),  # tag removed from declaration
+        Column("status", String()),
+    ],
+    comment="Customer master table (with contact details)",
+    tags={"domain": "sales"},
+    properties={Property.CHANGE_DATA_FEED: "true"},
+)
+
+registry = Registry()
+registry.register(customers, orders)
+report = engine.sync(registry)
+print(report)
+print(report.diff())
+
+assert report.any_failures is False
+assert ("email", "pii") not in inspector.column_tags_of("customers")
+print("Column tag unset by full-state reconciliation: customers.email pii removed")
+
+# COMMAND ----------
+
+# MAGIC %md
+# MAGIC ### Act 3e — Foreign-key drift on an existing table (own sync)
 # MAGIC
 # MAGIC Create a `regions` dimension, then add a `region_id` column and a foreign
 # MAGIC key to `customers` — which already exists. This is drift management on a
@@ -404,12 +468,12 @@ assert report.any_failures is False
 customer_fields = inspector.fields_of("customers")
 assert "region_id" in customer_fields and customer_fields["region_id"].nullable is True
 assert inspector.has_foreign_key("customers")
-print("Act 3d verified: foreign key added to an existing table.")
+print("Act 3e verified: foreign key added to an existing table.")
 
 # COMMAND ----------
 
 # MAGIC %md
-# MAGIC ### Act 3e — Properties are declared-subset (own sync)
+# MAGIC ### Act 3f — Properties are declared-subset (own sync)
 # MAGIC
 # MAGIC Set a property **out-of-band**, then resync `customers` without declaring
 # MAGIC it. The engine manages only declared property keys, so the out-of-band
@@ -422,7 +486,7 @@ spark.sql(
     f" SET TBLPROPERTIES ('delta.logRetentionDuration' = 'interval 7 days')"
 )
 
-# Re-declare customers exactly as in Act 3d (logRetentionDuration is NOT declared).
+# Re-declare customers exactly as in Act 3e (logRetentionDuration is NOT declared).
 customers = DeltaTable(
     catalog=CATALOG,
     schema=SCHEMA,
@@ -461,7 +525,7 @@ print(report.diff())
 
 assert report.any_failures is False
 assert inspector.properties_of("customers").get("delta.logRetentionDuration") == "interval 7 days"
-print("Act 3e verified: undeclared property left untouched (declared-subset).")
+print("Act 3f verified: undeclared property left untouched (declared-subset).")
 
 # COMMAND ----------
 
@@ -475,6 +539,7 @@ print("Act 3e verified: undeclared property left untouched (declared-subset).")
 # MAGIC otherwise take precedence and mask it).
 
 # COMMAND ----------
+
 
 def define_events(*, columns, partitioned_by=("event_date",)):
     """Build the events table from a column list (baseline plus one variation)."""

--- a/src/delta_engine/adapters/databricks/reader.py
+++ b/src/delta_engine/adapters/databricks/reader.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 import logging
 from types import MappingProxyType
 
@@ -116,7 +116,11 @@ class DatabricksReader:
             for c in self.spark.catalog.listColumns(str(qualified_name))
         )
         mappings = tuple(m for m in all_mappings if m is not None)
-        columns = tuple(m.column for m in mappings)
+        column_tags = self._fetch_column_tags(qualified_name)
+        columns = tuple(
+            replace(m.column, tags=column_tags.get(m.column.name, MappingProxyType({})))
+            for m in mappings
+        )
         partition_columns = tuple(m.column.name for m in mappings if m.is_partition)
         observed = ObservedTable(
             qualified_name=qualified_name,
@@ -212,6 +216,39 @@ class DatabricksReader:
         except AnalysisException:
             return MappingProxyType({})
         return MappingProxyType({row.tag_name: row.tag_value for row in rows})
+
+    def _fetch_column_tags(
+        self, qualified_name: QualifiedName
+    ) -> MappingProxyType[str, MappingProxyType[str, str]]:
+        """
+        Return the table's column tags as ``{column_name: {tag: value}}``.
+
+        Reads information_schema.column_tags in a single query for the whole
+        table (avoiding a per-column round-trip). Column names are casefolded to
+        match the domain's lowercase columns; tag keys and values are
+        case-sensitive and returned verbatim — never casefolded. Returns an empty
+        mapping on AnalysisException: information_schema is only available in
+        Unity Catalog, so on plain Spark (e.g. local tests) there are no column
+        tags to observe. Without this guard an unobservable tag would be re-set
+        on every sync and the differ would never converge.
+        """
+        catalog = backtick(qualified_name.catalog)
+        query = (
+            f"SELECT column_name, tag_name, tag_value"
+            f" FROM {catalog}.information_schema.column_tags"
+            f" WHERE schema_name = {quote_literal(qualified_name.schema)}"
+            f" AND table_name = {quote_literal(qualified_name.name)}"
+        )
+        try:
+            rows = self.spark.sql(query).collect()
+        except AnalysisException:
+            return MappingProxyType({})
+        grouped: dict[str, dict[str, str]] = {}
+        for row in rows:
+            grouped.setdefault(row.column_name.casefold(), {})[row.tag_name] = row.tag_value
+        return MappingProxyType(
+            {column: MappingProxyType(tags) for column, tags in grouped.items()}
+        )
 
     def _fetch_foreign_keys(
         self, qualified_name: QualifiedName

--- a/src/delta_engine/adapters/databricks/sql/compile.py
+++ b/src/delta_engine/adapters/databricks/sql/compile.py
@@ -29,11 +29,13 @@ from delta_engine.domain.plan.actions import (
     PartitioningChange,
     SetColumnComment,
     SetColumnNullability,
+    SetColumnTag,
     SetForeignKey,
     SetPrimaryKey,
     SetProperty,
     SetTableComment,
     SetTableTag,
+    UnsetColumnTag,
     UnsetTableTag,
 )
 
@@ -132,6 +134,22 @@ def _(action: SetTableTag, backticked_table_name: str) -> str:
 @_compile_action.register
 def _(action: UnsetTableTag, backticked_table_name: str) -> str:
     return f"ALTER TABLE {backticked_table_name} UNSET TAGS ({quote_literal(action.name)})"
+
+
+@_compile_action.register
+def _(action: SetColumnTag, backticked_table_name: str) -> str:
+    column = backtick(action.column_name)
+    pair = f"{quote_literal(action.name)}={quote_literal(action.value)}"
+    return f"ALTER TABLE {backticked_table_name} ALTER COLUMN {column} SET TAGS ({pair})"
+
+
+@_compile_action.register
+def _(action: UnsetColumnTag, backticked_table_name: str) -> str:
+    column = backtick(action.column_name)
+    return (
+        f"ALTER TABLE {backticked_table_name} ALTER COLUMN {column}"
+        f" UNSET TAGS ({quote_literal(action.name)})"
+    )
 
 
 @_compile_action.register

--- a/src/delta_engine/application/results.py
+++ b/src/delta_engine/application/results.py
@@ -29,11 +29,13 @@ from delta_engine.domain.plan.actions import (
     PartitioningChange,
     SetColumnComment,
     SetColumnNullability,
+    SetColumnTag,
     SetForeignKey,
     SetPrimaryKey,
     SetProperty,
     SetTableComment,
     SetTableTag,
+    UnsetColumnTag,
     UnsetTableTag,
 )
 
@@ -385,6 +387,16 @@ def _(action: SetTableTag) -> str:
 @_action_diff_line.register
 def _(action: UnsetTableTag) -> str:
     return f"- tag {action.name}"
+
+
+@_action_diff_line.register
+def _(action: SetColumnTag) -> str:
+    return f"~ column tag {action.column_name}.{action.name} = '{action.value}'"
+
+
+@_action_diff_line.register
+def _(action: UnsetColumnTag) -> str:
+    return f"- column tag {action.column_name}.{action.name}"
 
 
 @_action_diff_line.register

--- a/src/delta_engine/domain/model/column.py
+++ b/src/delta_engine/domain/model/column.py
@@ -2,7 +2,8 @@
 
 from __future__ import annotations
 
-from dataclasses import dataclass
+from collections.abc import Mapping
+from dataclasses import dataclass, field
 
 from delta_engine.domain.model.data_type import DataType
 
@@ -19,6 +20,9 @@ class Column:
         comment: Optional column comment.
         primary_key: Whether this column is part of the table's primary key.
             Used by the API layer to derive the table-level primary key tuple.
+        tags: Read-only mapping of Unity Catalog column tag keys to values. Tag
+            keys are case-sensitive and are stored verbatim (never casefolded,
+            unlike the column name).
 
     """
 
@@ -27,10 +31,14 @@ class Column:
     nullable: bool = True
     comment: str = ""
     primary_key: bool = False
+    tags: Mapping[str, str] = field(default_factory=dict)
 
     def __post_init__(self) -> None:
-        """Raise if the name is blank or contains uppercase characters."""
+        """Raise if the name is blank/uppercase, or a tag key is blank."""
         if not self.name.strip():
             raise ValueError(f"Column name must not be blank: {self.name!r}")
         if self.name != self.name.casefold():
             raise ValueError(f"Column name must be lowercase: {self.name!r}")
+        for tag_key in self.tags:
+            if not tag_key.strip():
+                raise ValueError(f"Tag key must not be blank: {tag_key!r}")

--- a/src/delta_engine/domain/plan/__init__.py
+++ b/src/delta_engine/domain/plan/__init__.py
@@ -11,11 +11,13 @@ from delta_engine.domain.plan.actions import (
     PartitioningChange,
     SetColumnComment,
     SetColumnNullability,
+    SetColumnTag,
     SetForeignKey,
     SetPrimaryKey,
     SetProperty,
     SetTableComment,
     SetTableTag,
+    UnsetColumnTag,
     UnsetTableTag,
 )
 
@@ -32,10 +34,12 @@ __all__ = [
     "PartitioningChange",
     "SetColumnComment",
     "SetColumnNullability",
+    "SetColumnTag",
     "SetForeignKey",
     "SetPrimaryKey",
     "SetProperty",
     "SetTableComment",
     "SetTableTag",
+    "UnsetColumnTag",
     "UnsetTableTag",
 ]

--- a/src/delta_engine/domain/plan/actions.py
+++ b/src/delta_engine/domain/plan/actions.py
@@ -33,6 +33,8 @@ class ActionPhase(IntEnum):
     DROP_PRIMARY_KEY = auto()
     ADD_COLUMN = auto()
     DROP_COLUMN = auto()
+    SET_COLUMN_TAG = auto()
+    UNSET_COLUMN_TAG = auto()
     SET_COLUMN_COMMENT = auto()
     SET_TABLE_COMMENT = auto()
     SET_COLUMN_NULLABILITY = auto()
@@ -160,6 +162,35 @@ class SetColumnComment(Action):
     @property
     def subject(self) -> str:
         return self.column_name
+
+
+@dataclass(frozen=True, slots=True)
+class SetColumnTag(Action):
+    """Set a Unity Catalog tag on a column (distinct from a column comment)."""
+
+    column_name: str
+    name: str
+    value: str
+
+    phase: ClassVar[ActionPhase] = ActionPhase.SET_COLUMN_TAG
+
+    @property
+    def subject(self) -> str:
+        return f"{self.column_name}.{self.name}"
+
+
+@dataclass(frozen=True, slots=True)
+class UnsetColumnTag(Action):
+    """Remove a Unity Catalog tag from a column."""
+
+    column_name: str
+    name: str
+
+    phase: ClassVar[ActionPhase] = ActionPhase.UNSET_COLUMN_TAG
+
+    @property
+    def subject(self) -> str:
+        return f"{self.column_name}.{self.name}"
 
 
 @dataclass(frozen=True, slots=True)

--- a/src/delta_engine/domain/plan/differ.py
+++ b/src/delta_engine/domain/plan/differ.py
@@ -28,11 +28,13 @@ from delta_engine.domain.plan.actions import (
     PartitioningChange,
     SetColumnComment,
     SetColumnNullability,
+    SetColumnTag,
     SetForeignKey,
     SetPrimaryKey,
     SetProperty,
     SetTableComment,
     SetTableTag,
+    UnsetColumnTag,
     UnsetTableTag,
 )
 
@@ -95,6 +97,7 @@ def compute_plan(desired: DesiredTable, observed: ObservedTable | None) -> Actio
         body: tuple[Action, ...] = (CreateTable(desired),)
         observed_foreign_keys: tuple[ForeignKeyConstraint, ...] = ()
         observed_tags: Mapping[str, str] = {}
+        observed_columns: tuple[Column, ...] = ()
     else:
         body = (
             _diff_columns(desired.columns, observed.columns)
@@ -105,15 +108,18 @@ def compute_plan(desired: DesiredTable, observed: ObservedTable | None) -> Actio
         )
         observed_foreign_keys = observed.foreign_keys
         observed_tags = observed.tags
+        observed_columns = observed.columns
 
-    # Tags, like foreign keys, are reconciled once for both the new-table and
-    # existing-table cases: a missing table has no observed tags (the empty
-    # mapping above), so every desired tag is set and none is unset. Tags cannot
-    # be declared inline in CREATE TABLE, so they are always applied as
-    # follow-up SET TAGS actions.
+    # Tags, foreign keys, and column tags are reconciled once for both the
+    # new-table and existing-table cases. A missing table has no observed tags
+    # (empty mapping), no observed foreign keys (empty tuple), and no observed
+    # column tags (empty column tuple), so every desired value is set and none
+    # is unset. None of these can be declared inline in CREATE TABLE, so they
+    # are always applied as follow-up actions.
     return ActionPlan(
         body
         + _diff_table_tags(desired.tags, observed_tags)
+        + _diff_column_tags(desired.columns, observed_columns)
         + _diff_foreign_keys(desired.foreign_keys, observed_foreign_keys)
     )
 
@@ -178,9 +184,7 @@ def _diff_properties(
     )
 
 
-def _diff_table_tags(
-    desired: Mapping[str, str], observed: Mapping[str, str]
-) -> tuple[Action, ...]:
+def _diff_table_tags(desired: Mapping[str, str], observed: Mapping[str, str]) -> tuple[Action, ...]:
     """
     Return the tag actions to align observed tags with desired.
 
@@ -201,6 +205,40 @@ def _diff_table_tags(
         UnsetTableTag(name=name) for name in observed if name not in desired
     )
     return set_actions + unset_actions
+
+
+def _diff_column_tags(
+    desired_columns: tuple[Column, ...],
+    observed_columns: tuple[Column, ...],
+) -> tuple[Action, ...]:
+    """
+    Return the column-tag actions to align observed columns with desired.
+
+    Column tags are full-state per column, exactly like `_diff_table_tags` is
+    for the table: for each column present in the desired definition, a declared
+    tag missing from or differing in the observed column is set, and an observed
+    tag not declared is unset. A newly added column (or every column in the
+    create case, where `observed_columns` is empty) has no observed tags, so all
+    its tags are set and none unset. Columns being dropped are not in
+    `desired_columns` and are skipped — dropping the column removes its tags, so
+    emitting UnsetColumnTag for them would be redundant (and would target a
+    column that no longer exists by the time tag actions run).
+    """
+    observed_tags_by_column = {column.name: column.tags for column in observed_columns}
+    actions: list[Action] = []
+    for desired_column in desired_columns:
+        observed_column_tags = observed_tags_by_column.get(desired_column.name, {})
+        actions.extend(
+            SetColumnTag(column_name=desired_column.name, name=name, value=value)
+            for name, value in desired_column.tags.items()
+            if observed_column_tags.get(name) != value
+        )
+        actions.extend(
+            UnsetColumnTag(column_name=desired_column.name, name=name)
+            for name in observed_column_tags
+            if name not in desired_column.tags
+        )
+    return tuple(actions)
 
 
 def _diff_partitioning(

--- a/tests/adapters/databricks/sql/test_compile.py
+++ b/tests/adapters/databricks/sql/test_compile.py
@@ -443,7 +443,7 @@ def test_unset_column_tag_renders_alter_column_unset_tags():
     statement = _compile_single(UnsetColumnTag(column_name="email", name="pii"))
 
     # Then it renders ALTER COLUMN ... UNSET TAGS with the quoted key only
-    assert statement == ("ALTER TABLE `cat`.`sch`.`tbl` ALTER COLUMN `email` UNSET TAGS ('pii')")
+    assert statement == "ALTER TABLE `cat`.`sch`.`tbl` ALTER COLUMN `email` UNSET TAGS ('pii')"
 
 
 def test_set_column_tag_escapes_single_quotes_in_key_and_value():

--- a/tests/adapters/databricks/sql/test_compile.py
+++ b/tests/adapters/databricks/sql/test_compile.py
@@ -19,11 +19,13 @@ from delta_engine.domain.plan.actions import (
     PartitioningChange,
     SetColumnComment,
     SetColumnNullability,
+    SetColumnTag,
     SetForeignKey,
     SetPrimaryKey,
     SetProperty,
     SetTableComment,
     SetTableTag,
+    UnsetColumnTag,
     UnsetTableTag,
 )
 
@@ -421,3 +423,34 @@ def test_set_table_tag_escapes_single_quotes_in_key_and_value():
 
     # Then both quotes are doubled all the way through compile
     assert statement == "ALTER TABLE `cat`.`sch`.`tbl` SET TAGS ('o''k'='v''x')"
+
+
+# ---------- column tags ----------
+
+
+def test_set_column_tag_renders_alter_column_set_tags():
+    # When compiling a SetColumnTag
+    statement = _compile_single(SetColumnTag(column_name="email", name="pii", value="true"))
+
+    # Then it renders ALTER COLUMN ... SET TAGS with backticked column and quoted pair
+    assert statement == (
+        "ALTER TABLE `cat`.`sch`.`tbl` ALTER COLUMN `email` SET TAGS ('pii'='true')"
+    )
+
+
+def test_unset_column_tag_renders_alter_column_unset_tags():
+    # When compiling an UnsetColumnTag
+    statement = _compile_single(UnsetColumnTag(column_name="email", name="pii"))
+
+    # Then it renders ALTER COLUMN ... UNSET TAGS with the quoted key only
+    assert statement == ("ALTER TABLE `cat`.`sch`.`tbl` ALTER COLUMN `email` UNSET TAGS ('pii')")
+
+
+def test_set_column_tag_escapes_single_quotes_in_key_and_value():
+    # Given a column-tag key and value each containing a single quote (escaping edge case)
+    statement = _compile_single(SetColumnTag(column_name="email", name="o'k", value="v'x"))
+
+    # Then both quotes are doubled all the way through compile
+    assert statement == (
+        "ALTER TABLE `cat`.`sch`.`tbl` ALTER COLUMN `email` SET TAGS ('o''k'='v''x')"
+    )

--- a/tests/adapters/databricks/test_reader.py
+++ b/tests/adapters/databricks/test_reader.py
@@ -101,10 +101,9 @@ class FakeSparkWithPrimaryKey:
     'referential_constraints'; the column_tags query references 'column_tags';
     the table_tags query references 'table_tags'; the PK query is the other
     'information_schema' query; everything else is treated as DESCRIBE DETAIL.
-    The 'column_tags' and 'table_tags' checks precede the generic
-    'information_schema' check because those queries also contain that string.
-    The 'column_tags' check must also precede the 'table_tags' check order is
-    unimportant between them, but both must come before 'information_schema'.
+    The 'column_tags' and 'table_tags' checks must both precede the generic
+    'information_schema' check because those queries also contain that string;
+    the order between 'column_tags' and 'table_tags' themselves is unimportant.
     """
 
     def __init__(

--- a/tests/adapters/databricks/test_reader.py
+++ b/tests/adapters/databricks/test_reader.py
@@ -93,14 +93,18 @@ class FakeSparkWithPrimaryKey:
     """
     Spark fake that handles the queries `fetch_state` issues against a present
     table: DESCRIBE DETAIL (properties), the information_schema primary key
-    query, the information_schema foreign key query, and the
-    information_schema.table_tags query.
+    query, the information_schema foreign key query, the
+    information_schema.table_tags query, and the
+    information_schema.column_tags query.
 
     sql() distinguishes them by query text: the FK query references
-    'referential_constraints'; the tag query references 'table_tags'; the PK
-    query is the other 'information_schema' query; everything else is treated as
-    DESCRIBE DETAIL. The 'table_tags' check precedes the generic
-    'information_schema' check because the tag query also contains that string.
+    'referential_constraints'; the column_tags query references 'column_tags';
+    the table_tags query references 'table_tags'; the PK query is the other
+    'information_schema' query; everything else is treated as DESCRIBE DETAIL.
+    The 'column_tags' and 'table_tags' checks precede the generic
+    'information_schema' check because those queries also contain that string.
+    The 'column_tags' check must also precede the 'table_tags' check order is
+    unimportant between them, but both must come before 'information_schema'.
     """
 
     def __init__(
@@ -114,6 +118,8 @@ class FakeSparkWithPrimaryKey:
         fk_exc: Exception | None = None,
         tag_rows=None,
         tags_exc: Exception | None = None,
+        column_tag_rows=None,
+        column_tags_exc: Exception | None = None,
     ):
         self._catalog = catalog
         self._describe_rows = describe_rows or [{"properties": {}}]
@@ -123,6 +129,8 @@ class FakeSparkWithPrimaryKey:
         self._fk_exc = fk_exc
         self._tag_rows = tag_rows or []
         self._tags_exc = tags_exc
+        self._column_tag_rows = column_tag_rows or []
+        self._column_tags_exc = column_tags_exc
 
     @property
     def catalog(self):
@@ -133,6 +141,10 @@ class FakeSparkWithPrimaryKey:
             if self._fk_exc is not None:
                 raise self._fk_exc
             return FakeDataFrame(self._fk_rows)
+        if "column_tags" in query.lower():
+            if self._column_tags_exc is not None:
+                raise self._column_tags_exc
+            return FakeDataFrame(self._column_tag_rows)
         if "table_tags" in query.lower():
             if self._tags_exc is not None:
                 raise self._tags_exc
@@ -968,3 +980,87 @@ def test_fetch_state_tags_are_empty_when_information_schema_unavailable(qn):
     # Then the read still succeeds with no tags (no UC = no tags to observe)
     assert isinstance(result, TablePresent)
     assert dict(result.table.tags) == {}
+
+
+# ---------- tests: column tags ----------
+
+
+def test_fetch_state_observes_column_tags(qn):
+    # Given a present table whose information_schema.column_tags carries tags on a column
+    catalog = FakeCatalog(
+        columns_by_table={str(qn): [make_catalog_col("email", dataType=T.StringType())]},
+        table_comments={str(qn): ""},
+    )
+    column_tag_rows = [
+        SimpleNamespace(column_name="email", tag_name="pii", tag_value="true"),
+        SimpleNamespace(column_name="email", tag_name="classification", tag_value="restricted"),
+    ]
+    spark = FakeSparkWithPrimaryKey(catalog=catalog, column_tag_rows=column_tag_rows)
+
+    # When we fetch state
+    result = DatabricksReader(spark).fetch_state(qn)
+
+    # Then the observed column carries the tags
+    assert isinstance(result, TablePresent)
+    (column,) = result.table.columns
+    assert dict(column.tags) == {"pii": "true", "classification": "restricted"}
+
+
+def test_fetch_state_lowercases_column_name_but_preserves_tag_key_case(qn):
+    # Given a catalog that reports a mixed-case column name and a mixed-case tag key
+    catalog = FakeCatalog(
+        columns_by_table={str(qn): [make_catalog_col("Email", dataType=T.StringType())]},
+        table_comments={str(qn): ""},
+    )
+    spark = FakeSparkWithPrimaryKey(
+        catalog=catalog,
+        column_tag_rows=[
+            SimpleNamespace(column_name="Email", tag_name="PII", tag_value="true"),
+        ],
+    )
+
+    # When we fetch state
+    result = DatabricksReader(spark).fetch_state(qn)
+
+    # Then the column name is lowercased to match the domain, but the tag key is NOT
+    assert isinstance(result, TablePresent)
+    (column,) = result.table.columns
+    assert column.name == "email"
+    assert dict(column.tags) == {"PII": "true"}
+
+
+def test_fetch_state_column_tags_are_empty_when_none_defined(qn):
+    # Given a present table whose column_tags query returns no rows
+    catalog = FakeCatalog(
+        columns_by_table={str(qn): [make_catalog_col("email", dataType=T.StringType())]},
+        table_comments={str(qn): ""},
+    )
+    spark = FakeSparkWithPrimaryKey(catalog=catalog, column_tag_rows=[])
+
+    # When we fetch state
+    result = DatabricksReader(spark).fetch_state(qn)
+
+    # Then no column tags are observed
+    assert isinstance(result, TablePresent)
+    (column,) = result.table.columns
+    assert dict(column.tags) == {}
+
+
+def test_fetch_state_column_tags_are_empty_when_information_schema_unavailable(qn):
+    # Given the column_tags query raises (non-Unity-Catalog Spark, e.g. local tests)
+    catalog = FakeCatalog(
+        columns_by_table={str(qn): [make_catalog_col("email", dataType=T.StringType())]},
+        table_comments={str(qn): ""},
+    )
+    spark = FakeSparkWithPrimaryKey(
+        catalog=catalog,
+        column_tags_exc=AnalysisException("TABLE_OR_VIEW_NOT_FOUND"),
+    )
+
+    # When we fetch state
+    result = DatabricksReader(spark).fetch_state(qn)
+
+    # Then the read still succeeds with no column tags (no UC = nothing to observe)
+    assert isinstance(result, TablePresent)
+    (column,) = result.table.columns
+    assert dict(column.tags) == {}

--- a/tests/application/test_results.py
+++ b/tests/application/test_results.py
@@ -22,7 +22,12 @@ from delta_engine.application.results import (
     _action_diff_line,
 )
 from delta_engine.domain.model import Column, Integer, ObservedTable, QualifiedName
-from delta_engine.domain.plan.actions import SetTableTag, UnsetTableTag
+from delta_engine.domain.plan.actions import (
+    SetColumnTag,
+    SetTableTag,
+    UnsetColumnTag,
+    UnsetTableTag,
+)
 
 # ---------- test builders
 
@@ -423,3 +428,22 @@ def test_unset_table_tag_renders_a_minus_tag_line():
 
     # Then it renders as a removal line naming the tag
     assert line == "- tag env"
+
+
+# ---------- column tag diff lines ----------
+
+
+def test_set_column_tag_renders_a_tilde_column_tag_line():
+    # Given a SetColumnTag action
+    line = _action_diff_line(SetColumnTag(column_name="email", name="pii", value="true"))
+
+    # Then it renders as a change line naming the column, tag, and value
+    assert line == "~ column tag email.pii = 'true'"
+
+
+def test_unset_column_tag_renders_a_minus_column_tag_line():
+    # Given an UnsetColumnTag action
+    line = _action_diff_line(UnsetColumnTag(column_name="email", name="pii"))
+
+    # Then it renders as a removal line naming the column and tag
+    assert line == "- column tag email.pii"

--- a/tests/domain/model/test_column.py
+++ b/tests/domain/model/test_column.py
@@ -27,3 +27,33 @@ def test_raises_when_name_is_blank(blank: str) -> None:
     # When/Then: constructing a Column fails
     with pytest.raises(ValueError, match="blank"):
         Column(blank, Integer())
+
+
+def test_tags_default_to_empty() -> None:
+    # Given: a column with no explicit tags
+    # When: constructing a Column
+    col = Column("id", Integer())
+    # Then: it defaults to an empty tag mapping
+    assert dict(col.tags) == {}
+
+
+def test_tags_are_stored_verbatim() -> None:
+    # Given a column declared with two tags
+    col = Column("email", Integer(), tags={"pii": "true", "classification": "restricted"})
+    # Then the tags are stored exactly as given
+    assert dict(col.tags) == {"pii": "true", "classification": "restricted"}
+
+
+def test_tag_keys_are_case_sensitive() -> None:
+    # Given tag keys differing only in case (UC tag keys are case-sensitive)
+    col = Column("email", Integer(), tags={"PII": "true", "pii": "false"})
+    # Then both keys are preserved distinctly (not casefolded like the column name)
+    assert dict(col.tags) == {"PII": "true", "pii": "false"}
+
+
+@pytest.mark.parametrize("blank", ["", "   ", "\t"], ids=["empty", "spaces", "tab"])
+def test_raises_when_tag_key_is_blank(blank: str) -> None:
+    # Given a blank or whitespace-only tag key
+    # When/Then: constructing a Column fails
+    with pytest.raises(ValueError, match="Tag key must not be blank"):
+        Column("id", Integer(), tags={blank: "v"})

--- a/tests/domain/plan/test_actions.py
+++ b/tests/domain/plan/test_actions.py
@@ -15,11 +15,13 @@ from delta_engine.domain.plan.actions import (
     PartitioningChange,
     SetColumnComment,
     SetColumnNullability,
+    SetColumnTag,
     SetForeignKey,
     SetPrimaryKey,
     SetProperty,
     SetTableComment,
     SetTableTag,
+    UnsetColumnTag,
     UnsetTableTag,
 )
 
@@ -232,6 +234,8 @@ def test_plan_full_phase_order_with_all_action_types():
             DropForeignKey(constraint_name="t_old_fk"),
             DropPrimaryKey(),
             DropColumn(column_name="d_col"),
+            SetColumnTag(column_name="email", name="pii", value="true"),
+            UnsetColumnTag(column_name="email", name="old"),
             SetColumnComment(column_name="c_col", comment="c"),
             _create_table_action(),
             SetTableTag(name="env", value="prod"),
@@ -249,6 +253,8 @@ def test_plan_full_phase_order_with_all_action_types():
         DropPrimaryKey,
         AddColumn,
         DropColumn,
+        SetColumnTag,
+        UnsetColumnTag,
         SetColumnComment,
         SetTableComment,
         SetColumnNullability,
@@ -348,3 +354,48 @@ def test_plan_orders_set_table_tag_before_unset_table_tag():
 
     # Then sets run before unsets (documented phase precedence)
     assert [type(a) for a in plan] == [SetTableTag, UnsetTableTag]
+
+
+# ----- SetColumnTag / UnsetColumnTag
+
+
+def test_set_column_tag_subject_is_column_and_tag_name():
+    # Given a SetColumnTag action
+    action = SetColumnTag(column_name="email", name="pii", value="true")
+
+    # Then its within-phase subject is "{column}.{tag}" (for deterministic ordering)
+    assert action.subject == "email.pii"
+
+
+def test_unset_column_tag_subject_is_column_and_tag_name():
+    # Given an UnsetColumnTag action
+    action = UnsetColumnTag(column_name="email", name="pii")
+
+    # Then its within-phase subject is "{column}.{tag}"
+    assert action.subject == "email.pii"
+
+
+def test_plan_orders_set_column_tag_after_add_column():
+    # Given an AddColumn and a SetColumnTag on that column in one plan
+    plan = ActionPlan(
+        (
+            SetColumnTag(column_name="email", name="pii", value="true"),
+            AddColumn(column=_column("email")),
+        )
+    )
+
+    # Then the column is added before it is tagged
+    assert [type(a) for a in plan] == [AddColumn, SetColumnTag]
+
+
+def test_plan_orders_set_column_tag_before_unset_column_tag():
+    # Given both a set and an unset column-tag action in one plan
+    plan = ActionPlan(
+        (
+            UnsetColumnTag(column_name="email", name="old"),
+            SetColumnTag(column_name="email", name="pii", value="true"),
+        )
+    )
+
+    # Then sets run before unsets (documented phase precedence)
+    assert [type(a) for a in plan] == [SetColumnTag, UnsetColumnTag]

--- a/tests/domain/plan/test_differ.py
+++ b/tests/domain/plan/test_differ.py
@@ -29,11 +29,13 @@ from delta_engine.domain.plan.actions import (
     PartitioningChange,
     SetColumnComment,
     SetColumnNullability,
+    SetColumnTag,
     SetForeignKey,
     SetPrimaryKey,
     SetProperty,
     SetTableComment,
     SetTableTag,
+    UnsetColumnTag,
     UnsetTableTag,
 )
 from delta_engine.domain.plan.differ import _diff_foreign_keys, compute_plan
@@ -940,9 +942,7 @@ def test_sets_tag_when_key_absent_in_observed():
 
 def test_updates_tag_when_value_differs():
     # Given the key matches but the value differs
-    plan = compute_plan(
-        _desired(tags={"env": "prod"}), _observed(tags={"env": "dev"})
-    )
+    plan = compute_plan(_desired(tags={"env": "prod"}), _observed(tags={"env": "dev"}))
 
     # Then a single SetTableTag updates the value
     assert plan.actions == (SetTableTag(name="env", value="prod"),)
@@ -981,3 +981,113 @@ def test_new_table_sets_all_desired_tags_after_creation():
     assert any(isinstance(a, CreateTable) for a in plan)
     set_tags = [a for a in plan if isinstance(a, SetTableTag)]
     assert set_tags == [SetTableTag(name="env", value="prod")]
+
+
+# ---------- column tag diffs (full-state) ----------
+
+
+def test_no_column_tag_actions_when_tags_match():
+    # Given a column whose desired and observed tags are identical
+    desired = _desired(columns=(Column("email", String(), tags={"pii": "true"}),))
+    observed = _observed(columns=(Column("email", String(), tags={"pii": "true"}),))
+
+    # When
+    plan = compute_plan(desired, observed)
+
+    # Then nothing to do
+    assert plan.actions == ()
+
+
+def test_sets_column_tag_when_absent_in_observed():
+    # Given the catalog column carries no tags but the desired column declares one
+    desired = _desired(columns=(Column("email", String(), tags={"pii": "true"}),))
+    observed = _observed(columns=(Column("email", String()),))
+
+    # When
+    plan = compute_plan(desired, observed)
+
+    # Then a SetColumnTag is emitted for that column
+    assert plan.actions == (SetColumnTag(column_name="email", name="pii", value="true"),)
+
+
+def test_updates_column_tag_when_value_differs():
+    # Given the tag key matches but the value differs
+    desired = _desired(columns=(Column("email", String(), tags={"pii": "true"}),))
+    observed = _observed(columns=(Column("email", String(), tags={"pii": "false"}),))
+
+    # When
+    plan = compute_plan(desired, observed)
+
+    # Then a single SetColumnTag updates the value
+    assert plan.actions == (SetColumnTag(column_name="email", name="pii", value="true"),)
+
+
+def test_unsets_observed_only_column_tag_under_full_state_ownership():
+    # Given the catalog column carries a tag the desired column does not declare
+    desired = _desired(columns=(Column("email", String()),))
+    observed = _observed(columns=(Column("email", String(), tags={"legacy": "1"}),))
+
+    # When
+    plan = compute_plan(desired, observed)
+
+    # Then the engine unsets it — column tags are full-state
+    assert plan.actions == (UnsetColumnTag(column_name="email", name="legacy"),)
+
+
+def test_sets_and_unsets_column_tags_in_one_plan():
+    # Given one tag to change and one observed-only tag to remove on the same column
+    desired = _desired(columns=(Column("email", String(), tags={"pii": "true"}),))
+    observed = _observed(columns=(Column("email", String(), tags={"pii": "false", "legacy": "1"}),))
+
+    # When
+    plan = compute_plan(desired, observed)
+
+    # Then the changed tag is set and the undeclared tag is unset
+    assert set(plan.actions) == {
+        SetColumnTag(column_name="email", name="pii", value="true"),
+        UnsetColumnTag(column_name="email", name="legacy"),
+    }
+
+
+def test_no_unset_column_tag_for_a_dropped_column():
+    # Given the observed table has a tagged column that the desired table drops
+    desired = _desired(columns=(Column("id", Integer()),))
+    observed = _observed(
+        columns=(Column("id", Integer()), Column("legacy", String(), tags={"pii": "true"}))
+    )
+
+    # When
+    plan = compute_plan(desired, observed)
+
+    # Then the column is dropped and NO UnsetColumnTag is emitted (drop removes its tags)
+    assert any(isinstance(a, DropColumn) for a in plan)
+    assert not any(isinstance(a, (SetColumnTag, UnsetColumnTag)) for a in plan)
+
+
+def test_new_column_gets_all_its_tags_set():
+    # Given an existing table gaining a new, tagged column
+    desired = _desired(
+        columns=(Column("id", Integer()), Column("email", String(), tags={"pii": "true"}))
+    )
+    observed = _observed(columns=(Column("id", Integer()),))
+
+    # When
+    plan = compute_plan(desired, observed)
+
+    # Then the column is added and its tag is set afterwards
+    assert any(isinstance(a, AddColumn) for a in plan)
+    set_tags = [a for a in plan if isinstance(a, SetColumnTag)]
+    assert set_tags == [SetColumnTag(column_name="email", name="pii", value="true")]
+
+
+def test_new_table_sets_all_column_tags_after_creation():
+    # Given a brand-new table (observed is None) whose column declares tags
+    desired = _desired(columns=(Column("email", String(), tags={"pii": "true"}),))
+
+    # When diffing against a missing table
+    plan = compute_plan(desired, observed=None)
+
+    # Then the plan creates the table and sets its column tags (no inline CREATE syntax)
+    assert any(isinstance(a, CreateTable) for a in plan)
+    set_tags = [a for a in plan if isinstance(a, SetColumnTag)]
+    assert set_tags == [SetColumnTag(column_name="email", name="pii", value="true")]


### PR DESCRIPTION
## Summary

Adds Unity Catalog **column-level tags** to delta-engine, closing the follow-up that was deliberately deferred when table tags shipped (#89). Tags are declared inline on a `Column` and reconciled end-to-end with **full-state ownership** — the engine sets declared tags and unsets any observed tag not declared, per column.

```python
Column("email", String(), tags={"pii": "true", "classification": "restricted"})
```

The change mirrors the merged table-tags feature layer for layer, one level down at column scope.

## What changed

- **Domain** — `Column` gains a `tags: Mapping[str, str]` field (case-sensitive keys, blank keys rejected). `Column` is never hashed, so this is a plain mapping field — no hashability change.
- **Actions** — `SetColumnTag` / `UnsetColumnTag`, ordered after column add/drop (a column must exist before it can be tagged).
- **Differ** — `_diff_column_tags`, a full-state reconciler called once in `compute_plan`; dropped columns are skipped.
- **SQL** — compiles to `ALTER TABLE … ALTER COLUMN … SET/UNSET TAGS (…)`.
- **Reader** — observes column tags from `information_schema.column_tags` in a single query, `AnalysisException`-guarded for non-UC environments; casefolds only the column name, tag keys/values verbatim. Closes the round-trip.
- **Diff rendering** — `~ column tag col.key = 'val'` / `- column tag col.key`.
- **Notebook** — `CatalogInspector.column_tags_of` + a walkthrough act demonstrating set-then-unset.
- **Docs** — "Column tags" section in the tags how-to guide.

## Semantics

Full-state, matching table tags: a column tag applied out-of-band (UI, another job, a classifier) is **removed** on the next sync unless it is also declared. This is the deliberate contrast with table *properties*, which are declared-subset.

## Testing

- Full suite: **375 passed**, coverage 93.02%; `ruff check`, `ruff format --check`, and `mypy .` all clean.
- Coverage across domain / differ (idempotent resync, added/dropped column, create case) / compiler / reader round-trip / results.
- The 16 pre-existing `JAVA_GATEWAY_EXITED` errors in the sandbox are environmental (no JVM), not introduced here.
- No E2E test for column tags — consistent with table tags, whose E2E suite runs on local non-UC Spark where tags can't round-trip; the fake-Spark reader tests are the round-trip coverage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)