### PR TITLE
refactor: chain Engine.sync over per-table records

### DIFF
--- a/src/delta_engine/application/dependency_resolution.py
+++ b/src/delta_engine/application/dependency_resolution.py
@@ -2,13 +2,8 @@
 Foreign key dependency resolution for sync ordering and failure classification.
 
 The public entry point is `resolve`, which takes the registered tables and
-returns them as a tuple of :class:`SyncCandidate` objects in dependency-first
-order — referenced tables before their dependents.
-
-Each candidate carries the table it represents and only the FK failures that
-`resolve` found for it (CYCLE, UNRESOLVABLE_REFERENCE, REFERENCED_COLUMNS_NOT_A_KEY,
-or BLOCKED_BY_FAILED_DEPENDENCY). A candidate with an empty `fk_failures` tuple
-may be executed; one with failures must be excluded.
+returns a :class:`ResolveResult` with all table names in dependency-first order
+and a mapping of FK failures per table.
 
 All graph-traversal implementation details (adjacency map, Tarjan's
 strongly-connected-components algorithm, reverse-reachability propagation) are
@@ -17,7 +12,7 @@ hidden behind that interface.
 
 from __future__ import annotations
 
-from collections.abc import Set as AbstractSet
+from collections.abc import Mapping, Set as AbstractSet
 from dataclasses import dataclass
 
 from delta_engine.application.results import ForeignKeyFailure, ForeignKeyFailureReason
@@ -35,37 +30,29 @@ def _primary_key_columns(table: DesiredTable) -> tuple[str, ...]:
 
 
 @dataclass(frozen=True, slots=True)
-class SyncCandidate:
+class ResolveResult:
     """
-    A table prepared for the sync loop, with the FK failures resolution found for it.
+    The outcome of foreign-key resolution across all registered tables.
 
     Attributes:
-        table: The desired table to sync.
-        fk_failures: Foreign-key failures this table incurred during resolution
-            (CYCLE / UNRESOLVABLE_REFERENCE / REFERENCED_COLUMNS_NOT_A_KEY /
-            BLOCKED_BY_FAILED_DEPENDENCY). Empty when resolution found none.
+        ordered_names: All table names in dependency-first order — referenced
+            tables before their dependents. Every registered table appears,
+            including ones that failed resolution (the engine gates those out
+            by their recorded failures).
+        fk_failures: The foreign-key failures resolution found, keyed by table.
+            A table absent from this mapping had no FK failure.
 
     """
 
-    table: DesiredTable
-    fk_failures: tuple[ForeignKeyFailure, ...] = ()
-
-    @property
-    def qualified_name(self) -> QualifiedName:
-        """The fully qualified name of the table this candidate represents."""
-        return self.table.qualified_name
-
-    @property
-    def can_execute(self) -> bool:
-        """True when resolution found no foreign-key failures for this table."""
-        return not self.fk_failures
+    ordered_names: tuple[QualifiedName, ...]
+    fk_failures: Mapping[QualifiedName, tuple[ForeignKeyFailure, ...]]
 
 
 def resolve(
     tables: tuple[DesiredTable, ...],
     *,
     blocked: AbstractSet[QualifiedName] = frozenset(),
-) -> tuple[SyncCandidate, ...]:
+) -> ResolveResult:
     """
     Resolve foreign key dependencies across all registered tables.
 
@@ -82,8 +69,9 @@ def resolve(
             phase that produced them.
 
     Returns:
-        A tuple of :class:`SyncCandidate` objects in dependency-first order,
-        each carrying only the FK failures resolution found for it.
+        A :class:`ResolveResult` with all tables in dependency-first
+        ``ordered_names`` and ``fk_failures`` keyed by table (absent means
+        no FK failure for that table).
 
     """
     already_failed = {str(qualified_name) for qualified_name in blocked}
@@ -96,13 +84,8 @@ def resolve(
     ordered = _order_tables(tables, components)
     failures_by_table = _classify_failures(tables, registered_names, cycle_members, already_failed)
 
-    return tuple(
-        SyncCandidate(
-            table=table,
-            fk_failures=failures_by_table.get(table.qualified_name, ()),
-        )
-        for table in ordered
-    )
+    ordered_names = tuple(table.qualified_name for table in ordered)
+    return ResolveResult(ordered_names=ordered_names, fk_failures=failures_by_table)
 
 
 def _build_dependency_graph(
@@ -193,8 +176,8 @@ def _order_tables(
 
     Tarjan emits components dependency-first, so concatenating their members
     yields an order in which every referenced table precedes its dependents.
-    Candidates that cannot execute (FK failures) appear too — the engine gates
-    them out via can_execute.
+    Tables that cannot execute (FK failures) appear too — the engine gates
+    them out by their recorded failures.
     """
     table_by_name = {str(table.qualified_name): table for table in tables}
     return [table_by_name[name] for component in components for name in component]

--- a/src/delta_engine/application/engine.py
+++ b/src/delta_engine/application/engine.py
@@ -1,18 +1,18 @@
 """
 High-level orchestration of planning, validation, and execution.
 
-`Engine.sync` reads current catalog state, computes a plan (schema diff +
-deterministic ordering), validates it against rules, resolves FK dependencies
-with full failure context, then executes passing plans. If any table fails,
+`Engine.sync` runs a chain of phases, each a pure transform over the per-table
+runs — one `TableRunReport` is born per table in the read phase and accretes
+its plan, failures, and execution as the chain proceeds. If any table fails,
 `SyncFailedError` is raised with a formatted summary.
 
-The sync runs five phases across all tables in sequence:
-  1. Read     — fetch current catalog state for every table
+The five phases, each taking the runs and returning them:
+  1. Read     — fetch current catalog state; birth one run per table
   2. Plan     — compute action plans from desired vs observed state
-  3. Validate — check every plan against rules; collect per-table failures
-  4. Resolve  — order tables by FK dependency; produce FK failures and
+  3. Validate — check every plan against rules; append per-table failures
+  4. Resolve  — order runs by FK dependency; append FK failures and
                 propagate blocking to dependents
-  5. Execute  — run plans for candidates with no pre-execution failures
+  5. Execute  — run the plan of every run with no failures and a non-empty plan
 
 Running `resolve()` after validation means a table that fails validation
 blocks its FK dependents with BLOCKED_BY_FAILED_DEPENDENCY, not just tables
@@ -20,13 +20,14 @@ with FK-structural failures (CYCLE / UNRESOLVABLE_REFERENCE). The rule is
 uniform: if a dependency won't reach desired state this sync, its dependents
 don't execute either.
 
-A table that fails in an early phase is carried forward as a partial result
-and skipped in later phases, so all tables are attempted and the report is
-always complete.
+A table that fails an early phase carries that failure forward on its run and
+is skipped by execution, so all tables are attempted and the report is always
+complete.
 """
 
 from __future__ import annotations
 
+from dataclasses import replace
 from datetime import UTC, datetime
 import logging
 
@@ -35,16 +36,12 @@ from delta_engine.application.errors import SyncFailedError
 from delta_engine.application.ports import CatalogStateReader, PlanExecutor
 from delta_engine.application.registry import Registry
 from delta_engine.application.results import (
-    CatalogState,
-    ExecutionSummary,
-    Failure,
     ReadFailed,
     SyncReport,
     TablePresent,
     TableRunReport,
 )
 from delta_engine.application.validation import validate_plan
-from delta_engine.domain.model import QualifiedName
 from delta_engine.domain.model.table import DesiredTable
 from delta_engine.domain.plan.actions import ActionPlan
 from delta_engine.domain.plan.differ import compute_plan
@@ -75,22 +72,21 @@ class Engine:
         """
         Synchronize all registered tables to their desired state.
 
-        Runs five phases across all tables in sequence:
-        read → plan → validate → resolve → execute. Resolve runs after
-        validate so that validation failures propagate to FK dependents the
-        same way FK-structural failures do.
+        Runs the phases as a chain, each transforming the per-table runs:
+        read → plan → validate → resolve → execute. Each ``TableRunReport``
+        is born in the read phase and accretes its plan, failures, and
+        execution as later phases run.
 
-        A table that fails in an early phase is skipped in later phases;
-        its partial result is included in the final report.
+        A table that fails an early phase carries that failure forward and is
+        skipped by execution; its partial run is still included in the report.
 
         Args:
             registry: The tables to synchronize.
             dry_run: When True, run read → plan → validate → resolve but skip
-                execution entirely (zero catalog mutations). Every table's
-                ``execution`` is ``None`` while its ``plan`` still records the
-                actions that would be applied, and the report is returned
-                instead of raising ``SyncFailedError`` even when a table would
-                fail — so the caller can inspect what would happen.
+                execution (zero catalog mutations). Every run's ``execution``
+                stays ``None`` while its ``plan`` still records the actions that
+                would be applied, and the report is returned instead of raising
+                ``SyncFailedError`` even when a table would fail.
 
         Returns:
             The aggregate :class:`SyncReport` for the run.
@@ -104,68 +100,133 @@ class Engine:
         run_started = datetime.now(UTC)
         logger.info("Starting sync for %d table(s)", len(registry))
 
-        tables = tuple(registry)
-        catalog_states = self._read(tables)
-        plans = self._plan(tables, catalog_states)
-
-        # One accumulator for every failure across all phases. Filled in order:
-        # read failures, validation failures, FK failures from resolve, then
-        # execution failures mirrored in after the execute phase. This makes
-        # `failures` on each TableRunReport the single place to read what went wrong.
-        pre_execution: dict[QualifiedName, list[Failure]] = {
-            table.qualified_name: [] for table in tables
-        }
-
-        for table in tables:
-            state = catalog_states[table.qualified_name]
-            if isinstance(state, ReadFailed):
-                pre_execution[table.qualified_name].append(state.failure)
-
-        for qualified_name, result in self._validate_plans(plans).items():
-            pre_execution[qualified_name].extend(result)
-
-        blocked = {qualified_name for qualified_name, failures in pre_execution.items() if failures}
-
-        candidates = resolve(tables, blocked=blocked)
-        for candidate in candidates:
-            pre_execution[candidate.qualified_name].extend(candidate.fk_failures)
-
-        plans_to_execute = {
-            candidate.qualified_name: plans[candidate.qualified_name]
-            for candidate in candidates
-            if not pre_execution[candidate.qualified_name]
-        }
-        executions: dict[QualifiedName, ExecutionSummary] = (
-            {} if dry_run else self._execute(plans_to_execute)
-        )
-
-        # Mirror execution failures into the one stream so `failures` is the
-        # single place to read what went wrong; ExecutionSummary stays for the
-        # per-action diff/preview.
-        for qualified_name, summary in executions.items():
-            pre_execution[qualified_name].extend(summary.failures)
-
-        table_reports = tuple(
-            TableRunReport(
-                qualified_name=candidate.qualified_name,
-                desired=candidate.table,
-                read=catalog_states[candidate.qualified_name],
-                plan=plans[candidate.qualified_name],
-                failures=tuple(pre_execution[candidate.qualified_name]),
-                execution=executions.get(candidate.qualified_name),
-            )
-            for candidate in candidates
-        )
+        runs = self._read(tuple(registry))
+        runs = self._plan(runs)
+        runs = self._validate(runs)
+        runs = self._resolve(runs)
+        runs = self._execute(runs, dry_run=dry_run)
 
         report = SyncReport(
             started_at=run_started,
             ended_at=datetime.now(UTC),
-            table_reports=table_reports,
+            table_reports=runs,
         )
-
         if not dry_run and report.any_failures:
             raise SyncFailedError(report)
+        self._log_outcome(report, dry_run=dry_run)
+        return report
 
+    def _read(self, tables: tuple[DesiredTable, ...]) -> tuple[TableRunReport, ...]:
+        """Fetch current catalog state for every table, birthing one run each."""
+        runs: list[TableRunReport] = []
+        for table in tables:
+            qualified_name = table.qualified_name
+            state = self.reader.fetch_state(qualified_name)
+            if isinstance(state, ReadFailed):
+                logger.error(
+                    "Read failed for %s: %s - %s",
+                    qualified_name,
+                    state.failure.exception_type,
+                    state.failure.message,
+                )
+                runs.append(
+                    TableRunReport(
+                        qualified_name=qualified_name,
+                        desired=table,
+                        read=state,
+                        failures=(state.failure,),
+                    )
+                )
+            else:
+                logger.info(
+                    "Read state for %s: %s",
+                    qualified_name,
+                    "present" if isinstance(state, TablePresent) else "absent",
+                )
+                runs.append(
+                    TableRunReport(qualified_name=qualified_name, desired=table, read=state)
+                )
+        return tuple(runs)
+
+    def _plan(self, runs: tuple[TableRunReport, ...]) -> tuple[TableRunReport, ...]:
+        """Compute an action plan for each run; read-failed runs get an empty plan."""
+        planned: list[TableRunReport] = []
+        for run in runs:
+            if isinstance(run.read, ReadFailed):
+                planned.append(replace(run, plan=ActionPlan()))
+                continue
+            observed = run.read.table if isinstance(run.read, TablePresent) else None
+            plan = compute_plan(desired=run.desired, observed=observed)
+            logger.info("Planned %d action(s) for %s", len(plan), run.qualified_name)
+            planned.append(replace(run, plan=plan))
+        return tuple(planned)
+
+    def _validate(self, runs: tuple[TableRunReport, ...]) -> tuple[TableRunReport, ...]:
+        """Validate every run's plan, appending any validation failures."""
+        validated: list[TableRunReport] = []
+        for run in runs:
+            result = validate_plan(run.plan)
+            if result.failed:
+                logger.error(
+                    "Validation failed for %s (%d failure(s))",
+                    run.qualified_name,
+                    len(result.failures),
+                )
+            else:
+                logger.info("Validation passed for %s", run.qualified_name)
+            validated.append(replace(run, failures=run.failures + tuple(result.failures)))
+        return tuple(validated)
+
+    def _resolve(self, runs: tuple[TableRunReport, ...]) -> tuple[TableRunReport, ...]:
+        """
+        Order runs by FK dependency and fold in FK failures.
+
+        Runs that already carry a failure (read or validation) seed the
+        blocked set, so their FK dependents are blocked with
+        BLOCKED_BY_FAILED_DEPENDENCY. Returns the runs in dependency-first order.
+        """
+        blocked = frozenset(run.qualified_name for run in runs if run.failures)
+        result = resolve(tuple(run.desired for run in runs), blocked=blocked)
+        by_name = {run.qualified_name: run for run in runs}
+        return tuple(
+            replace(
+                by_name[name],
+                failures=by_name[name].failures + result.fk_failures.get(name, ()),
+            )
+            for name in result.ordered_names
+        )
+
+    def _execute(
+        self, runs: tuple[TableRunReport, ...], *, dry_run: bool
+    ) -> tuple[TableRunReport, ...]:
+        """
+        Execute the plan of every run with no failures and a non-empty plan.
+
+        Skipped runs pass through unchanged. Execution failures are appended to
+        the run's ``failures`` and the summary is set on ``execution``. A dry run
+        executes nothing and returns the runs unchanged.
+        """
+        if dry_run:
+            return runs
+        executed: list[TableRunReport] = []
+        for run in runs:
+            if run.failures or not run.plan:
+                executed.append(run)
+                continue
+            summary = self.executor.execute(run.qualified_name, run.plan)
+            logger.info(
+                "Executed %d action(s) for %s (%d failed)",
+                len(summary.results),
+                run.qualified_name,
+                summary.failed_count,
+            )
+            executed.append(
+                replace(run, execution=summary, failures=run.failures + summary.failures)
+            )
+        return tuple(executed)
+
+    def _log_outcome(self, report: SyncReport, *, dry_run: bool) -> None:
+        """Log the run outcome (dry-run notice or success line)."""
         if dry_run:
             logger.info(
                 "Dry run complete for %d table(s); no changes were applied",
@@ -173,97 +234,3 @@ class Engine:
             )
         else:
             logger.info("Sync completed successfully for %d table(s)", len(report.table_reports))
-        return report
-
-    def _read(
-        self,
-        tables: tuple[DesiredTable, ...],
-    ) -> dict[QualifiedName, CatalogState]:
-        """Fetch current catalog state for every table."""
-        catalog_states: dict[QualifiedName, CatalogState] = {}
-        for table in tables:
-            qualified_name = table.qualified_name
-            catalog_state = self.reader.fetch_state(qualified_name)
-            catalog_states[qualified_name] = catalog_state
-            if isinstance(catalog_state, ReadFailed):
-                logger.error(
-                    "Read failed for %s: %s - %s",
-                    qualified_name,
-                    catalog_state.failure.exception_type,
-                    catalog_state.failure.message,
-                )
-            else:
-                logger.info(
-                    "Read state for %s: %s",
-                    qualified_name,
-                    "present" if isinstance(catalog_state, TablePresent) else "absent",
-                )
-        return catalog_states
-
-    def _plan(
-        self,
-        tables: tuple[DesiredTable, ...],
-        catalog_states: dict[QualifiedName, CatalogState],
-    ) -> dict[QualifiedName, ActionPlan]:
-        """
-        Compute an action plan for each table.
-
-        Tables that failed to read get an empty plan.
-        """
-        plans: dict[QualifiedName, ActionPlan] = {}
-        for table in tables:
-            qualified_name = table.qualified_name
-            catalog_state = catalog_states[qualified_name]
-            if isinstance(catalog_state, ReadFailed):
-                plans[qualified_name] = ActionPlan()
-                continue
-
-            observed = catalog_state.table if isinstance(catalog_state, TablePresent) else None
-            plan = compute_plan(desired=table, observed=observed)
-            plans[qualified_name] = plan
-            logger.info("Planned %d action(s) for %s", len(plan), qualified_name)
-
-        return plans
-
-    def _validate_plans(
-        self,
-        plans: dict[QualifiedName, ActionPlan],
-    ) -> dict[QualifiedName, tuple[Failure, ...]]:
-        """
-        Validate every plan and return per-table failures.
-
-        All tables are validated. The returned dict is passed to `resolve()` so
-        that validation-failed tables block their FK dependents.
-        """
-        validation_failures: dict[QualifiedName, tuple[Failure, ...]] = {}
-        for qualified_name, plan in plans.items():
-            result = validate_plan(plan)
-            validation_failures[qualified_name] = tuple(result.failures)
-            if result.failed:
-                logger.error(
-                    "Validation failed for %s (%d failure(s))",
-                    qualified_name,
-                    len(result.failures),
-                )
-            else:
-                logger.info("Validation passed for %s", qualified_name)
-        return validation_failures
-
-    def _execute(
-        self,
-        plans: dict[QualifiedName, ActionPlan],
-    ) -> dict[QualifiedName, ExecutionSummary]:
-        """Execute every plan in the given dict."""
-        executions: dict[QualifiedName, ExecutionSummary] = {}
-        for qualified_name, plan in plans.items():
-            if not plan:
-                continue
-            execution = self.executor.execute(qualified_name, plan)
-            executions[qualified_name] = execution
-            logger.info(
-                "Executed %d action(s) for %s (%d failed)",
-                len(execution.results),
-                qualified_name,
-                execution.failed_count,
-            )
-        return executions

--- a/src/delta_engine/application/engine.py
+++ b/src/delta_engine/application/engine.py
@@ -148,10 +148,11 @@ class Engine:
         table_reports = tuple(
             TableRunReport(
                 qualified_name=candidate.qualified_name,
+                desired=candidate.table,
                 read=catalog_states[candidate.qualified_name],
                 plan=plans[candidate.qualified_name],
-                execution=executions.get(candidate.qualified_name),
                 failures=tuple(pre_execution[candidate.qualified_name]),
+                execution=executions.get(candidate.qualified_name),
             )
             for candidate in candidates
         )

--- a/src/delta_engine/application/results.py
+++ b/src/delta_engine/application/results.py
@@ -17,6 +17,7 @@ from enum import IntEnum, StrEnum
 from typing import ClassVar
 
 from delta_engine.domain.model import ObservedTable, QualifiedName
+from delta_engine.domain.model.table import DesiredTable
 from delta_engine.domain.plan.actions import ActionPlan
 
 
@@ -253,10 +254,11 @@ class TableRunReport:
     """Per-table report with outcomes and a single phase-ordered failure stream."""
 
     qualified_name: QualifiedName
+    desired: DesiredTable
     read: CatalogState
     plan: ActionPlan = field(default_factory=ActionPlan)
-    execution: ExecutionSummary | None = None
     failures: tuple[Failure, ...] = ()
+    execution: ExecutionSummary | None = None
 
     @property
     def status(self) -> TableRunStatus:

--- a/tests/application/test_dependency_resolution.py
+++ b/tests/application/test_dependency_resolution.py
@@ -8,7 +8,7 @@ transitive propagation to dependents.
 """
 
 from delta_engine.api import Column, DeltaTable, String
-from delta_engine.application.dependency_resolution import SyncCandidate, resolve
+from delta_engine.application.dependency_resolution import ResolveResult, resolve
 from delta_engine.application.results import ForeignKeyFailureReason
 from delta_engine.domain.model import QualifiedName
 from delta_engine.domain.model.foreign_key import ForeignKeyConstraint
@@ -45,10 +45,17 @@ def _table_with_fk(fqn: str, references: str) -> DesiredTable:
     ).to_desired_table()
 
 
-def _candidates_by_name(
-    candidates: tuple[SyncCandidate, ...],
-) -> dict[str, SyncCandidate]:
-    return {str(candidate.qualified_name): candidate for candidate in candidates}
+def _names(result: ResolveResult) -> list[str]:
+    """Ordered table names, as strings, in dependency-first order."""
+    return [str(name) for name in result.ordered_names]
+
+
+def _failures_for(result: ResolveResult, fqn: str) -> tuple:
+    """FK failures resolve recorded for one table (empty tuple if none)."""
+    for name, failures in result.fk_failures.items():
+        if str(name) == fqn:
+            return failures
+    return ()
 
 
 def test_resolve_with_no_fks_preserves_registry_order():
@@ -56,12 +63,11 @@ def test_resolve_with_no_fks_preserves_registry_order():
     tables = (_table("cat.sch.a"), _table("cat.sch.b"), _table("cat.sch.c"))
 
     # When
-    candidates = resolve(tables)
+    result = resolve(tables)
 
-    # Then order is unchanged and all candidates can execute
-    names = [str(candidate.qualified_name) for candidate in candidates]
-    assert names == ["cat.sch.a", "cat.sch.b", "cat.sch.c"]
-    assert all(candidate.can_execute for candidate in candidates)
+    # Then order is unchanged and all tables have no FK failures
+    assert _names(result) == ["cat.sch.a", "cat.sch.b", "cat.sch.c"]
+    assert not result.fk_failures
 
 
 def test_resolve_orders_referenced_table_before_dependent():
@@ -72,12 +78,12 @@ def test_resolve_orders_referenced_table_before_dependent():
     )
 
     # When
-    candidates = resolve(tables)
+    result = resolve(tables)
 
-    # Then customers appears before orders and all candidates can execute
-    names = [str(candidate.qualified_name) for candidate in candidates]
+    # Then customers appears before orders and all tables have no FK failures
+    names = _names(result)
     assert names.index("cat.sch.customers") < names.index("cat.sch.orders")
-    assert all(candidate.can_execute for candidate in candidates)
+    assert not result.fk_failures
 
 
 def test_resolve_handles_chain_of_dependencies():
@@ -89,10 +95,10 @@ def test_resolve_handles_chain_of_dependencies():
     )
 
     # When
-    candidates = resolve(tables)
+    result = resolve(tables)
 
     # Then a before b before c
-    names = [str(candidate.qualified_name) for candidate in candidates]
+    names = _names(result)
     assert names.index("cat.sch.a") < names.index("cat.sch.b") < names.index("cat.sch.c")
 
 
@@ -101,15 +107,14 @@ def test_resolve_fails_table_with_unresolvable_reference():
     tables = (_table_with_fk("cat.sch.orders", "cat.sch.customers"),)
 
     # When
-    candidates = resolve(tables)
+    result = resolve(tables)
 
-    # Then orders cannot execute, with UNRESOLVABLE_REFERENCE
-    [candidate] = candidates
-    assert not candidate.can_execute
-    assert len(candidate.fk_failures) == 1
-    assert candidate.fk_failures[0].reason == ForeignKeyFailureReason.UNRESOLVABLE_REFERENCE
-    assert candidate.fk_failures[0].local_columns == ("ref_id",)
-    assert candidate.fk_failures[0].references == "cat.sch.customers"
+    # Then orders has one UNRESOLVABLE_REFERENCE failure with the FK's columns
+    failures = _failures_for(result, "cat.sch.orders")
+    assert len(failures) == 1
+    assert failures[0].reason == ForeignKeyFailureReason.UNRESOLVABLE_REFERENCE
+    assert failures[0].local_columns == ("ref_id",)
+    assert failures[0].references == "cat.sch.customers"
 
 
 def test_resolve_fails_both_members_of_a_cycle():
@@ -120,17 +125,16 @@ def test_resolve_fails_both_members_of_a_cycle():
     )
 
     # When
-    candidates = resolve(tables)
+    result = resolve(tables)
 
     # Then both tables cannot execute, each with CYCLE
-    by_name = _candidates_by_name(candidates)
-    assert not by_name["cat.sch.a"].can_execute
-    assert not by_name["cat.sch.b"].can_execute
-    assert by_name["cat.sch.a"].fk_failures[0].reason == ForeignKeyFailureReason.CYCLE
-    assert by_name["cat.sch.b"].fk_failures[0].reason == ForeignKeyFailureReason.CYCLE
+    assert _failures_for(result, "cat.sch.a")
+    assert _failures_for(result, "cat.sch.b")
+    assert _failures_for(result, "cat.sch.a")[0].reason == ForeignKeyFailureReason.CYCLE
+    assert _failures_for(result, "cat.sch.b")[0].reason == ForeignKeyFailureReason.CYCLE
 
 
-def test_resolve_includes_failed_tables_in_candidates():
+def test_resolve_ordering_includes_failed_tables():
     # Given a mutual cycle between a and b
     tables = (
         _table_with_fk("cat.sch.a", "cat.sch.b"),
@@ -138,11 +142,10 @@ def test_resolve_includes_failed_tables_in_candidates():
     )
 
     # When
-    candidates = resolve(tables)
+    result = resolve(tables)
 
-    # Then both tables still appear as candidates (the engine gates them out via can_execute)
-    names = {str(candidate.qualified_name) for candidate in candidates}
-    assert names == {"cat.sch.a", "cat.sch.b"}
+    # Then both tables still appear in the ordering (the engine gates them out via their failures)
+    assert set(_names(result)) == {"cat.sch.a", "cat.sch.b"}
 
 
 def test_resolve_blocks_table_that_references_an_unresolvable_table():
@@ -153,16 +156,15 @@ def test_resolve_blocks_table_that_references_an_unresolvable_table():
     )
 
     # When
-    candidates = resolve(tables)
+    result = resolve(tables)
 
     # Then customers fails directly, and orders cannot execute because customers will not build
-    by_name = _candidates_by_name(candidates)
     assert (
-        by_name["cat.sch.customers"].fk_failures[0].reason
+        _failures_for(result, "cat.sch.customers")[0].reason
         == ForeignKeyFailureReason.UNRESOLVABLE_REFERENCE
     )
     assert (
-        by_name["cat.sch.orders"].fk_failures[0].reason
+        _failures_for(result, "cat.sch.orders")[0].reason
         == ForeignKeyFailureReason.BLOCKED_BY_FAILED_DEPENDENCY
     )
 
@@ -177,16 +179,16 @@ def test_resolve_propagates_block_along_a_chain():
     )
 
     # When
-    candidates = resolve(tables)
+    result = resolve(tables)
 
     # Then a fails directly and b, c, d are all blocked transitively
-    by_name = _candidates_by_name(candidates)
     assert (
-        by_name["cat.sch.a"].fk_failures[0].reason == ForeignKeyFailureReason.UNRESOLVABLE_REFERENCE
+        _failures_for(result, "cat.sch.a")[0].reason
+        == ForeignKeyFailureReason.UNRESOLVABLE_REFERENCE
     )
     for blocked in ("cat.sch.b", "cat.sch.c", "cat.sch.d"):
         assert (
-            by_name[blocked].fk_failures[0].reason
+            _failures_for(result, blocked)[0].reason
             == ForeignKeyFailureReason.BLOCKED_BY_FAILED_DEPENDENCY
         )
 
@@ -200,14 +202,13 @@ def test_resolve_blocks_table_that_depends_on_a_cycle():
     )
 
     # When
-    candidates = resolve(tables)
+    result = resolve(tables)
 
     # Then b and c fail as CYCLE, and a cannot execute because b will not build
-    by_name = _candidates_by_name(candidates)
-    assert by_name["cat.sch.b"].fk_failures[0].reason == ForeignKeyFailureReason.CYCLE
-    assert by_name["cat.sch.c"].fk_failures[0].reason == ForeignKeyFailureReason.CYCLE
+    assert _failures_for(result, "cat.sch.b")[0].reason == ForeignKeyFailureReason.CYCLE
+    assert _failures_for(result, "cat.sch.c")[0].reason == ForeignKeyFailureReason.CYCLE
     assert (
-        by_name["cat.sch.a"].fk_failures[0].reason
+        _failures_for(result, "cat.sch.a")[0].reason
         == ForeignKeyFailureReason.BLOCKED_BY_FAILED_DEPENDENCY
     )
 
@@ -220,12 +221,11 @@ def test_resolve_does_not_block_an_unrelated_sibling():
     )
 
     # When
-    candidates = resolve(tables)
+    result = resolve(tables)
 
     # Then only orders cannot execute; the unrelated table is fine
-    by_name = _candidates_by_name(candidates)
-    assert not by_name["cat.sch.orders"].can_execute
-    assert by_name["cat.sch.unrelated"].can_execute
+    assert _failures_for(result, "cat.sch.orders")
+    assert _failures_for(result, "cat.sch.unrelated") == ()
 
 
 def test_resolve_treats_self_referential_fk_as_applicable():
@@ -248,12 +248,11 @@ def test_resolve_treats_self_referential_fk_as_applicable():
     ).to_desired_table()
 
     # When
-    candidates = resolve((table,))
+    result = resolve((table,))
 
     # Then the self-referencing FK does not prevent execution
-    [candidate] = candidates
-    assert candidate.can_execute
-    assert str(candidate.qualified_name) == "cat.sch.employees"
+    assert _names(result) == ["cat.sch.employees"]
+    assert _failures_for(result, "cat.sch.employees") == ()
 
 
 def test_resolve_propagates_block_through_a_diamond():
@@ -285,28 +284,28 @@ def test_resolve_propagates_block_through_a_diamond():
     )
 
     # When
-    candidates = resolve(tables)
+    result = resolve(tables)
 
     # Then a fails directly; b, c, and d are all blocked
-    by_name = _candidates_by_name(candidates)
     assert (
-        by_name["cat.sch.a"].fk_failures[0].reason == ForeignKeyFailureReason.UNRESOLVABLE_REFERENCE
+        _failures_for(result, "cat.sch.a")[0].reason
+        == ForeignKeyFailureReason.UNRESOLVABLE_REFERENCE
     )
     for blocked in ("cat.sch.b", "cat.sch.c", "cat.sch.d"):
         assert all(
             f.reason == ForeignKeyFailureReason.BLOCKED_BY_FAILED_DEPENDENCY
-            for f in by_name[blocked].fk_failures
+            for f in _failures_for(result, blocked)
         )
     # d has two blocking FKs, so it records two failures (one per FK)
-    assert len(by_name["cat.sch.d"].fk_failures) == 2
+    assert len(_failures_for(result, "cat.sch.d")) == 2
 
 
 def test_resolve_with_empty_tables_returns_empty_tuple():
     # Given / When
-    candidates = resolve(())
+    result = resolve(())
 
     # Then
-    assert candidates == ()
+    assert result.ordered_names == () and result.fk_failures == {}
 
 
 def test_resolve_blocks_table_passed_in_blocked_set():
@@ -315,12 +314,11 @@ def test_resolve_blocks_table_passed_in_blocked_set():
     blocked = frozenset({QualifiedName("cat", "sch", "orders")})
 
     # When resolving with that table blocked
-    candidates = resolve((table,), blocked=blocked)
+    result = resolve((table,), blocked=blocked)
 
     # Then it produces no FK failures of its own (it was blocked for an external reason)
     # and, having no FKs, it is not further classified by resolve
-    [candidate] = candidates
-    assert candidate.fk_failures == ()
+    assert _failures_for(result, "cat.sch.orders") == ()
 
 
 def test_resolve_blocks_fk_dependent_of_a_blocked_table():
@@ -330,14 +328,13 @@ def test_resolve_blocks_fk_dependent_of_a_blocked_table():
     blocked = frozenset({QualifiedName("cat", "sch", "orders")})
 
     # When resolving
-    candidates = resolve((orders, shipments), blocked=blocked)
+    result = resolve((orders, shipments), blocked=blocked)
 
     # Then shipments is blocked-by-failed-dependency; orders itself has no FK failure
-    by_name = _candidates_by_name(candidates)
-    assert by_name["cat.sch.orders"].fk_failures == ()
-    assert not by_name["cat.sch.shipments"].can_execute
+    assert _failures_for(result, "cat.sch.orders") == ()
+    assert _failures_for(result, "cat.sch.shipments")
     assert (
-        by_name["cat.sch.shipments"].fk_failures[0].reason
+        _failures_for(result, "cat.sch.shipments")[0].reason
         == ForeignKeyFailureReason.BLOCKED_BY_FAILED_DEPENDENCY
     )
 
@@ -350,10 +347,10 @@ def test_resolve_passes_when_fk_targets_the_parents_primary_key():
     )
 
     # When
-    candidates = resolve(tables)
+    result = resolve(tables)
 
     # Then every table can execute
-    assert all(candidate.can_execute for candidate in candidates)
+    assert not result.fk_failures
 
 
 def test_resolve_fails_fk_that_targets_a_non_key_column():
@@ -370,17 +367,16 @@ def test_resolve_fails_fk_that_targets_a_non_key_column():
     )
 
     # When
-    candidates = resolve(tables)
+    result = resolve(tables)
 
     # Then orders cannot execute: its referenced columns are not the parent's PK
-    by_name = _candidates_by_name(candidates)
-    assert not by_name["cat.sch.orders"].can_execute
+    assert _failures_for(result, "cat.sch.orders")
     assert (
-        by_name["cat.sch.orders"].fk_failures[0].reason
+        _failures_for(result, "cat.sch.orders")[0].reason
         == ForeignKeyFailureReason.REFERENCED_COLUMNS_NOT_A_KEY
     )
     # customers has no FK of its own, so it is unaffected and can execute
-    assert by_name["cat.sch.customers"].can_execute
+    assert _failures_for(result, "cat.sch.customers") == ()
 
 
 def test_resolve_fails_fk_whose_referenced_columns_are_not_the_pk():
@@ -410,12 +406,11 @@ def test_resolve_fails_fk_whose_referenced_columns_are_not_the_pk():
     ).to_desired_table()
 
     # When
-    candidates = resolve((orders, customers))
+    result = resolve((orders, customers))
 
     # Then orders is rejected: email is not customers' primary key
-    by_name = _candidates_by_name(candidates)
     assert (
-        by_name["cat.sch.orders"].fk_failures[0].reason
+        _failures_for(result, "cat.sch.orders")[0].reason
         == ForeignKeyFailureReason.REFERENCED_COLUMNS_NOT_A_KEY
     )
 
@@ -444,7 +439,7 @@ def test_resolve_valid_chain_with_primary_keys_executes():
     )
 
     # When
-    candidates = resolve(tables)
+    result = resolve(tables)
 
     # Then the whole chain validates and executes
-    assert all(candidate.can_execute for candidate in candidates)
+    assert not result.fk_failures

--- a/tests/application/test_errors.py
+++ b/tests/application/test_errors.py
@@ -16,7 +16,8 @@ from delta_engine.application.results import (
     TableRunReport,
     ValidationFailure,
 )
-from delta_engine.domain.model import QualifiedName
+from delta_engine.domain.model import Column, Integer, QualifiedName
+from delta_engine.domain.model.table import DesiredTable
 
 _AT = datetime(2026, 1, 1, tzinfo=UTC)
 _QN = QualifiedName("cat", "sch", "tbl")
@@ -30,6 +31,7 @@ def _table_report(
 ) -> TableRunReport:
     return TableRunReport(
         qualified_name=_QN,
+        desired=DesiredTable(qualified_name=_QN, columns=(Column("id", Integer()),)),
         read=read,
         failures=failures,
         execution=execution,

--- a/tests/application/test_results.py
+++ b/tests/application/test_results.py
@@ -3,6 +3,7 @@ from datetime import datetime
 from hypothesis import given, strategies as st
 
 from delta_engine.application.results import (
+    ActionPlan,
     ExecutionFailed,
     ExecutionFailure,
     ExecutionResult,
@@ -20,7 +21,7 @@ from delta_engine.application.results import (
     ValidationFailure,
     ValidationResult,
 )
-from delta_engine.domain.model import Column, Integer, ObservedTable, QualifiedName
+from delta_engine.domain.model import Column, DesiredTable, Integer, ObservedTable, QualifiedName
 
 # ---------- test builders
 
@@ -31,6 +32,14 @@ def _an_observed_table(partitioned_by=()):
         qualified_name=QualifiedName("cat", "schema", "observed"),
         columns=(Column("id", Integer()),),
         partitioned_by=partitioned_by,
+    )
+
+
+def _a_desired_table(name="observed"):
+    """Build a minimal real DesiredTable for pipeline-record construction."""
+    return DesiredTable(
+        qualified_name=QualifiedName("cat", "schema", name),
+        columns=(Column("id", Integer()),),
     )
 
 
@@ -194,6 +203,7 @@ def test_table_status_success_when_all_actions_succeed():
     # When aggregating
     report = TableRunReport(
         qualified_name=QualifiedName("cat", "schema", "tbl"),
+        desired=_a_desired_table("tbl"),
         read=read,
         execution=execution,
     )
@@ -208,11 +218,13 @@ def test_sync_report_any_failures_true_if_any_table_has_failures():
     # Given two tables: one success, one with execution failure
     t_ok = TableRunReport(
         qualified_name=QualifiedName("cat", "s", "a"),
+        desired=_a_desired_table("a"),
         read=TablePresent(table=_an_observed_table()),
         execution=ExecutionSummary((_ok_exec(0),)),
     )
     t_bad = TableRunReport(
         qualified_name=QualifiedName("cat", "s", "b"),
+        desired=_a_desired_table("b"),
         read=TablePresent(table=_an_observed_table()),
         execution=ExecutionSummary((_failed_exec(0),)),
         failures=(
@@ -275,11 +287,13 @@ def test_sync_report_failures_by_table_maps_only_failed_tables():
     failed_name = QualifiedName("cat", "s", "y")
     t_ok = TableRunReport(
         qualified_name=ok_name,
+        desired=_a_desired_table("x"),
         read=TablePresent(table=_an_observed_table()),
         execution=ExecutionSummary((_ok_exec(0),)),
     )
     t_bad = TableRunReport(
         qualified_name=failed_name,
+        desired=_a_desired_table("y"),
         read=TableAbsent(),
         failures=(ValidationFailure("R", "v"),),
         execution=ExecutionSummary(),
@@ -320,6 +334,7 @@ def test_table_run_report_status_is_foreign_key_failed_when_fk_failure_present()
     # Given a table that read cleanly but has an FK failure in failures
     report = TableRunReport(
         qualified_name=QualifiedName("cat", "sch", "orders"),
+        desired=_a_desired_table("orders"),
         read=TablePresent(table=_an_observed_table()),
         failures=(
             ForeignKeyFailure(
@@ -341,6 +356,7 @@ def test_table_run_report_status_is_validation_failed_when_only_validation_failu
     # Given a table that read cleanly but has a validation failure and no FK failure
     report = TableRunReport(
         qualified_name=QualifiedName("cat", "sch", "tbl"),
+        desired=_a_desired_table("tbl"),
         read=TablePresent(table=_an_observed_table()),
         failures=(
             ValidationFailure(rule_name="NonNullableColumnAdd", message="cannot add NOT NULL"),
@@ -356,6 +372,7 @@ def test_table_run_report_status_is_validation_failed_when_both_fk_and_validatio
     # Given a table with both a validation failure and an FK failure
     report = TableRunReport(
         qualified_name=QualifiedName("cat", "sch", "orders"),
+        desired=_a_desired_table("orders"),
         read=TablePresent(table=_an_observed_table()),
         failures=(
             ValidationFailure(rule_name="NonNullableColumnAdd", message="cannot add NOT NULL"),
@@ -377,6 +394,7 @@ def test_table_run_report_with_no_failures_is_success():
     # Given a clean table with no failures
     report = TableRunReport(
         qualified_name=QualifiedName("cat", "sch", "ok"),
+        desired=_a_desired_table("ok"),
         read=TablePresent(table=_an_observed_table()),
         execution=ExecutionSummary((_ok_exec(0),)),
     )
@@ -462,6 +480,7 @@ def test_status_reflects_the_earliest_failing_phase():
     read = TablePresent(table=_an_observed_table())
     exec_only = TableRunReport(
         qualified_name=QualifiedName("cat", "s", "e"),
+        desired=_a_desired_table("e"),
         read=read,
         execution=ExecutionSummary((_failed_exec(0),)),
         failures=(
@@ -476,6 +495,7 @@ def test_status_reflects_the_earliest_failing_phase():
     # Given a read failure present in the stream, it dominates any later phase
     read_and_exec = TableRunReport(
         qualified_name=QualifiedName("cat", "s", "r"),
+        desired=_a_desired_table("r"),
         read=ReadFailed(ReadFailure("IOError", "boom")),
         failures=(
             ReadFailure("IOError", "boom"),
@@ -486,3 +506,19 @@ def test_status_reflects_the_earliest_failing_phase():
     )
     # Then READ_FAILED wins (earliest phase)
     assert read_and_exec.status is TableRunStatus.READ_FAILED
+
+
+def test_table_run_report_carries_its_desired_definition():
+    # Given a freshly-born run: read set, other phase fields at defaults
+    desired = _a_desired_table("customers")
+    report = TableRunReport(
+        qualified_name=QualifiedName("cat", "schema", "customers"),
+        desired=desired,
+        read=TablePresent(table=_an_observed_table()),
+    )
+
+    # Then it carries the desired definition and is a clean success so far
+    assert report.desired is desired
+    assert report.status is TableRunStatus.SUCCESS
+    assert report.failures == ()
+    assert report.plan == ActionPlan()


### PR DESCRIPTION
## What & why

`Engine.sync` had the right phases but they didn't *chain*: four parallel `dict[QualifiedName, X]` were threaded through the method, a `pre_execution` accumulator was mutated across four loops, and two orderings (registry vs. dependency) had to be reconciled with a `blocked`-set derivation and a `plans_to_execute` filter. This makes `sync` read as a natural pipeline instead — addressing `docs/todo.md` lines 44 (should resolve live on the engine) and 45 (stop rebuilding per-table dicts).

## The result

```python
runs = self._read(tuple(registry))
runs = self._plan(runs)
runs = self._validate(runs)
runs = self._resolve(runs)
runs = self._execute(runs, dry_run=dry_run)
return SyncReport(..., table_reports=runs)
```

## Key changes

- **`TableRunReport` is the pipeline record.** It gains a `desired: DesiredTable` field, is born in `_read`, and accretes its plan/failures/execution via `dataclasses.replace`. Each phase is a pure `tuple[TableRunReport, ...] -> tuple[TableRunReport, ...]`.
- **`resolve()` returns `ResolveResult(ordered_names, fk_failures)`** instead of `SyncCandidate` objects. `SyncCandidate`/`can_execute` are deleted — the record's `failures` already answers "can this execute?". The pure graph algorithms (Tarjan SCC, propagation, PK-target check) are untouched.
- **The four parallel dicts, the `blocked`-set threading, and the `plans_to_execute` filter are gone.** `_resolve` derives `blocked` from the runs' own failures; execution gates per-record on `run.failures`. One ordering after resolve.

## No behaviour change

Identical `SyncReport` / `SyncFailedError` output for every input: same dependency-first order, same statuses, same `failures` contents, same message, same dry-run semantics, same all-or-nothing FK blocking. The existing engine tests are the contract and pass unchanged; the resolution tests were migrated to assert on `ResolveResult`.

## Testing

`uv run pytest` → 382 passed. `ruff check` + `ruff format --check` + `mypy src` clean.

> The 16 `JAVA_GATEWAY_EXITED` errors in local runs are pre-existing/environmental (no JVM in the dev sandbox), unchanged by this branch and expected to pass in CI.

Builds on #96 (unified failure model).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
