### PR TITLE
refactor: eliminate special cases (audit clusters D, E, F)

### DIFF
--- a/src/delta_engine/api/table.py
+++ b/src/delta_engine/api/table.py
@@ -61,9 +61,7 @@ class ForeignKey:
             case DeltaTable() as target:
                 desired = target.to_desired_table()
                 referenced_table = desired.qualified_name
-                referenced_columns = (
-                    desired.primary_key.columns if desired.primary_key is not None else ()
-                )
+                referenced_columns = desired.primary_key_columns
             case _:
                 raise TypeError(
                     f"foreign key references must be a DeltaTable or Self; got {self.references!r}"
@@ -165,8 +163,7 @@ class DeltaTable:
     @property
     def primary_key(self) -> tuple[str, ...]:
         """Column names declared as the primary key, in declaration order."""
-        constraint = self._desired_table.primary_key
-        return constraint.columns if constraint is not None else ()
+        return self._desired_table.primary_key_columns
 
     @property
     def foreign_keys(self) -> tuple[ForeignKeyConstraint, ...]:

--- a/src/delta_engine/application/dependency_resolution.py
+++ b/src/delta_engine/application/dependency_resolution.py
@@ -24,11 +24,6 @@ from delta_engine.domain.model.table import DesiredTable
 # recursion depth of the SCC traversal below stays far under Python's limit.
 
 
-def _primary_key_columns(table: DesiredTable) -> tuple[str, ...]:
-    """Return the table's primary key column names (empty when it has none)."""
-    return table.primary_key.columns if table.primary_key is not None else ()
-
-
 @dataclass(frozen=True, slots=True)
 class ResolveResult:
     """
@@ -224,9 +219,7 @@ def _classify_failures(
     # referenced table's primary key (Databricks rejects other targets at DDL
     # time). Compared as sets: a primary key's declaration order is not part of
     # its identity, and referenced_columns is aligned to local_columns, not PK order.
-    primary_key_by_name = {
-        table.qualified_name: set(_primary_key_columns(table)) for table in tables
-    }
+    primary_key_by_name = {table.qualified_name: set(table.primary_key_columns) for table in tables}
 
     # Pass 1 — direct failures.
     for table in tables:

--- a/src/delta_engine/application/dependency_resolution.py
+++ b/src/delta_engine/application/dependency_resolution.py
@@ -124,7 +124,7 @@ def _strongly_connected_components(
     index_counter = 0
     indices: dict[QualifiedName, int] = {}
     low_links: dict[QualifiedName, int] = {}
-    on_stack: dict[QualifiedName, bool] = {}
+    on_stack: set[QualifiedName] = set()
     stack: list[QualifiedName] = []
     components: list[list[QualifiedName]] = []
 
@@ -134,20 +134,20 @@ def _strongly_connected_components(
         low_links[node] = index_counter
         index_counter += 1
         stack.append(node)
-        on_stack[node] = True
+        on_stack.add(node)
 
         for neighbour in sorted(graph[node], key=str):
             if neighbour not in indices:
                 strong_connect(neighbour)
                 low_links[node] = min(low_links[node], low_links[neighbour])
-            elif on_stack.get(neighbour):
+            elif neighbour in on_stack:
                 low_links[node] = min(low_links[node], indices[neighbour])
 
         if low_links[node] == indices[node]:
             component: list[QualifiedName] = []
             while True:
                 member = stack.pop()
-                on_stack[member] = False
+                on_stack.discard(member)
                 component.append(member)
                 if member == node:
                     break

--- a/src/delta_engine/application/engine.py
+++ b/src/delta_engine/application/engine.py
@@ -157,7 +157,7 @@ class Engine:
 
         if not dry_run and report.any_failures:
             raise SyncFailedError(report)
-          
+
         self._log_outcome(report, dry_run=dry_run)
 
         return report

--- a/src/delta_engine/application/rendering.py
+++ b/src/delta_engine/application/rendering.py
@@ -142,6 +142,12 @@ def _(action: PartitioningChange) -> str:
     return f"~ partitioning {action.observed_partitioning} → {action.desired_partitioning}"
 
 
+# Shown wherever a report has a readable state but no planned actions. One
+# spelling, two presentations: bare in the grid's DETAIL cell, parenthesised as
+# a standalone line in the diff block.
+_NO_CHANGES = "no changes"
+
+
 def render_diff_block(report: TableRunReport) -> str:
     """Render one table's change block: its name then one line per planned action."""
     from delta_engine.application.ports import ReadFailed
@@ -150,7 +156,7 @@ def render_diff_block(report: TableRunReport) -> str:
     if isinstance(report.read, ReadFailed):
         return f"{header}\n  (could not read — no diff)"
     if not report.plan:
-        return f"{header}\n  (no changes)"
+        return f"{header}\n  ({_NO_CHANGES})"
     lines = [f"  {action_diff_line(action)}" for action in report.plan]
     return "\n".join([header, *lines])
 
@@ -167,9 +173,7 @@ def _grid_detail(report: TableRunReport) -> str:
         first = failures[0].format_lines()[0]
         extra = len(failures) - 1
         return f"{first} (+{extra} more)" if extra else first
-    if len(report.plan):
-        return ", ".join(type(action).__name__ for action in report.plan)
-    return "no changes"
+    return ", ".join(type(action).__name__ for action in report.plan) or _NO_CHANGES
 
 
 def _truncate(text: str, limit: int = _DETAIL_MAX_CHARS) -> str:

--- a/src/delta_engine/application/report.py
+++ b/src/delta_engine/application/report.py
@@ -112,6 +112,4 @@ class SyncReport:
         """Render the run as an aligned grid followed by a summary footer."""
         from delta_engine.application.rendering import render_grid, run_summary_footer
 
-        if not self.table_reports:
-            return "Sync report: 0 tables"
         return f"{render_grid(self.table_reports)}\n\n{run_summary_footer(self)}"

--- a/src/delta_engine/domain/model/table.py
+++ b/src/delta_engine/domain/model/table.py
@@ -36,6 +36,11 @@ class TableSnapshot:
     primary_key: PrimaryKeyConstraint | None = None
     foreign_keys: tuple[ForeignKeyConstraint, ...] = ()
 
+    @property
+    def primary_key_columns(self) -> tuple[str, ...]:
+        """Primary key column names, or ``()`` when the table has no primary key."""
+        return self.primary_key.columns if self.primary_key is not None else ()
+
     def __post_init__(self) -> None:
         """
         Validate the snapshot's structural invariants.

--- a/src/delta_engine/domain/model/table.py
+++ b/src/delta_engine/domain/model/table.py
@@ -58,31 +58,29 @@ class TableSnapshot:
                 raise ValueError(f"Duplicate column name: {column.name}")
             seen_names.add(column.name)
 
-        if self.partitioned_by:
-            for name in self.partitioned_by:
-                if name != name.casefold():
-                    raise ValueError(f"Partition column name must be lowercase: {name!r}")
+        for name in self.partitioned_by:
+            if name != name.casefold():
+                raise ValueError(f"Partition column name must be lowercase: {name!r}")
 
-            missing = [name for name in self.partitioned_by if name not in seen_names]
-            if missing:
-                raise ValueError(f"Partition column not found: {missing[0]}")
+        missing = [name for name in self.partitioned_by if name not in seen_names]
+        if missing:
+            raise ValueError(f"Partition column not found: {missing[0]}")
 
-            seen_partitions: set[str] = set()
-            for name in self.partitioned_by:
-                if name in seen_partitions:
-                    raise ValueError(f"Duplicate partition column: {name}")
-                seen_partitions.add(name)
+        seen_partitions: set[str] = set()
+        for name in self.partitioned_by:
+            if name in seen_partitions:
+                raise ValueError(f"Duplicate partition column: {name}")
+            seen_partitions.add(name)
 
         if self.primary_key is not None:
             missing_pk = [name for name in self.primary_key.columns if name not in seen_names]
             if missing_pk:
                 raise ValueError(f"Primary key column not found in columns: {missing_pk[0]}")
 
-        if self.foreign_keys:
-            for foreign_key in self.foreign_keys:
-                missing = [col for col in foreign_key.local_columns if col not in seen_names]
-                if missing:
-                    raise ValueError(f"Foreign key local column not found in columns: {missing[0]}")
+        for foreign_key in self.foreign_keys:
+            missing = [col for col in foreign_key.local_columns if col not in seen_names]
+            if missing:
+                raise ValueError(f"Foreign key local column not found in columns: {missing[0]}")
 
         for tag_key in self.tags:
             if not tag_key.strip():

--- a/tests/application/test_report.py
+++ b/tests/application/test_report.py
@@ -88,6 +88,18 @@ def test_table_status_success_when_all_actions_succeed():
     assert report.execution.failures == ()
 
 
+def test_sync_report_with_no_tables_renders_grid_header_and_zero_footer():
+    # Given a run over no tables
+    sr = SyncReport(started_at=_t0(), ended_at=_t1(), table_reports=())
+
+    # When rendered
+    # Then the general grid+footer path produces a header row and a zero-count
+    # footer -- no dedicated empty-run sentinel string
+    rendered = str(sr)
+    assert rendered.splitlines()[0].split() == ["TABLE", "STATUS", "ACTIONS", "DETAIL"]
+    assert rendered.endswith("0 tables: 0 changed, 0 unchanged, 0 failed (300.0s)")
+
+
 def test_sync_report_any_failures_true_if_any_table_has_failures():
     # Given two tables: one success, one with execution failure
     t_ok = TableRunReport(

--- a/tests/domain/model/test_table.py
+++ b/tests/domain/model/test_table.py
@@ -73,6 +73,26 @@ def test_table_snapshot_primary_key_defaults_to_none():
     assert table.primary_key is None
 
 
+def test_primary_key_columns_is_empty_when_no_primary_key():
+    # Given a table with no primary key
+    table = DesiredTable(qualified_name=_QN, columns=(_COL,))
+
+    # Then primary_key_columns is the empty tuple, not None
+    assert table.primary_key_columns == ()
+
+
+def test_primary_key_columns_returns_the_constraint_columns():
+    # Given a table with a two-column primary key
+    table = ObservedTable(
+        qualified_name=_QN,
+        columns=(Column("id", Integer()), Column("tenant_id", Integer())),
+        primary_key=PrimaryKeyConstraint(columns=("id", "tenant_id"), constraint_name="t_pk"),
+    )
+
+    # Then primary_key_columns returns those column names in declaration order
+    assert table.primary_key_columns == ("id", "tenant_id")
+
+
 def test_table_snapshot_rejects_pk_column_not_in_columns():
     # Given a primary_key naming a column that does not exist
     # Then construction raises ValueError


### PR DESCRIPTION
Continues the special-case audit (`docs/todo/2026-07-03-special-case-audit.md`). Clusters A–C shipped in #109 and #111; this branch covers **D**, **E**, and **F**. Each cluster is one commit.

## F — repeated PK unwrap across layers (`8a2ce26`)
Three sites hand-unwrapped the optional primary key with the same `x.columns if x is not None else ()` idiom:
- `application/dependency_resolution.py` (via a private `_primary_key_columns` helper)
- `api/table.py` — `DeltaTable.primary_key` property
- `api/table.py` — `ForeignKey._to_constraint`, on the *referenced* table

Pulled the unwrap **down into the domain model** as `TableSnapshot.primary_key_columns` (returns `()` when no PK) and deleted all three call sites. `_to_constraint` now reads the referenced table's PK through the property instead of re-unwrapping the domain optional a layer deeper than it needed to. The subsequent `if not referenced_columns: raise ValueError` **stays** — a missing PK on an FK target is a genuine user error, not an empty-collection case.

## E — wrong data structure encoding a set (`44e27ca`)
Tarjan's `_strongly_connected_components` tracked stack membership in a `dict[QualifiedName, bool]` whose value was only ever `True` (push) / `False` (pop), read solely as a truthiness check via `.get()`. The implicit-`None` fallback was unreachable. Replaced with `set[QualifiedName]` — `add` / `discard` / `in`. Behaviour identical; local to one function.

## D — empty-collection branches the general path already handles
**`2a8a24b` — `TableSnapshot.__post_init__`:** dropped the `if self.partitioned_by:` and `if self.foreign_keys:` wrappers. The loops/comprehensions inside already no-op on empty collections, so the guards only added nesting. The `if self.primary_key is not None:` check stays — a real None guard on an optional, not an empty-collection branch.

**`ddce6d3` — rendering + report:**
- `rendering.py`: the `"no changes"` string was written twice; extracted a single `_NO_CHANGES` constant. `_grid_detail`'s `if len(report.plan)` empty branch collapses into `", ".join(...) or _NO_CHANGES`. `render_diff_block` keeps its `(could not read)` / `(no changes)` branch structure — that's a genuine display contract, not a collection-safety guard. **No behaviour change.**
- `report.py`: **⚠️ behaviour change (approved).** Deleted `SyncReport.__str__`'s zero-table sentinel `"Sync report: 0 tables"`. The general grid+footer path already renders an empty run correctly — a header-only grid plus `0 tables: 0 changed, 0 unchanged, 0 failed (0.0s)` — which is well-formed and more informative. Pinned by a new test. No test pinned the old string.

## Note
The F commit also carries a one-line unrelated cleanup in `engine.py`: ruff's default `--fix` stripped trailing whitespace from a blank line. Correct, harmless, mentioned here for transparency.

## Verification
- **360 passed** locally (up from 357 — three new tests: two for `primary_key_columns`, one for the empty `SyncReport`).
- The 50 erroring tests are the known Delta-jar SSL baseline (local Maven fetch blocked by the TLS-inspecting proxy) — identical before and after these changes, unrelated to D/E/F, and green in CI.
- `ruff check`, `ruff format --check`, and `mypy src` all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)