### PR TITLE
docs: add quickstart code example to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,28 @@
 
 Declarative schema management for Delta Lake tables on Databricks. Define the schema you want; the engine plans, validates, and applies the DDL.
 
+## Quickstart
+
+```python
+from delta_engine import Column, DeltaTable, Integer, String, Registry, build_databricks_engine
+
+customers = DeltaTable(
+    catalog="dev",
+    schema="silver",
+    name="customers",
+    columns=[
+        Column("id", Integer()),
+        Column("name", String()),
+    ],
+)
+
+registry = Registry()
+registry.register(customers)
+
+engine = build_databricks_engine(spark)
+engine.sync(registry)  # creates the table, or no-ops if it already matches
+```
+
 ## How-to guides
 
 - [Getting started](docs/tutorial-getting-started.md) — define a table and run your first sync

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -25,7 +25,7 @@
 - [ ] Test that table order is kept from resolve through to execute on engine
 - [x] Delete redundant Claude documentation
 - [ ] Do we need action_index?
-- [ ] Add quick code example to README
+- [x] Add quick code example to README
 - [ ] How to declare partitioned tables doesnt need its own doc. Put it alongside general how to
 - [ ] consider replacing typle comps in validation with regular loops for readability
 - [x] clean up claude documentation


### PR DESCRIPTION
## Summary

- Adds a **Quickstart** section to the README with a minimal end-to-end Python example
- Shows the define → register → sync flow in one snippet
- Inline comment explains idempotent behaviour

## Test plan

- [ ] Verify the code example renders correctly on GitHub
- [ ] Confirm imports match the public API

🤖 Generated with [Claude Code](https://claude.com/claude-code)