### PR TITLE
refactor: eliminate special cases (audit clusters B and C)

### DIFF
--- a/src/delta_engine/adapters/databricks/reader.py
+++ b/src/delta_engine/adapters/databricks/reader.py
@@ -9,11 +9,12 @@ from types import MappingProxyType
 from pyspark.errors.exceptions.base import AnalysisException
 from pyspark.sql import SparkSession
 from pyspark.sql.catalog import Column as SparkColumn
+from pyspark.sql.types import DataType as SparkType
 
 from delta_engine.adapters.databricks.sql import (
     backtick,
     backtick_qualified_name,
-    domain_type_from_ddl,
+    domain_type_from_spark,
     error_preview,
     exception_type_name,
     quote_literal,
@@ -53,8 +54,12 @@ def _to_column_mapping(
     mismatch out of the domain. The partition name in ``_ColumnMapping`` is
     therefore derived from the already-normalised domain column name, not from
     the raw Spark object.
+
+    Unity Catalog reports a column's type as a DDL string (e.g. ``"array<int>"``);
+    parsing that into a ``SparkType`` is this adapter's job, so the domain-type
+    mapper receives a parsed instance.
     """
-    domain_data_type = domain_type_from_ddl(spark_column.dataType)
+    domain_data_type = domain_type_from_spark(SparkType.fromDDL(spark_column.dataType))
     if domain_data_type is None:
         logger.warning(
             "Skipping column %r in %s: unrecognised Spark type %r"

--- a/src/delta_engine/adapters/databricks/reader.py
+++ b/src/delta_engine/adapters/databricks/reader.py
@@ -13,7 +13,7 @@ from pyspark.sql.catalog import Column as SparkColumn
 from delta_engine.adapters.databricks.sql import (
     backtick,
     backtick_qualified_name,
-    domain_type_from_spark,
+    domain_type_from_ddl,
     error_preview,
     exception_type_name,
     quote_literal,
@@ -54,7 +54,7 @@ def _to_column_mapping(
     therefore derived from the already-normalised domain column name, not from
     the raw Spark object.
     """
-    domain_data_type = domain_type_from_spark(spark_column.dataType)
+    domain_data_type = domain_type_from_ddl(spark_column.dataType)
     if domain_data_type is None:
         logger.warning(
             "Skipping column %r in %s: unrecognised Spark type %r"

--- a/src/delta_engine/adapters/databricks/sql/__init__.py
+++ b/src/delta_engine/adapters/databricks/sql/__init__.py
@@ -19,7 +19,7 @@ from delta_engine.adapters.databricks.sql.preview import (
     sql_preview,
 )
 from delta_engine.adapters.databricks.sql.types import (
-    domain_type_from_spark,
+    domain_type_from_ddl,
     sql_type_for_data_type,
 )
 
@@ -27,7 +27,7 @@ __all__ = [
     "backtick",
     "backtick_qualified_name",
     "compile_plan",
-    "domain_type_from_spark",
+    "domain_type_from_ddl",
     "error_preview",
     "exception_type_name",
     "quote_literal",

--- a/src/delta_engine/adapters/databricks/sql/__init__.py
+++ b/src/delta_engine/adapters/databricks/sql/__init__.py
@@ -19,7 +19,7 @@ from delta_engine.adapters.databricks.sql.preview import (
     sql_preview,
 )
 from delta_engine.adapters.databricks.sql.types import (
-    domain_type_from_ddl,
+    domain_type_from_spark,
     sql_type_for_data_type,
 )
 
@@ -27,7 +27,7 @@ __all__ = [
     "backtick",
     "backtick_qualified_name",
     "compile_plan",
-    "domain_type_from_ddl",
+    "domain_type_from_spark",
     "error_preview",
     "exception_type_name",
     "quote_literal",

--- a/src/delta_engine/adapters/databricks/sql/compile.py
+++ b/src/delta_engine/adapters/databricks/sql/compile.py
@@ -251,7 +251,7 @@ def _set_table_comment(comment: str) -> str:
     return f"COMMENT {quote_literal(comment)}"
 
 
-def _set_properties(props: Mapping[str, str] | None) -> str:
+def _set_properties(props: Mapping[str, str]) -> str:
     if not props:
         return ""
     pairs = ", ".join(f"{quote_literal(k)}={quote_literal(v)}" for k, v in sorted(props.items()))

--- a/src/delta_engine/adapters/databricks/sql/preview.py
+++ b/src/delta_engine/adapters/databricks/sql/preview.py
@@ -3,16 +3,14 @@
 from __future__ import annotations
 
 
-def sql_preview(sql: str, *, max_chars: int = 240, single_line: bool = True) -> str:
+def sql_preview(sql: str, *, max_chars: int = 240) -> str:
     """
     Return a compact, bounded preview of a SQL statement for logs/errors.
 
-    - Normalizes whitespace to a single line when single_line=True.
+    - Normalizes all runs of whitespace to single spaces on one line.
     - Truncates with an ellipsis when longer than max_chars.
     """
-    s = sql.strip()
-    if single_line:
-        s = " ".join(s.split())
+    s = " ".join(sql.split())
     return s if len(s) <= max_chars else (s[:max_chars] + "…")
 
 

--- a/src/delta_engine/adapters/databricks/sql/types.py
+++ b/src/delta_engine/adapters/databricks/sql/types.py
@@ -75,20 +75,7 @@ def sql_type_for_data_type(data_type: DataType) -> str:
             raise TypeError(f"Unsupported DataType variant: {cls}")
 
 
-def domain_type_from_ddl(ddl: str) -> DataType | None:
-    """
-    Map a Spark SQL DDL type string (e.g. ``"array<int>"``) to a domain type.
-
-    This is the reader's entry point: Unity Catalog reports a column's type as a
-    DDL string, which this parses (via ``SparkType.fromDDL``) before mapping.
-    Parsing requires an active :class:`SparkSession`. See
-    :func:`domain_type_from_spark_type` for the mapping semantics and the
-    ``None`` contract.
-    """
-    return domain_type_from_spark_type(SparkType.fromDDL(ddl))
-
-
-def domain_type_from_spark_type(spark_type: SparkType) -> DataType | None:
+def domain_type_from_spark(spark_type: SparkType) -> DataType | None:
     """
     Map a ``pyspark`` type instance to a domain type.
 
@@ -99,9 +86,10 @@ def domain_type_from_spark_type(spark_type: SparkType) -> DataType | None:
     ``None`` return, not an exception. Callers decide what to do with ``None``
     (the reader skips the column and logs a warning).
 
-    Unlike :func:`domain_type_from_ddl`, this operates on an already-parsed type
-    instance and needs no ``SparkSession``, so the mapping table is exercisable
-    in isolation.
+    Takes an already-parsed type instance, not a DDL string: parsing catalog DDL
+    text is the reader's concern (``SparkType.fromDDL``), kept out of this
+    module. Operating on instances also means the whole mapping table needs no
+    ``SparkSession`` to exercise.
     """
     match spark_type:
         case IntegerType():
@@ -123,11 +111,11 @@ def domain_type_from_spark_type(spark_type: SparkType) -> DataType | None:
         case DecimalType():
             return Decimal(spark_type.precision, spark_type.scale)
         case ArrayType():
-            element = domain_type_from_spark_type(spark_type.elementType)
+            element = domain_type_from_spark(spark_type.elementType)
             return Array(element) if element is not None else None
         case MapType():
-            key = domain_type_from_spark_type(spark_type.keyType)
-            value = domain_type_from_spark_type(spark_type.valueType)
+            key = domain_type_from_spark(spark_type.keyType)
+            value = domain_type_from_spark(spark_type.valueType)
             if key is None or value is None:
                 return None
             return Map(key, value)

--- a/src/delta_engine/adapters/databricks/sql/types.py
+++ b/src/delta_engine/adapters/databricks/sql/types.py
@@ -75,9 +75,22 @@ def sql_type_for_data_type(data_type: DataType) -> str:
             raise TypeError(f"Unsupported DataType variant: {cls}")
 
 
-def domain_type_from_spark(spark_type: str | SparkType) -> DataType | None:
+def domain_type_from_ddl(ddl: str) -> DataType | None:
     """
-    Map a Spark SQL type (instance or DDL string) to a domain type.
+    Map a Spark SQL DDL type string (e.g. ``"array<int>"``) to a domain type.
+
+    This is the reader's entry point: Unity Catalog reports a column's type as a
+    DDL string, which this parses (via ``SparkType.fromDDL``) before mapping.
+    Parsing requires an active :class:`SparkSession`. See
+    :func:`domain_type_from_spark_type` for the mapping semantics and the
+    ``None`` contract.
+    """
+    return domain_type_from_spark_type(SparkType.fromDDL(ddl))
+
+
+def domain_type_from_spark_type(spark_type: SparkType) -> DataType | None:
+    """
+    Map a ``pyspark`` type instance to a domain type.
 
     Returns ``None`` when the type has no domain mapping (e.g. ``BINARY``,
     ``STRUCT``, ``VARIANT``, ``TIMESTAMP_NTZ``). An unmappable element inside an
@@ -85,10 +98,11 @@ def domain_type_from_spark(spark_type: str | SparkType) -> DataType | None:
     routine, expected condition -- new Spark types appear over time -- so it is a
     ``None`` return, not an exception. Callers decide what to do with ``None``
     (the reader skips the column and logs a warning).
-    """
-    if isinstance(spark_type, str):
-        spark_type = SparkType.fromDDL(spark_type)
 
+    Unlike :func:`domain_type_from_ddl`, this operates on an already-parsed type
+    instance and needs no ``SparkSession``, so the mapping table is exercisable
+    in isolation.
+    """
     match spark_type:
         case IntegerType():
             return Integer()
@@ -109,11 +123,11 @@ def domain_type_from_spark(spark_type: str | SparkType) -> DataType | None:
         case DecimalType():
             return Decimal(spark_type.precision, spark_type.scale)
         case ArrayType():
-            element = domain_type_from_spark(spark_type.elementType)
+            element = domain_type_from_spark_type(spark_type.elementType)
             return Array(element) if element is not None else None
         case MapType():
-            key = domain_type_from_spark(spark_type.keyType)
-            value = domain_type_from_spark(spark_type.valueType)
+            key = domain_type_from_spark_type(spark_type.keyType)
+            value = domain_type_from_spark_type(spark_type.valueType)
             if key is None or value is None:
                 return None
             return Map(key, value)

--- a/src/delta_engine/api/table.py
+++ b/src/delta_engine/api/table.py
@@ -113,7 +113,7 @@ class DeltaTable:
         comment: str = "",
         properties: dict[str, str] | None = None,
         tags: dict[str, str] | None = None,
-        partitioned_by: Iterable[str] | None = None,
+        partitioned_by: Iterable[str] = (),
         foreign_keys: Iterable[ForeignKey] | None = None,
     ) -> None:
         user_properties = dict(properties or {})
@@ -152,7 +152,7 @@ class DeltaTable:
             comment=comment,
             properties=effective_properties,
             tags=dict(tags or {}),
-            partitioned_by=tuple(partitioned_by) if partitioned_by is not None else (),
+            partitioned_by=tuple(partitioned_by),
             primary_key=primary_key,
             foreign_keys=lowered_foreign_keys,
         )

--- a/tests/adapters/databricks/sql/test_preview.py
+++ b/tests/adapters/databricks/sql/test_preview.py
@@ -13,21 +13,13 @@ from delta_engine.adapters.databricks.sql.preview import (
 
 def test_sql_preview_single_line_normalization_and_no_truncation() -> None:
     sql = " \nSELECT   *\nFROM  foo\tWHERE  a = 1  \n"
-    out = sql_preview(sql, max_chars=10_000, single_line=True)
+    out = sql_preview(sql, max_chars=10_000)
     assert out == "SELECT * FROM foo WHERE a = 1"
-
-
-def test_sql_preview_preserves_internal_whitespace_when_single_line_false() -> None:
-    sql = "SELECT   *\nFROM  foo\nWHERE a = 1"
-    out = sql_preview(sql, max_chars=10_000, single_line=False)
-    # Leading/trailing stripped, but internal newlines/spaces kept
-    assert out.startswith("SELECT   *\nFROM  foo")
-    assert "\nWHERE a = 1" in out
 
 
 def test_sql_preview_truncates_and_appends_unicode_ellipsis() -> None:
     sql = "SELECT " + "x" * 300 + " FROM t"
-    out = sql_preview(sql, max_chars=50, single_line=True)
+    out = sql_preview(sql, max_chars=50)
     assert out.endswith("…")
     assert len(out) > 50  # because the ellipsis is appended after slicing
     # sanity: prefix preserved
@@ -48,7 +40,7 @@ def test_sql_preview_truncates_only_beyond_max_chars(length: int, truncated: boo
     sql = "x" * length
 
     # When previewing it with max_chars=10
-    out = sql_preview(sql, max_chars=10, single_line=True)
+    out = sql_preview(sql, max_chars=10)
 
     # Then it is left intact at or below the limit, and truncated only beyond it
     if truncated:
@@ -93,7 +85,6 @@ def test_exception_type_name_returns_python_class_for_plain_exception() -> None:
 @given(st.text(), st.integers(min_value=1, max_value=500))
 def test_sql_preview_single_line_output_never_contains_newline(sql: str, max_chars: int) -> None:
     # Given: any SQL string and any max_chars
-    # When: previewing with single_line=True
-    result = sql_preview(sql, max_chars=max_chars, single_line=True)
+    result = sql_preview(sql, max_chars=max_chars)
     # Then: the output never contains a newline regardless of input content
     assert "\n" not in result

--- a/tests/adapters/databricks/sql/test_types.py
+++ b/tests/adapters/databricks/sql/test_types.py
@@ -2,7 +2,8 @@ import pyspark.sql.types as T
 import pytest
 
 from delta_engine.adapters.databricks.sql.types import (
-    domain_type_from_spark,
+    domain_type_from_ddl,
+    domain_type_from_spark_type,
     sql_type_for_data_type,
 )
 from delta_engine.domain.model.data_type import (
@@ -42,41 +43,42 @@ def test_sql_type_for_decimal_array_map_recursive() -> None:
     assert sql_type_for_data_type(nested) == "ARRAY<MAP<STRING,DECIMAL(9,0)>>"
 
 
-def test_domain_type_from_spark_returns_none_for_unmappable_type() -> None:
+def test_domain_type_from_spark_type_returns_none_for_unmappable_type() -> None:
     # Given a Spark type the engine does not map
     # Then the conversion returns None rather than raising
-    assert domain_type_from_spark(T.BinaryType()) is None
+    assert domain_type_from_spark_type(T.BinaryType()) is None
 
 
-def test_domain_type_from_spark_returns_domain_type_for_known_type() -> None:
+def test_domain_type_from_spark_type_returns_domain_type_for_known_type() -> None:
     # Given a Spark type the engine maps
     # Then the domain type is returned
-    assert domain_type_from_spark(T.IntegerType()) == Integer()
+    assert domain_type_from_spark_type(T.IntegerType()) == Integer()
 
 
-def test_domain_type_from_spark_returns_none_when_collection_element_is_unmappable() -> None:
+def test_domain_type_from_spark_type_returns_none_when_collection_element_is_unmappable() -> None:
     # Given a collection whose element type has no domain mapping
     # Then the whole type is unmappable
-    assert domain_type_from_spark(T.ArrayType(T.BinaryType())) is None
-    assert domain_type_from_spark(T.MapType(T.StringType(), T.BinaryType())) is None
+    assert domain_type_from_spark_type(T.ArrayType(T.BinaryType())) is None
+    assert domain_type_from_spark_type(T.MapType(T.StringType(), T.BinaryType())) is None
 
 
-def test_domain_type_from_spark_primitives_via_strings(spark) -> None:
-    # Using DDL strings exercises the fromDDL path
-    assert domain_type_from_spark("int") == Integer()
-    assert domain_type_from_spark("bigint") == Long()
-    assert domain_type_from_spark("float") == Float()
-    assert domain_type_from_spark("double") == Double()
-    assert domain_type_from_spark("boolean") == Boolean()
-    assert domain_type_from_spark("string") == String()
-    assert domain_type_from_spark("date") == Date()
-    assert domain_type_from_spark("timestamp") == Timestamp()
+def test_domain_type_from_ddl_primitives(spark) -> None:
+    # Given DDL type strings as the catalog reports them, the fromDDL parse path
+    # maps each to its domain primitive
+    assert domain_type_from_ddl("int") == Integer()
+    assert domain_type_from_ddl("bigint") == Long()
+    assert domain_type_from_ddl("float") == Float()
+    assert domain_type_from_ddl("double") == Double()
+    assert domain_type_from_ddl("boolean") == Boolean()
+    assert domain_type_from_ddl("string") == String()
+    assert domain_type_from_ddl("date") == Date()
+    assert domain_type_from_ddl("timestamp") == Timestamp()
 
 
-def test_domain_type_from_spark_decimal_array_map_recursive(spark) -> None:
-    assert domain_type_from_spark("decimal(12,3)") == Decimal(12, 3)
-    assert domain_type_from_spark("array<string>") == Array(String())
-    assert domain_type_from_spark("map<string,int>") == Map(String(), Integer())
-    assert domain_type_from_spark("array<map<string,decimal(9,0)>>") == Array(
+def test_domain_type_from_ddl_decimal_array_map_recursive(spark) -> None:
+    assert domain_type_from_ddl("decimal(12,3)") == Decimal(12, 3)
+    assert domain_type_from_ddl("array<string>") == Array(String())
+    assert domain_type_from_ddl("map<string,int>") == Map(String(), Integer())
+    assert domain_type_from_ddl("array<map<string,decimal(9,0)>>") == Array(
         Map(String(), Decimal(9, 0))
     )

--- a/tests/adapters/databricks/sql/test_types.py
+++ b/tests/adapters/databricks/sql/test_types.py
@@ -2,8 +2,7 @@ import pyspark.sql.types as T
 import pytest
 
 from delta_engine.adapters.databricks.sql.types import (
-    domain_type_from_ddl,
-    domain_type_from_spark_type,
+    domain_type_from_spark,
     sql_type_for_data_type,
 )
 from delta_engine.domain.model.data_type import (
@@ -43,42 +42,39 @@ def test_sql_type_for_decimal_array_map_recursive() -> None:
     assert sql_type_for_data_type(nested) == "ARRAY<MAP<STRING,DECIMAL(9,0)>>"
 
 
-def test_domain_type_from_spark_type_returns_none_for_unmappable_type() -> None:
+def test_domain_type_from_spark_returns_none_for_unmappable_type() -> None:
     # Given a Spark type the engine does not map
     # Then the conversion returns None rather than raising
-    assert domain_type_from_spark_type(T.BinaryType()) is None
+    assert domain_type_from_spark(T.BinaryType()) is None
 
 
-def test_domain_type_from_spark_type_returns_domain_type_for_known_type() -> None:
-    # Given a Spark type the engine maps
-    # Then the domain type is returned
-    assert domain_type_from_spark_type(T.IntegerType()) == Integer()
+def test_domain_type_from_spark_maps_primitives() -> None:
+    # Given each Spark primitive the engine supports
+    # Then it maps to the matching domain type
+    assert domain_type_from_spark(T.IntegerType()) == Integer()
+    assert domain_type_from_spark(T.LongType()) == Long()
+    assert domain_type_from_spark(T.FloatType()) == Float()
+    assert domain_type_from_spark(T.DoubleType()) == Double()
+    assert domain_type_from_spark(T.BooleanType()) == Boolean()
+    assert domain_type_from_spark(T.StringType()) == String()
+    assert domain_type_from_spark(T.DateType()) == Date()
+    assert domain_type_from_spark(T.TimestampType()) == Timestamp()
 
 
-def test_domain_type_from_spark_type_returns_none_when_collection_element_is_unmappable() -> None:
+def test_domain_type_from_spark_maps_decimal_and_nested_collections() -> None:
+    # Given decimal, array, and map types (including nesting)
+    # Then the mapping recurses into element and key/value types
+    assert domain_type_from_spark(T.DecimalType(12, 3)) == Decimal(12, 3)
+    assert domain_type_from_spark(T.ArrayType(T.StringType())) == Array(String())
+    assert domain_type_from_spark(T.MapType(T.StringType(), T.IntegerType())) == Map(
+        String(), Integer()
+    )
+    nested = T.ArrayType(T.MapType(T.StringType(), T.DecimalType(9, 0)))
+    assert domain_type_from_spark(nested) == Array(Map(String(), Decimal(9, 0)))
+
+
+def test_domain_type_from_spark_returns_none_when_collection_element_is_unmappable() -> None:
     # Given a collection whose element type has no domain mapping
     # Then the whole type is unmappable
-    assert domain_type_from_spark_type(T.ArrayType(T.BinaryType())) is None
-    assert domain_type_from_spark_type(T.MapType(T.StringType(), T.BinaryType())) is None
-
-
-def test_domain_type_from_ddl_primitives(spark) -> None:
-    # Given DDL type strings as the catalog reports them, the fromDDL parse path
-    # maps each to its domain primitive
-    assert domain_type_from_ddl("int") == Integer()
-    assert domain_type_from_ddl("bigint") == Long()
-    assert domain_type_from_ddl("float") == Float()
-    assert domain_type_from_ddl("double") == Double()
-    assert domain_type_from_ddl("boolean") == Boolean()
-    assert domain_type_from_ddl("string") == String()
-    assert domain_type_from_ddl("date") == Date()
-    assert domain_type_from_ddl("timestamp") == Timestamp()
-
-
-def test_domain_type_from_ddl_decimal_array_map_recursive(spark) -> None:
-    assert domain_type_from_ddl("decimal(12,3)") == Decimal(12, 3)
-    assert domain_type_from_ddl("array<string>") == Array(String())
-    assert domain_type_from_ddl("map<string,int>") == Map(String(), Integer())
-    assert domain_type_from_ddl("array<map<string,decimal(9,0)>>") == Array(
-        Map(String(), Decimal(9, 0))
-    )
+    assert domain_type_from_spark(T.ArrayType(T.BinaryType())) is None
+    assert domain_type_from_spark(T.MapType(T.StringType(), T.BinaryType())) is None

--- a/tests/adapters/databricks/test_reader.py
+++ b/tests/adapters/databricks/test_reader.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 from types import SimpleNamespace
 
 from pyspark.errors.exceptions.base import AnalysisException
-import pyspark.sql.types as T
 import pytest
 
 from delta_engine.adapters.databricks.reader import DatabricksReader
@@ -176,6 +175,20 @@ def make_catalog_col(
 # ---------- shared fixtures ----------
 
 
+@pytest.fixture(autouse=True)
+def _active_spark_session(spark):
+    """
+    Keep a live SparkSession up for every test in this module.
+
+    The reader maps each catalog column's DDL type string through
+    ``domain_type_from_ddl``, which delegates to ``SparkType.fromDDL`` — and that
+    parser needs an active session. Production always has one; requesting the
+    session fixture here exercises the column-mapping path against the same DDL
+    strings Unity Catalog reports, rather than pre-parsed type instances the
+    reader never actually receives.
+    """
+
+
 @pytest.fixture
 def qn() -> QualifiedName:
     return QualifiedName("c", "s", "t")
@@ -189,10 +202,8 @@ def test_columns_maps_name_nullability_and_comment(qn):
     catalog = FakeCatalog(
         columns_by_table={
             str(qn): [
-                make_catalog_col(
-                    "id", dataType=T.IntegerType(), nullable=False, description="identifier"
-                ),
-                make_catalog_col("p_date", dataType=T.DateType(), nullable=True, description=""),
+                make_catalog_col("id", dataType="int", nullable=False, description="identifier"),
+                make_catalog_col("p_date", dataType="date", nullable=True, description=""),
             ]
         }
     )
@@ -214,9 +225,9 @@ def test_partition_columns_returns_only_partition_names_in_order(qn):
     catalog = FakeCatalog(
         columns_by_table={
             str(qn): [
-                make_catalog_col("id", dataType=T.IntegerType(), isPartition=False),
-                make_catalog_col("p_store", dataType=T.StringType(), isPartition=True),
-                make_catalog_col("p_date", dataType=T.DateType(), isPartition=True),
+                make_catalog_col("id", dataType="int", isPartition=False),
+                make_catalog_col("p_store", dataType="string", isPartition=True),
+                make_catalog_col("p_date", dataType="date", isPartition=True),
             ]
         }
     )
@@ -239,8 +250,8 @@ def test_partition_columns_ignores_missing_or_false_flags():
     catalog = FakeCatalog(
         columns_by_table={
             str(qn): [
-                NoIsPartition(name="a", dataType=T.IntegerType(), nullable=True, description=""),
-                make_catalog_col("b", dataType=T.StringType(), isPartition=False),
+                NoIsPartition(name="a", dataType="int", nullable=True, description=""),
+                make_catalog_col("b", dataType="string", isPartition=False),
             ]
         }
     )
@@ -260,7 +271,7 @@ def test_partition_columns_ignores_missing_or_false_flags():
 def test_observed_properties_are_empty_and_read_only_when_describe_has_no_rows(qn):
     # Given a present table whose DESCRIBE DETAIL yields no rows
     catalog = FakeCatalog(
-        columns_by_table={str(qn): [make_catalog_col("id", dataType=T.IntegerType())]},
+        columns_by_table={str(qn): [make_catalog_col("id", dataType="int")]},
         table_comments={str(qn): ""},
     )
     reader = DatabricksReader(FakeSparkWithPrimaryKey(catalog=catalog, describe_rows=[]))
@@ -279,7 +290,7 @@ def test_observed_properties_are_empty_and_read_only_when_describe_has_no_rows(q
 def test_observed_properties_pass_through_catalog_map_unfiltered(qn):
     # Given a present table whose DESCRIBE DETAIL returns properties the engine does not manage
     catalog = FakeCatalog(
-        columns_by_table={str(qn): [make_catalog_col("id", dataType=T.IntegerType())]},
+        columns_by_table={str(qn): [make_catalog_col("id", dataType="int")]},
         table_comments={str(qn): ""},
     )
     describe_rows = [
@@ -318,7 +329,7 @@ def test_observed_comment_is_description_or_empty_string(desc_value, expected):
     # Given a present table whose catalog description may be set, None, or empty
     qualified_name = QualifiedName("c", "s", "t")
     catalog = FakeCatalog(
-        columns_by_table={str(qualified_name): [make_catalog_col("id", dataType=T.IntegerType())]},
+        columns_by_table={str(qualified_name): [make_catalog_col("id", dataType="int")]},
         table_comments={str(qualified_name): desc_value},
     )
     reader = DatabricksReader(FakeSparkWithPrimaryKey(catalog=catalog))
@@ -350,10 +361,8 @@ def test_fetch_state_returns_present_with_columns_partitions_comment_and_propert
     catalog = FakeCatalog(
         columns_by_table={
             fq: [
-                make_catalog_col(
-                    "id", dataType=T.IntegerType(), nullable=False, description="identifier"
-                ),
-                make_catalog_col("p_date", dataType=T.DateType(), isPartition=True),
+                make_catalog_col("id", dataType="int", nullable=False, description="identifier"),
+                make_catalog_col("p_date", dataType="date", isPartition=True),
             ]
         },
         table_comments={fq: "orders table"},
@@ -392,7 +401,7 @@ def test_fetch_state_returns_present_with_empty_properties_when_describe_has_no_
     fq = str(qn)
 
     catalog = FakeCatalog(
-        columns_by_table={fq: [make_catalog_col("id", dataType=T.IntegerType(), nullable=False)]},
+        columns_by_table={fq: [make_catalog_col("id", dataType="int", nullable=False)]},
         table_comments={fq: ""},
     )
     reader = DatabricksReader(
@@ -446,7 +455,7 @@ def test_fetch_state_returns_failed_when_all_columns_are_unsupported():
     # Given a table whose only column has a type the engine cannot map (BinaryType)
     qn = QualifiedName("c", "s", "structy")
     catalog = FakeCatalog(
-        columns_by_table={str(qn): [make_catalog_col("payload", dataType=T.BinaryType())]},
+        columns_by_table={str(qn): [make_catalog_col("payload", dataType="binary")]},
         table_comments={str(qn): ""},
     )
     reader = DatabricksReader(
@@ -467,9 +476,9 @@ def test_fetch_state_skips_unsupported_column_leaves_mappable_columns_intact():
     catalog = FakeCatalog(
         columns_by_table={
             str(qn): [
-                make_catalog_col("id", dataType=T.IntegerType()),
-                make_catalog_col("payload", dataType=T.BinaryType()),
-                make_catalog_col("name", dataType=T.StringType()),
+                make_catalog_col("id", dataType="int"),
+                make_catalog_col("payload", dataType="binary"),
+                make_catalog_col("name", dataType="string"),
             ]
         },
         table_comments={str(qn): ""},
@@ -492,8 +501,8 @@ def test_fetch_state_lowercases_mixed_case_column_names_from_catalog():
     catalog = FakeCatalog(
         columns_by_table={
             str(qn): [
-                make_catalog_col("EventId", dataType=T.IntegerType()),
-                make_catalog_col("UserName", dataType=T.StringType(), isPartition=True),
+                make_catalog_col("EventId", dataType="int"),
+                make_catalog_col("UserName", dataType="string", isPartition=True),
             ]
         },
         table_comments={str(qn): ""},
@@ -519,7 +528,7 @@ def test_fetch_state_lowercases_primary_key_column_names_from_catalog():
     qn = QualifiedName("c", "s", "t")
     fq = str(qn)
     catalog = FakeCatalog(
-        columns_by_table={fq: [make_catalog_col("orderid", dataType=T.IntegerType())]},
+        columns_by_table={fq: [make_catalog_col("orderid", dataType="int")]},
         table_comments={fq: ""},
     )
     spark = FakeSparkWithPrimaryKey(
@@ -544,7 +553,7 @@ def test_fetch_state_includes_primary_key_in_observed_table():
     fq = str(qn)
     catalog = FakeCatalog(
         columns_by_table={
-            fq: [make_catalog_col("id", dataType=T.IntegerType(), nullable=False)],
+            fq: [make_catalog_col("id", dataType="int", nullable=False)],
         },
         table_comments={fq: ""},
     )
@@ -568,7 +577,7 @@ def test_fetch_state_primary_key_is_empty_when_none_defined():
     fq = str(qn)
     catalog = FakeCatalog(
         columns_by_table={
-            fq: [make_catalog_col("id", dataType=T.IntegerType())],
+            fq: [make_catalog_col("id", dataType="int")],
         },
         table_comments={fq: ""},
     )
@@ -591,7 +600,7 @@ def test_fetch_primary_key_returns_empty_when_information_schema_unavailable():
     qn = QualifiedName("c", "s", "t")
     fq = str(qn)
     catalog = FakeCatalog(
-        columns_by_table={fq: [make_catalog_col("id", dataType=T.IntegerType())]},
+        columns_by_table={fq: [make_catalog_col("id", dataType="int")]},
         table_comments={fq: ""},
     )
     spark = FakeSparkWithPrimaryKey(
@@ -617,8 +626,8 @@ def _orders_catalog() -> FakeCatalog:
     return FakeCatalog(
         columns_by_table={
             fq: [
-                make_catalog_col("tenant_id", dataType=T.IntegerType()),
-                make_catalog_col("customer_id", dataType=T.IntegerType()),
+                make_catalog_col("tenant_id", dataType="int"),
+                make_catalog_col("customer_id", dataType="int"),
             ]
         },
         table_comments={fq: ""},
@@ -910,7 +919,7 @@ def test_fetch_state_lowercases_foreign_key_constraint_name():
 def test_fetch_state_observes_table_tags(qn):
     # Given a present table whose information_schema.table_tags carries two tags
     catalog = FakeCatalog(
-        columns_by_table={str(qn): [make_catalog_col("id", dataType=T.IntegerType())]},
+        columns_by_table={str(qn): [make_catalog_col("id", dataType="int")]},
         table_comments={str(qn): ""},
     )
     tag_rows = [
@@ -932,7 +941,7 @@ def test_fetch_state_observes_table_tags(qn):
 def test_fetch_state_preserves_tag_key_case(qn):
     # Given a catalog tag with a mixed-case key (UC tag keys are case-sensitive)
     catalog = FakeCatalog(
-        columns_by_table={str(qn): [make_catalog_col("id", dataType=T.IntegerType())]},
+        columns_by_table={str(qn): [make_catalog_col("id", dataType="int")]},
         table_comments={str(qn): ""},
     )
     spark = FakeSparkWithPrimaryKey(
@@ -951,7 +960,7 @@ def test_fetch_state_preserves_tag_key_case(qn):
 def test_fetch_state_tags_are_empty_when_none_defined(qn):
     # Given a present table whose table_tags query returns no rows
     catalog = FakeCatalog(
-        columns_by_table={str(qn): [make_catalog_col("id", dataType=T.IntegerType())]},
+        columns_by_table={str(qn): [make_catalog_col("id", dataType="int")]},
         table_comments={str(qn): ""},
     )
     spark = FakeSparkWithPrimaryKey(catalog=catalog, tag_rows=[])
@@ -967,7 +976,7 @@ def test_fetch_state_tags_are_empty_when_none_defined(qn):
 def test_fetch_state_tags_are_empty_when_information_schema_unavailable(qn):
     # Given the table_tags query raises (non-Unity-Catalog Spark, e.g. local tests)
     catalog = FakeCatalog(
-        columns_by_table={str(qn): [make_catalog_col("id", dataType=T.IntegerType())]},
+        columns_by_table={str(qn): [make_catalog_col("id", dataType="int")]},
         table_comments={str(qn): ""},
     )
     spark = FakeSparkWithPrimaryKey(
@@ -989,7 +998,7 @@ def test_fetch_state_tags_are_empty_when_information_schema_unavailable(qn):
 def test_fetch_state_observes_column_tags(qn):
     # Given a present table whose information_schema.column_tags carries tags on a column
     catalog = FakeCatalog(
-        columns_by_table={str(qn): [make_catalog_col("email", dataType=T.StringType())]},
+        columns_by_table={str(qn): [make_catalog_col("email", dataType="string")]},
         table_comments={str(qn): ""},
     )
     column_tag_rows = [
@@ -1010,7 +1019,7 @@ def test_fetch_state_observes_column_tags(qn):
 def test_fetch_state_lowercases_column_name_but_preserves_tag_key_case(qn):
     # Given a catalog that reports a mixed-case column name and a mixed-case tag key
     catalog = FakeCatalog(
-        columns_by_table={str(qn): [make_catalog_col("Email", dataType=T.StringType())]},
+        columns_by_table={str(qn): [make_catalog_col("Email", dataType="string")]},
         table_comments={str(qn): ""},
     )
     spark = FakeSparkWithPrimaryKey(
@@ -1033,7 +1042,7 @@ def test_fetch_state_lowercases_column_name_but_preserves_tag_key_case(qn):
 def test_fetch_state_column_tags_are_empty_when_none_defined(qn):
     # Given a present table whose column_tags query returns no rows
     catalog = FakeCatalog(
-        columns_by_table={str(qn): [make_catalog_col("email", dataType=T.StringType())]},
+        columns_by_table={str(qn): [make_catalog_col("email", dataType="string")]},
         table_comments={str(qn): ""},
     )
     spark = FakeSparkWithPrimaryKey(catalog=catalog, column_tag_rows=[])
@@ -1050,7 +1059,7 @@ def test_fetch_state_column_tags_are_empty_when_none_defined(qn):
 def test_fetch_state_column_tags_are_empty_when_information_schema_unavailable(qn):
     # Given the column_tags query raises (non-Unity-Catalog Spark, e.g. local tests)
     catalog = FakeCatalog(
-        columns_by_table={str(qn): [make_catalog_col("email", dataType=T.StringType())]},
+        columns_by_table={str(qn): [make_catalog_col("email", dataType="string")]},
         table_comments={str(qn): ""},
     )
     spark = FakeSparkWithPrimaryKey(


### PR DESCRIPTION
Implements clusters **B** (optional-collection widening) and **C** (dead generality) from the [special-case audit](docs/todo/2026-07-03-special-case-audit.md). Cluster A shipped in #109.

## Changes

### B — Optional-collection widening (`c38dcc6`)
- **`api/table.py`**: `partitioned_by` defaults to `()` instead of `None`, collapsing `tuple(x) if x is not None else ()` to `tuple(x)`. No caller ever passed `None`; `()` already meant the same thing. `properties`/`tags` correctly keep `| None` (a `dict` default is the mutable-default trap).

### C — Dead generality
- **`sql/preview.py`** (`c38dcc6`): dropped the `single_line` flag from `sql_preview`. The sole production caller used the default; the `False` arm existed only for one test. Whitespace normalisation is now unconditional.
- **`sql/compile.py`** (`c38dcc6`): tightened `_set_properties(props)` to `Mapping[str, str]`. The `| None` was dead — the caller passes `table.properties`, which the domain defaults to `{}`. The empty-map guard stays (`TBLPROPERTIES ()` is invalid SQL).
- **`sql/types.py`** (`c1c6eec`, refined by `79508bf`): `domain_type_from_spark` accepted `str | SparkType` and opened with an `isinstance` dispatch. The two shapes have a fixed relationship — the reader only ever has a DDL string, the Array/Map recursion only ever has `SparkType` instances. Narrowed the mapper to a single input shape, `domain_type_from_spark(spark_type: SparkType)`, and moved the `SparkType.fromDDL` parse to the reader, where parsing catalog DDL is native adapter vocabulary. The `isinstance` is gone and each layer owns its own concern.

## A finding that reshaped the audit's scope

The audit predates the cluster A merge and under-scoped the type-mapping item: it billed the split as "small, one file," but production's `listColumns().dataType` is a **DDL string** while all reader test doubles stubbed it as a `SparkType` **instance** — the wrong shape, which only passed because the old dual-shape function tolerated both. This PR realigns those doubles to DDL strings (matching production).

**Test coverage note.** `SparkType.fromDDL` requires a live `SparkSession`, so the reader tests now exercise that parse path and depend on the `spark` fixture (which some local environments can't provision, as it downloads the Delta jar). This is inherent to testing a Databricks adapter against its real input shape. The **type-mapping table itself stays fully covered without Spark** — its tests map `SparkType` instances directly. Net effect on locally-measured coverage is small (the residual gap is `reader.py`, which needs Spark in either design); CI runs the full suite. Verified the reader's DDL→domain path end-to-end on a plain (non-Delta) Spark session locally, so the CI-only reader tests are logic-proven.

## Verification
- `mypy src`: clean (statically proves the `_set_properties` and reader `SparkType` tightenings safe)
- `ruff check` + `ruff format --check`: clean
- `types.py` tests: all pass **without** Spark; the module is at 96% local coverage (only the unreachable `case _` fallback uncovered)
- B/C preview/compile changes: fully local-green

🤖 Generated with [Claude Code](https://claude.com/claude-code)