### PR TITLE
fix: Fix adapter execution failure example

### DIFF
--- a/docs/how-to-implement-adapter.md
+++ b/docs/how-to-implement-adapter.md
@@ -58,7 +58,6 @@ class MyExecutor:
             except Exception as exc:
                 results.append(ExecutionFailed(
                     action=repr(action),
-                    action_index=i,
                     failure=ExecutionFailure(
                         action_index=i,
                         exception_type=type(exc).__name__,


### PR DESCRIPTION
## Summary

Fix the custom adapter guide's `PlanExecutor` example so it matches the `ExecutionFailed` dataclass constructor.

## Why

`ExecutionFailed` carries only `action` and `failure`; the action index belongs inside `ExecutionFailure`. The previous snippet passed `action_index` to the wrong constructor, which would fail if copied directly.

## Validation

- `uv run --group docs sphinx-build -W -b html docs /private/tmp/delta-engine-docs-html`