### PR TITLE
ci: run typecheck, lint, test, and docs as parallel jobs

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -9,15 +9,12 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  ci:
+  typecheck:
     runs-on: ubuntu-latest
-
     steps:
       - uses: actions/checkout@v5
 
       - name: Install uv
-        # Pinned to an exact version: setup-uv stopped publishing a floating
-        # `v8` major tag from v8.0.0 onward ("secure tags").
         uses: astral-sh/setup-uv@v8.2.0
         with:
           enable-cache: true
@@ -32,8 +29,62 @@ jobs:
       - name: Type check
         run: uv run mypy .
 
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v8.2.0
+        with:
+          enable-cache: true
+          cache-dependency-glob: uv.lock
+
+      - name: Set up Python
+        run: uv python install 3.12
+
+      - name: Install dependencies
+        run: uv sync --locked --group dev
+
       - name: Lint
         run: uv run ruff check .
 
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v8.2.0
+        with:
+          enable-cache: true
+          cache-dependency-glob: uv.lock
+
+      - name: Set up Python
+        run: uv python install 3.12
+
+      - name: Install dependencies
+        run: uv sync --locked --group dev
+
       - name: Test
         run: uv run pytest -q
+
+  docs:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v8.2.0
+        with:
+          enable-cache: true
+          cache-dependency-glob: uv.lock
+
+      - name: Set up Python
+        run: uv python install 3.12
+
+      - name: Install dependencies
+        run: uv sync --locked --group docs
+
+      - name: Build docs
+        run: uv run sphinx-build -W -b html docs docs/_build/html

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -14,7 +14,7 @@
 - [ ] should databricks rules live in validator?
 - [x] add clarifying comments to differ functions
 - [x] add clarifying comments to validation rules
-- [ ] make each CI step independently in parallel
+- [x] make each CI step independently in parallel
 - [ ] review except AnalysisException in reader's _fetch_primary_key()
 - [ ] Think of whether to make DeltaTable automatically make columns unique if they are PK cols
 - [ ] Document that DBR runtime & delta table version issues are for the user to resolve. If they want to use Databricks unique constraints or CDF, they have to make sure they are on the right runtime/Delta version. The way the engine is designed, it will fail and return the relevant error.


### PR DESCRIPTION
## Summary

- Splits the single sequential `ci` job into four independent parallel jobs: `typecheck`, `lint`, `test`, `docs`
- Adds a Sphinx docs build job using `--group docs` and `sphinx-build -W` (warnings-as-errors)
- Wall-clock time is now determined by the slowest job rather than the sum of all

## Test plan

- [ ] Confirm all four jobs appear and run in parallel on this PR
- [ ] Confirm the docs job passes (verified locally — clean build with no warnings)

🤖 Generated with [Claude Code](https://claude.com/claude-code)