### PR TITLE
[codex] Document runtime feature compatibility

### DIFF
--- a/docs/how-to-configure-properties.md
+++ b/docs/how-to-configure-properties.md
@@ -58,7 +58,7 @@ your Databricks Runtime or Delta table protocol supports each feature. For
 example, if you enable change data feed on a table or runtime that cannot support
 it, Databricks rejects the statement and `sync` reports an `EXECUTION_FAILED`
 table with the original error. See
-[how-to-handle-sync-failures.md](how-to-handle-sync-failures.md#runtime-and-delta-feature-compatibility).
+{ref}`runtime-and-delta-feature-compatibility`.
 
 ## Available properties
 

--- a/docs/how-to-configure-properties.md
+++ b/docs/how-to-configure-properties.md
@@ -53,6 +53,13 @@ table = DeltaTable(
 )
 ```
 
+The engine emits the requested table-property DDL but does not verify whether
+your Databricks Runtime or Delta table protocol supports each feature. For
+example, if you enable change data feed on a table or runtime that cannot support
+it, Databricks rejects the statement and `sync` reports an `EXECUTION_FAILED`
+table with the original error. See
+[how-to-handle-sync-failures.md](how-to-handle-sync-failures.md#runtime-and-delta-feature-compatibility).
+
 ## Available properties
 
 | `Property` member | Delta table property key |

--- a/docs/how-to-declare-foreign-keys.md
+++ b/docs/how-to-declare-foreign-keys.md
@@ -131,3 +131,10 @@ Matching by content keeps syncs idempotent: a foreign key created outside this e
 Databricks foreign key constraints are informational, not enforced. They do not block inserts that violate referential integrity, but they enable query optimizations and document intent in Unity Catalog.
 
 The referenced table needs a matching primary or unique key for Databricks to accept the constraint at execution time.
+
+Key-constraint support, including unique constraints used as referenced keys,
+depends on your Databricks environment. The engine does not preflight Databricks
+Runtime or Delta table protocol compatibility for you; if Databricks rejects the
+constraint DDL, `sync` reports an `EXECUTION_FAILED` table with the original
+error. See
+[how-to-handle-sync-failures.md](how-to-handle-sync-failures.md#runtime-and-delta-feature-compatibility).

--- a/docs/how-to-declare-foreign-keys.md
+++ b/docs/how-to-declare-foreign-keys.md
@@ -137,4 +137,4 @@ depends on your Databricks environment. The engine does not preflight Databricks
 Runtime or Delta table protocol compatibility for you; if Databricks rejects the
 constraint DDL, `sync` reports an `EXECUTION_FAILED` table with the original
 error. See
-[how-to-handle-sync-failures.md](how-to-handle-sync-failures.md#runtime-and-delta-feature-compatibility).
+{ref}`runtime-and-delta-feature-compatibility`.

--- a/docs/how-to-declare-primary-keys.md
+++ b/docs/how-to-declare-primary-keys.md
@@ -59,3 +59,9 @@ Column order within the key is ignored when detecting drift — `(a, b)` and `(b
 Databricks primary key constraints are informational, not enforced. They do not prevent duplicate or null values at write time, but they enable query optimizations in Unity Catalog.
 
 A primary key column must be `NOT NULL` — a nullable primary key is not a well-formed table definition, and Databricks rejects it at execution time regardless. The engine enforces this when you construct the `DeltaTable`: declaring a primary key on a nullable column raises `ValueError` at definition time, before any sync runs.
+
+Key-constraint support depends on your Databricks environment. The engine does
+not preflight Databricks Runtime or Delta table protocol compatibility for you;
+if Databricks rejects the constraint DDL, `sync` reports an `EXECUTION_FAILED`
+table with the original error. See
+[how-to-handle-sync-failures.md](how-to-handle-sync-failures.md#runtime-and-delta-feature-compatibility).

--- a/docs/how-to-declare-primary-keys.md
+++ b/docs/how-to-declare-primary-keys.md
@@ -64,4 +64,4 @@ Key-constraint support depends on your Databricks environment. The engine does
 not preflight Databricks Runtime or Delta table protocol compatibility for you;
 if Databricks rejects the constraint DDL, `sync` reports an `EXECUTION_FAILED`
 table with the original error. See
-[how-to-handle-sync-failures.md](how-to-handle-sync-failures.md#runtime-and-delta-feature-compatibility).
+{ref}`runtime-and-delta-feature-compatibility`.

--- a/docs/how-to-handle-sync-failures.md
+++ b/docs/how-to-handle-sync-failures.md
@@ -92,3 +92,17 @@ See [how-to-declare-foreign-keys.md](how-to-declare-foreign-keys.md) for how dep
 ## Act on execution failures
 
 Execution failures are partial: actions before the failure ran and committed; actions after were not attempted. Fix the root cause and re-run — the engine re-reads live state and plans only the remaining drift.
+
+(runtime-and-delta-feature-compatibility)=
+
+## Runtime and Delta feature compatibility
+
+delta-engine does not preflight Databricks Runtime or Delta table protocol
+versions for every feature it can declare. If you use a Databricks feature such
+as key constraints, tags, deletion vectors, or change data feed, make sure your
+workspace, runtime, table protocol, and privileges support that feature.
+
+When Databricks rejects a statement because the runtime or Delta table version is
+too old, the engine reports it as an `EXECUTION_FAILED` table with the original
+exception type, message, and SQL preview. Upgrade or configure the Databricks
+environment, then re-run `sync`.

--- a/docs/todo/todo.md
+++ b/docs/todo/todo.md
@@ -10,7 +10,6 @@
 - [ ] should databricks rules live in validator?
 - [ ] review except AnalysisException in reader's _fetch_primary_key()
 - [ ] Think of whether to make DeltaTable automatically make columns unique if they are PK cols
-- [ ] Document that DBR runtime & delta table version issues are for the user to resolve. If they want to use Databricks unique constraints or CDF, they have to make sure they are on the right runtime/Delta version. The way the engine is designed, it will fail and return the relevant error.
 - [ ] make the nested if else statments in engine more readable
 - [ ] do we need backticked things in sql compiler or can we do without?
 - [ ] allow a way for existing constraint names (PK/FK) to be passed to DeltaTable


### PR DESCRIPTION
## Summary

- Add a sync-failure section explaining that Databricks Runtime and Delta table protocol compatibility are user-owned concerns.
- Cross-link that guidance from table properties, primary-key constraints, and foreign-key constraints.
- Remove the completed todo entry.

## Impact

Users get clearer expectations for CDF, deletion vectors, tags, and key constraints: delta-engine reports Databricks runtime/protocol failures rather than preflighting every feature version.

## Validation

- `uv run --group docs sphinx-build -b html docs docs/_build/html`