### PR TITLE
refactor: unify the failure model into one phase-ordered stream

### DIFF
--- a/docs/how-to-handle-sync-failures.md
+++ b/docs/how-to-handle-sync-failures.md
@@ -44,11 +44,11 @@ from delta_engine import TableRunStatus
 
 for table_report in report:
     if table_report.status == TableRunStatus.VALIDATION_FAILED:
-        for failure in table_report.all_failures:
+        for failure in table_report.failures:
             print("\n".join(failure.format_lines()))
 ```
 
-`table_report.all_failures` returns every `Failure` across all phases. Each `Failure` renders itself via `format_lines()`.
+`table_report.failures` is the single phase-ordered stream of every `Failure` for that table (read → validation → foreign key → execution). Each `Failure` renders itself via `format_lines()`.
 
 ## Check which tables failed
 
@@ -70,7 +70,7 @@ Validation failures mean no SQL ran for that table. The failure message names th
 for table_report in report:
     if table_report.status == TableRunStatus.VALIDATION_FAILED:
         # Safe to retry after fixing the declaration
-        for failure in table_report.all_failures:
+        for failure in table_report.failures:
             print(failure.format_lines()[0])
 ```
 
@@ -83,7 +83,7 @@ A `FOREIGN_KEY_FAILED` table ran no SQL. The cause is one of: a reference to an 
 ```python
 for table_report in report:
     if table_report.status == TableRunStatus.FOREIGN_KEY_FAILED:
-        for failure in table_report.all_failures:
+        for failure in table_report.failures:
             print(failure.format_lines()[0])
 ```
 

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -59,3 +59,4 @@
 - [ ] Review the user report formatting. Make sure is has everything it needs
 - [ ] look for redundancies; things like frozenset for local variables
 - [ ] review if we need from __future__ import annotations
+- [ ] review types hints; things like Mapping, AbstractSet, etc

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -56,3 +56,6 @@
 - [ ] make sure docstrings & comments are accurate
 - [ ] investigate TableSnapshot.__post_init__(self) on DesiredTable. Should all validation be in DesiredTable?
 - [ ] Add a note to the step 6 markdown in the walkthrough notebook clarifying the phase distinction: the "Validation passed" log is the plan-safety (validate) phase, while the foreign-key check is a separate, later (resolve) phase — so "Validation passed" then `FOREIGN_KEY_FAILED` is expected, not contradictory. Also note the Diff renders the intended plan, not what executed (the report STATUS/footer are the truth).
+- [ ] Review the user report formatting. Make sure is has everything it needs
+- [ ] look for redundancies; things like frozenset for local variables
+- [ ] review if we need from __future__ import annotations

--- a/src/delta_engine/adapters/databricks/executor.py
+++ b/src/delta_engine/adapters/databricks/executor.py
@@ -99,7 +99,6 @@ def _run_statement(
         logger.warning("%s failed: %s\nSQL: %s", action_name, error_message, preview)
         return ExecutionFailed(
             action=action_name,
-            action_index=action_index,
             failure=ExecutionFailure(
                 action_index=action_index,
                 exception_type=exception_type_name(exception),

--- a/src/delta_engine/application/dependency_resolution.py
+++ b/src/delta_engine/application/dependency_resolution.py
@@ -5,10 +5,10 @@ The public entry point is `resolve`, which takes the registered tables and
 returns them as a tuple of :class:`SyncCandidate` objects in dependency-first
 order — referenced tables before their dependents.
 
-Each candidate carries the table it represents and any foreign key failures
-that prevent the table from being executed (CYCLE, UNRESOLVABLE_REFERENCE, or
-BLOCKED_BY_FAILED_DEPENDENCY). A candidate whose `failures` list is empty may
-be executed; one with failures must be excluded.
+Each candidate carries the table it represents and only the FK failures that
+`resolve` found for it (CYCLE, UNRESOLVABLE_REFERENCE, REFERENCED_COLUMNS_NOT_A_KEY,
+or BLOCKED_BY_FAILED_DEPENDENCY). A candidate with an empty `fk_failures` tuple
+may be executed; one with failures must be excluded.
 
 All graph-traversal implementation details (adjacency map, Tarjan's
 strongly-connected-components algorithm, reverse-reachability propagation) are
@@ -19,7 +19,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 
-from delta_engine.application.results import Failure, ForeignKeyFailure, ForeignKeyFailureReason
+from delta_engine.application.results import ForeignKeyFailure, ForeignKeyFailureReason
 from delta_engine.domain.model import QualifiedName
 from delta_engine.domain.model.foreign_key import ForeignKeyConstraint
 from delta_engine.domain.model.table import DesiredTable
@@ -36,18 +36,18 @@ def _primary_key_columns(table: DesiredTable) -> tuple[str, ...]:
 @dataclass(frozen=True, slots=True)
 class SyncCandidate:
     """
-    A table prepared for the sync loop, together with its pre-execution failure verdict.
+    A table prepared for the sync loop, with the FK failures resolution found for it.
 
     Attributes:
         table: The desired table to sync.
-        failures: All pre-execution failures — external failures (e.g. validation)
-            prepended, FK structural failures appended. Assembled by `resolve()`;
-            the engine does not modify this after construction.
+        fk_failures: Foreign-key failures this table incurred during resolution
+            (CYCLE / UNRESOLVABLE_REFERENCE / REFERENCED_COLUMNS_NOT_A_KEY /
+            BLOCKED_BY_FAILED_DEPENDENCY). Empty when resolution found none.
 
     """
 
     table: DesiredTable
-    failures: tuple[Failure, ...] = ()
+    fk_failures: tuple[ForeignKeyFailure, ...] = ()
 
     @property
     def qualified_name(self) -> QualifiedName:
@@ -56,41 +56,36 @@ class SyncCandidate:
 
     @property
     def can_execute(self) -> bool:
-        """True when the table has no pre-execution failures and may be executed."""
-        return not self.failures
+        """True when resolution found no foreign-key failures for this table."""
+        return not self.fk_failures
 
 
 def resolve(
     tables: tuple[DesiredTable, ...],
-    external_failures: dict[QualifiedName, tuple[Failure, ...]] | None = None,
+    *,
+    blocked: frozenset[QualifiedName] = frozenset(),
 ) -> tuple[SyncCandidate, ...]:
     """
     Resolve foreign key dependencies across all registered tables.
 
     Builds a dependency graph, runs Tarjan's strongly-connected-components
     algorithm to find the safe sync order and detect true cycles, then
-    classifies every table as buildable or failed.
+    classifies every table's foreign-key failures.
 
     Args:
         tables: All desired tables from the registry, in registry order.
-        external_failures: Failures already known before FK resolution — typically
-            validation failures computed by the engine. Tables with non-empty
-            external failures are treated as will-not-build when propagating
-            BLOCKED_BY_FAILED_DEPENDENCY to their FK dependents. Their failures
-            are prepended to the candidate's failure list so all pre-execution
-            failures appear together.
+        blocked: Tables already known to be failing before FK resolution
+            (e.g. failed read or validation). Their FK dependents are blocked
+            with BLOCKED_BY_FAILED_DEPENDENCY, but resolve records no failure
+            for the blocked tables themselves — their failures are owned by the
+            phase that produced them.
 
     Returns:
-        A tuple of :class:`SyncCandidate` objects in dependency-first order.
-        Each candidate carries its table and any pre-execution failures (external
-        failures first, then FK failures). A candidate with no failures is ready
-        to sync; one with failures must be excluded from execution.
+        A tuple of :class:`SyncCandidate` objects in dependency-first order,
+        each carrying only the FK failures resolution found for it.
 
     """
-    external = external_failures or {}
-    already_failed = frozenset(
-        str(qualified_name) for qualified_name, failures in external.items() if failures
-    )
+    already_failed = frozenset(str(qualified_name) for qualified_name in blocked)
 
     registered_names = {str(table.qualified_name) for table in tables}
     graph = _build_dependency_graph(tables, registered_names)
@@ -103,10 +98,7 @@ def resolve(
     return tuple(
         SyncCandidate(
             table=table,
-            failures=tuple(
-                list(external.get(table.qualified_name, ()))
-                + list(failures_by_table.get(table.qualified_name, ()))
-            ),
+            fk_failures=failures_by_table.get(table.qualified_name, ()),
         )
         for table in ordered
     )
@@ -212,7 +204,7 @@ def _classify_failures(
     registered_names: set[str],
     cycle_members: set[str],
     already_failed: frozenset[str] = frozenset(),
-) -> dict[QualifiedName, tuple[Failure, ...]]:
+) -> dict[QualifiedName, tuple[ForeignKeyFailure, ...]]:
     """
     Classify every table as buildable or failed because of a foreign key.
 

--- a/src/delta_engine/application/dependency_resolution.py
+++ b/src/delta_engine/application/dependency_resolution.py
@@ -17,6 +17,7 @@ hidden behind that interface.
 
 from __future__ import annotations
 
+from collections.abc import Set as AbstractSet
 from dataclasses import dataclass
 
 from delta_engine.application.results import ForeignKeyFailure, ForeignKeyFailureReason
@@ -63,7 +64,7 @@ class SyncCandidate:
 def resolve(
     tables: tuple[DesiredTable, ...],
     *,
-    blocked: frozenset[QualifiedName] = frozenset(),
+    blocked: AbstractSet[QualifiedName] = frozenset(),
 ) -> tuple[SyncCandidate, ...]:
     """
     Resolve foreign key dependencies across all registered tables.
@@ -85,7 +86,7 @@ def resolve(
         each carrying only the FK failures resolution found for it.
 
     """
-    already_failed = frozenset(str(qualified_name) for qualified_name in blocked)
+    already_failed = {str(qualified_name) for qualified_name in blocked}
 
     registered_names = {str(table.qualified_name) for table in tables}
     graph = _build_dependency_graph(tables, registered_names)
@@ -203,7 +204,7 @@ def _classify_failures(
     tables: tuple[DesiredTable, ...],
     registered_names: set[str],
     cycle_members: set[str],
-    already_failed: frozenset[str] = frozenset(),
+    already_failed: set[str],
 ) -> dict[QualifiedName, tuple[ForeignKeyFailure, ...]]:
     """
     Classify every table as buildable or failed because of a foreign key.

--- a/src/delta_engine/application/engine.py
+++ b/src/delta_engine/application/engine.py
@@ -107,24 +107,36 @@ class Engine:
         tables = tuple(registry)
         catalog_states = self._read(tables)
         plans = self._plan(tables, catalog_states)
-        validation_failures = self._validate_plans(plans)
 
-        # Merge read failures into external_failures so read-failed tables are
-        # treated as "won't build" during FK propagation, blocking their dependents
-        # with BLOCKED_BY_FAILED_DEPENDENCY just as validation-failed tables do.
-        external_failures: dict[QualifiedName, tuple[Failure, ...]] = dict(validation_failures)
-        for table in tables:
-            qn = table.qualified_name
-            state = catalog_states[qn]
-            if isinstance(state, ReadFailed) and not external_failures.get(qn):
-                external_failures[qn] = (state.failure,)
+        # One accumulator, filled phase by phase. Read failures are NOT put here:
+        # they live on the table's CatalogState (`read`) and are surfaced by the
+        # report. The accumulator holds the pre-execution failures the report's
+        # `pre_execution_failures` field carries (validation, then FK), plus any
+        # execution failures appended after the execute phase.
+        pre_execution: dict[QualifiedName, list[Failure]] = {
+            table.qualified_name: [] for table in tables
+        }
+        for qualified_name, result in self._validate_plans(plans).items():
+            pre_execution[qualified_name].extend(result)
 
-        candidates = resolve(tables, external_failures=external_failures)
+        read_failed = frozenset(
+            table.qualified_name
+            for table in tables
+            if isinstance(catalog_states[table.qualified_name], ReadFailed)
+        )
+        blocked = read_failed | frozenset(
+            qualified_name for qualified_name, failures in pre_execution.items() if failures
+        )
+
+        candidates = resolve(tables, blocked=blocked)
+        for candidate in candidates:
+            pre_execution[candidate.qualified_name].extend(candidate.fk_failures)
 
         plans_to_execute = {
             candidate.qualified_name: plans[candidate.qualified_name]
             for candidate in candidates
-            if candidate.can_execute
+            if candidate.qualified_name not in read_failed
+            and not pre_execution[candidate.qualified_name]
         }
         executions: dict[QualifiedName, ExecutionSummary] = (
             {} if dry_run else self._execute(plans_to_execute)
@@ -135,7 +147,7 @@ class Engine:
                 qualified_name=candidate.qualified_name,
                 read=catalog_states[candidate.qualified_name],
                 plan=plans[candidate.qualified_name],
-                pre_execution_failures=tuple(candidate.failures),
+                pre_execution_failures=tuple(pre_execution[candidate.qualified_name]),
                 execution=executions.get(candidate.qualified_name),
             )
             for candidate in candidates

--- a/src/delta_engine/application/engine.py
+++ b/src/delta_engine/application/engine.py
@@ -10,8 +10,8 @@ The sync runs five phases across all tables in sequence:
   1. Read     — fetch current catalog state for every table
   2. Plan     — compute action plans from desired vs observed state
   3. Validate — check every plan against rules; collect per-table failures
-  4. Resolve  — order tables by FK dependency; propagate all failures
-                (FK-structural and validation) to dependents
+  4. Resolve  — order tables by FK dependency; produce FK failures and
+                propagate blocking to dependents
   5. Execute  — run plans for candidates with no pre-execution failures
 
 Running `resolve()` after validation means a table that fails validation
@@ -108,23 +108,23 @@ class Engine:
         catalog_states = self._read(tables)
         plans = self._plan(tables, catalog_states)
 
-        # One accumulator, filled phase by phase. Read failures are NOT put here:
-        # they live on the table's CatalogState (`read`) and are surfaced by the
-        # report. The accumulator holds the pre-execution failures the report's
-        # `pre_execution_failures` field carries (validation, then FK), plus any
-        # execution failures appended after the execute phase.
+        # One accumulator for every failure across all phases. Filled in order:
+        # read failures, validation failures, FK failures from resolve, then
+        # execution failures mirrored in after the execute phase. This makes
+        # `failures` on each TableRunReport the single place to read what went wrong.
         pre_execution: dict[QualifiedName, list[Failure]] = {
             table.qualified_name: [] for table in tables
         }
+
+        for table in tables:
+            state = catalog_states[table.qualified_name]
+            if isinstance(state, ReadFailed):
+                pre_execution[table.qualified_name].append(state.failure)
+
         for qualified_name, result in self._validate_plans(plans).items():
             pre_execution[qualified_name].extend(result)
 
-        read_failed = frozenset(
-            table.qualified_name
-            for table in tables
-            if isinstance(catalog_states[table.qualified_name], ReadFailed)
-        )
-        blocked = read_failed | frozenset(
+        blocked = frozenset(
             qualified_name for qualified_name, failures in pre_execution.items() if failures
         )
 
@@ -135,20 +135,25 @@ class Engine:
         plans_to_execute = {
             candidate.qualified_name: plans[candidate.qualified_name]
             for candidate in candidates
-            if candidate.qualified_name not in read_failed
-            and not pre_execution[candidate.qualified_name]
+            if not pre_execution[candidate.qualified_name]
         }
         executions: dict[QualifiedName, ExecutionSummary] = (
             {} if dry_run else self._execute(plans_to_execute)
         )
+
+        # Mirror execution failures into the one stream so `failures` is the
+        # single place to read what went wrong; ExecutionSummary stays for the
+        # per-action diff/preview.
+        for qualified_name, summary in executions.items():
+            pre_execution[qualified_name].extend(summary.failures)
 
         table_reports = tuple(
             TableRunReport(
                 qualified_name=candidate.qualified_name,
                 read=catalog_states[candidate.qualified_name],
                 plan=plans[candidate.qualified_name],
-                pre_execution_failures=tuple(pre_execution[candidate.qualified_name]),
                 execution=executions.get(candidate.qualified_name),
+                failures=tuple(pre_execution[candidate.qualified_name]),
             )
             for candidate in candidates
         )

--- a/src/delta_engine/application/engine.py
+++ b/src/delta_engine/application/engine.py
@@ -124,9 +124,7 @@ class Engine:
         for qualified_name, result in self._validate_plans(plans).items():
             pre_execution[qualified_name].extend(result)
 
-        blocked = frozenset(
-            qualified_name for qualified_name, failures in pre_execution.items() if failures
-        )
+        blocked = {qualified_name for qualified_name, failures in pre_execution.items() if failures}
 
         candidates = resolve(tables, blocked=blocked)
         for candidate in candidates:

--- a/src/delta_engine/application/errors.py
+++ b/src/delta_engine/application/errors.py
@@ -31,7 +31,7 @@ class SyncFailedError(Exception):
 def _format_failure_detail(table_report: TableRunReport) -> list[str]:
     """Return the detail lines describing why a single table failed."""
     lines = [f"\n❌ {table_report.qualified_name} [{table_report.status.value}]"]
-    for failure in table_report.all_failures:
+    for failure in table_report.failures:
         for line in failure.format_lines():
             lines.append(f"    {line}")
     return lines

--- a/src/delta_engine/application/rendering.py
+++ b/src/delta_engine/application/rendering.py
@@ -1,0 +1,214 @@
+"""
+Diff and grid rendering for table and sync run reports.
+
+Separates display logic from the result/report value types in results.py.
+The three public entry points are render_diff_block, render_grid, and
+run_summary_footer; action_diff_line handles per-action diff lines via
+singledispatch.
+"""
+
+from __future__ import annotations
+
+import functools
+from typing import TYPE_CHECKING
+
+from delta_engine.domain.plan.actions import (
+    Action,
+    AddColumn,
+    ColumnTypeChange,
+    CreateTable,
+    DropColumn,
+    DropForeignKey,
+    DropPrimaryKey,
+    PartitioningChange,
+    SetColumnComment,
+    SetColumnNullability,
+    SetColumnTag,
+    SetForeignKey,
+    SetPrimaryKey,
+    SetProperty,
+    SetTableComment,
+    SetTableTag,
+    UnsetColumnTag,
+    UnsetTableTag,
+)
+
+if TYPE_CHECKING:
+    from delta_engine.application.results import SyncReport, TableRunReport
+
+
+def _type_name(data_type: object) -> str:
+    """Backend-agnostic display name for a domain data type (e.g. 'String')."""
+    return type(data_type).__name__
+
+
+@functools.singledispatch
+def action_diff_line(action: Action) -> str:
+    """Render one plan action as a single +/-/~ diff line."""
+    raise NotImplementedError(f"No diff line for action {type(action).__name__}")
+
+
+@action_diff_line.register
+def _(action: CreateTable) -> str:
+    columns = ", ".join(column.name for column in action.table.columns)
+    return f"+ create table (columns: {columns})"
+
+
+@action_diff_line.register
+def _(action: AddColumn) -> str:
+    nullable = "" if action.column.nullable else " NOT NULL"
+    return f"+ column {action.column.name} {_type_name(action.column.data_type)}{nullable}"
+
+
+@action_diff_line.register
+def _(action: DropColumn) -> str:
+    return f"- column {action.column_name}"
+
+
+@action_diff_line.register
+def _(action: SetColumnNullability) -> str:
+    direction = "drop" if action.nullable else "set"
+    return f"~ column {action.column_name} {direction} NOT NULL"
+
+
+@action_diff_line.register
+def _(action: SetColumnComment) -> str:
+    suffix = "" if action.comment else " (unset)"
+    return f"~ comment on column {action.column_name}{suffix}"
+
+
+@action_diff_line.register
+def _(action: SetTableComment) -> str:
+    return "~ comment on table"
+
+
+@action_diff_line.register
+def _(action: SetProperty) -> str:
+    return f"~ property {action.name} = '{action.value}'"
+
+
+@action_diff_line.register
+def _(action: SetTableTag) -> str:
+    return f"~ tag {action.name} = '{action.value}'"
+
+
+@action_diff_line.register
+def _(action: UnsetTableTag) -> str:
+    return f"- tag {action.name}"
+
+
+@action_diff_line.register
+def _(action: SetColumnTag) -> str:
+    return f"~ column tag {action.column_name}.{action.name} = '{action.value}'"
+
+
+@action_diff_line.register
+def _(action: UnsetColumnTag) -> str:
+    return f"- column tag {action.column_name}.{action.name}"
+
+
+@action_diff_line.register
+def _(action: SetPrimaryKey) -> str:
+    columns = ", ".join(action.columns)
+    return f"+ primary key ({columns})"
+
+
+@action_diff_line.register
+def _(action: DropPrimaryKey) -> str:
+    return "- primary key"
+
+
+@action_diff_line.register
+def _(action: SetForeignKey) -> str:
+    columns = ", ".join(action.foreign_key.local_columns)
+    return f"+ foreign key ({columns}) → {action.foreign_key.references}"
+
+
+@action_diff_line.register
+def _(action: DropForeignKey) -> str:
+    return f"- foreign key {action.constraint_name}"
+
+
+@action_diff_line.register
+def _(action: ColumnTypeChange) -> str:
+    return (
+        f"~ column {action.column_name} type "
+        f"{_type_name(action.from_type)} → {_type_name(action.to_type)}"
+    )
+
+
+@action_diff_line.register
+def _(action: PartitioningChange) -> str:
+    return f"~ partitioning {action.observed_partitioning} → {action.desired_partitioning}"
+
+
+def render_diff_block(report: TableRunReport) -> str:
+    """Render one table's change block: its name then one line per planned action."""
+    from delta_engine.application.results import ReadFailed
+
+    header = str(report.qualified_name)
+    if isinstance(report.read, ReadFailed):
+        return f"{header}\n  (could not read — no diff)"
+    if not report.plan:
+        return f"{header}\n  (no changes)"
+    lines = [f"  {action_diff_line(action)}" for action in report.plan]
+    return "\n".join([header, *lines])
+
+
+_DETAIL_MAX_CHARS = 60
+
+_GRID_HEADERS = ("TABLE", "STATUS", "ACTIONS", "DETAIL")
+
+
+def _grid_detail(report: TableRunReport) -> str:
+    """Return the DETAIL cell: first failure summary, action names, or 'no changes'."""
+    if report.has_failures:
+        failures = report.failures
+        first = failures[0].format_lines()[0]
+        extra = len(failures) - 1
+        return f"{first} (+{extra} more)" if extra else first
+    if len(report.plan):
+        return ", ".join(type(action).__name__ for action in report.plan)
+    return "no changes"
+
+
+def _truncate(text: str, limit: int = _DETAIL_MAX_CHARS) -> str:
+    """Truncate with an ellipsis when longer than ``limit``."""
+    return text if len(text) <= limit else text[: limit - 1] + "…"
+
+
+def _grid_row_cells(report: TableRunReport) -> tuple[str, str, str, str]:
+    """Return the four grid cells for one report (DETAIL already truncated)."""
+    return (
+        str(report.qualified_name),
+        report.status.value,
+        str(len(report.plan)),
+        _truncate(_grid_detail(report)),
+    )
+
+
+def render_grid(reports: tuple[TableRunReport, ...]) -> str:
+    """Render an aligned TABLE | STATUS | ACTIONS | DETAIL grid for ``reports``."""
+    rows = [_GRID_HEADERS, *(_grid_row_cells(report) for report in reports)]
+    widths = [max(len(row[col]) for row in rows) for col in range(len(_GRID_HEADERS))]
+    return "\n".join(
+        "  ".join(cell.ljust(widths[col]) for col, cell in enumerate(row)).rstrip() for row in rows
+    )
+
+
+def run_summary_footer(report: SyncReport) -> str:
+    """One-line summary: table total, changed/unchanged/failed counts, duration."""
+    changed = unchanged = failed = 0
+    for table_report in report.table_reports:
+        if table_report.has_failures:
+            failed += 1
+        elif len(table_report.plan):
+            changed += 1
+        else:
+            unchanged += 1
+    seconds = (report.ended_at - report.started_at).total_seconds()
+    total = len(report.table_reports)
+    return (
+        f"{total} tables: {changed} changed, {unchanged} unchanged, "
+        f"{failed} failed ({seconds:.1f}s)"
+    )

--- a/src/delta_engine/application/results.py
+++ b/src/delta_engine/application/results.py
@@ -218,7 +218,6 @@ class ExecutionFailed:
     """A single plan action that raised while executing."""
 
     action: str
-    action_index: int
     failure: ExecutionFailure
 
 

--- a/src/delta_engine/application/results.py
+++ b/src/delta_engine/application/results.py
@@ -14,31 +14,10 @@ from collections.abc import Iterator
 from dataclasses import dataclass, field
 from datetime import datetime
 from enum import IntEnum, StrEnum
-import functools
 from typing import ClassVar
 
 from delta_engine.domain.model import ObservedTable, QualifiedName
-from delta_engine.domain.plan.actions import (
-    Action,
-    ActionPlan,
-    AddColumn,
-    ColumnTypeChange,
-    CreateTable,
-    DropColumn,
-    DropForeignKey,
-    DropPrimaryKey,
-    PartitioningChange,
-    SetColumnComment,
-    SetColumnNullability,
-    SetColumnTag,
-    SetForeignKey,
-    SetPrimaryKey,
-    SetProperty,
-    SetTableComment,
-    SetTableTag,
-    UnsetColumnTag,
-    UnsetTableTag,
-)
+from delta_engine.domain.plan.actions import ActionPlan
 
 
 class FailurePhase(IntEnum):
@@ -293,11 +272,15 @@ class TableRunReport:
 
     def diff(self) -> str:
         """Render this table's planned changes as a +/-/~ change list."""
-        return _render_diff_block(self)
+        from delta_engine.application.rendering import render_diff_block
+
+        return render_diff_block(self)
 
     def __str__(self) -> str:
         """Render this report as the grid header plus its single row."""
-        return _render_grid((self,))
+        from delta_engine.application.rendering import render_grid
+
+        return render_grid((self,))
 
 
 @dataclass(frozen=True, slots=True)
@@ -323,188 +306,14 @@ class SyncReport:
 
     def diff(self) -> str:
         """Render every table's planned changes, in report order."""
-        return "\n\n".join(_render_diff_block(report) for report in self.table_reports)
+        from delta_engine.application.rendering import render_diff_block
+
+        return "\n\n".join(render_diff_block(report) for report in self.table_reports)
 
     def __str__(self) -> str:
         """Render the run as an aligned grid followed by a summary footer."""
+        from delta_engine.application.rendering import render_grid, run_summary_footer
+
         if not self.table_reports:
             return "Sync report: 0 tables"
-        return f"{_render_grid(self.table_reports)}\n\n{_run_summary_footer(self)}"
-
-
-# ---------- Display
-
-
-def _type_name(data_type: object) -> str:
-    """Backend-agnostic display name for a domain data type (e.g. 'String')."""
-    return type(data_type).__name__
-
-
-@functools.singledispatch
-def _action_diff_line(action: Action) -> str:
-    """Render one plan action as a single +/-/~ diff line."""
-    raise NotImplementedError(f"No diff line for action {type(action).__name__}")
-
-
-@_action_diff_line.register
-def _(action: CreateTable) -> str:
-    columns = ", ".join(column.name for column in action.table.columns)
-    return f"+ create table (columns: {columns})"
-
-
-@_action_diff_line.register
-def _(action: AddColumn) -> str:
-    nullable = "" if action.column.nullable else " NOT NULL"
-    return f"+ column {action.column.name} {_type_name(action.column.data_type)}{nullable}"
-
-
-@_action_diff_line.register
-def _(action: DropColumn) -> str:
-    return f"- column {action.column_name}"
-
-
-@_action_diff_line.register
-def _(action: SetColumnNullability) -> str:
-    direction = "drop" if action.nullable else "set"
-    return f"~ column {action.column_name} {direction} NOT NULL"
-
-
-@_action_diff_line.register
-def _(action: SetColumnComment) -> str:
-    suffix = "" if action.comment else " (unset)"
-    return f"~ comment on column {action.column_name}{suffix}"
-
-
-@_action_diff_line.register
-def _(action: SetTableComment) -> str:
-    return "~ comment on table"
-
-
-@_action_diff_line.register
-def _(action: SetProperty) -> str:
-    return f"~ property {action.name} = '{action.value}'"
-
-
-@_action_diff_line.register
-def _(action: SetTableTag) -> str:
-    return f"~ tag {action.name} = '{action.value}'"
-
-
-@_action_diff_line.register
-def _(action: UnsetTableTag) -> str:
-    return f"- tag {action.name}"
-
-
-@_action_diff_line.register
-def _(action: SetColumnTag) -> str:
-    return f"~ column tag {action.column_name}.{action.name} = '{action.value}'"
-
-
-@_action_diff_line.register
-def _(action: UnsetColumnTag) -> str:
-    return f"- column tag {action.column_name}.{action.name}"
-
-
-@_action_diff_line.register
-def _(action: SetPrimaryKey) -> str:
-    columns = ", ".join(action.columns)
-    return f"+ primary key ({columns})"
-
-
-@_action_diff_line.register
-def _(action: DropPrimaryKey) -> str:
-    return "- primary key"
-
-
-@_action_diff_line.register
-def _(action: SetForeignKey) -> str:
-    columns = ", ".join(action.foreign_key.local_columns)
-    return f"+ foreign key ({columns}) → {action.foreign_key.references}"
-
-
-@_action_diff_line.register
-def _(action: DropForeignKey) -> str:
-    return f"- foreign key {action.constraint_name}"
-
-
-@_action_diff_line.register
-def _(action: ColumnTypeChange) -> str:
-    return (
-        f"~ column {action.column_name} type "
-        f"{_type_name(action.from_type)} → {_type_name(action.to_type)}"
-    )
-
-
-@_action_diff_line.register
-def _(action: PartitioningChange) -> str:
-    return f"~ partitioning {action.observed_partitioning} → {action.desired_partitioning}"
-
-
-def _render_diff_block(report: TableRunReport) -> str:
-    """Render one table's change block: its name then one line per planned action."""
-    header = str(report.qualified_name)
-    if isinstance(report.read, ReadFailed):
-        return f"{header}\n  (could not read — no diff)"
-    if not report.plan:
-        return f"{header}\n  (no changes)"
-    lines = [f"  {_action_diff_line(action)}" for action in report.plan]
-    return "\n".join([header, *lines])
-
-
-_DETAIL_MAX_CHARS = 60
-
-_GRID_HEADERS = ("TABLE", "STATUS", "ACTIONS", "DETAIL")
-
-
-def _grid_detail(report: TableRunReport) -> str:
-    """Return the DETAIL cell: first failure summary, action names, or 'no changes'."""
-    if report.has_failures:
-        failures = report.failures
-        first = failures[0].format_lines()[0]
-        extra = len(failures) - 1
-        return f"{first} (+{extra} more)" if extra else first
-    if len(report.plan):
-        return ", ".join(type(action).__name__ for action in report.plan)
-    return "no changes"
-
-
-def _truncate(text: str, limit: int = _DETAIL_MAX_CHARS) -> str:
-    """Truncate with an ellipsis when longer than ``limit``."""
-    return text if len(text) <= limit else text[: limit - 1] + "…"
-
-
-def _grid_row_cells(report: TableRunReport) -> tuple[str, str, str, str]:
-    """Return the four grid cells for one report (DETAIL already truncated)."""
-    return (
-        str(report.qualified_name),
-        report.status.value,
-        str(len(report.plan)),
-        _truncate(_grid_detail(report)),
-    )
-
-
-def _render_grid(reports: tuple[TableRunReport, ...]) -> str:
-    """Render an aligned TABLE | STATUS | ACTIONS | DETAIL grid for ``reports``."""
-    rows = [_GRID_HEADERS, *(_grid_row_cells(report) for report in reports)]
-    widths = [max(len(row[col]) for row in rows) for col in range(len(_GRID_HEADERS))]
-    return "\n".join(
-        "  ".join(cell.ljust(widths[col]) for col, cell in enumerate(row)).rstrip() for row in rows
-    )
-
-
-def _run_summary_footer(report: SyncReport) -> str:
-    """One-line summary: table total, changed/unchanged/failed counts, duration."""
-    changed = unchanged = failed = 0
-    for table_report in report.table_reports:
-        if table_report.has_failures:
-            failed += 1
-        elif len(table_report.plan):
-            changed += 1
-        else:
-            unchanged += 1
-    seconds = (report.ended_at - report.started_at).total_seconds()
-    total = len(report.table_reports)
-    return (
-        f"{total} tables: {changed} changed, {unchanged} unchanged, "
-        f"{failed} failed ({seconds:.1f}s)"
-    )
+        return f"{render_grid(self.table_reports)}\n\n{run_summary_footer(self)}"

--- a/src/delta_engine/application/results.py
+++ b/src/delta_engine/application/results.py
@@ -13,8 +13,9 @@ from abc import ABC, abstractmethod
 from collections.abc import Iterator
 from dataclasses import dataclass, field
 from datetime import datetime
-from enum import StrEnum
+from enum import IntEnum, StrEnum
 import functools
+from typing import ClassVar
 
 from delta_engine.domain.model import ObservedTable, QualifiedName
 from delta_engine.domain.plan.actions import (
@@ -39,6 +40,16 @@ from delta_engine.domain.plan.actions import (
     UnsetTableTag,
 )
 
+
+class FailurePhase(IntEnum):
+    """The sync phase that produced a failure. Ordered so the earliest wins."""
+
+    READ = 1
+    VALIDATION = 2
+    FOREIGN_KEY = 3
+    EXECUTION = 4
+
+
 # ---------- Status enums ----------
 
 
@@ -60,26 +71,27 @@ class ForeignKeyFailureReason(StrEnum):
     BLOCKED_BY_FAILED_DEPENDENCY = "BLOCKED_BY_FAILED_DEPENDENCY"
     REFERENCED_COLUMNS_NOT_A_KEY = "REFERENCED_COLUMNS_NOT_A_KEY"
 
-
-_FOREIGN_KEY_REASON_DETAIL: dict[ForeignKeyFailureReason, str] = {
-    ForeignKeyFailureReason.CYCLE: "it is part of a foreign key dependency cycle",
-    ForeignKeyFailureReason.UNRESOLVABLE_REFERENCE: (
-        "it references a table that is not registered"
-    ),
-    ForeignKeyFailureReason.BLOCKED_BY_FAILED_DEPENDENCY: (
-        "it references a table that failed to sync"
-    ),
-    ForeignKeyFailureReason.REFERENCED_COLUMNS_NOT_A_KEY: (
-        "its referenced columns are not the primary key of the referenced table"
-    ),
-}
+    @property
+    def detail(self) -> str:
+        """Human-readable reason clause for a failure message."""
+        match self:
+            case ForeignKeyFailureReason.CYCLE:
+                return "it is part of a foreign key dependency cycle"
+            case ForeignKeyFailureReason.UNRESOLVABLE_REFERENCE:
+                return "it references a table that is not registered"
+            case ForeignKeyFailureReason.BLOCKED_BY_FAILED_DEPENDENCY:
+                return "it references a table that failed to sync"
+            case ForeignKeyFailureReason.REFERENCED_COLUMNS_NOT_A_KEY:
+                return "its referenced columns are not the primary key of the referenced table"
 
 
 # ---------- Failure value objects ----------
 
 
 class Failure(ABC):
-    """A failure that can render itself as display lines."""
+    """A failure that can render itself as display lines, tagged with its phase."""
+
+    phase: ClassVar[FailurePhase]
 
     @abstractmethod
     def format_lines(self) -> tuple[str, ...]:
@@ -91,6 +103,7 @@ class Failure(ABC):
 class ReadFailure(Failure):
     """Failure reading current catalog state for a table."""
 
+    phase: ClassVar[FailurePhase] = FailurePhase.READ
     exception_type: str
     message: str
 
@@ -102,6 +115,7 @@ class ReadFailure(Failure):
 class ValidationFailure(Failure):
     """Description of a validation rule failure."""
 
+    phase: ClassVar[FailurePhase] = FailurePhase.VALIDATION
     rule_name: str
     message: str
 
@@ -113,6 +127,7 @@ class ValidationFailure(Failure):
 class ExecutionFailure(Failure):
     """Details about a failed action execution."""
 
+    phase: ClassVar[FailurePhase] = FailurePhase.EXECUTION
     action_index: int
     exception_type: str
     message: str
@@ -130,6 +145,7 @@ class ExecutionFailure(Failure):
 class ForeignKeyFailure(Failure):
     """A foreign key constraint that could not be applied, failing its whole table."""
 
+    phase: ClassVar[FailurePhase] = FailurePhase.FOREIGN_KEY
     table: QualifiedName
     local_columns: tuple[str, ...]
     references: str
@@ -139,7 +155,7 @@ class ForeignKeyFailure(Failure):
         columns = ", ".join(self.local_columns)
         return (
             f"Foreign key ({columns}) → {self.references} on {self.table} was not applied: "
-            f"{_FOREIGN_KEY_REASON_DETAIL[self.reason]}.",
+            f"{self.reason.detail}.",
         )
 
 

--- a/src/delta_engine/application/results.py
+++ b/src/delta_engine/application/results.py
@@ -261,44 +261,35 @@ class ExecutionSummary:
 # ---------- Reports ----------
 
 
+_STATUS_FOR_PHASE: dict[FailurePhase, TableRunStatus] = {
+    FailurePhase.READ: TableRunStatus.READ_FAILED,
+    FailurePhase.VALIDATION: TableRunStatus.VALIDATION_FAILED,
+    FailurePhase.FOREIGN_KEY: TableRunStatus.FOREIGN_KEY_FAILED,
+    FailurePhase.EXECUTION: TableRunStatus.EXECUTION_FAILED,
+}
+
+
 @dataclass(frozen=True, slots=True)
 class TableRunReport:
-    """Per-table report with outcomes and failures."""
+    """Per-table report with outcomes and a single phase-ordered failure stream."""
 
     qualified_name: QualifiedName
     read: CatalogState
     plan: ActionPlan = field(default_factory=ActionPlan)
-    pre_execution_failures: tuple[Failure, ...] = ()
     execution: ExecutionSummary | None = None
+    failures: tuple[Failure, ...] = ()
 
     @property
     def status(self) -> TableRunStatus:
-        """Aggregate table status across read, pre-execution, and execution phases."""
-        if isinstance(self.read, ReadFailed):
-            return TableRunStatus.READ_FAILED
-        if any(isinstance(f, ForeignKeyFailure) for f in self.pre_execution_failures):
-            return TableRunStatus.FOREIGN_KEY_FAILED
-        if any(isinstance(f, ValidationFailure) for f in self.pre_execution_failures):
-            return TableRunStatus.VALIDATION_FAILED
-        if self.execution is not None and self.execution.failed:
-            return TableRunStatus.EXECUTION_FAILED
-        return TableRunStatus.SUCCESS
+        """Status of the earliest phase that failed; SUCCESS when nothing failed."""
+        if not self.failures:
+            return TableRunStatus.SUCCESS
+        return _STATUS_FOR_PHASE[min(failure.phase for failure in self.failures)]
 
     @property
     def has_failures(self) -> bool:
         """True if the table did not fully succeed."""
-        return self.status is not TableRunStatus.SUCCESS
-
-    @property
-    def all_failures(self) -> tuple[Failure, ...]:
-        """All failures for this table (read, pre-execution, execution)."""
-        out: list[Failure] = []
-        if isinstance(self.read, ReadFailed):
-            out.append(self.read.failure)
-        out.extend(self.pre_execution_failures)
-        if self.execution is not None:
-            out.extend(self.execution.failures)
-        return tuple(out)
+        return bool(self.failures)
 
     def diff(self) -> str:
         """Render this table's planned changes as a +/-/~ change list."""
@@ -325,7 +316,7 @@ class SyncReport:
     @property
     def failures_by_table(self) -> dict[QualifiedName, tuple[Failure, ...]]:
         """Mapping of qualified table name to its failures (if any)."""
-        return {t.qualified_name: t.all_failures for t in self.table_reports if t.has_failures}
+        return {t.qualified_name: t.failures for t in self.table_reports if t.has_failures}
 
     def __iter__(self) -> Iterator[TableRunReport]:
         return iter(self.table_reports)
@@ -468,7 +459,7 @@ _GRID_HEADERS = ("TABLE", "STATUS", "ACTIONS", "DETAIL")
 def _grid_detail(report: TableRunReport) -> str:
     """Return the DETAIL cell: first failure summary, action names, or 'no changes'."""
     if report.has_failures:
-        failures = report.all_failures
+        failures = report.failures
         first = failures[0].format_lines()[0]
         extra = len(failures) - 1
         return f"{first} (+{extra} more)" if extra else first

--- a/tests/adapters/databricks/test_executor.py
+++ b/tests/adapters/databricks/test_executor.py
@@ -67,10 +67,11 @@ def test_execute_maps_success_and_failure_without_leakage():
     # Then the success and failure are mapped with correct metadata and no leakage
     results = summary.results
     assert [r.action for r in results] == ["AddColumn", "DropColumn"]
-    assert [r.action_index for r in results] == [0, 1]
     assert isinstance(results[0], ExecutionSucceeded)
     assert isinstance(results[1], ExecutionFailed)
-    assert results[1].failure is not None
+    # Then the success carries its index and the failure carries its index on the detail
+    assert results[0].action_index == 0
+    assert results[1].failure.action_index == 1
 
 
 def test_execute_stops_at_first_failure_to_avoid_half_migrating():
@@ -99,7 +100,8 @@ def test_execute_stops_at_first_failure_to_avoid_half_migrating():
     # And the report covers only the attempted actions, ending at the failure
     results = summary.results
     assert [type(r) for r in results] == [ExecutionSucceeded, ExecutionFailed]
-    assert [r.action_index for r in results] == [0, 1]
+    assert results[0].action_index == 0
+    assert results[1].failure.action_index == 1
 
 
 def test_execute_returns_empty_summary_for_empty_plan():

--- a/tests/application/test_dependency_resolution.py
+++ b/tests/application/test_dependency_resolution.py
@@ -9,7 +9,7 @@ transitive propagation to dependents.
 
 from delta_engine.api import Column, DeltaTable, String
 from delta_engine.application.dependency_resolution import SyncCandidate, resolve
-from delta_engine.application.results import ForeignKeyFailureReason, ValidationFailure
+from delta_engine.application.results import ForeignKeyFailureReason
 from delta_engine.domain.model import QualifiedName
 from delta_engine.domain.model.foreign_key import ForeignKeyConstraint
 from delta_engine.domain.model.table import DesiredTable
@@ -106,10 +106,10 @@ def test_resolve_fails_table_with_unresolvable_reference():
     # Then orders cannot execute, with UNRESOLVABLE_REFERENCE
     [candidate] = candidates
     assert not candidate.can_execute
-    assert len(candidate.failures) == 1
-    assert candidate.failures[0].reason == ForeignKeyFailureReason.UNRESOLVABLE_REFERENCE
-    assert candidate.failures[0].local_columns == ("ref_id",)
-    assert candidate.failures[0].references == "cat.sch.customers"
+    assert len(candidate.fk_failures) == 1
+    assert candidate.fk_failures[0].reason == ForeignKeyFailureReason.UNRESOLVABLE_REFERENCE
+    assert candidate.fk_failures[0].local_columns == ("ref_id",)
+    assert candidate.fk_failures[0].references == "cat.sch.customers"
 
 
 def test_resolve_fails_both_members_of_a_cycle():
@@ -126,8 +126,8 @@ def test_resolve_fails_both_members_of_a_cycle():
     by_name = _candidates_by_name(candidates)
     assert not by_name["cat.sch.a"].can_execute
     assert not by_name["cat.sch.b"].can_execute
-    assert by_name["cat.sch.a"].failures[0].reason == ForeignKeyFailureReason.CYCLE
-    assert by_name["cat.sch.b"].failures[0].reason == ForeignKeyFailureReason.CYCLE
+    assert by_name["cat.sch.a"].fk_failures[0].reason == ForeignKeyFailureReason.CYCLE
+    assert by_name["cat.sch.b"].fk_failures[0].reason == ForeignKeyFailureReason.CYCLE
 
 
 def test_resolve_includes_failed_tables_in_candidates():
@@ -158,11 +158,11 @@ def test_resolve_blocks_table_that_references_an_unresolvable_table():
     # Then customers fails directly, and orders cannot execute because customers will not build
     by_name = _candidates_by_name(candidates)
     assert (
-        by_name["cat.sch.customers"].failures[0].reason
+        by_name["cat.sch.customers"].fk_failures[0].reason
         == ForeignKeyFailureReason.UNRESOLVABLE_REFERENCE
     )
     assert (
-        by_name["cat.sch.orders"].failures[0].reason
+        by_name["cat.sch.orders"].fk_failures[0].reason
         == ForeignKeyFailureReason.BLOCKED_BY_FAILED_DEPENDENCY
     )
 
@@ -181,10 +181,12 @@ def test_resolve_propagates_block_along_a_chain():
 
     # Then a fails directly and b, c, d are all blocked transitively
     by_name = _candidates_by_name(candidates)
-    assert by_name["cat.sch.a"].failures[0].reason == ForeignKeyFailureReason.UNRESOLVABLE_REFERENCE
+    assert (
+        by_name["cat.sch.a"].fk_failures[0].reason == ForeignKeyFailureReason.UNRESOLVABLE_REFERENCE
+    )
     for blocked in ("cat.sch.b", "cat.sch.c", "cat.sch.d"):
         assert (
-            by_name[blocked].failures[0].reason
+            by_name[blocked].fk_failures[0].reason
             == ForeignKeyFailureReason.BLOCKED_BY_FAILED_DEPENDENCY
         )
 
@@ -202,10 +204,10 @@ def test_resolve_blocks_table_that_depends_on_a_cycle():
 
     # Then b and c fail as CYCLE, and a cannot execute because b will not build
     by_name = _candidates_by_name(candidates)
-    assert by_name["cat.sch.b"].failures[0].reason == ForeignKeyFailureReason.CYCLE
-    assert by_name["cat.sch.c"].failures[0].reason == ForeignKeyFailureReason.CYCLE
+    assert by_name["cat.sch.b"].fk_failures[0].reason == ForeignKeyFailureReason.CYCLE
+    assert by_name["cat.sch.c"].fk_failures[0].reason == ForeignKeyFailureReason.CYCLE
     assert (
-        by_name["cat.sch.a"].failures[0].reason
+        by_name["cat.sch.a"].fk_failures[0].reason
         == ForeignKeyFailureReason.BLOCKED_BY_FAILED_DEPENDENCY
     )
 
@@ -287,14 +289,16 @@ def test_resolve_propagates_block_through_a_diamond():
 
     # Then a fails directly; b, c, and d are all blocked
     by_name = _candidates_by_name(candidates)
-    assert by_name["cat.sch.a"].failures[0].reason == ForeignKeyFailureReason.UNRESOLVABLE_REFERENCE
+    assert (
+        by_name["cat.sch.a"].fk_failures[0].reason == ForeignKeyFailureReason.UNRESOLVABLE_REFERENCE
+    )
     for blocked in ("cat.sch.b", "cat.sch.c", "cat.sch.d"):
         assert all(
             f.reason == ForeignKeyFailureReason.BLOCKED_BY_FAILED_DEPENDENCY
-            for f in by_name[blocked].failures
+            for f in by_name[blocked].fk_failures
         )
     # d has two blocking FKs, so it records two failures (one per FK)
-    assert len(by_name["cat.sch.d"].failures) == 2
+    assert len(by_name["cat.sch.d"].fk_failures) == 2
 
 
 def test_resolve_with_empty_tables_returns_empty_tuple():
@@ -305,44 +309,35 @@ def test_resolve_with_empty_tables_returns_empty_tuple():
     assert candidates == ()
 
 
-def test_resolve_blocks_table_passed_in_external_failures():
-    # Given one table with no FKs, passed as externally failed
+def test_resolve_blocks_table_passed_in_blocked_set():
+    # Given one table with no FKs, named as already-blocked (e.g. failed validation upstream)
     table = _table("cat.sch.orders")
-    external_failures = {
-        QualifiedName("cat", "sch", "orders"): (
-            ValidationFailure(rule_name="NonNullableColumnAdd", message="cannot add NOT NULL"),
-        )
-    }
+    blocked = frozenset({QualifiedName("cat", "sch", "orders")})
 
-    # When
-    candidates = resolve((table,), external_failures=external_failures)
+    # When resolving with that table blocked
+    candidates = resolve((table,), blocked=blocked)
 
-    # Then orders cannot execute and carries the validation failure
+    # Then it produces no FK failures of its own (it was blocked for an external reason)
+    # and, having no FKs, it is not further classified by resolve
     [candidate] = candidates
-    assert not candidate.can_execute
-    assert len(candidate.failures) == 1
-    assert isinstance(candidate.failures[0], ValidationFailure)
+    assert candidate.fk_failures == ()
 
 
-def test_resolve_blocks_fk_dependent_of_externally_failed_table():
-    # Given orders (no FKs) is externally failed, and shipments has a FK on orders
+def test_resolve_blocks_fk_dependent_of_a_blocked_table():
+    # Given orders (no FKs) is blocked, and shipments has a FK on orders
     orders = _table("cat.sch.orders")
     shipments = _table_with_fk("cat.sch.shipments", "cat.sch.orders")
-    external_failures = {
-        QualifiedName("cat", "sch", "orders"): (
-            ValidationFailure(rule_name="NonNullableColumnAdd", message="cannot add NOT NULL"),
-        )
-    }
+    blocked = frozenset({QualifiedName("cat", "sch", "orders")})
 
-    # When
-    candidates = resolve((orders, shipments), external_failures=external_failures)
+    # When resolving
+    candidates = resolve((orders, shipments), blocked=blocked)
 
-    # Then orders carries the validation failure; shipments is blocked by failed dependency
+    # Then shipments is blocked-by-failed-dependency; orders itself has no FK failure
     by_name = _candidates_by_name(candidates)
-    assert not by_name["cat.sch.orders"].can_execute
+    assert by_name["cat.sch.orders"].fk_failures == ()
     assert not by_name["cat.sch.shipments"].can_execute
     assert (
-        by_name["cat.sch.shipments"].failures[0].reason
+        by_name["cat.sch.shipments"].fk_failures[0].reason
         == ForeignKeyFailureReason.BLOCKED_BY_FAILED_DEPENDENCY
     )
 
@@ -381,7 +376,7 @@ def test_resolve_fails_fk_that_targets_a_non_key_column():
     by_name = _candidates_by_name(candidates)
     assert not by_name["cat.sch.orders"].can_execute
     assert (
-        by_name["cat.sch.orders"].failures[0].reason
+        by_name["cat.sch.orders"].fk_failures[0].reason
         == ForeignKeyFailureReason.REFERENCED_COLUMNS_NOT_A_KEY
     )
     # customers has no FK of its own, so it is unaffected and can execute
@@ -420,7 +415,7 @@ def test_resolve_fails_fk_whose_referenced_columns_are_not_the_pk():
     # Then orders is rejected: email is not customers' primary key
     by_name = _candidates_by_name(candidates)
     assert (
-        by_name["cat.sch.orders"].failures[0].reason
+        by_name["cat.sch.orders"].fk_failures[0].reason
         == ForeignKeyFailureReason.REFERENCED_COLUMNS_NOT_A_KEY
     )
 

--- a/tests/application/test_engine.py
+++ b/tests/application/test_engine.py
@@ -118,7 +118,6 @@ def _ok_exec(idx: int = 0) -> ExecutionResult:
 def _failed_exec(idx: int = 0, exc="AnalysisException", msg="boom") -> ExecutionResult:
     return ExecutionFailed(
         action="X",
-        action_index=idx,
         failure=ExecutionFailure(
             action_index=idx, exception_type=exc, message=msg, statement_preview="-- bad sql"
         ),

--- a/tests/application/test_engine.py
+++ b/tests/application/test_engine.py
@@ -422,9 +422,9 @@ def test_sync_report_has_no_fk_failures_when_no_fks_declared():
     # When
     report = engine.sync(registry)
 
-    # Then the single table has no pre-execution failures and succeeds
+    # Then the single table has no failures and succeeds
     [tr] = list(report)
-    assert tr.pre_execution_failures == ()
+    assert tr.failures == ()
     assert tr.status is TableRunStatus.SUCCESS
 
 
@@ -440,7 +440,7 @@ def test_sync_fails_table_whose_fk_references_table_not_in_registry():
         engine.sync(registry)
     [tr] = list(err.value.report)
     assert tr.status is TableRunStatus.FOREIGN_KEY_FAILED
-    fk_failures = [f for f in tr.pre_execution_failures if isinstance(f, ForeignKeyFailure)]
+    fk_failures = [f for f in tr.failures if isinstance(f, ForeignKeyFailure)]
     assert fk_failures[0].reason == ForeignKeyFailureReason.UNRESOLVABLE_REFERENCE
     assert tr.execution is None  # all-or-nothing: the table was not built
 
@@ -508,7 +508,7 @@ def test_sync_fails_all_tables_in_a_detected_cycle():
     reasons = {
         failure.reason
         for tr in err.value.report
-        for failure in tr.pre_execution_failures
+        for failure in tr.failures
         if isinstance(failure, ForeignKeyFailure)
     }
     assert reasons == {ForeignKeyFailureReason.CYCLE}
@@ -538,16 +538,12 @@ def test_sync_blocks_table_whose_dependency_has_an_unresolvable_fk():
     reports = {str(tr.qualified_name): tr for tr in err.value.report}
     assert reports["cat.sch.customers"].status is TableRunStatus.FOREIGN_KEY_FAILED
     customers_fk_failures = [
-        f
-        for f in reports["cat.sch.customers"].pre_execution_failures
-        if isinstance(f, ForeignKeyFailure)
+        f for f in reports["cat.sch.customers"].failures if isinstance(f, ForeignKeyFailure)
     ]
     assert customers_fk_failures[0].reason == ForeignKeyFailureReason.UNRESOLVABLE_REFERENCE
     assert reports["cat.sch.orders"].status is TableRunStatus.FOREIGN_KEY_FAILED
     orders_fk_failures = [
-        f
-        for f in reports["cat.sch.orders"].pre_execution_failures
-        if isinstance(f, ForeignKeyFailure)
+        f for f in reports["cat.sch.orders"].failures if isinstance(f, ForeignKeyFailure)
     ]
     assert orders_fk_failures[0].reason == ForeignKeyFailureReason.BLOCKED_BY_FAILED_DEPENDENCY
     assert executed == []
@@ -623,9 +619,9 @@ def test_sync_surfaces_both_fk_and_validation_failures_for_a_blocked_table():
     with pytest.raises(SyncFailedError) as err:
         Engine(reader=reader, executor=executor).sync(registry)
     [tr] = list(err.value.report)
-    assert tr.status is TableRunStatus.FOREIGN_KEY_FAILED
-    fk_failures = [f for f in tr.pre_execution_failures if isinstance(f, ForeignKeyFailure)]
-    val_failures = [f for f in tr.pre_execution_failures if isinstance(f, ValidationFailure)]
+    assert tr.status is TableRunStatus.VALIDATION_FAILED
+    fk_failures = [f for f in tr.failures if isinstance(f, ForeignKeyFailure)]
+    val_failures = [f for f in tr.failures if isinstance(f, ValidationFailure)]
     assert len(fk_failures) == 1
     assert fk_failures[0].reason == ForeignKeyFailureReason.UNRESOLVABLE_REFERENCE
     assert len(val_failures) == 1  # NonNullableColumnAdd fires on the NOT NULL ref_id
@@ -655,9 +651,7 @@ def test_validation_failure_in_upstream_blocks_fk_dependent():
     assert reports["cat.sch.customers"].status is TableRunStatus.VALIDATION_FAILED
     assert reports["cat.sch.orders"].status is TableRunStatus.FOREIGN_KEY_FAILED
     orders_fk_failures = [
-        f
-        for f in reports["cat.sch.orders"].pre_execution_failures
-        if isinstance(f, ForeignKeyFailure)
+        f for f in reports["cat.sch.orders"].failures if isinstance(f, ForeignKeyFailure)
     ]
     assert len(orders_fk_failures) == 1
     assert orders_fk_failures[0].reason == ForeignKeyFailureReason.BLOCKED_BY_FAILED_DEPENDENCY
@@ -691,9 +685,7 @@ def test_read_failure_in_upstream_blocks_fk_dependent():
     reports = {str(tr.qualified_name): tr for tr in err.value.report}
     assert reports["cat.sch.a"].status is TableRunStatus.READ_FAILED
     assert reports["cat.sch.b"].status is TableRunStatus.FOREIGN_KEY_FAILED
-    b_fk_failures = [
-        f for f in reports["cat.sch.b"].pre_execution_failures if isinstance(f, ForeignKeyFailure)
-    ]
+    b_fk_failures = [f for f in reports["cat.sch.b"].failures if isinstance(f, ForeignKeyFailure)]
     assert len(b_fk_failures) == 1
     assert b_fk_failures[0].reason == ForeignKeyFailureReason.BLOCKED_BY_FAILED_DEPENDENCY
     assert executed == []
@@ -825,7 +817,7 @@ def test_read_failure_is_reported_exactly_once():
     # Then the read failure appears exactly once across the table's failures
     [tr] = list(err.value.report)
     assert tr.status is TableRunStatus.READ_FAILED
-    assert len(tr.all_failures) == 1
+    assert len(tr.failures) == 1
     # And the rendered error message lists it once, not twice
     message = str(err.value)
     assert message.count("Read error: IOError - cannot read") == 1
@@ -844,7 +836,7 @@ def test_sync_fails_fk_that_does_not_reference_a_primary_key():
     reports = {str(tr.qualified_name): tr for tr in err.value.report}
     orders = reports["cat.sch.orders"]
     assert orders.status is TableRunStatus.FOREIGN_KEY_FAILED
-    fk_failures = [f for f in orders.pre_execution_failures if isinstance(f, ForeignKeyFailure)]
+    fk_failures = [f for f in orders.failures if isinstance(f, ForeignKeyFailure)]
     assert fk_failures[0].reason == ForeignKeyFailureReason.REFERENCED_COLUMNS_NOT_A_KEY
     assert orders.execution is None
     # customers is a clean create with no FK — it is not itself foreign-key-failed

--- a/tests/application/test_engine.py
+++ b/tests/application/test_engine.py
@@ -811,6 +811,26 @@ def test_real_run_records_the_planned_actions_on_the_report():
     assert tr.status is TableRunStatus.SUCCESS
 
 
+def test_read_failure_is_reported_exactly_once():
+    # Given a table whose read fails
+    reg = Registry()
+    reg.register(_spec("c.s.read_fail"))
+    reader = _FakeReader({"c.s.read_fail": ReadFailed(ReadFailure("IOError", "cannot read"))})
+    executor = _FakeExecutor(results=())
+
+    # When syncing
+    with pytest.raises(SyncFailedError) as err:
+        Engine(reader=reader, executor=executor).sync(reg)
+
+    # Then the read failure appears exactly once across the table's failures
+    [tr] = list(err.value.report)
+    assert tr.status is TableRunStatus.READ_FAILED
+    assert len(tr.all_failures) == 1
+    # And the rendered error message lists it once, not twice
+    message = str(err.value)
+    assert message.count("Read error: IOError - cannot read") == 1
+
+
 def test_sync_fails_fk_that_does_not_reference_a_primary_key():
     # Given orders references customers, customers is registered but has NO PK
     registry = Registry()

--- a/tests/application/test_errors.py
+++ b/tests/application/test_errors.py
@@ -25,13 +25,13 @@ _QN = QualifiedName("cat", "sch", "tbl")
 def _table_report(
     *,
     read: CatalogState,
-    pre_execution_failures: tuple[Failure, ...] = (),
+    failures: tuple[Failure, ...] = (),
     execution: ExecutionSummary | None = None,
 ) -> TableRunReport:
     return TableRunReport(
         qualified_name=_QN,
         read=read,
-        pre_execution_failures=pre_execution_failures,
+        failures=failures,
         execution=execution,
     )
 
@@ -44,7 +44,10 @@ def _message_for(table_report: TableRunReport) -> str:
 
 def test_message_headline_counts_failed_tables():
     # Given a run with a single failed table
-    report = _table_report(read=ReadFailed(ReadFailure("AnalysisException", "table not found")))
+    report = _table_report(
+        read=ReadFailed(ReadFailure("AnalysisException", "table not found")),
+        failures=(ReadFailure("AnalysisException", "table not found"),),
+    )
 
     # When building the error message
     message = _message_for(report)
@@ -55,7 +58,10 @@ def test_message_headline_counts_failed_tables():
 
 def test_message_renders_read_failure_detail():
     # Given a table whose read phase failed
-    report = _table_report(read=ReadFailed(ReadFailure("AnalysisException", "table not found")))
+    report = _table_report(
+        read=ReadFailed(ReadFailure("AnalysisException", "table not found")),
+        failures=(ReadFailure("AnalysisException", "table not found"),),
+    )
 
     # When building the error message
     message = _message_for(report)
@@ -69,9 +75,7 @@ def test_message_renders_validation_failure_detail():
     # Given a table whose validation phase failed
     report = _table_report(
         read=TableAbsent(),
-        pre_execution_failures=(
-            ValidationFailure("DisallowPartitioningChange", "cannot repartition"),
-        ),
+        failures=(ValidationFailure("DisallowPartitioningChange", "cannot repartition"),),
     )
 
     # When building the error message
@@ -86,7 +90,7 @@ def test_message_renders_every_validation_failure_when_a_table_breaks_several_ru
     # Given a table whose plan tripped two rules at once
     report = _table_report(
         read=TableAbsent(),
-        pre_execution_failures=(
+        failures=(
             ValidationFailure("NonNullableColumnAdd", "cannot add NOT NULL column 'age'"),
             ValidationFailure("DisallowPartitioningChange", "cannot repartition"),
         ),
@@ -111,7 +115,18 @@ def test_message_renders_execution_failure_detail_with_sql_preview():
             statement_preview="ALTER TABLE cat.sch.tbl ADD COLUMN x INT",
         ),
     )
-    report = _table_report(read=TableAbsent(), execution=ExecutionSummary((failed_result,)))
+    report = _table_report(
+        read=TableAbsent(),
+        execution=ExecutionSummary((failed_result,)),
+        failures=(
+            ExecutionFailure(
+                action_index=2,
+                exception_type="SparkException",
+                message="boom",
+                statement_preview="ALTER TABLE cat.sch.tbl ADD COLUMN x INT",
+            ),
+        ),
+    )
 
     # When building the error message
     message = _message_for(report)
@@ -126,7 +141,7 @@ def test_message_renders_fk_failure_detail():
     # Given a table with an FK failure described by its content
     report = _table_report(
         read=TableAbsent(),
-        pre_execution_failures=(
+        failures=(
             ForeignKeyFailure(
                 table=_QN,
                 local_columns=("ref_id",),

--- a/tests/application/test_errors.py
+++ b/tests/application/test_errors.py
@@ -104,7 +104,6 @@ def test_message_renders_execution_failure_detail_with_sql_preview():
     # Given a table whose execution phase failed on one action
     failed_result = ExecutionFailed(
         action="AddColumn",
-        action_index=2,
         failure=ExecutionFailure(
             action_index=2,
             exception_type="SparkException",

--- a/tests/application/test_rendering.py
+++ b/tests/application/test_rendering.py
@@ -1,0 +1,44 @@
+from delta_engine.application.rendering import action_diff_line
+from delta_engine.domain.plan.actions import (
+    SetColumnTag,
+    SetTableTag,
+    UnsetColumnTag,
+    UnsetTableTag,
+)
+
+# ---------- tag diff lines ----------
+
+
+def test_set_table_tag_renders_a_tilde_tag_line():
+    # Given a SetTableTag action
+    line = action_diff_line(SetTableTag(name="env", value="prod"))
+
+    # Then it renders as a change line naming the tag and its value
+    assert line == "~ tag env = 'prod'"
+
+
+def test_unset_table_tag_renders_a_minus_tag_line():
+    # Given an UnsetTableTag action
+    line = action_diff_line(UnsetTableTag(name="env"))
+
+    # Then it renders as a removal line naming the tag
+    assert line == "- tag env"
+
+
+# ---------- column tag diff lines ----------
+
+
+def test_set_column_tag_renders_a_tilde_column_tag_line():
+    # Given a SetColumnTag action
+    line = action_diff_line(SetColumnTag(column_name="email", name="pii", value="true"))
+
+    # Then it renders as a change line naming the column, tag, and value
+    assert line == "~ column tag email.pii = 'true'"
+
+
+def test_unset_column_tag_renders_a_minus_column_tag_line():
+    # Given an UnsetColumnTag action
+    line = action_diff_line(UnsetColumnTag(column_name="email", name="pii"))
+
+    # Then it renders as a removal line naming the column and tag
+    assert line == "- column tag email.pii"

--- a/tests/application/test_results.py
+++ b/tests/application/test_results.py
@@ -447,3 +447,41 @@ def test_unset_column_tag_renders_a_minus_column_tag_line():
 
     # Then it renders as a removal line naming the column and tag
     assert line == "- column tag email.pii"
+
+
+def test_each_failure_kind_declares_its_producing_phase():
+    # Given the four failure kinds
+    # Then each declares the phase that produced it, ordered read < validation < fk < execution
+    from delta_engine.application.results import FailurePhase
+
+    assert ReadFailure("E", "m").phase is FailurePhase.READ
+    assert ValidationFailure("R", "m").phase is FailurePhase.VALIDATION
+    assert (
+        ForeignKeyFailure(
+            table=QualifiedName("c", "s", "t"),
+            local_columns=("x",),
+            references="c.s.o",
+            reason=ForeignKeyFailureReason.CYCLE,
+        ).phase
+        is FailurePhase.FOREIGN_KEY
+    )
+    assert (
+        ExecutionFailure(
+            action_index=0, exception_type="E", message="m", statement_preview="SQL"
+        ).phase
+        is FailurePhase.EXECUTION
+    )
+    assert (
+        FailurePhase.READ
+        < FailurePhase.VALIDATION
+        < FailurePhase.FOREIGN_KEY
+        < FailurePhase.EXECUTION
+    )
+
+
+def test_foreign_key_reason_detail_is_defined_for_every_member():
+    # Given every FK failure reason
+    # Then each renders a non-empty human-readable detail string from the enum itself
+    for reason in ForeignKeyFailureReason:
+        assert reason.detail
+        assert isinstance(reason.detail, str)

--- a/tests/application/test_results.py
+++ b/tests/application/test_results.py
@@ -58,7 +58,6 @@ def _failed_exec(
 ):
     return ExecutionFailed(
         action=action,
-        action_index=idx,
         failure=ExecutionFailure(
             action_index=idx, exception_type=exc, message=msg, statement_preview=preview
         ),
@@ -184,7 +183,6 @@ def test_execution_outcome_variants_carry_the_right_payload():
     succeeded = ExecutionSucceeded(action="AddColumn", action_index=0, statement_preview="SQL")
     failed = ExecutionFailed(
         action="AddColumn",
-        action_index=1,
         failure=ExecutionFailure(
             action_index=1, exception_type="E", message="m", statement_preview="SQL"
         ),
@@ -246,7 +244,6 @@ _EXECUTION_RESULT = st.one_of(
     st.builds(
         ExecutionFailed,
         action=st.just("AddColumn"),
-        action_index=st.integers(min_value=0, max_value=100),
         failure=st.builds(
             ExecutionFailure,
             action_index=st.integers(min_value=0, max_value=100),
@@ -485,3 +482,17 @@ def test_foreign_key_reason_detail_is_defined_for_every_member():
     for reason in ForeignKeyFailureReason:
         assert reason.detail
         assert isinstance(reason.detail, str)
+
+
+def test_execution_failed_carries_index_only_on_its_failure_detail():
+    # Given a failed action
+    failed = ExecutionFailed(
+        action="AddColumn",
+        failure=ExecutionFailure(
+            action_index=3, exception_type="E", message="m", statement_preview="SQL"
+        ),
+    )
+
+    # Then the index lives on the failure detail, not duplicated on the carrier
+    assert failed.failure.action_index == 3
+    assert not hasattr(failed, "action_index")

--- a/tests/application/test_results.py
+++ b/tests/application/test_results.py
@@ -222,6 +222,14 @@ def test_sync_report_any_failures_true_if_any_table_has_failures():
         qualified_name=QualifiedName("cat", "s", "b"),
         read=TablePresent(table=_an_observed_table()),
         execution=ExecutionSummary((_failed_exec(0),)),
+        failures=(
+            ExecutionFailure(
+                action_index=0,
+                exception_type="ValueError",
+                message="boom",
+                statement_preview="ALTER TABLE ...",
+            ),
+        ),
     )
 
     # When aggregating the sync
@@ -280,7 +288,7 @@ def test_sync_report_failures_by_table_maps_only_failed_tables():
     t_bad = TableRunReport(
         qualified_name=failed_name,
         read=TableAbsent(),
-        pre_execution_failures=(ValidationFailure("R", "v"),),
+        failures=(ValidationFailure("R", "v"),),
         execution=ExecutionSummary(),
     )
 
@@ -316,11 +324,11 @@ def test_foreign_key_failure_renders_a_descriptive_line():
 
 
 def test_table_run_report_status_is_foreign_key_failed_when_fk_failure_present():
-    # Given a table that read cleanly but has an FK failure in pre_execution_failures
+    # Given a table that read cleanly but has an FK failure in failures
     report = TableRunReport(
         qualified_name=QualifiedName("cat", "sch", "orders"),
         read=TablePresent(table=_an_observed_table()),
-        pre_execution_failures=(
+        failures=(
             ForeignKeyFailure(
                 table=QualifiedName("cat", "sch", "orders"),
                 local_columns=("customer_id",),
@@ -333,7 +341,7 @@ def test_table_run_report_status_is_foreign_key_failed_when_fk_failure_present()
     # Then its status reflects the FK failure and it counts as a failure
     assert report.status is TableRunStatus.FOREIGN_KEY_FAILED
     assert report.has_failures is True
-    assert report.all_failures[0].format_lines()[0].startswith("Foreign key")
+    assert report.failures[0].format_lines()[0].startswith("Foreign key")
 
 
 def test_table_run_report_status_is_validation_failed_when_only_validation_failure_present():
@@ -341,7 +349,7 @@ def test_table_run_report_status_is_validation_failed_when_only_validation_failu
     report = TableRunReport(
         qualified_name=QualifiedName("cat", "sch", "tbl"),
         read=TablePresent(table=_an_observed_table()),
-        pre_execution_failures=(
+        failures=(
             ValidationFailure(rule_name="NonNullableColumnAdd", message="cannot add NOT NULL"),
         ),
     )
@@ -351,29 +359,25 @@ def test_table_run_report_status_is_validation_failed_when_only_validation_failu
     assert report.has_failures is True
 
 
-def test_table_run_report_status_is_fk_failed_when_both_fk_and_validation_failures_present():
-    # Given a table with both an FK failure and a validation failure
+def test_table_run_report_status_is_validation_failed_when_both_fk_and_validation_present():
+    # Given a table with both a validation failure and an FK failure
     report = TableRunReport(
         qualified_name=QualifiedName("cat", "sch", "orders"),
         read=TablePresent(table=_an_observed_table()),
-        pre_execution_failures=(
+        failures=(
+            ValidationFailure(rule_name="NonNullableColumnAdd", message="cannot add NOT NULL"),
             ForeignKeyFailure(
                 table=QualifiedName("cat", "sch", "orders"),
                 local_columns=("customer_id",),
                 references="cat.sch.customers",
                 reason=ForeignKeyFailureReason.UNRESOLVABLE_REFERENCE,
             ),
-            ValidationFailure(rule_name="NonNullableColumnAdd", message="cannot add NOT NULL"),
         ),
     )
 
-    # Then FOREIGN_KEY_FAILED takes priority, and both failures are surfaced
-    assert report.status is TableRunStatus.FOREIGN_KEY_FAILED
-    assert len(report.pre_execution_failures) == 2
-    fk_failures = [f for f in report.pre_execution_failures if isinstance(f, ForeignKeyFailure)]
-    val_failures = [f for f in report.pre_execution_failures if isinstance(f, ValidationFailure)]
-    assert len(fk_failures) == 1
-    assert len(val_failures) == 1
+    # Then VALIDATION_FAILED wins: it is the earlier phase and the actionable root cause
+    assert report.status is TableRunStatus.VALIDATION_FAILED
+    assert len(report.failures) == 2
 
 
 def test_table_run_report_with_no_pre_execution_failures_is_success():
@@ -384,9 +388,9 @@ def test_table_run_report_with_no_pre_execution_failures_is_success():
         execution=ExecutionSummary((_ok_exec(0),)),
     )
 
-    # Then it is a success and carries no pre-execution failures
+    # Then it is a success and carries no failures
     assert report.status is TableRunStatus.SUCCESS
-    assert report.pre_execution_failures == ()
+    assert report.failures == ()
 
 
 def test_foreign_key_failure_renders_not_a_key_reason():
@@ -496,3 +500,34 @@ def test_execution_failed_carries_index_only_on_its_failure_detail():
     # Then the index lives on the failure detail, not duplicated on the carrier
     assert failed.failure.action_index == 3
     assert not hasattr(failed, "action_index")
+
+
+def test_status_reflects_the_earliest_failing_phase():
+    # Given a table with an execution failure only
+    read = TablePresent(table=_an_observed_table())
+    exec_only = TableRunReport(
+        qualified_name=QualifiedName("cat", "s", "e"),
+        read=read,
+        execution=ExecutionSummary((_failed_exec(0),)),
+        failures=(
+            ExecutionFailure(
+                action_index=0, exception_type="E", message="m", statement_preview="SQL"
+            ),
+        ),
+    )
+    # Then it is EXECUTION_FAILED
+    assert exec_only.status is TableRunStatus.EXECUTION_FAILED
+
+    # Given a read failure present in the stream, it dominates any later phase
+    read_and_exec = TableRunReport(
+        qualified_name=QualifiedName("cat", "s", "r"),
+        read=ReadFailed(ReadFailure("IOError", "boom")),
+        failures=(
+            ReadFailure("IOError", "boom"),
+            ExecutionFailure(
+                action_index=0, exception_type="E", message="m", statement_preview="SQL"
+            ),
+        ),
+    )
+    # Then READ_FAILED wins (earliest phase)
+    assert read_and_exec.status is TableRunStatus.READ_FAILED

--- a/tests/application/test_results.py
+++ b/tests/application/test_results.py
@@ -19,15 +19,8 @@ from delta_engine.application.results import (
     TableRunStatus,
     ValidationFailure,
     ValidationResult,
-    _action_diff_line,
 )
 from delta_engine.domain.model import Column, Integer, ObservedTable, QualifiedName
-from delta_engine.domain.plan.actions import (
-    SetColumnTag,
-    SetTableTag,
-    UnsetColumnTag,
-    UnsetTableTag,
-)
 
 # ---------- test builders
 
@@ -410,44 +403,6 @@ def test_foreign_key_failure_renders_not_a_key_reason():
     assert "cat.sch.customers" in line
     assert "cat.sch.orders" in line
     assert "not the primary key" in line
-
-
-# ---------- tag diff lines ----------
-
-
-def test_set_table_tag_renders_a_tilde_tag_line():
-    # Given a SetTableTag action
-    line = _action_diff_line(SetTableTag(name="env", value="prod"))
-
-    # Then it renders as a change line naming the tag and its value
-    assert line == "~ tag env = 'prod'"
-
-
-def test_unset_table_tag_renders_a_minus_tag_line():
-    # Given an UnsetTableTag action
-    line = _action_diff_line(UnsetTableTag(name="env"))
-
-    # Then it renders as a removal line naming the tag
-    assert line == "- tag env"
-
-
-# ---------- column tag diff lines ----------
-
-
-def test_set_column_tag_renders_a_tilde_column_tag_line():
-    # Given a SetColumnTag action
-    line = _action_diff_line(SetColumnTag(column_name="email", name="pii", value="true"))
-
-    # Then it renders as a change line naming the column, tag, and value
-    assert line == "~ column tag email.pii = 'true'"
-
-
-def test_unset_column_tag_renders_a_minus_column_tag_line():
-    # Given an UnsetColumnTag action
-    line = _action_diff_line(UnsetColumnTag(column_name="email", name="pii"))
-
-    # Then it renders as a removal line naming the column and tag
-    assert line == "- column tag email.pii"
 
 
 def test_each_failure_kind_declares_its_producing_phase():

--- a/tests/application/test_results.py
+++ b/tests/application/test_results.py
@@ -373,8 +373,8 @@ def test_table_run_report_status_is_validation_failed_when_both_fk_and_validatio
     assert len(report.failures) == 2
 
 
-def test_table_run_report_with_no_pre_execution_failures_is_success():
-    # Given a clean table with no pre-execution failures
+def test_table_run_report_with_no_failures_is_success():
+    # Given a clean table with no failures
     report = TableRunReport(
         qualified_name=QualifiedName("cat", "sch", "ok"),
         read=TablePresent(table=_an_observed_table()),

--- a/tests/e2e/test_engine_e2e.py
+++ b/tests/e2e/test_engine_e2e.py
@@ -160,7 +160,7 @@ def test_engine_sync_fails_when_adding_non_nullable_column(spark, monkeypatch, t
     # and the error message names the offending column so an operator can act
     [table_report] = excinfo.value.report.table_reports
     assert table_report.status is TableRunStatus.VALIDATION_FAILED
-    assert any(isinstance(f, ValidationFailure) for f in table_report.all_failures)
+    assert any(isinstance(f, ValidationFailure) for f in table_report.failures)
     assert "age" in str(excinfo.value)
 
     # And the schema is unchanged: the invalid 'age' column was never added


### PR DESCRIPTION
## What & why

Failure handling was spread across four modules with inconsistent structure, and one path produced an observable bug: a read-failed table reported its error **twice** (the `external_failures` dict fed the failure into `pre_execution_failures` while `all_failures` also pulled it from `read.failure`). Addresses `docs/todo.md` items on unifying execution/validation/FK/external failure logic (lines 34, 35, 37, 41).

This unifies the model around one idea: **every `Failure` declares the phase that produced it, and each table carries a single phase-ordered `failures` stream.**

## Key changes

- **`FailurePhase` (READ < VALIDATION < FOREIGN_KEY < EXECUTION)** — each `Failure` subclass declares its phase. `TableRunReport.status` derives from the earliest failing phase instead of an `isinstance` chain.
- **Single accumulator in `Engine.sync`** — one `dict[QualifiedName, list[Failure]]` filled phase by phase. The `external_failures` concept is **deleted**.
- **`resolve()` no longer carries failures it didn't produce** — it takes `blocked: frozenset[QualifiedName]` (to seed `BLOCKED_BY_FAILED_DEPENDENCY` propagation) and returns `SyncCandidate` with only `fk_failures`.
- **`TableRunReport` collapses to one `failures` stream** — `pre_execution_failures` and `all_failures` removed. Double-count is now structurally impossible.
- **FK reason detail** moved into `ForeignKeyFailureReason.detail` (match, no `case _` → mypy-checked exhaustiveness, no runtime `KeyError`).
- **Rendering split out** of `results.py` into a new `rendering.py` (results.py shrank ~217 lines).
- Dropped the redundant `ExecutionFailed.action_index` (kept on the nested `ExecutionFailure`).

## Behaviour change (intentional)

Status precedence reversed: a table failing **both** validation and FK now reports `VALIDATION_FAILED` (earlier phase, more actionable root cause) rather than `FOREIGN_KEY_FAILED`. `docs/how-to-handle-sync-failures.md` updated.

## Testing

`uv run pytest` → 381 passed. `ruff check` + `ruff format --check` + `mypy src` all clean. A regression test pins the read-failure-once fix; new tests cover phase-derived status precedence and the `resolve(blocked=...)` contract.

> The 16 `JAVA_GATEWAY_EXITED` errors in local runs are pre-existing/environmental (no JVM in the dev sandbox) — unchanged by this branch and expected to pass in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
