### PR TITLE
[codex] Expand architecture documentation

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -17,6 +17,7 @@ extensions = [
 ]
 
 myst_enable_extensions = ["colon_fence"]
+myst_fence_as_directive = ["mermaid"]
 
 html_theme = "furo"
 html_title = "delta-engine"

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -12,6 +12,7 @@ extensions = [
     "sphinx.ext.napoleon",
     "sphinx_autodoc_typehints",
     "sphinx_copybutton",
+    "sphinxcontrib.mermaid",
     "myst_parser",
 ]
 

--- a/docs/explanation-architecture.md
+++ b/docs/explanation-architecture.md
@@ -21,7 +21,7 @@ Most code lives in one of four packages:
 | `delta_engine.domain` | Backend-free schema snapshots, action plans, and diffing | `DesiredTable`, `ObservedTable`, `ActionPlan`, `compute_plan` |
 | `delta_engine.adapters` | Backend integration and translation | `DatabricksReader`, `DatabricksExecutor`, SQL compiler |
 
-```{mermaid}
+```mermaid
 flowchart TB
     User[User code] --> API[api<br/>DeltaTable, ForeignKey]
     API --> Domain[domain<br/>DesiredTable, ObservedTable, ActionPlan]
@@ -44,7 +44,7 @@ so importing table declarations does not require PySpark.
 The application owns the ports. Adapters implement them; the engine only sees the
 protocols and typed return values.
 
-```{mermaid}
+```mermaid
 flowchart LR
     Engine[Engine] --> ReaderPort[CatalogStateReader<br/>fetch_state]
     Engine --> ExecutorPort[PlanExecutor<br/>execute]
@@ -73,7 +73,7 @@ reporting the rest of the run.
 the sync; that run accumulates read state, a plan, failures, and execution
 results before being frozen into a public `TableRunReport`.
 
-```{mermaid}
+```mermaid
 sequenceDiagram
     participant User
     participant API as DeltaTable/API
@@ -167,7 +167,7 @@ table must be synced before a dependent table tries to apply its FK constraint.
 Resolution also propagates failures: if a dependency cannot reach its desired
 state in this run, every downstream table that depends on it is blocked.
 
-```{mermaid}
+```mermaid
 flowchart LR
     Customers[customers<br/>validation failed] --> Orders[orders<br/>blocked by failed dependency]
     Orders --> Shipments[shipments<br/>blocked by failed dependency]

--- a/docs/explanation-architecture.md
+++ b/docs/explanation-architecture.md
@@ -5,42 +5,125 @@ tags:
 
 # Architecture
 
-delta-engine uses a hexagonal (ports and adapters) architecture layered over a domain-driven design. This keeps the core planning logic independent of any backend, so the Databricks adapter can be swapped or extended without touching the domain or application layers.
+delta-engine uses a hexagonal (ports and adapters) architecture layered over a
+small domain model. The goal is to keep the planning core independent of any
+backend, so a Databricks implementation can be replaced or extended without
+changing the domain or application orchestration.
 
-## The four layers
+## Package structure
 
-Dependencies point strictly inward: Adapters → Ports → Application → Domain.
+Most code lives in one of four packages:
 
+| Package | Responsibility | Examples |
+|---|---|---|
+| `delta_engine.api` | User-facing declarations and import surface | `DeltaTable`, `ForeignKey`, `Property` |
+| `delta_engine.application` | Use-case orchestration, ports, failures, reports | `Engine`, `CatalogStateReader`, `PlanExecutor`, `validate_plan`, `resolve` |
+| `delta_engine.domain` | Backend-free schema snapshots, action plans, and diffing | `DesiredTable`, `ObservedTable`, `ActionPlan`, `compute_plan` |
+| `delta_engine.adapters` | Backend integration and translation | `DatabricksReader`, `DatabricksExecutor`, SQL compiler |
+
+```{mermaid}
+flowchart TB
+    User[User code] --> API[api<br/>DeltaTable, ForeignKey]
+    API --> Domain[domain<br/>DesiredTable, ObservedTable, ActionPlan]
+    App[application<br/>Engine, validation, reports] --> Domain
+    Adapters[adapters<br/>Databricks reader, executor, SQL compiler] --> Ports[application ports<br/>CatalogStateReader, PlanExecutor]
+    App --> Ports
+    Public[delta_engine.__init__<br/>curated public exports] --> API
+    Public --> App
+    Public -. lazy .-> Adapters
 ```
-Adapters  (databricks reader, executor, SQL compiler)
-   │
-Ports     (CatalogStateReader, PlanExecutor — Python Protocols)
-   │
-Application  (Engine, validate_plan, result types)
-   │
-Domain    (DeltaTable model, Column, ActionPlan, differ)
+
+The arrows show dependencies. Backend-specific code depends inward on the
+application ports and domain vocabulary; the domain does not depend on Spark,
+Databricks, or adapter code. The top-level `delta_engine` package eagerly exposes
+the pure-Python API and application surface, and lazily exposes Databricks helpers
+so importing table declarations does not require PySpark.
+
+## Hexagonal boundary
+
+The application owns the ports. Adapters implement them; the engine only sees the
+protocols and typed return values.
+
+```{mermaid}
+flowchart LR
+    Engine[Engine] --> ReaderPort[CatalogStateReader<br/>fetch_state]
+    Engine --> ExecutorPort[PlanExecutor<br/>execute]
+    ReaderPort <|.. Reader[DatabricksReader]
+    ExecutorPort <|.. Executor[DatabricksExecutor]
+    Reader --> Catalog[Unity Catalog / Spark catalog]
+    Executor --> Compiler[SQL compiler]
+    Compiler --> Spark[Spark SQL]
 ```
 
-### Domain
+`CatalogStateReader.fetch_state(qualified_name)` returns one of:
 
-Pure Python — zero imports outside the standard library. Defines immutable value objects (`Column`, `QualifiedName`, data types) and the planning logic (`compute_plan`, `ActionPlan`, `Action` subtypes). No knowledge of Spark, Delta, or any backend.
+- `TablePresent(table=ObservedTable(...))`
+- `TableAbsent()`
+- `ReadFailed(failure=ReadFailure(...))`
 
-### Application
+`PlanExecutor.execute(qualified_name, plan)` returns an `ExecutionSummary` with
+one result per attempted action. Both ports are **total**: implementations catch
+backend exceptions and return typed failures instead of raising. That boundary is
+what lets one table fail while the engine continues reading, planning, and
+reporting the rest of the run.
 
-Orchestrates the sync loop: prepare the desired tables, fetch state via the reader port, compute a plan, validate it, execute via the executor port, collect results. Owns `Engine`, `validate_plan`, and all result/report types. No knowledge of Databricks.
+## Sync lifecycle
 
-### Ports
+`Engine.sync(...)` is a phase chain. Each table gets a private run object during
+the sync; that run accumulates read state, a plan, failures, and execution
+results before being frozen into a public `TableRunReport`.
 
-Two `Protocol` interfaces are the only seams the engine crosses:
+```{mermaid}
+sequenceDiagram
+    participant User
+    participant API as DeltaTable/API
+    participant Engine
+    participant Reader as CatalogStateReader
+    participant Domain as Domain planner
+    participant Validator
+    participant Resolver
+    participant Executor as PlanExecutor
 
-- `CatalogStateReader.fetch_state(qualified_name)` — returns the table's current state or a `ReadFailed`.
-- `PlanExecutor.execute(qualified_name, plan)` — executes the plan and returns an `ExecutionSummary`.
+    User->>Engine: sync(customers, orders)
+    Engine->>API: to_desired_table()
+    API-->>Engine: DesiredTable
+    Engine->>Reader: fetch_state(qualified_name)
+    Reader-->>Engine: TablePresent / TableAbsent / ReadFailed
+    Engine->>Domain: compute_plan(desired, observed)
+    Domain-->>Engine: ActionPlan
+    Engine->>Validator: validate_plan(plan)
+    Validator-->>Engine: ValidationResult
+    Engine->>Resolver: resolve(tables, blocked=failed_tables)
+    Resolver-->>Engine: dependency order + FK failures
+    Engine->>Executor: execute(qualified_name, plan)
+    Executor-->>Engine: ExecutionSummary
+    Engine-->>User: SyncReport or SyncFailedError(report)
+```
 
-Both are **total**: implementations must catch all exceptions internally and return a typed failure rather than raising. This ensures a failure on one table never aborts the sync of others.
+The phases are:
 
-### Adapters
+1. **Prepare**: lower user-facing table declarations to `DesiredTable` values and
+   reject duplicate qualified names.
+2. **Read**: ask the reader port for the current catalog state of each table.
+3. **Plan**: diff desired state against observed state with `compute_plan`.
+4. **Validate**: reject unsafe plans before SQL runs.
+5. **Resolve**: order tables by foreign-key dependency and block dependents of
+   failed tables.
+6. **Execute**: execute non-empty plans for tables that have no failures.
+7. **Report**: return `SyncReport`, or raise `SyncFailedError` with the report on
+   real runs that failed.
 
-The `delta_engine.adapters.databricks` package implements both ports for Databricks/Spark. The SQL compiler uses `functools.singledispatch` — one registered handler per `Action` subtype. Type mapping uses structural `match`/`case` patterns.
+## Boundary data shapes
+
+| Shape | Produced by | Consumed by | Purpose |
+|---|---|---|---|
+| `DeltaTable` | User code | Application preparation | Public declaration object |
+| `DesiredTable` | API lowering | Domain planner, resolver, report | Target schema snapshot |
+| `ObservedTable` | Reader adapter | Domain planner, report | Catalog schema snapshot |
+| `ActionPlan` | `compute_plan` | Validation, executor, report | Ordered table-local changes |
+| `CatalogState` | Reader port | Engine | Present, absent, or read-failed state |
+| `ExecutionSummary` | Executor port | Engine, report | Attempted action outcomes |
+| `SyncReport` | Engine | User code | Immutable run result |
 
 ## Planning and determinism
 
@@ -77,6 +160,26 @@ This is a deliberate design choice. An object reference makes the dependency exp
 
 References by name are intentionally not supported in this iteration. If they are ever needed — for a table declared in another module, or one that exists in the catalog but is not managed here — the `references` union can be widened to also accept a `QualifiedName`. That is a backward-compatible addition: existing object-reference declarations keep working, and the new branch would require explicit referenced columns, since a bare name carries no primary key to infer from.
 
+## Foreign key dependency resolution
+
+Foreign keys affect table order, not just table-local SQL order. A referenced
+table must be synced before a dependent table tries to apply its FK constraint.
+Resolution also propagates failures: if a dependency cannot reach its desired
+state in this run, every downstream table that depends on it is blocked.
+
+```{mermaid}
+flowchart LR
+    Customers[customers<br/>validation failed] --> Orders[orders<br/>blocked by failed dependency]
+    Orders --> Shipments[shipments<br/>blocked by failed dependency]
+    Products[products<br/>success] --> OrderLines[order_lines<br/>success]
+    Orders --> OrderLines
+```
+
+The resolver treats read failures, validation failures, FK failures, and
+execution failures as table-level blockers for downstream FKs. It still includes
+every registered table in the final report, so users can see the full blast
+radius in one run.
+
 ## Validation
 
 Each rule implements a `Rule` protocol: a `name` class variable and an `evaluate(plan)` method returning zero or more `ValidationFailure` objects. `validate_plan` runs all rules in `DEFAULT_RULES` and aggregates failures. Rules receive the full plan, so they can reason across actions (e.g. "does this plan add a NOT NULL column to a table that already exists?").
@@ -84,3 +187,24 @@ Each rule implements a `Rule` protocol: a `name` class variable and an `evaluate
 ## Lazy pyspark import
 
 `delta_engine.__init__` uses PEP 562 `__getattr__` to defer import of `build_databricks_engine` and `configure_logging` until first access. This means `import delta_engine` and table declarations work without a Spark install — useful for testing and schema-only environments.
+
+## Where to make changes
+
+| Change | Main location | Notes |
+|---|---|---|
+| Add a new backend | `delta_engine.adapters` | Implement `CatalogStateReader` and `PlanExecutor`; keep backend exceptions inside the adapter. |
+| Add a new action type | `delta_engine.domain.plan` and adapter compiler | Define the action and phase in the domain, emit it from the differ, then compile it in the backend adapter. |
+| Add a safety rule | `delta_engine.application.validation` | Rules inspect `ActionPlan` and return `ValidationFailure` values. |
+| Add a data type | `delta_engine.domain.model.data_type` and adapter type mapping | The domain type is backend-free; SQL names and Spark parsing live in the Databricks adapter. |
+| Change public declarations | `delta_engine.api` | Lower public API choices into domain snapshots before the engine phases begin. |
+| Change report output | `delta_engine.application.report` / `rendering` | Keep display formatting out of domain objects. |
+
+## Architectural rules
+
+- Keep PySpark and Databricks imports inside `delta_engine.adapters`.
+- Keep the domain backend-free and deterministic.
+- Put orchestration and failure policy in the application layer.
+- Put backend normalization at adapter boundaries, such as lowercasing catalog
+  identifiers or mapping Spark types to domain types.
+- Return typed failures across ports instead of raising backend exceptions.
+- Let `ActionPlan` own action ordering; callers should not sort plans manually.

--- a/docs/todo/todo.md
+++ b/docs/todo/todo.md
@@ -19,7 +19,7 @@
 - [ ] Review foreign key logic
 - [ ] Simplify `_fetch_foreign_keys` in the reader: replace the stringly-typed `dict[str, dict]` grouping with `itertools.groupby` (the query already does `ORDER BY constraint_name, ordinal_position`, so rows are contiguous) plus a named `_foreign_key_from_rows(constraint_name, rows)` helper that reads local/referenced columns in ordinal order and takes the referenced table from the first row
 - [ ] utilise __init__ __all__ so that we can reduce the number of import line
-- [ ] Add more to architecture documentation, including visualisations
+- [x] Add more to architecture documentation, including visualisations
 - [ ] Add build docs to pre-commit?
 - [ ] add validation rule to check if `delta.columnMapping.mode`` is ``name`` if there is a drop column action
 - [ ] should report.any_failures be report.has_any_failures?

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,7 @@ docs = [
   "myst-parser>=4.0",
   "sphinx-copybutton>=0.5",
   "sphinx-autodoc-typehints>=2.0",
+  "sphinxcontrib-mermaid>=1.0",
 ]
 
 [build-system]

--- a/uv.lock
+++ b/uv.lock
@@ -285,6 +285,7 @@ docs = [
     { name = "sphinx" },
     { name = "sphinx-autodoc-typehints" },
     { name = "sphinx-copybutton" },
+    { name = "sphinxcontrib-mermaid" },
 ]
 
 [package.metadata]
@@ -305,6 +306,7 @@ docs = [
     { name = "sphinx", specifier = ">=8.0" },
     { name = "sphinx-autodoc-typehints", specifier = ">=2.0" },
     { name = "sphinx-copybutton", specifier = ">=0.5" },
+    { name = "sphinxcontrib-mermaid", specifier = ">=1.0" },
 ]
 
 [[package]]
@@ -938,6 +940,20 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/b2/e8/9ed3830aeed71f17c026a07a5097edcf44b692850ef215b161b8ad875729/sphinxcontrib-jsmath-1.0.1.tar.gz", hash = "sha256:a9925e4a4587247ed2191a22df5f6970656cb8ca2bd6284309578f2153e0c4b8", size = 5787, upload-time = "2019-01-21T16:10:16.347Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c2/42/4c8646762ee83602e3fb3fbe774c2fac12f317deb0b5dbeeedd2d3ba4b77/sphinxcontrib_jsmath-1.0.1-py2.py3-none-any.whl", hash = "sha256:2ec2eaebfb78f3f2078e73666b1415417a116cc848b72e5172e596c871103178", size = 5071, upload-time = "2019-01-21T16:10:14.333Z" },
+]
+
+[[package]]
+name = "sphinxcontrib-mermaid"
+version = "2.0.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "jinja2" },
+    { name = "pyyaml" },
+    { name = "sphinx" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/19/75/3a1cc926da8c563c58ddc124a7b3fe5ccadcae96c96e3a6f8ac3653a210a/sphinxcontrib_mermaid-2.0.2.tar.gz", hash = "sha256:f09576c78ca93fa0e3034fd9c45aaffa7c44ab449de9c43b8b8d262afe52bc66", size = 19265, upload-time = "2026-05-05T13:59:02.959Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/16/8d/93be7e0f7fa915a576859b3bfac7a7baa3303181c44d7db7eefbd3e8a69f/sphinxcontrib_mermaid-2.0.2-py3-none-any.whl", hash = "sha256:d862e514991279fb4816302c5cfe167d2557bf3ce7125ae0cb47dac80a0f46ce", size = 14094, upload-time = "2026-05-05T13:59:01.585Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- expands the architecture explanation around the repo's API, application, domain, and adapter boundaries
- adds Mermaid diagrams for package structure, ports/adapters, sync lifecycle, and foreign-key dependency blocking
- adds developer guidance for where to make architecture-related changes
- enables Mermaid rendering in the docs build and marks the architecture docs todo complete

## Validation

- `uv run --group docs sphinx-build -W -b html docs /private/tmp/delta-engine-docs-html`
- `git diff --check`