### PR TITLE
chore: remove ENABLE_DELETION_VECTORS from default table properties

### DIFF
--- a/docs/how-to-configure-properties.md
+++ b/docs/how-to-configure-properties.md
@@ -9,14 +9,15 @@ tags:
 
 ## Default properties
 
-Every `DeltaTable` applies two defaults unless you override them:
+Every `DeltaTable` applies one default unless you override it:
 
 | Property | Default value |
 |---|---|
-| `Property.ENABLE_DELETION_VECTORS` | `"true"` |
 | `Property.COLUMN_MAPPING_MODE` | `"name"` |
 
 `COLUMN_MAPPING_MODE=name` is required for column drops to work. Override it to `none` only if you never drop columns.
+
+Deletion vectors are intentionally **not** defaulted here — current Databricks runtimes enable them automatically. The engine reconciles only the properties you declare, so leaving `ENABLE_DELETION_VECTORS` undeclared lets the runtime own it. Declare it explicitly if you need to pin a specific value.
 
 ## Override a default
 
@@ -29,7 +30,7 @@ table = DeltaTable(
     name="events",
     columns=[Column("id", String())],
     properties={
-        Property.ENABLE_DELETION_VECTORS: "false",
+        Property.COLUMN_MAPPING_MODE: "none",
     },
 )
 ```

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -1,6 +1,6 @@
 # Open questions and decisions
 
-- [ ] Decide whether to remove `ENABLE_DELETION_VECTORS` from the default properties applied to every `DeltaTable`
+- [x] Decide whether to remove `ENABLE_DELETION_VECTORS` from the default properties applied to every `DeltaTable` (removed: current DBR runtimes enable it by default, and the engine only reconciles declared properties)
 - [ ] Decide whether to create an enum for `Property` values as well as keys (currently only keys are enumerated)
 - [ ] Figure out how to add existing tables (tables that already exist in the catalog but are not yet declared in the registry)
 - [x] Add support for foreign keys

--- a/src/delta_engine/api/table.py
+++ b/src/delta_engine/api/table.py
@@ -23,7 +23,6 @@ class DeltaTable:
 
     default_properties: ClassVar[Mapping[str, str]] = MappingProxyType(
         {
-            Property.ENABLE_DELETION_VECTORS.value: "true",
             Property.COLUMN_MAPPING_MODE.value: "name",
         }
     )

--- a/tests/api/test_table.py
+++ b/tests/api/test_table.py
@@ -7,9 +7,9 @@ from delta_engine.domain.model.primary_key import PrimaryKeyConstraint
 
 
 def test_user_overrides_take_precedence_over_defaults():
-    # Given default properties include deletion vectors=true, column mapping=name
+    # Given the sole default property (column mapping=name) is overridden by the user
     user_properties = {
-        Property.ENABLE_DELETION_VECTORS.value: "false",  # user wants to disable
+        Property.COLUMN_MAPPING_MODE.value: "none",  # user wants to disable
     }
     table = DeltaTable(
         catalog="coredev",
@@ -22,9 +22,8 @@ def test_user_overrides_take_precedence_over_defaults():
     # When computing effective properties
     effective = table.effective_properties
 
-    # Then user value wins; other defaults still present
-    assert effective[Property.ENABLE_DELETION_VECTORS.value] == "false"
-    assert effective[Property.COLUMN_MAPPING_MODE.value] == "name"
+    # Then the user value wins over the default
+    assert effective[Property.COLUMN_MAPPING_MODE.value] == "none"
 
 
 def test_defaults_are_applied_when_no_user_properties_given():
@@ -39,9 +38,9 @@ def test_defaults_are_applied_when_no_user_properties_given():
     # When computing effective properties
     effective = table.effective_properties
 
-    # Then all defaults are present
-    assert effective[Property.ENABLE_DELETION_VECTORS.value] == "true"
-    assert effective[Property.COLUMN_MAPPING_MODE.value] == "name"
+    # Then the column-mapping default is present and no other property is defaulted in
+    # (deletion vectors is left to the Databricks runtime default, not managed here)
+    assert effective == {Property.COLUMN_MAPPING_MODE.value: "name"}
 
 
 @pytest.mark.parametrize(
@@ -165,7 +164,7 @@ def test_to_desired_table_preserves_columns_and_metadata():
 
 
 def test_to_desired_table_carries_effective_properties_with_defaults():
-    # Given a table where the user overrides one default property
+    # Given a table where the user declares a property alongside the defaults
     table = DeltaTable(
         catalog="cat",
         schema="core",

--- a/tests/application/test_engine.py
+++ b/tests/application/test_engine.py
@@ -73,8 +73,11 @@ def _existing_id_table_synced(fqn: str) -> TablePresent:
     """
     Build the present-state read of a table that is already fully in sync with _spec.
 
-    Includes the default Delta properties that _spec produces so that diffing
-    against _spec yields an empty plan.
+    Includes the default Delta property that _spec produces (column mapping) so
+    that diffing against _spec yields an empty plan. Also carries an
+    observed-only ``delta.enableDeletionVectors`` (as the Databricks runtime
+    enables autonomously) to confirm the engine leaves undeclared properties
+    untouched rather than emitting a spurious action.
     """
     catalog, schema, name = fqn.split(".")
     return TablePresent(


### PR DESCRIPTION
## Summary

Removes `ENABLE_DELETION_VECTORS` from the default properties applied to every `DeltaTable`. Current Databricks runtimes enable deletion vectors by default, making the engine-level default redundant.

## Why it's safe

Property reconciliation is a *declared-subset* diff (`_diff_properties` in `domain/plan/differ.py`): the engine only sets keys the user declares and **never unsets** observed-only keys. Dropping the default therefore just means the engine stops managing deletion vectors — the runtime default takes over. There is no risk of the engine trying to disable it on existing tables. `ENABLE_DELETION_VECTORS` remains in the `Property` enum, so callers can still declare it explicitly to pin a value.

## Changes

- `api/table.py` — remove the default entry; `COLUMN_MAPPING_MODE=name` remains (required for column drops).
- `tests/api/test_table.py` — retarget the default/override tests onto `COLUMN_MAPPING_MODE`; the no-properties test now asserts the exact effective set.
- `tests/application/test_engine.py` — correct the `_existing_id_table_synced` docstring; the observed-only `enableDeletionVectors` now documents the "engine leaves undeclared properties untouched" case.
- `docs/how-to-configure-properties.md` — update the defaults table and override example, add a note on why deletion vectors is left to the runtime.
- `docs/todo.md` — check off the decision with rationale.

## Verification

- 376 passed, ruff clean, mypy clean.
- The databricks-adapter/e2e Spark suites error out locally due to a pre-existing TLS failure fetching the `delta-spark` Maven artifact (confirmed reproducible on the pristine tree); unrelated to this change.