### PR TITLE
docs: todo to review the _TableRun / TableRunReport split

### DIFF
--- a/docs/todo.md
+++ b/docs/todo.md
@@ -60,3 +60,4 @@
 - [ ] look for redundancies; things like frozenset for local variables
 - [ ] review if we need from __future__ import annotations
 - [ ] review types hints; things like Mapping, AbstractSet, etc
+- [ ] Review whether `_TableRun` and `TableRunReport` should stay as two types. `_TableRun` (mutable, private to engine.py) and `TableRunReport` (frozen, public) currently share an identical 6-field list plus a `to_report()` bridge, so adding a field means touching three places. The split buys clean phase code (mutate in place, no `dataclasses.replace`) AND an immutable published report. Collapsing to one type means dropping one of those: single frozen type reintroduces `replace()`; single mutable type makes the public `SyncReport` mutable (and the only mutable type in `results.py`). Decide whether the duplication is worth those guarantees.


### PR DESCRIPTION
## What

Adds one open-questions item to `docs/todo.md`: revisit whether the sync pipeline needs both `_TableRun` (mutable, private to `engine.py`) and `TableRunReport` (frozen, public), given they currently share an identical 6-field list plus a `to_report()` bridge.

The note records the trade-off so the decision can be made later without re-deriving it: the two-type split buys clean phase code (mutate in place, no `dataclasses.replace`) **and** an immutable published report, at the cost of the field-list duplication. Collapsing to one type drops one of those guarantees.

Docs-only; no code change.
