### PR TITLE
refactor: replace _TableRun dataclass with plain accumulator class

### DIFF
--- a/docs/todo.md
+++ b/docs/todo.md
@@ -45,5 +45,4 @@
 - [ ] review if we need from __future__ import annotations
 - [ ] review types hints; things like Mapping, AbstractSet, etc
 - [ ] review Matched and Matched.common, particularly in _diff_columns
-- [ ] Review whether `_TableRun` and `TableRunReport` should stay as two types. `_TableRun` (mutable, private to engine.py) and `TableRunReport` (frozen, public) currently share an identical 6-field list plus a `to_report()` bridge, so adding a field means touching three places. The split buys clean phase code (mutate in place, no `dataclasses.replace`) AND an immutable published report. Collapsing to one type means dropping one of those: single frozen type reintroduces `replace()`; single mutable type makes the public `SyncReport` mutable (and the only mutable type in `results.py`). Decide whether the duplication is worth those guarantees.
 - [ ] Add tags, comment, etc as properties to DeltaTable

--- a/src/delta_engine/application/engine.py
+++ b/src/delta_engine/application/engine.py
@@ -27,7 +27,6 @@ complete.
 
 from __future__ import annotations
 
-from dataclasses import dataclass, field
 from datetime import UTC, datetime
 import logging
 
@@ -56,10 +55,9 @@ from delta_engine.domain.plan.differ import compute_plan
 logger = logging.getLogger(__name__)
 
 
-@dataclass(slots=True)
 class _TableRun:
     """
-    Mutable per-table record threaded through the sync phases.
+    Mutable scratch pad threaded through the sync phases.
 
     Born in the read phase, it accretes its plan, failures, and execution as the
     phase chain proceeds, then is frozen into a public :class:`TableRunReport`
@@ -67,12 +65,18 @@ class _TableRun:
     immutable while the phases mutate in place.
     """
 
-    qualified_name: QualifiedName
-    desired: DesiredTable
-    read: CatalogState
-    plan: ActionPlan = field(default_factory=ActionPlan)
-    failures: list[Failure] = field(default_factory=list)
-    execution: ExecutionSummary | None = None
+    def __init__(
+        self,
+        qualified_name: QualifiedName,
+        desired: DesiredTable,
+        read: CatalogState,
+    ) -> None:
+        self.qualified_name = qualified_name
+        self.desired = desired
+        self.read = read
+        self.plan = ActionPlan()
+        self.failures: list[Failure] = []
+        self.execution: ExecutionSummary | None = None
 
     def to_report(self) -> TableRunReport:
         """Freeze this run into its public, immutable report."""


### PR DESCRIPTION
## Summary

- `_TableRun` is a write-only construction scratch pad, not a value object — the `@dataclass` decorator was advertising equality, `repr`, and slots that the engine never uses and that are misleading on a mutable type
- Replaced with a plain class and explicit `__init__`, which honestly signals the construction-only contract
- No behaviour change; all call sites are unaffected

## Test plan

- [ ] `uv run pytest tests/` — 382 passed (16 pre-existing Spark/Databricks env errors unaffected)