### PR TITLE
[codex] Add user-facing import paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,8 @@ Declarative schema management for Delta Lake tables on Databricks. Define the sc
 ## Quickstart
 
 ```python
-from delta_engine import Column, DeltaTable, Integer, String, build_databricks_engine
+from delta_engine.databricks import build_engine
+from delta_engine.schema import Column, DeltaTable, Integer, String
 
 customers = DeltaTable(
     catalog="dev",
@@ -17,7 +18,7 @@ customers = DeltaTable(
     ],
 )
 
-engine = build_databricks_engine(spark)
+engine = build_engine(spark)
 engine.sync(customers)  # creates the table, or no-ops if it already matches
 ```
 

--- a/docs/explanation-architecture.md
+++ b/docs/explanation-architecture.md
@@ -222,8 +222,8 @@ flowchart TB
 The arrows show source dependencies. The domain does not import Spark,
 Databricks, the application layer, or adapter code. Backend-specific code
 depends inward on the application ports and domain vocabulary. The top-level
-`delta_engine` package eagerly exposes the pure-Python API and application
-surface, and lazily exposes Databricks helpers so `import delta_engine` does not
+`delta_engine` package eagerly exposes backend-neutral runtime types such as
+`Engine`, `SyncReport`, and `SyncFailedError`, so `import delta_engine` does not
 require PySpark.
 
 `delta_engine.schema` and `delta_engine.databricks` are public import aliases
@@ -490,10 +490,9 @@ including `DeltaTable`, data types, `Engine`, `SyncReport`, and
 
 Databricks helpers live in the adapter package and import PySpark. The
 preferred import path is `delta_engine.databricks`, whose public functions
-import the real adapter only when called. `delta_engine.__init__` also exposes
-the legacy root names lazily with PEP 562 `__getattr__`:
+import the real adapter only when called:
 
-- `build_databricks_engine`
+- `build_engine`
 - `configure_logging`
 
 Calling the Databricks factory imports `delta_engine.adapters.databricks` on

--- a/docs/explanation-architecture.md
+++ b/docs/explanation-architecture.md
@@ -197,7 +197,7 @@ An `ActionPlan` is produced by iterating each change's `.actions()`; actions are
 
 | Package | Responsibility | Examples |
 |---|---|---|
-| `delta_engine.api` | User-facing declarations and import surface | `DeltaTable`, `ForeignKey`, `Property` |
+| `delta_engine.schema` / `delta_engine.api` | User-facing declarations and import surface | `DeltaTable`, `ForeignKey`, `Property` |
 | `delta_engine.application` | Use-case orchestration, ports, failures, validation, dependency resolution, reports | `Engine`, `CatalogStateReader`, `PlanExecutor`, `validate_diff`, `resolve`, `SyncReport` |
 | `delta_engine.domain` | Backend-free snapshots, diffs, actions, and deterministic planning | `DesiredTable`, `ObservedTable`, `TableDiff`, `ActionPlan` |
 | `delta_engine.adapters` | Backend integration and translation | `DatabricksReader`, `DatabricksExecutor`, SQL compiler |
@@ -205,7 +205,7 @@ An `ActionPlan` is produced by iterating each change's `.actions()`; actions are
 ```mermaid
 flowchart TB
     Public[delta_engine.__init__<br/>curated public exports]
-    API[api<br/>DeltaTable, ForeignKey, Property]
+    API[schema / api<br/>DeltaTable, ForeignKey, Property]
     App[application<br/>Engine, ports, validation, reports]
     Domain[domain<br/>snapshots, diffs, actions]
     Adapters[adapters<br/>Databricks reader, executor, SQL compiler]
@@ -225,6 +225,10 @@ depends inward on the application ports and domain vocabulary. The top-level
 `delta_engine` package eagerly exposes the pure-Python API and application
 surface, and lazily exposes Databricks helpers so `import delta_engine` does not
 require PySpark.
+
+`delta_engine.schema` and `delta_engine.databricks` are public import aliases
+for users: schema declarations still live in `delta_engine.api`, and Databricks
+integration still lives in `delta_engine.adapters.databricks`.
 
 ## Diff-first planning
 
@@ -484,14 +488,17 @@ PySpark installed. It eagerly exports pure-Python API and application objects,
 including `DeltaTable`, data types, `Engine`, `SyncReport`, and
 `SyncFailedError`.
 
-Databricks helpers live in the adapter package and import PySpark, so
-`delta_engine.__init__` exposes them lazily with PEP 562 `__getattr__`:
+Databricks helpers live in the adapter package and import PySpark. The
+preferred import path is `delta_engine.databricks`, whose public functions
+import the real adapter only when called. `delta_engine.__init__` also exposes
+the legacy root names lazily with PEP 562 `__getattr__`:
 
 - `build_databricks_engine`
 - `configure_logging`
 
-Accessing either name imports `delta_engine.adapters.databricks` on demand.
-Plain table declarations and schema-only tests do not pay that dependency cost.
+Calling the Databricks factory imports `delta_engine.adapters.databricks` on
+demand. Plain table declarations and schema-only tests do not pay that
+dependency cost.
 
 ## Where to make changes
 
@@ -502,7 +509,7 @@ Plain table declarations and schema-only tests do not pay that dependency cost.
 | Add a new action type | `delta_engine.domain.plan` and adapter compiler | Define the action and phase in `actions.py`, emit it from the relevant change's `actions()` method, then compile it in the backend adapter. |
 | Add a safety rule | `delta_engine.application.validation` | Rules inspect the `TableDrift` changes and return `ValidationFailure` values. |
 | Add a data type | `delta_engine.domain.model.data_type` and adapter type mapping | The domain type is backend-free; SQL names and Spark parsing live in the Databricks adapter. |
-| Change public declarations | `delta_engine.api` | Keep public ergonomics here and lower choices into domain snapshots before the engine phases begin. |
+| Change public declarations | `delta_engine.api`, surfaced through `delta_engine.schema` | Keep public ergonomics here and lower choices into domain snapshots before the engine phases begin. |
 | Change FK ordering or blocking | `delta_engine.application.dependency_resolution` | Cross-table dependency policy lives in the application layer, not in the domain plan or SQL compiler. |
 | Change report output | `delta_engine.application.report` and `delta_engine.application.rendering` | Keep display formatting out of domain objects. |
 | Change Databricks SQL | `delta_engine.adapters.databricks.sql` | Compile domain actions to backend statements at the adapter boundary. |
@@ -517,5 +524,5 @@ Plain table declarations and schema-only tests do not pay that dependency cost.
   identifiers, parsing Spark types, and quoting SQL.
 - Return typed failures across ports instead of raising backend exceptions.
 - Let `ActionPlan` own action ordering; callers should not sort plans manually.
-- Keep user-facing convenience in `delta_engine.api`, then lower to domain
-  snapshots before planning begins.
+- Keep user-facing schema convenience in `delta_engine.schema` / `delta_engine.api`,
+  then lower to domain snapshots before planning begins.

--- a/docs/how-to-configure-properties.md
+++ b/docs/how-to-configure-properties.md
@@ -22,7 +22,7 @@ Deletion vectors are intentionally **not** defaulted here — current Databricks
 ## Override a default
 
 ```python
-from delta_engine import Column, DeltaTable, Property, String
+from delta_engine.schema import Column, DeltaTable, Property, String
 
 table = DeltaTable(
     catalog="dev",
@@ -38,7 +38,7 @@ table = DeltaTable(
 ## Set additional properties
 
 ```python
-from delta_engine import Column, DeltaTable, Property, String
+from delta_engine.schema import Column, DeltaTable, Property, String
 
 table = DeltaTable(
     catalog="dev",

--- a/docs/how-to-configure-tags.md
+++ b/docs/how-to-configure-tags.md
@@ -12,7 +12,7 @@ Tags are **not** `TBLPROPERTIES`. If you want to change Delta behaviour (deletio
 ## Declare tags
 
 ```python
-from delta_engine import Column, DeltaTable, String
+from delta_engine.schema import Column, DeltaTable, String
 
 table = DeltaTable(
     catalog="dev",
@@ -52,7 +52,7 @@ Tags can also be declared on individual columns. Pass a `tags` dict to a
 `Column`:
 
 ```python
-from delta_engine import Column, DeltaTable, String
+from delta_engine.schema import Column, DeltaTable, String
 
 table = DeltaTable(
     catalog="dev",

--- a/docs/how-to-declare-foreign-keys.md
+++ b/docs/how-to-declare-foreign-keys.md
@@ -8,7 +8,7 @@ tags:
 Pass `foreign_keys` to `DeltaTable` with one `ForeignKey` per constraint. Each foreign key names the local columns and the table they reference; the referenced columns are inferred from that table's primary key.
 
 ```python
-from delta_engine import Column, DeltaTable, ForeignKey, Long, String
+from delta_engine.schema import Column, DeltaTable, ForeignKey, Long, String
 
 customers = DeltaTable(
     catalog="dev",
@@ -45,7 +45,7 @@ The engine derives the constraint name as `{table_name}_{local_columns}_fk` — 
 Use the `Self` sentinel when a table references itself:
 
 ```python
-from delta_engine import Self
+from delta_engine.schema import Self
 
 employees = DeltaTable(
     catalog="dev",

--- a/docs/how-to-declare-primary-keys.md
+++ b/docs/how-to-declare-primary-keys.md
@@ -8,7 +8,7 @@ tags:
 Declare a primary key by setting `primary_key=True` on one or more `Column` objects. All primary key columns must be `NOT NULL`.
 
 ```python
-from delta_engine import Column, DeltaTable, Integer, String
+from delta_engine.schema import Column, DeltaTable, Integer, String
 
 orders = DeltaTable(
     catalog="dev",

--- a/docs/how-to-deploy-metadata-only.md
+++ b/docs/how-to-deploy-metadata-only.md
@@ -16,7 +16,7 @@ change can slip in.
 ## Declare a metadata-only table
 
 ```python
-from delta_engine import Column, DeltaTable, Integer, String
+from delta_engine.schema import Column, DeltaTable, Integer, String
 
 table = DeltaTable(
     catalog="dev",

--- a/docs/reference-api.md
+++ b/docs/reference-api.md
@@ -5,12 +5,12 @@ tags:
 
 # API reference
 
-## User-facing surface
+## Schema declarations
 
 ### DeltaTable
 
 ```{eval-rst}
-.. autoclass:: delta_engine.DeltaTable
+.. autoclass:: delta_engine.schema.DeltaTable
    :members:
    :undoc-members:
    :show-inheritance:
@@ -26,7 +26,7 @@ exactly — any structural drift causes validation to fail.
 ### Column
 
 ```{eval-rst}
-.. autoclass:: delta_engine.Column
+.. autoclass:: delta_engine.schema.Column
    :members:
    :undoc-members:
 ```
@@ -34,7 +34,7 @@ exactly — any structural drift causes validation to fail.
 ### ForeignKey
 
 ```{eval-rst}
-.. autoclass:: delta_engine.ForeignKey
+.. autoclass:: delta_engine.schema.ForeignKey
    :members:
    :undoc-members:
 ```
@@ -42,15 +42,17 @@ exactly — any structural drift causes validation to fail.
 ### Self
 
 ```{eval-rst}
-.. autodata:: delta_engine.Self
+.. autodata:: delta_engine.schema.Self
 ```
 
 ### Property
 
 ```{eval-rst}
-.. autoclass:: delta_engine.Property
+.. autoclass:: delta_engine.schema.Property
    :members:
 ```
+
+## Engine
 
 ### Engine
 
@@ -92,9 +94,9 @@ exactly — any structural drift causes validation to fail.
 ## Databricks adapter
 
 ```{eval-rst}
-.. autofunction:: delta_engine.build_databricks_engine
+.. autofunction:: delta_engine.databricks.build_engine
 ```
 
 ```{eval-rst}
-.. autofunction:: delta_engine.configure_logging
+.. autofunction:: delta_engine.databricks.configure_logging
 ```

--- a/docs/todo/todo.md
+++ b/docs/todo/todo.md
@@ -43,5 +43,4 @@
 - [ ] Should we remove the concept of default properties altogether?
 - [ ] restructure files so that important things come first
 - [ ] is it possible to remove Changed[T] so that everything is either Added or Removed?
-- [ ] build_databricks_engine should live in API
-
+- [x] Teach Databricks factory through `delta_engine.databricks.build_engine` instead of moving it into API

--- a/docs/tutorial-getting-started.md
+++ b/docs/tutorial-getting-started.md
@@ -18,7 +18,7 @@ This tutorial walks you through defining your first Delta table, registering it,
 Import the building blocks and describe your table:
 
 ```python
-from delta_engine import Column, DeltaTable, Integer, String
+from delta_engine.schema import Column, DeltaTable, Integer, String
 
 customers = DeltaTable(
     catalog="dev",
@@ -39,7 +39,7 @@ Pass `partitioned_by` to `DeltaTable` to set partition columns when the table is
 created:
 
 ```python
-from delta_engine import Column, Date, DeltaTable, String
+from delta_engine.schema import Column, Date, DeltaTable, String
 
 events = DeltaTable(
     catalog="dev",
@@ -69,9 +69,9 @@ list of changes the engine rejects at validation.
 Build an engine and pass your table definitions straight to `sync`. The engine reads the current catalog state, computes a plan, validates it, and executes any DDL needed:
 
 ```python
-from delta_engine import build_databricks_engine
+from delta_engine.databricks import build_engine
 
-engine = build_databricks_engine(spark)
+engine = build_engine(spark)
 engine.sync(customers)
 ```
 
@@ -82,7 +82,7 @@ If the table does not exist, the engine creates it. If it already matches your d
 Call `configure_logging()` before `sync` to see colored progress output:
 
 ```python
-from delta_engine import configure_logging
+from delta_engine.databricks import configure_logging
 
 configure_logging()
 engine.sync(customers)

--- a/notebooks/delta_engine_walkthrough.py
+++ b/notebooks/delta_engine_walkthrough.py
@@ -23,7 +23,9 @@ import sys
 
 import pyspark.sql.types as T
 
-from delta_engine import (
+from delta_engine import SyncFailedError, SyncReport, TableRunStatus
+from delta_engine.databricks import build_engine, configure_logging
+from delta_engine.schema import (
     Column,
     Date,
     Decimal,
@@ -34,12 +36,7 @@ from delta_engine import (
     Property,
     Self,
     String,
-    SyncFailedError,
-    SyncReport,
-    TableRunStatus,
     Timestamp,
-    build_databricks_engine,
-    configure_logging,
 )
 
 # COMMAND ----------
@@ -148,7 +145,7 @@ orders = DeltaTable(
 
 tables = [orders, customers]  # passed orders-first on purpose
 
-engine = build_databricks_engine(spark)
+engine = build_engine(spark)
 report = engine.sync(*tables)
 show_report(report)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -148,17 +148,23 @@ name = "Hexagonal package layers"
 type = "layers"
 containers = ["delta_engine"]
 layers = [
-  "adapters | api",
+  "databricks | schema | adapters | api",
   "application",
   "domain",
 ]
 exhaustive = true
+ignore_imports = [
+  # Public import aliases only; implementations remain in api/adapters.
+  "delta_engine.databricks -> delta_engine.adapters.databricks",
+  "delta_engine.schema -> delta_engine.api",
+]
 
 [[tool.importlinter.contracts]]
 id = "backend-imports-stay-in-adapters"
 name = "Backend imports stay in adapters"
 type = "forbidden"
 source_modules = [
+  "delta_engine.schema",
   "delta_engine.api",
   "delta_engine.application",
   "delta_engine.domain",

--- a/src/delta_engine/__init__.py
+++ b/src/delta_engine/__init__.py
@@ -1,15 +1,17 @@
 """
 delta-engine: declarative schema management for Delta Lake tables.
 
-This is the curated entry point. The common workflow imports from here directly::
+This is the curated compatibility entry point. The preferred user imports are::
 
-    from delta_engine import DeltaTable, Column, Integer, Engine, build_databricks_engine
+    from delta_engine.schema import DeltaTable, Column, Integer
+    from delta_engine.databricks import build_engine
+    from delta_engine import Engine
 
 The schema and engine surface (defining tables, the engine and its result types)
-is pyspark-free and eagerly available. ``build_databricks_engine``
-and ``configure_logging`` are exposed here too but imported lazily, so
-``import delta_engine`` never requires pyspark -- tables can be defined and
-planned without a Spark install.
+is still available here for compatibility. ``build_databricks_engine`` and
+``configure_logging`` are exposed here too but imported lazily, so ``import
+delta_engine`` never requires pyspark -- tables can be defined and planned
+without a Spark install.
 """
 
 from typing import TYPE_CHECKING

--- a/src/delta_engine/__init__.py
+++ b/src/delta_engine/__init__.py
@@ -1,39 +1,16 @@
 """
 delta-engine: declarative schema management for Delta Lake tables.
 
-This is the curated compatibility entry point. The preferred user imports are::
+This is the curated runtime entry point. The preferred user imports are::
 
     from delta_engine.schema import DeltaTable, Column, Integer
     from delta_engine.databricks import build_engine
     from delta_engine import Engine
 
-The schema and engine surface (defining tables, the engine and its result types)
-is still available here for compatibility. ``build_databricks_engine`` and
-``configure_logging`` are exposed here too but imported lazily, so ``import
-delta_engine`` never requires pyspark -- tables can be defined and planned
-without a Spark install.
+Only backend-neutral runtime types live here. Schema declarations belong in
+``delta_engine.schema`` and Databricks helpers belong in ``delta_engine.databricks``.
 """
 
-from typing import TYPE_CHECKING
-
-from delta_engine.api import (
-    Array,
-    Boolean,
-    Column,
-    Date,
-    Decimal,
-    DeltaTable,
-    Double,
-    Float,
-    ForeignKey,
-    Integer,
-    Long,
-    Map,
-    Property,
-    Self,
-    String,
-    Timestamp,
-)
 from delta_engine.application import (
     Engine,
     Failure,
@@ -42,45 +19,10 @@ from delta_engine.application import (
     TableRunStatus,
 )
 
-# Lazily-exposed names. These live in the Databricks adapter, which imports
-# pyspark; resolving them here on demand keeps the eager surface above
-# importable without a Spark install. See __getattr__ below (PEP 562).
-_LAZY_EXPORTS = frozenset({"build_databricks_engine", "configure_logging"})
-
-if TYPE_CHECKING:  # let type checkers / IDEs see the lazy names statically
-    from delta_engine.adapters.databricks import build_databricks_engine, configure_logging
-
 __all__ = [
-    "Array",
-    "Boolean",
-    "Column",
-    "Date",
-    "Decimal",
-    "DeltaTable",
-    "Double",
     "Engine",
     "Failure",
-    "Float",
-    "ForeignKey",
-    "Integer",
-    "Long",
-    "Map",
-    "Property",
-    "Self",
-    "String",
     "SyncFailedError",
     "SyncReport",
     "TableRunStatus",
-    "Timestamp",
-    "build_databricks_engine",
-    "configure_logging",
 ]
-
-
-def __getattr__(name: str) -> object:
-    """Resolve the pyspark-bound exports on first access (PEP 562)."""
-    if name in _LAZY_EXPORTS:
-        from delta_engine.adapters import databricks
-
-        return getattr(databricks, name)
-    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/src/delta_engine/adapters/databricks/__init__.py
+++ b/src/delta_engine/adapters/databricks/__init__.py
@@ -1,4 +1,20 @@
-from delta_engine.adapters.databricks.build_engine import build_databricks_engine
-from delta_engine.adapters.databricks.log_config import configure_logging
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from delta_engine.adapters.databricks.build_engine import build_databricks_engine
+    from delta_engine.adapters.databricks.log_config import configure_logging
 
 __all__ = ["build_databricks_engine", "configure_logging"]
+
+
+def __getattr__(name: str) -> object:
+    """Resolve Databricks helpers without importing PySpark until needed."""
+    if name == "build_databricks_engine":
+        from delta_engine.adapters.databricks.build_engine import build_databricks_engine
+
+        return build_databricks_engine
+    if name == "configure_logging":
+        from delta_engine.adapters.databricks.log_config import configure_logging
+
+        return configure_logging
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/src/delta_engine/adapters/databricks/__init__.py
+++ b/src/delta_engine/adapters/databricks/__init__.py
@@ -1,18 +1,18 @@
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
-    from delta_engine.adapters.databricks.build_engine import build_databricks_engine
+    from delta_engine.adapters.databricks.factory import build_engine
     from delta_engine.adapters.databricks.log_config import configure_logging
 
-__all__ = ["build_databricks_engine", "configure_logging"]
+__all__ = ["build_engine", "configure_logging"]
 
 
 def __getattr__(name: str) -> object:
     """Resolve Databricks helpers without importing PySpark until needed."""
-    if name == "build_databricks_engine":
-        from delta_engine.adapters.databricks.build_engine import build_databricks_engine
+    if name == "build_engine":
+        from delta_engine.adapters.databricks.factory import build_engine
 
-        return build_databricks_engine
+        return build_engine
     if name == "configure_logging":
         from delta_engine.adapters.databricks.log_config import configure_logging
 

--- a/src/delta_engine/adapters/databricks/factory.py
+++ b/src/delta_engine/adapters/databricks/factory.py
@@ -7,7 +7,7 @@ from delta_engine.adapters.databricks.reader import DatabricksReader
 from delta_engine.application.engine import Engine
 
 
-def build_databricks_engine(spark: SparkSession) -> Engine:
+def build_engine(spark: SparkSession) -> Engine:
     """
     Create an engine configured for Databricks.
 

--- a/src/delta_engine/databricks.py
+++ b/src/delta_engine/databricks.py
@@ -16,19 +16,14 @@ from delta_engine.application.engine import Engine
 if TYPE_CHECKING:
     from pyspark.sql import SparkSession
 
-__all__ = ["build_databricks_engine", "build_engine", "configure_logging"]
+__all__ = ["build_engine", "configure_logging"]
 
 
 def build_engine(spark: SparkSession) -> Engine:
     """Create an engine configured for Databricks."""
-    from delta_engine.adapters.databricks import build_databricks_engine
+    from delta_engine.adapters.databricks import build_engine as _build_engine
 
-    return build_databricks_engine(spark)
-
-
-def build_databricks_engine(spark: SparkSession) -> Engine:
-    """Compatibility alias for :func:`build_engine`."""
-    return build_engine(spark)
+    return _build_engine(spark)
 
 
 def configure_logging(level: int = logging.INFO, stream: TextIO | None = None) -> None:

--- a/src/delta_engine/databricks.py
+++ b/src/delta_engine/databricks.py
@@ -1,0 +1,38 @@
+"""
+Public Databricks entry points.
+
+The implementation lives in ``delta_engine.adapters.databricks``. This module
+keeps the user-facing Databricks import path short while preserving lazy PySpark
+imports for code that only declares schemas or inspects result types.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING, TextIO
+
+from delta_engine.application.engine import Engine
+
+if TYPE_CHECKING:
+    from pyspark.sql import SparkSession
+
+__all__ = ["build_databricks_engine", "build_engine", "configure_logging"]
+
+
+def build_engine(spark: SparkSession) -> Engine:
+    """Create an engine configured for Databricks."""
+    from delta_engine.adapters.databricks import build_databricks_engine
+
+    return build_databricks_engine(spark)
+
+
+def build_databricks_engine(spark: SparkSession) -> Engine:
+    """Compatibility alias for :func:`build_engine`."""
+    return build_engine(spark)
+
+
+def configure_logging(level: int = logging.INFO, stream: TextIO | None = None) -> None:
+    """Install the package's colored logging handler."""
+    from delta_engine.adapters.databricks import configure_logging as _configure_logging
+
+    _configure_logging(level=level, stream=stream)

--- a/src/delta_engine/schema.py
+++ b/src/delta_engine/schema.py
@@ -1,0 +1,44 @@
+"""
+Public schema declaration surface.
+
+Import table declarations, columns, data types, properties, and key helpers
+from here when defining desired Delta table schemas.
+"""
+
+from delta_engine.api import (
+    Array,
+    Boolean,
+    Column,
+    Date,
+    Decimal,
+    DeltaTable,
+    Double,
+    Float,
+    ForeignKey,
+    Integer,
+    Long,
+    Map,
+    Property,
+    Self,
+    String,
+    Timestamp,
+)
+
+__all__ = [
+    "Array",
+    "Boolean",
+    "Column",
+    "Date",
+    "Decimal",
+    "DeltaTable",
+    "Double",
+    "Float",
+    "ForeignKey",
+    "Integer",
+    "Long",
+    "Map",
+    "Property",
+    "Self",
+    "String",
+    "Timestamp",
+]

--- a/tests/adapters/databricks/test_build_engine.py
+++ b/tests/adapters/databricks/test_build_engine.py
@@ -2,7 +2,7 @@ import io
 import logging
 
 from delta_engine.adapters.databricks import (
-    build_databricks_engine,
+    build_engine,
     configure_logging,
 )
 from delta_engine.adapters.databricks.log_config import LevelColorFormatter
@@ -13,23 +13,23 @@ class _DummySpark:
     """Stand-in for a SparkSession; the factory only stores it on the adapters."""
 
 
-def test_build_databricks_engine_returns_an_engine():
+def test_build_engine_returns_an_engine():
     # Given a Spark session
     # When building the engine
-    engine = build_databricks_engine(_DummySpark())
+    engine = build_engine(_DummySpark())
 
     # Then a wired Engine is returned
     assert isinstance(engine, Engine)
 
 
-def test_build_databricks_engine_does_not_touch_root_logging():
+def test_build_engine_does_not_touch_root_logging():
     # Given a caller that has installed its own root log handler
     root = logging.getLogger()
     sentinel = logging.NullHandler()
     root.addHandler(sentinel)
     try:
         # When building the engine
-        build_databricks_engine(_DummySpark())
+        build_engine(_DummySpark())
 
         # Then the caller's handler survives -- the factory has no logging side effect
         assert sentinel in root.handlers

--- a/tests/adapters/databricks/test_build_engine.py
+++ b/tests/adapters/databricks/test_build_engine.py
@@ -1,7 +1,10 @@
 import io
 import logging
 
-from delta_engine.adapters.databricks import build_databricks_engine, configure_logging
+from delta_engine.adapters.databricks import (
+    build_databricks_engine,
+    configure_logging,
+)
 from delta_engine.adapters.databricks.log_config import LevelColorFormatter
 from delta_engine.application.engine import Engine
 

--- a/tests/test_public_api.py
+++ b/tests/test_public_api.py
@@ -1,5 +1,5 @@
 """
-The top-level `delta_engine` namespace is the curated one-import entry point.
+The top-level `delta_engine` namespace is the curated compatibility entry point.
 
 The pyspark-free surface (define a table, the engine and its result types) is
 eagerly available. The Databricks factory and logging helper

--- a/tests/test_public_api.py
+++ b/tests/test_public_api.py
@@ -1,10 +1,9 @@
 """
-The top-level `delta_engine` namespace is the curated compatibility entry point.
+The top-level `delta_engine` namespace is the curated runtime entry point.
 
-The pyspark-free surface (define a table, the engine and its result types) is
-eagerly available. The Databricks factory and logging helper
-are exposed too, but imported lazily so `import delta_engine` never requires
-pyspark — keeping the "define tables without Spark" capability intact.
+The engine and its result types are eagerly available and pyspark-free. Schema
+declarations live in `delta_engine.schema`; Databricks helpers live in
+`delta_engine.databricks`.
 """
 
 import subprocess
@@ -15,66 +14,36 @@ import pytest
 import delta_engine
 
 _EAGER = {
-    # schema: define a table
-    "DeltaTable",
-    "Column",
-    "Array",
-    "Boolean",
-    "Date",
-    "Decimal",
-    "Double",
-    "Float",
-    "ForeignKey",
-    "Integer",
-    "Long",
-    "Map",
-    "Property",
-    "Self",
-    "String",
-    "Timestamp",
-    # application: run a sync and read the outcome
     "Engine",
     "SyncReport",
     "SyncFailedError",
     "Failure",
     "TableRunStatus",
 }
-_LAZY = {"build_databricks_engine", "configure_logging"}
 
 
 def test_eager_names_are_importable_and_identical_to_their_source():
     # Given the curated root namespace
     # Then every pyspark-free name resolves to the same object as its source module
-    from delta_engine import Column, DeltaTable, Engine, Property
-    from delta_engine.api import (
-        Column as ColumnImpl,
-        DeltaTable as DeltaTableImpl,
-        Property as PropertyImpl,
+    from delta_engine import Engine, Failure, SyncFailedError, SyncReport, TableRunStatus
+    from delta_engine.application import (
+        Engine as EngineImpl,
+        Failure as FailureImpl,
+        SyncFailedError as SyncFailedErrorImpl,
+        SyncReport as SyncReportImpl,
+        TableRunStatus as TableRunStatusImpl,
     )
-    from delta_engine.application import Engine as EngineImpl
 
-    assert DeltaTable is DeltaTableImpl
-    assert Column is ColumnImpl
     assert Engine is EngineImpl
-    assert Property is PropertyImpl
-
-
-def test_lazy_factory_names_resolve_to_their_source():
-    # Given the lazily-exposed Databricks entry points
-    from delta_engine import build_databricks_engine, configure_logging
-    from delta_engine.adapters.databricks import (
-        build_databricks_engine as factory_impl,
-        configure_logging as configure_impl,
-    )
-
-    # Then they resolve to the same objects as their source module
-    assert build_databricks_engine is factory_impl
-    assert configure_logging is configure_impl
+    assert Failure is FailureImpl
+    assert SyncFailedError is SyncFailedErrorImpl
+    assert SyncReport is SyncReportImpl
+    assert TableRunStatus is TableRunStatusImpl
 
 
 def test_all_advertises_eager_and_lazy_names():
-    # Then __all__ lists the full curated surface, eager and lazy alike
-    assert set(delta_engine.__all__) == _EAGER | _LAZY
+    # Then __all__ lists the root runtime surface exactly
+    assert set(delta_engine.__all__) == _EAGER
 
 
 def test_unknown_attribute_raises_attribute_error():
@@ -90,10 +59,7 @@ def test_eager_surface_imports_without_pyspark_installed():
     # pyspark is a dev-only dependency)
     program = (
         "import sys; sys.modules['pyspark'] = None\n"
-        "from delta_engine import (\n"
-        "    DeltaTable, Column, Integer, Property, Engine,\n"
-        "    SyncReport, SyncFailedError, Failure,\n"
-        ")\n"
+        "from delta_engine import Engine, SyncReport, SyncFailedError, Failure\n"
         "print('ok')\n"
     )
 

--- a/tests/test_public_imports.py
+++ b/tests/test_public_imports.py
@@ -1,0 +1,103 @@
+"""Preferred public import paths for library users."""
+
+import subprocess
+import sys
+
+import delta_engine.databricks as databricks
+import delta_engine.schema as schema
+
+_SCHEMA_EXPORTS = {
+    "Array",
+    "Boolean",
+    "Column",
+    "Date",
+    "Decimal",
+    "DeltaTable",
+    "Double",
+    "Float",
+    "ForeignKey",
+    "Integer",
+    "Long",
+    "Map",
+    "Property",
+    "Self",
+    "String",
+    "Timestamp",
+}
+
+
+class _DummySpark:
+    """Stand-in for a SparkSession; the factory only stores it on the adapters."""
+
+
+def test_schema_import_path_matches_the_existing_api_surface():
+    # Given the preferred user-facing schema import path
+    import delta_engine.api as api
+
+    # Then it exposes exactly the same declaration names as the existing API
+    assert set(schema.__all__) == _SCHEMA_EXPORTS
+    for name in _SCHEMA_EXPORTS:
+        assert getattr(schema, name) is getattr(api, name)
+
+
+def test_databricks_import_path_exposes_backend_entry_points():
+    # Given the preferred user-facing Databricks import path
+    from delta_engine.application import Engine
+
+    # Then the shorter factory name builds the same wired Engine
+    engine = databricks.build_engine(_DummySpark())
+    assert isinstance(engine, Engine)
+    assert set(databricks.__all__) == {
+        "build_engine",
+        "build_databricks_engine",
+        "configure_logging",
+    }
+
+
+def test_compat_databricks_factory_alias_builds_an_engine():
+    # Given callers who still use the backend-specific factory name
+    from delta_engine.application import Engine
+
+    # Then the new Databricks import path still supports it
+    engine = databricks.build_databricks_engine(_DummySpark())
+    assert isinstance(engine, Engine)
+
+
+def test_preferred_pure_imports_and_databricks_module_import_do_not_require_pyspark():
+    # Given an interpreter where pyspark cannot be imported
+    program = (
+        "import sys; sys.modules['pyspark'] = None\n"
+        "from delta_engine.schema import Column, DeltaTable, Integer\n"
+        "from delta_engine import Engine, SyncFailedError, SyncReport, TableRunStatus\n"
+        "from delta_engine.databricks import (\n"
+        "    build_engine, build_databricks_engine, configure_logging,\n"
+        ")\n"
+        "print('ok')\n"
+    )
+
+    # When importing the preferred schema path, root runtime types, and the
+    # Databricks module itself
+    result = subprocess.run([sys.executable, "-c", program], capture_output=True, text=True)
+
+    # Then no PySpark import is required until a Databricks factory is called
+    assert result.returncode == 0, result.stderr
+    assert result.stdout.strip() == "ok"
+
+
+def test_logging_configuration_imports_and_runs_without_pyspark_installed():
+    # Given an interpreter where pyspark cannot be imported
+    program = (
+        "import sys; sys.modules['pyspark'] = None\n"
+        "from delta_engine import configure_logging as configure_root_logging\n"
+        "from delta_engine.databricks import configure_logging as configure_databricks_logging\n"
+        "configure_root_logging()\n"
+        "configure_databricks_logging()\n"
+        "print('ok')\n"
+    )
+
+    # When resolving and calling the logging helpers
+    result = subprocess.run([sys.executable, "-c", program], capture_output=True, text=True)
+
+    # Then logging setup does not require the Spark-bound engine factory
+    assert result.returncode == 0, result.stderr
+    assert result.stdout.strip() == "ok"

--- a/tests/test_public_imports.py
+++ b/tests/test_public_imports.py
@@ -49,18 +49,8 @@ def test_databricks_import_path_exposes_backend_entry_points():
     assert isinstance(engine, Engine)
     assert set(databricks.__all__) == {
         "build_engine",
-        "build_databricks_engine",
         "configure_logging",
     }
-
-
-def test_compat_databricks_factory_alias_builds_an_engine():
-    # Given callers who still use the backend-specific factory name
-    from delta_engine.application import Engine
-
-    # Then the new Databricks import path still supports it
-    engine = databricks.build_databricks_engine(_DummySpark())
-    assert isinstance(engine, Engine)
 
 
 def test_preferred_pure_imports_and_databricks_module_import_do_not_require_pyspark():
@@ -70,7 +60,7 @@ def test_preferred_pure_imports_and_databricks_module_import_do_not_require_pysp
         "from delta_engine.schema import Column, DeltaTable, Integer\n"
         "from delta_engine import Engine, SyncFailedError, SyncReport, TableRunStatus\n"
         "from delta_engine.databricks import (\n"
-        "    build_engine, build_databricks_engine, configure_logging,\n"
+        "    build_engine, configure_logging,\n"
         ")\n"
         "print('ok')\n"
     )
@@ -88,9 +78,7 @@ def test_logging_configuration_imports_and_runs_without_pyspark_installed():
     # Given an interpreter where pyspark cannot be imported
     program = (
         "import sys; sys.modules['pyspark'] = None\n"
-        "from delta_engine import configure_logging as configure_root_logging\n"
         "from delta_engine.databricks import configure_logging as configure_databricks_logging\n"
-        "configure_root_logging()\n"
         "configure_databricks_logging()\n"
         "print('ok')\n"
     )


### PR DESCRIPTION
## Summary

Adds clearer user-facing import paths without moving the underlying hexagonal implementation:

- `delta_engine.schema` re-exports the existing schema declaration surface from `delta_engine.api`.
- `delta_engine.databricks` exposes the Databricks user entry points: `build_engine` and `configure_logging`.
- The root `delta_engine` namespace is now runtime-only, exposing `Engine`, result types, and errors.
- Docs, README, and the walkthrough notebook now teach the schema/databricks import split.

## Architecture

The real implementation stays in the existing packages: schema declarations in `delta_engine.api`, Databricks integration in `delta_engine.adapters.databricks`, application orchestration in `delta_engine.application`, and domain logic in `delta_engine.domain`.

Import Linter remains strict for the hexagonal layers, with narrow exceptions only for the two public alias modules.

## Validation

- `uv run ruff check src tests notebooks/delta_engine_walkthrough.py`
- `uv run pytest tests/test_public_api.py tests/test_public_imports.py tests/api/test_public_api.py tests/adapters/databricks/test_build_engine.py --no-cov`
- `uv run lint-imports`
- `uv run mypy src`
- `uv run --group docs sphinx-build -W -b html docs /private/tmp/delta-engine-docs-html`
- `git diff --check`