### PR TITLE
[codex] Expand GWT test comments

### DIFF
--- a/tests/adapters/databricks/sql/test_compile.py
+++ b/tests/adapters/databricks/sql/test_compile.py
@@ -342,13 +342,13 @@ def test_create_table_without_pk_omits_constraint_clause():
 
 
 def test_drop_foreign_key_renders_drop_constraint_if_exists():
-    # Given
+    # Given a DropForeignKey action with a catalog constraint name
     action = DropForeignKey(constraint_name="orders_customer_id_fk")
 
-    # When
+    # When compiling the action
     statement = _compile_single(action)
 
-    # Then
+    # Then the SQL drops that constraint if it exists
     assert statement == (
         "ALTER TABLE `cat`.`sch`.`tbl` DROP CONSTRAINT IF EXISTS `orders_customer_id_fk`"
     )

--- a/tests/adapters/databricks/test_reader.py
+++ b/tests/adapters/databricks/test_reader.py
@@ -563,7 +563,7 @@ def test_fetch_state_includes_primary_key_in_observed_table():
         pk_column_rows=[{"column_name": "id", "constraint_name": "t_pk"}],
     )
 
-    # When
+    # When fetching state for the table
     result = DatabricksReader(spark).fetch_state(qn)
 
     # Then: primary_key is populated on the ObservedTable, carrying the catalog name
@@ -587,7 +587,7 @@ def test_fetch_state_primary_key_is_empty_when_none_defined():
         pk_column_rows=[],
     )
 
-    # When
+    # When fetching state for the table
     result = DatabricksReader(spark).fetch_state(qn)
 
     # Then: primary_key is None (no constraint defined)
@@ -609,7 +609,7 @@ def test_fetch_primary_key_returns_empty_when_information_schema_unavailable():
         pk_exc=AnalysisException("TABLE_OR_VIEW_NOT_FOUND"),
     )
 
-    # When
+    # When fetching state for the table
     result = DatabricksReader(spark).fetch_state(qn)
 
     # Then: the read succeeds and primary_key is None (no UC = no PK constraints)
@@ -905,7 +905,7 @@ def test_fetch_state_lowercases_foreign_key_constraint_name():
     ]
     spark = _FakeSparkRawForeignKeyRows(catalog=_orders_catalog(), fk_rows=fk_rows)
 
-    # When
+    # When fetching state for the table
     result = DatabricksReader(spark).fetch_state(qn)
 
     # Then the observed constraint name is normalised to lowercase

--- a/tests/api/test_table.py
+++ b/tests/api/test_table.py
@@ -313,7 +313,7 @@ def test_delta_table_defaults_to_no_foreign_keys():
         columns=[Column("id", Integer())],
     )
 
-    # Then
+    # Then foreign_keys defaults to an empty tuple
     assert table.foreign_keys == ()
 
 

--- a/tests/application/test_dependency_resolution.py
+++ b/tests/application/test_dependency_resolution.py
@@ -70,7 +70,7 @@ def test_resolve_with_no_fks_preserves_input_order():
     # Given three tables with no FKs
     tables = (_table("cat.sch.a"), _table("cat.sch.b"), _table("cat.sch.c"))
 
-    # When
+    # When resolving foreign-key dependencies
     result = resolve(tables)
 
     # Then order is unchanged and all tables have no FK failures
@@ -85,7 +85,7 @@ def test_resolve_orders_referenced_table_before_dependent():
         _table("cat.sch.customers"),
     )
 
-    # When
+    # When resolving foreign-key dependencies
     result = resolve(tables)
 
     # Then customers appears before orders and all tables have no FK failures
@@ -102,7 +102,7 @@ def test_resolve_handles_chain_of_dependencies():
         _table("cat.sch.a"),
     )
 
-    # When
+    # When resolving foreign-key dependencies
     result = resolve(tables)
 
     # Then a before b before c
@@ -114,7 +114,7 @@ def test_resolve_fails_table_with_unresolvable_reference():
     # Given orders references customers but customers is not registered
     tables = (_table_with_fk("cat.sch.orders", "cat.sch.customers"),)
 
-    # When
+    # When resolving foreign-key dependencies
     result = resolve(tables)
 
     # Then orders has one UNRESOLVABLE_REFERENCE failure with the FK's columns
@@ -132,7 +132,7 @@ def test_resolve_fails_both_members_of_a_cycle():
         _table_with_fk("cat.sch.b", "cat.sch.a"),
     )
 
-    # When
+    # When resolving foreign-key dependencies
     result = resolve(tables)
 
     # Then both tables cannot execute, each with CYCLE
@@ -149,7 +149,7 @@ def test_resolve_ordering_includes_failed_tables():
         _table_with_fk("cat.sch.b", "cat.sch.a"),
     )
 
-    # When
+    # When resolving foreign-key dependencies
     result = resolve(tables)
 
     # Then both tables still appear in the ordering (the engine gates them out via their failures)
@@ -163,7 +163,7 @@ def test_resolve_blocks_table_that_references_an_unresolvable_table():
         _table_with_fk("cat.sch.customers", "cat.sch.archive"),
     )
 
-    # When
+    # When resolving foreign-key dependencies
     result = resolve(tables)
 
     # Then customers fails directly, and orders cannot execute because customers will not build
@@ -186,7 +186,7 @@ def test_resolve_propagates_block_along_a_chain():
         _table_with_fk("cat.sch.a", "cat.sch.missing"),
     )
 
-    # When
+    # When resolving foreign-key dependencies
     result = resolve(tables)
 
     # Then a fails directly and b, c, d are all blocked transitively
@@ -209,7 +209,7 @@ def test_resolve_blocks_table_that_depends_on_a_cycle():
         _table_with_fk("cat.sch.c", "cat.sch.b"),
     )
 
-    # When
+    # When resolving foreign-key dependencies
     result = resolve(tables)
 
     # Then b and c fail as CYCLE, and a cannot execute because b will not build
@@ -228,7 +228,7 @@ def test_resolve_does_not_block_an_unrelated_sibling():
         _table("cat.sch.unrelated"),
     )
 
-    # When
+    # When resolving foreign-key dependencies
     result = resolve(tables)
 
     # Then only orders cannot execute; the unrelated table is fine
@@ -249,7 +249,7 @@ def test_resolve_treats_self_referential_fk_as_applicable():
         foreign_keys=[ForeignKey(local_columns=("manager_id",), references=Self)],
     ).to_desired_table()
 
-    # When
+    # When resolving foreign-key dependencies
     result = resolve((table,))
 
     # Then the self-referencing FK does not prevent execution
@@ -281,7 +281,7 @@ def test_resolve_propagates_block_through_a_diamond():
         _table_with_fk("cat.sch.a", "cat.sch.missing"),
     )
 
-    # When
+    # When resolving foreign-key dependencies
     result = resolve(tables)
 
     # Then a fails directly; b, c, and d are all blocked
@@ -299,10 +299,11 @@ def test_resolve_propagates_block_through_a_diamond():
 
 
 def test_resolve_with_empty_tables_returns_empty_tuple():
-    # Given / When
+    # Given no tables are passed to the resolver
+    # When resolving the empty input
     result = resolve(())
 
-    # Then
+    # Then the ordered names and FK failures are both empty
     assert result.ordered_names == () and result.fk_failures == {}
 
 
@@ -344,7 +345,7 @@ def test_resolve_passes_when_fk_targets_the_parents_primary_key():
         _table("cat.sch.customers"),
     )
 
-    # When
+    # When resolving foreign-key dependencies
     result = resolve(tables)
 
     # Then every table can execute
@@ -364,7 +365,7 @@ def test_resolve_fails_fk_that_targets_a_non_key_column():
         customers_no_pk,
     )
 
-    # When
+    # When resolving foreign-key dependencies
     result = resolve(tables)
 
     # Then orders cannot execute: its referenced columns are not the parent's PK
@@ -406,7 +407,7 @@ def test_resolve_fails_fk_whose_referenced_columns_are_not_the_pk():
         ),
     )
 
-    # When
+    # When resolving foreign-key dependencies
     result = resolve((orders, customers))
 
     # Then orders is rejected: email is not customers' primary key
@@ -437,7 +438,7 @@ def test_resolve_valid_chain_with_primary_keys_executes():
         _table("cat.sch.b"),
     )
 
-    # When
+    # When resolving foreign-key dependencies
     result = resolve(tables)
 
     # Then the whole chain validates and executes

--- a/tests/application/test_engine.py
+++ b/tests/application/test_engine.py
@@ -212,7 +212,7 @@ def test_engine_reads_all_tables_then_raises_on_any_read_failure():
     executor = _FakeExecutor(results=(_ok_exec(0),))  # irrelevant for a; used for b
     engine = Engine(reader=reader, executor=executor)
 
-    # When
+    # When syncing the requested tables
     with pytest.raises(SyncFailedError) as err:
         engine.sync(_spec("c.s.a"), _spec("c.s.b"))
 
@@ -237,7 +237,7 @@ def test_engine_validates_all_tables_executes_only_the_passing_ones_then_raises(
     executor = _FakeExecutor(results=(_ok_exec(0), _ok_exec(1)))  # used only for b
     engine = Engine(reader=reader, executor=executor)
 
-    # When
+    # When syncing the requested tables
     with pytest.raises(SyncFailedError) as err:
         engine.sync(_spec_adding_not_null("c.s.a"), _spec("c.s.b"))
 
@@ -265,7 +265,7 @@ def test_engine_executes_all_tables_then_raises_if_any_execution_failed():
     )
     engine = Engine(reader=reader, executor=executor)
 
-    # When
+    # When syncing the requested tables
     with pytest.raises(SyncFailedError) as err:
         engine.sync(_spec("c.s.a"), _spec("c.s.b"))
 
@@ -290,7 +290,7 @@ def test_engine_executes_remaining_tables_even_if_first_execution_fails():
     )
     engine = Engine(reader=reader, executor=executor)
 
-    # When
+    # When syncing the requested tables
     with pytest.raises(SyncFailedError) as err:
         engine.sync(_spec("c.s.a"), _spec("c.s.b"))
 
@@ -328,7 +328,7 @@ def test_read_phase_attempts_all_tables_before_any_execution():
     executor = _FakeExecutor(results=(_ok_exec(0), _ok_exec(0)))
     engine = Engine(_TrackingReader(), executor)
 
-    # When
+    # When syncing the requested tables
     with pytest.raises(SyncFailedError) as err:
         engine.sync(_spec("c.s.a"), _spec("c.s.b"), _spec("c.s.c"))
 
@@ -359,7 +359,7 @@ def test_validate_phase_validates_all_tables_before_any_execution():
 
     engine = Engine(reader, _TrackingExecutor())
 
-    # When
+    # When syncing the requested tables
     with pytest.raises(SyncFailedError) as err:
         engine.sync(_spec_adding_not_null("c.s.a"), _spec("c.s.b"))
 
@@ -403,7 +403,7 @@ def test_sync_report_has_no_fk_failures_when_no_fks_declared():
     # Given a table with no FKs
     engine = Engine(_FakeReader({}), _FakeExecutor((_ok_exec(),)))
 
-    # When
+    # When syncing the requested tables
     report = engine.sync(_spec("cat.sch.tbl"))
 
     # Then the single table has no failures and succeeds
@@ -438,7 +438,7 @@ def test_sync_processes_tables_in_fk_dependency_order():
 
     engine = Engine(_FakeReader({}), _OrderCapturingExecutor())
 
-    # When
+    # When syncing the requested tables
     engine.sync(_spec_with_fk("cat.sch.orders", "cat.sch.customers"), _spec("cat.sch.customers"))
 
     # Then customers syncs before orders regardless of the order they were passed

--- a/tests/application/test_report.py
+++ b/tests/application/test_report.py
@@ -136,7 +136,7 @@ def test_sync_report_failures_by_table_maps_only_failed_tables():
         execution=ExecutionSummary(),
     )
 
-    # When
+    # When aggregating the sync report
     sr = SyncReport(started_at=_t0(), ended_at=_t1(), table_reports=(t_ok, t_bad))
 
     # Then only the failed table appears, keyed by its QualifiedName, with its failures

--- a/tests/domain/plan/test_actions.py
+++ b/tests/domain/plan/test_actions.py
@@ -294,7 +294,7 @@ def test_plan_orders_drop_foreign_key_before_drop_primary_key():
 
 
 def test_drop_foreign_key_subject_is_constraint_name():
-    # Given
+    # Given a DropForeignKey action with a constraint name
     action = DropForeignKey(constraint_name="orders_customer_id_fk")
 
     # Then subject is the constraint name (for deterministic ordering within the phase)
@@ -302,7 +302,7 @@ def test_drop_foreign_key_subject_is_constraint_name():
 
 
 def test_set_foreign_key_subject_is_local_columns_joined():
-    # Given
+    # Given a SetForeignKey action with one local column
     action = SetForeignKey(
         local_columns=("customer_id",),
         referenced_table=QualifiedName("cat", "sch", "customers"),

--- a/tests/domain/plan/test_differ.py
+++ b/tests/domain/plan/test_differ.py
@@ -217,7 +217,7 @@ def test_no_actions_when_desired_equals_observed():
         partitioned_by=("event_date",),
     )
 
-    # When
+    # When computing the plan
     plan = compute_plan(desired, observed)
 
     # Then: nothing to do
@@ -250,7 +250,7 @@ def test_combines_column_property_comment_and_partition_diffs():
         partitioned_by=("event_date",),  # different partition spec
     )
 
-    # When
+    # When computing the plan
     plan = compute_plan(desired, observed)
 
     # Then: the plan contains the expected representative actions
@@ -276,7 +276,7 @@ def test_no_column_actions_when_columns_are_identical():
     # Given: desired and observed have the same columns, comments, and nullability
     columns = (Column("id", Integer()), Column("name", String(), comment="customer name"))
 
-    # When
+    # When computing the plan
     plan = compute_plan(_desired(columns=columns), _observed(columns=columns))
 
     # Then: nothing to do
@@ -288,7 +288,7 @@ def test_adds_columns_present_only_in_desired():
     desired = _desired(columns=(Column("id", Integer()), Column("age", Integer())))
     observed = _observed(columns=(Column("id", Integer()),))
 
-    # When
+    # When computing the plan
     plan = compute_plan(desired, observed)
 
     # Then: an AddColumn for "age" is produced
@@ -300,7 +300,7 @@ def test_drops_columns_present_only_in_observed():
     desired = _desired(columns=(Column("id", Integer()),))
     observed = _observed(columns=(Column("id", Integer()), Column("legacy", String())))
 
-    # When
+    # When computing the plan
     plan = compute_plan(desired, observed)
 
     # Then: a DropColumn for "legacy" is produced
@@ -312,7 +312,7 @@ def test_sets_column_comment_when_desired_differs_from_observed():
     desired = _desired(columns=(Column("name", String(), comment="customer"),))
     observed = _observed(columns=(Column("name", String(), comment=""),))
 
-    # When
+    # When computing the plan
     plan = compute_plan(desired, observed)
 
     # Then: a SetColumnComment aligns the comment
@@ -324,7 +324,7 @@ def test_clears_column_comment_when_desired_is_empty_and_observed_is_not():
     desired = _desired(columns=(Column("name", String(), comment=""),))
     observed = _observed(columns=(Column("name", String(), comment="customer"),))
 
-    # When
+    # When computing the plan
     plan = compute_plan(desired, observed)
 
     # Then: a SetColumnComment clears it to empty
@@ -336,7 +336,7 @@ def test_sets_column_nullability_when_flag_differs():
     desired = _desired(columns=(Column("active", String(), nullable=False),))
     observed = _observed(columns=(Column("active", String(), nullable=True),))
 
-    # When
+    # When computing the plan
     plan = compute_plan(desired, observed)
 
     # Then: a SetColumnNullability aligns the flag
@@ -355,7 +355,7 @@ def test_combines_column_add_drop_and_updates_without_duplicates():
         columns=(Column("keep", Integer(), comment=""), Column("drop_me", String()))
     )
 
-    # When
+    # When computing the plan
     plan = compute_plan(desired, observed)
 
     # Then: exactly three actions — no redundant comment/nullability for the added column
@@ -376,7 +376,7 @@ def test_adding_column_to_existing_table_emits_only_add_column():
     )
     observed = _observed(columns=(Column("id", Integer()),))
 
-    # When
+    # When computing the plan
     plan = compute_plan(desired, observed)
 
     # Then: only one AddColumn; no redundant SetColumnComment or SetColumnNullability
@@ -390,7 +390,7 @@ def test_emits_column_type_change_action_when_type_differs():
     desired = _desired(columns=(Column("id", String()),))
     observed = _observed(columns=(Column("id", Integer()),))
 
-    # When
+    # When computing the plan
     plan = compute_plan(desired, observed)
 
     # Then: the drift is surfaced as a ColumnTypeChange action
@@ -407,7 +407,7 @@ def test_emits_partitioning_change_action_when_partition_spec_differs():
     desired = _desired(columns=columns, partitioned_by=("ds",))
     observed = _observed(columns=columns, partitioned_by=())
 
-    # When
+    # When computing the plan
     plan = compute_plan(desired, observed)
 
     # Then: the conflict is surfaced as a PartitioningChange action
@@ -436,7 +436,7 @@ def test_no_property_actions_when_mappings_are_identical():
     # Given: desired and observed have identical properties
     props = {"delta.appendOnly": "true", "owner": "cdm"}
 
-    # When
+    # When computing the plan
     plan = compute_plan(_desired(properties=props), _observed(properties=props))
 
     # Then: nothing to do
@@ -448,7 +448,7 @@ def test_sets_property_when_missing_in_observed():
     desired = _desired(properties={"delta.appendOnly": "true"})
     observed = _observed(properties={})
 
-    # When
+    # When computing the plan
     plan = compute_plan(desired, observed)
 
     # Then: a SetProperty is emitted with the desired value
@@ -460,7 +460,7 @@ def test_updates_property_when_value_differs():
     desired = _desired(properties={"delta.appendOnly": "false"})
     observed = _observed(properties={"delta.appendOnly": "true"})
 
-    # When
+    # When computing the plan
     plan = compute_plan(desired, observed)
 
     # Then: a single SetProperty updates the value
@@ -473,7 +473,7 @@ def test_ignores_observed_only_properties():
     desired = _desired(properties={"owner": "cdm"})
     observed = _observed(properties={"owner": "cdm", "delta.minReaderVersion": "2"})
 
-    # When
+    # When computing the plan
     plan = compute_plan(desired, observed)
 
     # Then: the undeclared property is left untouched — no unset is emitted
@@ -487,7 +487,7 @@ def test_no_comment_action_when_comments_match():
     # Given: same comment on desired and observed
     plan = compute_plan(_desired(comment="core table"), _observed(comment="core table"))
 
-    # Then
+    # Then no table-comment action is emitted
     assert plan.actions == ()
 
 
@@ -579,7 +579,7 @@ def test_emits_set_primary_key_when_desired_has_pk_and_observed_has_none():
     desired = _desired_with_pk(["id"])
     observed = _observed_with_pk([])
 
-    # When
+    # When computing the plan
     plan = compute_plan(desired, observed)
 
     # Then: a SetPrimaryKey is emitted carrying the PK column names; no DropPrimaryKey
@@ -594,7 +594,7 @@ def test_emits_drop_primary_key_when_desired_has_no_pk_and_observed_has_one():
     desired = _desired(columns=(Column("id", Integer()),))
     observed = _observed_with_pk(["id"])
 
-    # When
+    # When computing the plan
     plan = compute_plan(desired, observed)
 
     # Then: a DropPrimaryKey is emitted; no SetPrimaryKey
@@ -607,7 +607,7 @@ def test_emits_drop_and_set_when_pk_columns_change():
     desired = _desired_with_pk(["id"])
     observed = _observed_with_pk(["name"])
 
-    # When
+    # When computing the plan
     plan = compute_plan(desired, observed)
 
     # Then: both DropPrimaryKey and SetPrimaryKey are emitted
@@ -636,7 +636,7 @@ def test_no_pk_actions_when_pk_columns_match_regardless_of_order():
         primary_key=PrimaryKeyConstraint(columns=("tenant_id", "id"), constraint_name="test_pk"),
     )
 
-    # When
+    # When computing the plan
     plan = compute_plan(desired, observed)
 
     # Then: order difference alone does not trigger a PK change
@@ -656,7 +656,7 @@ def test_drop_primary_key_runs_before_add_column_in_plan():
         primary_key=PrimaryKeyConstraint(columns=("id",), constraint_name="test_pk"),
     )
 
-    # When
+    # When computing the plan
     plan = compute_plan(desired, observed)
 
     types = [type(a) for a in plan.actions]
@@ -680,7 +680,7 @@ def test_set_primary_key_runs_after_set_column_nullability_in_plan():
         primary_key=None,
     )
 
-    # When
+    # When computing the plan
     plan = compute_plan(desired, observed)
 
     types = [type(a) for a in plan.actions]
@@ -735,10 +735,10 @@ def test_no_fk_on_either_side_produces_no_fk_actions():
         columns=(Column("id", Integer()),),
     )
 
-    # When
+    # When computing the plan
     plan = compute_plan(desired, observed)
 
-    # Then
+    # Then no foreign-key actions are emitted
     fk_actions = [a for a in plan if isinstance(a, (DropForeignKey, SetForeignKey))]
     assert fk_actions == []
 
@@ -748,7 +748,7 @@ def test_new_fk_on_desired_only_emits_set_foreign_key():
     desired = _orders_with_fk(_FK)
     observed = _observed_orders()
 
-    # When
+    # When computing the plan
     plan = compute_plan(desired, observed)
 
     # Then exactly one SetForeignKey is emitted, carrying the desired FK with its
@@ -773,7 +773,7 @@ def test_fk_removed_from_desired_emits_drop_then_no_set():
     )
     observed = _observed_orders((observed_fk,))
 
-    # When
+    # When computing the plan
     plan = compute_plan(desired, observed)
 
     # Then a DropForeignKey is emitted using the observed catalog name, no SetForeignKey
@@ -789,7 +789,7 @@ def test_fk_same_on_both_sides_produces_no_fk_actions():
     desired = _orders_with_fk(_FK)
     observed = _observed_orders((_FK,))
 
-    # When
+    # When computing the plan
     plan = compute_plan(desired, observed)
 
     # Then no FK actions
@@ -815,7 +815,7 @@ def test_fk_changed_emits_drop_and_set():
     desired = _orders_with_fk(new_fk)
     observed = _observed_orders((old_fk,))
 
-    # When
+    # When computing the plan
     plan = compute_plan(desired, observed)
 
     # Then drop the old one (using the catalog name), set the new one carrying
@@ -832,7 +832,7 @@ def test_new_table_with_fk_includes_set_foreign_key_in_plan():
     # Given a brand-new table (observed=None) with a FK
     desired = _orders_with_fk(_FK)
 
-    # When
+    # When computing the plan
     plan = compute_plan(desired, None)
 
     # Then plan contains CreateTable — and a SetForeignKey (FK applied after creation)
@@ -861,7 +861,7 @@ def test_sync_is_idempotent_when_catalog_fk_has_externally_chosen_name():
     desired = _orders_with_fk(desired_fk)
     observed = _observed_orders((observed_fk,))
 
-    # When
+    # When computing the plan
     plan = compute_plan(desired, observed)
 
     # Then no FK actions — the relationship already exists, name notwithstanding
@@ -895,7 +895,7 @@ def test_sync_is_idempotent_when_fk_already_exists_in_catalog():
         foreign_keys=(observed_fk,),
     )
 
-    # When
+    # When computing the plan
     plan = compute_plan(desired, observed)
 
     # Then no FK actions are emitted — the FK is already in the right state
@@ -935,7 +935,7 @@ def test_no_tag_actions_when_tag_maps_are_identical():
     # Given desired and observed carry the same tags
     tags = {"env": "prod", "domain": "sales"}
 
-    # When
+    # When computing the plan
     plan = compute_plan(_desired(tags=tags), _observed(tags=tags))
 
     # Then nothing to do
@@ -1001,7 +1001,7 @@ def test_no_column_tag_actions_when_tags_match():
     desired = _desired(columns=(Column("email", String(), tags={"pii": "true"}),))
     observed = _observed(columns=(Column("email", String(), tags={"pii": "true"}),))
 
-    # When
+    # When computing the plan
     plan = compute_plan(desired, observed)
 
     # Then nothing to do
@@ -1013,7 +1013,7 @@ def test_sets_column_tag_when_absent_in_observed():
     desired = _desired(columns=(Column("email", String(), tags={"pii": "true"}),))
     observed = _observed(columns=(Column("email", String()),))
 
-    # When
+    # When computing the plan
     plan = compute_plan(desired, observed)
 
     # Then a SetColumnTag is emitted for that column
@@ -1025,7 +1025,7 @@ def test_updates_column_tag_when_value_differs():
     desired = _desired(columns=(Column("email", String(), tags={"pii": "true"}),))
     observed = _observed(columns=(Column("email", String(), tags={"pii": "false"}),))
 
-    # When
+    # When computing the plan
     plan = compute_plan(desired, observed)
 
     # Then a single SetColumnTag updates the value
@@ -1037,7 +1037,7 @@ def test_unsets_observed_only_column_tag_under_full_state_ownership():
     desired = _desired(columns=(Column("email", String()),))
     observed = _observed(columns=(Column("email", String(), tags={"legacy": "1"}),))
 
-    # When
+    # When computing the plan
     plan = compute_plan(desired, observed)
 
     # Then the engine unsets it — column tags are full-state
@@ -1049,7 +1049,7 @@ def test_sets_and_unsets_column_tags_in_one_plan():
     desired = _desired(columns=(Column("email", String(), tags={"pii": "true"}),))
     observed = _observed(columns=(Column("email", String(), tags={"pii": "false", "legacy": "1"}),))
 
-    # When
+    # When computing the plan
     plan = compute_plan(desired, observed)
 
     # Then the changed tag is set and the undeclared tag is unset
@@ -1066,7 +1066,7 @@ def test_no_unset_column_tag_for_a_dropped_column():
         columns=(Column("id", Integer()), Column("legacy", String(), tags={"pii": "true"}))
     )
 
-    # When
+    # When computing the plan
     plan = compute_plan(desired, observed)
 
     # Then the column is dropped and NO UnsetColumnTag is emitted (drop removes its tags)
@@ -1081,7 +1081,7 @@ def test_new_column_gets_all_its_tags_set():
     )
     observed = _observed(columns=(Column("id", Integer()),))
 
-    # When
+    # When computing the plan
     plan = compute_plan(desired, observed)
 
     # Then the column is added and its tag is set afterwards


### PR DESCRIPTION
## Summary

Expand bare Given/When/Then comments in the test suite so each marker describes the setup, action, or assertion being exercised.

## Why

The todo requested full Given/When/Then comments rather than standalone labels. This keeps the existing test structure while making the comments useful when scanning tests.

## Validation

- `uv run ruff format tests --check`
- `uv run ruff check tests`
- `uv run pytest --no-cov tests/adapters/databricks/sql/test_compile.py tests/adapters/databricks/test_reader.py tests/api/test_table.py tests/application/test_dependency_resolution.py tests/application/test_engine.py tests/application/test_report.py tests/domain/plan/test_actions.py tests/domain/plan/test_differ.py`