### PR TITLE
fix: fail loud on empty DESCRIBE DETAIL for a present table (audit cluster G)

### DIFF
--- a/src/delta_engine/adapters/databricks/reader.py
+++ b/src/delta_engine/adapters/databricks/reader.py
@@ -153,15 +153,29 @@ class DatabricksReader:
         return self.spark.catalog.tableExists(str(qualified_name))
 
     def _fetch_properties(self, qualified_name: QualifiedName) -> MappingProxyType[str, str]:
-        """Return all catalog table properties as a read-only mapping."""
+        """
+        Return all catalog table properties as a read-only mapping.
+
+        Raises when ``DESCRIBE DETAIL`` yields no row for a table the existence
+        probe just reported present: an empty result there is not "a table with
+        no properties" (that is a present row with an empty map) but a race or a
+        catalog inconsistency. Failing loud lets ``fetch_state``'s error boundary
+        return ``ReadFailed`` — the honest outcome for "could not determine
+        state" — rather than a ``TablePresent`` with no properties, which would
+        make the differ re-apply every managed property on every sync.
+        """
         # The name is interpolated into SQL text here, so it must be backtick-quoted
         # to stay an identifier (and escape any embedded backtick). This differs
         # deliberately from the catalog.* calls, which take the plain ``str()`` form
         # because they parse the dot-separated parts themselves. Don't unify the two.
         query = f"DESCRIBE DETAIL {backtick_qualified_name(qualified_name)}"
         row = self.spark.sql(query).first()
-        if not row:
-            return MappingProxyType({})
+        if row is None:
+            raise RuntimeError(
+                f"DESCRIBE DETAIL returned no rows for {qualified_name}, which the"
+                " existence probe just reported as present — the table was dropped"
+                " mid-read or the catalog is inconsistent."
+            )
         return MappingProxyType(dict(row["properties"]))
 
     def _fetch_primary_key(self, qualified_name: QualifiedName) -> PrimaryKeyConstraint | None:

--- a/tests/adapters/databricks/test_reader.py
+++ b/tests/adapters/databricks/test_reader.py
@@ -81,6 +81,8 @@ class FakeSparkForFetchState:
     def sql(self, query: str):
         if "referential_constraints" in query:
             return FakeDataFrame([])
+        if "column_tags" in query.lower():
+            return FakeDataFrame([])
         if "table_tags" in query.lower():
             return FakeDataFrame([])
         if self._describe_exc is not None:
@@ -268,13 +270,15 @@ def test_partition_columns_ignores_missing_or_false_flags():
 # ---------- tests: properties ----------
 
 
-def test_observed_properties_are_empty_and_read_only_when_describe_has_no_rows(qn):
-    # Given a present table whose DESCRIBE DETAIL yields no rows
+def test_observed_properties_are_empty_and_read_only_when_table_has_no_properties(qn):
+    # Given a present table whose DESCRIBE DETAIL yields a row with an empty properties map
     catalog = FakeCatalog(
         columns_by_table={str(qn): [make_catalog_col("id", dataType="int")]},
         table_comments={str(qn): ""},
     )
-    reader = DatabricksReader(FakeSparkWithPrimaryKey(catalog=catalog, describe_rows=[]))
+    reader = DatabricksReader(
+        FakeSparkWithPrimaryKey(catalog=catalog, describe_rows=[{"properties": {}}])
+    )
 
     # When we fetch state
     result = reader.fetch_state(qn)
@@ -285,6 +289,25 @@ def test_observed_properties_are_empty_and_read_only_when_describe_has_no_rows(q
     assert dict(properties) == {}
     with pytest.raises(TypeError):
         properties["x"] = "y"  # type: ignore[index]
+
+
+def test_fetch_state_fails_when_describe_detail_returns_no_rows(qn):
+    # Given a table the existence probe reports present, but DESCRIBE DETAIL
+    # yields no row at all -- a race or catalog inconsistency, distinct from a
+    # table whose properties map is merely empty
+    catalog = FakeCatalog(
+        columns_by_table={str(qn): [make_catalog_col("id", dataType="int")]},
+        table_comments={str(qn): ""},
+    )
+    reader = DatabricksReader(FakeSparkForFetchState(catalog=catalog, describe_rows=[]))
+
+    # When we fetch state
+    result = reader.fetch_state(qn)
+
+    # Then the read fails loud rather than reporting a property-less present table,
+    # so the differ never re-applies every managed property against a phantom state
+    assert isinstance(result, ReadFailed)
+    assert result.failure.exception_type == "RuntimeError"
 
 
 def test_observed_properties_pass_through_catalog_map_unfiltered(qn):
@@ -395,8 +418,8 @@ def test_fetch_state_returns_present_with_columns_partitions_comment_and_propert
     }
 
 
-def test_fetch_state_returns_present_with_empty_properties_when_describe_has_no_rows():
-    # Given a table that exists but DESCRIBE DETAIL returns no rows
+def test_fetch_state_returns_present_with_empty_properties_when_table_has_no_properties():
+    # Given a table that exists and whose DESCRIBE DETAIL row carries an empty properties map
     qn = QualifiedName("c", "s", "no_props")
     fq = str(qn)
 
@@ -405,7 +428,7 @@ def test_fetch_state_returns_present_with_empty_properties_when_describe_has_no_
         table_comments={fq: ""},
     )
     reader = DatabricksReader(
-        FakeSparkWithPrimaryKey(catalog=catalog, describe_rows=[]),
+        FakeSparkWithPrimaryKey(catalog=catalog, describe_rows=[{"properties": {}}]),
     )
 
     # When we fetch state


### PR DESCRIPTION
## Cluster G — a guard that masked an invariant violation

`DatabricksReader._fetch_properties` ran `DESCRIBE DETAIL` and, when it returned no rows, silently returned an empty property map:

```python
row = self.spark.sql(query).first()
if not row:
    return MappingProxyType({})
```

For a table `_table_exists` **just confirmed present**, an empty `DESCRIBE DETAIL` result is not "a table with no properties" — that case is a present row whose `properties` map is empty. An empty *result* signals a race (table dropped mid-read) or a catalog inconsistency. The silent fallback reported `TablePresent` with no properties, so the differ would re-apply every managed property on **every** sync and never converge.

### The fix (Ousterhoutian: fail loud, don't mask)

Raise on the true no-rows signal. `fetch_state`'s total error boundary (`except Exception → ReadFailed`) already converts it to `ReadFailed` — the honest outcome for "could not determine state":

```python
row = self.spark.sql(query).first()
if row is None:
    raise RuntimeError(
        f"DESCRIBE DETAIL returned no rows for {qualified_name}, which the"
        " existence probe just reported as present — the table was dropped"
        " mid-read or the catalog is inconsistent."
    )
return MappingProxyType(dict(row["properties"]))
```

- `RuntimeError`, not `AssertionError` (asserts are stripped under `-O`; this is a genuine runtime race).
- Narrowed `if not row` → `if row is None`: `DataFrame.first()` is typed `Optional[Row]` and a `Row` is truthy even when empty, so `is None` is the precise guard for the only real no-row case.

### Tests

- **New:** `test_fetch_state_fails_when_describe_detail_returns_no_rows` — asserts `ReadFailed` with `exception_type == "RuntimeError"`.
- **Renamed two misleading tests.** They passed `describe_rows=[]` into `FakeSparkWithPrimaryKey`, whose `describe_rows or [{"properties": {}}]` default *silently substituted a non-empty row* — so despite their "…when describe has no rows" names they always exercised the empty-properties-**map** path, never the no-rows path. (This trap is exactly what led the audit doc to believe these tests "pinned the silent behaviour" and would flip to `ReadFailed`; they don't, and shouldn't.) Renamed to `…when_table_has_no_properties`, made the row explicit, kept their `TablePresent` assertions.
- Added the missing `column_tags` branch to `FakeSparkForFetchState.sql()` so the new test's read path is correct by construction rather than by accident (surfaced by adversarial review).

### On the audit's decision item 2

The audit said this "flips two pinned tests from `TablePresent`-with-empty-properties to `ReadFailed`." That was based on the misleading test names above — **no test actually pinned the no-rows→`TablePresent` behaviour**. The only intended behaviour change is the genuine no-rows case; the legitimate empty-properties-map case stays `TablePresent`.

### Deliberately left silent

The `except AnalysisException: return <empty>` guards on `_fetch_table_tags`, `_fetch_column_tags`, `_fetch_primary_key`, `_fetch_foreign_keys` are **not** the same pattern: `information_schema` is legitimately unavailable on plain Spark / non-UC, so an empty result there is an expected operational state, not an unexpected failure. `DESCRIBE DETAIL` on a confirmed-present table has no such caveat. The asymmetry is intentional and already documented in each method.

### Verification

- 360 passed locally; ruff + mypy clean.
- The new reader test errors locally only on the `spark` fixture's Delta-jar Maven download (TLS-inspecting proxy — the known ~50-error local baseline shared by all `test_reader.py`/e2e tests); it runs in CI's `test` check. Core paths verified directly via a `uv run python` probe (raise fires on `None`; empty-map path stays `TablePresent`; boundary yields `ReadFailed(RuntimeError)`).
- Changes reviewed adversarially across correctness / test-integrity / design lenses; verdict safe-to-commit, the one actionable finding (the fake's `column_tags` gap) fixed above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)