### PR TITLE
fix: block FK dependents when a parent fails during execution

### DIFF
--- a/docs/how-to-declare-foreign-keys.md
+++ b/docs/how-to-declare-foreign-keys.md
@@ -108,7 +108,7 @@ A foreign key fails its whole table when:
 - It forms a dependency cycle with other tables (`CYCLE`).
 - The table it references won't reach its desired state this sync, for any reason (`BLOCKED_BY_FAILED_DEPENDENCY`).
 
-The third case is transitive. If `customers` fails validation, `orders` won't execute either — and any table that references `orders` is blocked in turn. A dependency that won't build blocks every table downstream of it.
+The third case is transitive and applies at any point in the run. If `customers` fails validation, `orders` won't execute either — and any table that references `orders` is blocked in turn. The same happens when `customers` fails during execution: `orders` is blocked before any of its SQL runs. A dependency that won't build blocks every table downstream of it.
 
 A blocked table reports `FOREIGN_KEY_FAILED`. See [how-to-handle-sync-failures.md](how-to-handle-sync-failures.md) for reading the failure report.
 
@@ -116,13 +116,13 @@ A blocked table reports `FOREIGN_KEY_FAILED`. See [how-to-handle-sync-failures.m
 
 The engine matches foreign keys by content — local columns, referenced table, and referenced columns — not by constraint name.
 
-| Change | Actions emitted |
-|---|---|
-| Foreign key added | `SetForeignKey` |
-| Foreign key removed | `DropForeignKey` |
-| Foreign key changed | `DropForeignKey` then `SetForeignKey` |
-| Same foreign key, different constraint name | nothing |
-| No change | nothing |
+| Change                                      | Actions emitted                       |
+| ------------------------------------------- | ------------------------------------- |
+| Foreign key added                           | `SetForeignKey`                       |
+| Foreign key removed                         | `DropForeignKey`                      |
+| Foreign key changed                         | `DropForeignKey` then `SetForeignKey` |
+| Same foreign key, different constraint name | nothing                               |
+| No change                                   | nothing                               |
 
 Matching by content keeps syncs idempotent: a foreign key created outside this engine, under a name the engine wouldn't derive, produces no actions as long as its columns and referenced table match the declaration.
 

--- a/docs/how-to-handle-sync-failures.md
+++ b/docs/how-to-handle-sync-failures.md
@@ -29,13 +29,13 @@ for table_report in report:
 
 `table_report.status` is one of five `TableRunStatus` values:
 
-| Status | Meaning |
-|---|---|
-| `SUCCESS` | Table synced without issues |
-| `READ_FAILED` | Could not read current catalog state |
-| `VALIDATION_FAILED` | Plan was rejected before any SQL ran |
+| Status               | Meaning                                                         |
+| -------------------- | --------------------------------------------------------------- |
+| `SUCCESS`            | Table synced without issues                                     |
+| `READ_FAILED`        | Could not read current catalog state                            |
+| `VALIDATION_FAILED`  | Plan was rejected before any SQL ran                            |
 | `FOREIGN_KEY_FAILED` | A foreign key could not be applied, or a dependency won't build |
-| `EXECUTION_FAILED` | SQL ran but a statement failed |
+| `EXECUTION_FAILED`   | SQL ran but a statement failed                                  |
 
 ## Read failure details
 
@@ -78,7 +78,7 @@ See [reference-safe-change-rules.md](reference-safe-change-rules.md) for the ful
 
 ## Act on foreign key failures
 
-A `FOREIGN_KEY_FAILED` table ran no SQL. The cause is one of: a reference to an unregistered table, a dependency cycle, or a dependency that won't reach its desired state this sync. When a dependency fails, every table downstream of it is blocked too — so fix the upstream table first, then re-run.
+A `FOREIGN_KEY_FAILED` table ran no SQL. The cause is one of: a reference to an unregistered table, a dependency cycle, a foreign key that does not target the referenced table's primary key, or a dependency that won't reach its desired state this sync — whether it failed before execution (read or validation) or while executing earlier in the same run. When a dependency fails, every table downstream of it is blocked too — so fix the upstream table first, then re-run.
 
 ```python
 for table_report in report:
@@ -91,7 +91,7 @@ See [how-to-declare-foreign-keys.md](how-to-declare-foreign-keys.md) for how dep
 
 ## Act on execution failures
 
-Execution failures are partial: actions before the failure ran and committed; actions after were not attempted. Fix the root cause and re-run — the engine re-reads live state and plans only the remaining drift.
+Execution failures are partial: actions before the failure ran and committed; actions after were not attempted. Tables whose foreign keys depend on the failed table are blocked in the same run and report `FOREIGN_KEY_FAILED`. Fix the root cause and re-run — the engine re-reads live state and plans only the remaining drift.
 
 (runtime-and-delta-feature-compatibility)=
 

--- a/src/delta_engine/application/dependency_resolution.py
+++ b/src/delta_engine/application/dependency_resolution.py
@@ -1,9 +1,13 @@
 """
 Foreign key dependency resolution for sync ordering and failure classification.
 
-The public entry point is `resolve`, which takes the registered tables and
+The public entry points are `resolve`, which takes the registered tables and
 returns a :class:`ResolveResult` with all table names in dependency-first order
-and a mapping of FK failures per table.
+and a mapping of FK failures per table, and `blocking_failures`, which
+classifies which of one table's foreign keys reference already-failed tables.
+`resolve` uses `blocking_failures` for pre-execution propagation and the
+engine reuses it while executing, so both phases block dependents by the
+same rule.
 
 All graph-traversal implementation details (adjacency map, Tarjan's
 strongly-connected-components algorithm, reverse-reachability propagation) are
@@ -79,6 +83,31 @@ def resolve(
 
     ordered_names = tuple(table.qualified_name for table in ordered)
     return ResolveResult(ordered_names=ordered_names, fk_failures=failures_by_table)
+
+
+def blocking_failures(
+    table: DesiredTable,
+    failed: AbstractSet[QualifiedName],
+) -> tuple[ForeignKeyFailure, ...]:
+    """
+    Classify which of ``table``'s foreign keys are blocked by failed tables.
+
+    Returns one BLOCKED_BY_FAILED_DEPENDENCY failure per foreign key that
+    references a table in ``failed``. This is the single owner of the blocking
+    rule: `resolve` applies it when propagating pre-execution failures, and the
+    engine applies it again while executing, so a dependency that will not
+    reach desired state blocks its dependents identically in every phase.
+    """
+    return tuple(
+        ForeignKeyFailure(
+            table=table.qualified_name,
+            local_columns=foreign_key.local_columns,
+            references=foreign_key.referenced_table,
+            reason=ForeignKeyFailureReason.BLOCKED_BY_FAILED_DEPENDENCY,
+        )
+        for foreign_key in table.foreign_keys
+        if foreign_key.referenced_table in failed
+    )
 
 
 def _build_dependency_graph(
@@ -245,10 +274,9 @@ def _classify_failures(
             table_name = table.qualified_name
             if table_name in failed_names:
                 continue
-            blocking = [fk for fk in table.foreign_keys if fk.referenced_table in failed_names]
+            blocking = blocking_failures(table, failed_names)
             if blocking:
-                for foreign_key in blocking:
-                    record(table, foreign_key, ForeignKeyFailureReason.BLOCKED_BY_FAILED_DEPENDENCY)
+                failures.setdefault(table_name, []).extend(blocking)
                 failed_names.add(table_name)
                 changed = True
 

--- a/src/delta_engine/application/engine.py
+++ b/src/delta_engine/application/engine.py
@@ -13,13 +13,16 @@ The six phases, each taking the runs and returning them:
   4. Plan     — lower every diff into its action plan
   5. Resolve  — order runs by FK dependency; append FK failures and
                 propagate blocking to dependents
-  6. Execute  — run the plan of every run with no failures and a non-empty plan
+  6. Execute  — run the plan of every run with no failures and a non-empty
+                plan, blocking FK dependents of runs that fail mid-execution
 
 Running `resolve()` after validation means a table that fails validation
 blocks its FK dependents with BLOCKED_BY_FAILED_DEPENDENCY, not just tables
-with FK-structural failures (CYCLE / UNRESOLVABLE_REFERENCE). The rule is
-uniform: if a dependency won't reach desired state this sync, its dependents
-don't execute either.
+with FK-structural failures (CYCLE / UNRESOLVABLE_REFERENCE). Execution
+applies the same rule as it walks the dependency-ordered runs: a run whose
+dependency fails during execution is blocked rather than executed. The rule
+is uniform: if a dependency won't reach desired state this sync, its
+dependents don't execute either.
 
 A table that fails an early phase carries that failure forward on its run and
 is skipped by execution, so all tables are attempted and the report is always
@@ -31,7 +34,7 @@ from __future__ import annotations
 from datetime import UTC, datetime
 import logging
 
-from delta_engine.application.dependency_resolution import resolve
+from delta_engine.application.dependency_resolution import blocking_failures, resolve
 from delta_engine.application.desired_tables import DesiredTableSource, prepare_desired_tables
 from delta_engine.application.errors import SyncFailedError
 from delta_engine.application.failures import Failure
@@ -257,14 +260,34 @@ class Engine:
         """
         Execute the plan of every run with no failures and a non-empty plan.
 
-        Skipped runs pass through unchanged. Execution failures are appended to
-        the run's ``failures`` and the summary is set on ``execution``. A dry run
-        executes nothing and returns the runs unchanged.
+        Walks the runs in dependency-first order, tracking every table that has
+        failed so far. A run whose foreign key references a failed table is
+        blocked with BLOCKED_BY_FAILED_DEPENDENCY instead of executed, so an
+        execution failure in a parent blocks its FK dependents in the same
+        sync — even dependents with no work of their own. A run with an empty
+        plan and no blocking failures is skipped and counts as a healthy
+        parent. Execution failures are appended to the run's ``failures`` and
+        the summary is set on ``execution``. A dry run executes nothing and
+        returns the runs unchanged.
         """
         if dry_run:
             return runs
+        failed: set[QualifiedName] = set()
         for run in runs:
-            if run.failures or not run.plan:
+            if run.failures:
+                failed.add(run.qualified_name)
+                continue
+            blocking = blocking_failures(run.desired, failed)
+            if blocking:
+                logger.error(
+                    "Execution blocked for %s (%d foreign key failure(s))",
+                    run.qualified_name,
+                    len(blocking),
+                )
+                run.failures.extend(blocking)
+                failed.add(run.qualified_name)
+                continue
+            if not run.plan:
                 continue
             summary = self.executor.execute(run.qualified_name, run.plan)
             logger.info(
@@ -275,4 +298,6 @@ class Engine:
             )
             run.execution = summary
             run.failures.extend(summary.failures)
+            if run.failures:
+                failed.add(run.qualified_name)
         return runs

--- a/tests/application/test_engine.py
+++ b/tests/application/test_engine.py
@@ -912,6 +912,25 @@ def test_execution_failure_blocks_diamond_dependent_with_one_failure_per_fk():
     assert executor.executed_names == ["cat.sch.a"]
 
 
+def test_synced_fk_parent_with_no_work_does_not_block_dependent():
+    # Given customers already matches its declaration and orders is absent
+    reader = _RecordingReader({"cat.sch.customers": _existing_id_table_synced("cat.sch.customers")})
+    executor = _RecordingExecutor([(_ok_exec(0),)])  # orders only
+    engine = Engine(reader=reader, executor=executor)
+
+    # When syncing
+    report = engine.sync(
+        _spec_with_fk("cat.sch.orders", "cat.sch.customers"),
+        _spec("cat.sch.customers"),
+    )
+
+    # Then the healthy no-op parent does not block its dependent
+    assert report.any_failures is False
+    _assert_status(report, "cat.sch.customers", TableRunStatus.SUCCESS)
+    _assert_status(report, "cat.sch.orders", TableRunStatus.SUCCESS)
+    assert executor.executed_names == ["cat.sch.orders"]
+
+
 # ---------------------------------------------------------------------------
 # Duplicate declarations
 # ---------------------------------------------------------------------------

--- a/tests/application/test_engine.py
+++ b/tests/application/test_engine.py
@@ -147,6 +147,20 @@ def _existing_id_table_synced(fqn: str) -> TablePresent:
     )
 
 
+def _existing_fk_table_synced(fqn: str, references: str) -> TablePresent:
+    """Build an observed table that already matches _spec_with_fk(fqn, references)."""
+    desired = _spec_with_fk(fqn, references).to_desired_table()
+
+    return TablePresent(
+        table=ObservedTable(
+            qualified_name=desired.qualified_name,
+            columns=desired.columns,
+            primary_key=desired.primary_key,
+            foreign_keys=desired.foreign_keys,
+        )
+    )
+
+
 def _metadata_only_spec(fqn: str) -> DeltaTable:
     """Build a metadata-only declaration with table and column comments."""
     catalog, schema, table_name = _split_fqn(fqn)
@@ -707,13 +721,6 @@ def test_sync_fails_fk_that_does_not_reference_a_primary_key():
     assert executor.executed_names == ["cat.sch.customers"]
 
 
-@pytest.mark.xfail(
-    strict=True,
-    reason=(
-        "Current Engine._execute() does not yet block FK dependents when a "
-        "parent fails during execution. Remove this marker after fixing _execute()."
-    ),
-)
 def test_execution_failure_in_fk_parent_blocks_dependent_before_execution():
     # Given orders depends on customers, and customers fails during execution
     reader = _RecordingReader()
@@ -754,6 +761,155 @@ def test_execution_failure_in_fk_parent_blocks_dependent_before_execution():
         reason=ForeignKeyFailureReason.BLOCKED_BY_FAILED_DEPENDENCY,
         references="cat.sch.customers",
     )
+
+
+def test_execution_failure_blocks_transitively_along_fk_chain():
+    # Given c -> b -> a, and a fails during execution
+    reader = _RecordingReader()
+    executor = _RecordingExecutor([(_failed_exec(0),)])  # a only; b and c must not run
+    engine = Engine(reader=reader, executor=executor)
+
+    # When syncing
+    with pytest.raises(SyncFailedError) as exc_info:
+        engine.sync(
+            _spec_with_fk("cat.sch.c", "cat.sch.b"),
+            _spec_with_fk("cat.sch.b", "cat.sch.a"),
+            _spec("cat.sch.a"),
+        )
+
+    # Then the block propagates from a through b to c before execution
+    report = exc_info.value.report
+    _assert_status(report, "cat.sch.a", TableRunStatus.EXECUTION_FAILED)
+    table_b = _assert_status(report, "cat.sch.b", TableRunStatus.FOREIGN_KEY_FAILED)
+    table_c = _assert_status(report, "cat.sch.c", TableRunStatus.FOREIGN_KEY_FAILED)
+
+    _assert_has_fk_failure(
+        table_b,
+        reason=ForeignKeyFailureReason.BLOCKED_BY_FAILED_DEPENDENCY,
+        references="cat.sch.a",
+    )
+    _assert_has_fk_failure(
+        table_c,
+        reason=ForeignKeyFailureReason.BLOCKED_BY_FAILED_DEPENDENCY,
+        references="cat.sch.b",
+    )
+
+    assert table_b.execution is None
+    assert table_c.execution is None
+    assert executor.executed_names == ["cat.sch.a"]
+
+
+def test_partial_execution_failure_in_parent_blocks_dependent():
+    # Given customers' plan fails on one action among successful ones
+    reader = _RecordingReader()
+    executor = _RecordingExecutor([(_ok_exec(0), _failed_exec(1))])
+    engine = Engine(reader=reader, executor=executor)
+
+    # When syncing
+    with pytest.raises(SyncFailedError) as exc_info:
+        engine.sync(
+            _spec_with_fk("cat.sch.orders", "cat.sch.customers"),
+            _spec("cat.sch.customers"),
+        )
+
+    # Then a partially failed parent still blocks its dependent
+    report = exc_info.value.report
+    customers = _assert_status(report, "cat.sch.customers", TableRunStatus.EXECUTION_FAILED)
+    orders = _assert_status(report, "cat.sch.orders", TableRunStatus.FOREIGN_KEY_FAILED)
+
+    _assert_has_fk_failure(
+        orders,
+        reason=ForeignKeyFailureReason.BLOCKED_BY_FAILED_DEPENDENCY,
+        references="cat.sch.customers",
+    )
+
+    assert customers.execution is not None
+    assert orders.execution is None
+    assert executor.executed_names == ["cat.sch.customers"]
+
+
+def test_execution_failure_blocks_dependent_that_needed_no_changes():
+    # Given orders already matches its declaration (empty plan)
+    # and customers fails during execution
+    reader = _RecordingReader(
+        {"cat.sch.orders": _existing_fk_table_synced("cat.sch.orders", "cat.sch.customers")}
+    )
+    executor = _RecordingExecutor([(_failed_exec(0),)])  # customers only
+    engine = Engine(reader=reader, executor=executor)
+
+    # When syncing
+    with pytest.raises(SyncFailedError) as exc_info:
+        engine.sync(
+            _spec_with_fk("cat.sch.orders", "cat.sch.customers"),
+            _spec("cat.sch.customers"),
+        )
+
+    # Then the no-op dependent is blocked too: one blocking rule everywhere
+    report = exc_info.value.report
+    _assert_status(report, "cat.sch.customers", TableRunStatus.EXECUTION_FAILED)
+    orders = _assert_status(report, "cat.sch.orders", TableRunStatus.FOREIGN_KEY_FAILED)
+
+    _assert_has_fk_failure(
+        orders,
+        reason=ForeignKeyFailureReason.BLOCKED_BY_FAILED_DEPENDENCY,
+        references="cat.sch.customers",
+    )
+
+    assert orders.execution is None
+    assert executor.executed_names == ["cat.sch.customers"]
+
+
+def test_execution_failure_blocks_diamond_dependent_with_one_failure_per_fk():
+    # Given d -> b and d -> c, both b and c -> a, and a fails during execution
+    spec_d = DeltaTable(
+        "cat",
+        "sch",
+        "d",
+        columns=(
+            Column("id", String(), nullable=False, primary_key=True),
+            Column("b_id", String()),
+            Column("c_id", String()),
+        ),
+        foreign_keys=[
+            ForeignKey(local_columns=("b_id",), references=_referenced_spec("cat.sch.b")),
+            ForeignKey(local_columns=("c_id",), references=_referenced_spec("cat.sch.c")),
+        ],
+    )
+
+    reader = _RecordingReader()
+    executor = _RecordingExecutor([(_failed_exec(0),)])  # a only
+    engine = Engine(reader=reader, executor=executor)
+
+    # When syncing
+    with pytest.raises(SyncFailedError) as exc_info:
+        engine.sync(
+            spec_d,
+            _spec_with_fk("cat.sch.b", "cat.sch.a"),
+            _spec_with_fk("cat.sch.c", "cat.sch.a"),
+            _spec("cat.sch.a"),
+        )
+
+    # Then the block flows through both branches and d records both blocking FKs
+    report = exc_info.value.report
+    _assert_status(report, "cat.sch.a", TableRunStatus.EXECUTION_FAILED)
+    _assert_status(report, "cat.sch.b", TableRunStatus.FOREIGN_KEY_FAILED)
+    _assert_status(report, "cat.sch.c", TableRunStatus.FOREIGN_KEY_FAILED)
+    table_d = _assert_status(report, "cat.sch.d", TableRunStatus.FOREIGN_KEY_FAILED)
+
+    assert len(_foreign_key_failures(table_d)) == 2
+    _assert_has_fk_failure(
+        table_d,
+        reason=ForeignKeyFailureReason.BLOCKED_BY_FAILED_DEPENDENCY,
+        references="cat.sch.b",
+        local_columns=("b_id",),
+    )
+    _assert_has_fk_failure(
+        table_d,
+        reason=ForeignKeyFailureReason.BLOCKED_BY_FAILED_DEPENDENCY,
+        references="cat.sch.c",
+        local_columns=("c_id",),
+    )
+    assert executor.executed_names == ["cat.sch.a"]
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Closes the last gap in the engine's uniform blocking rule ("if a dependency won't reach desired state this sync, its dependents don't execute"): a table that fails **during execution** now blocks its FK dependents — direct or transitive — in the same run, instead of executing their DDL against a parent that never reached desired state. Removes the strict xfail that pinned this gap.

- `dependency_resolution.py`: new public `blocking_failures()` helper — the single owner of the "blocked by failed dependency" rule, reused by `resolve()`'s pre-execution propagation pass (behaviour-preserving refactor).
- `engine.py::_execute()`: walks the dependency-ordered runs threading a failed set — pre-failed runs feed the set, blocked runs record `ForeignKeyFailure(BLOCKED_BY_FAILED_DEPENDENCY)` and are skipped, empty-plan healthy runs stay healthy parents, any failed action marks its table failed (partial failures included). Blocked dependents report `FOREIGN_KEY_FAILED` with no execution, identical in shape to pre-execution blocking. Dry runs unchanged.
- Docs: execution-time blocking added to `how-to-handle-sync-failures.md` and `how-to-declare-foreign-keys.md`; the FK failure-cause list also gains the previously missing `REFERENCED_COLUMNS_NOT_A_KEY` cause.

Behaviour change to be aware of: dependents of a mid-run-failed parent (including no-op dependents already at desired state) now report `FOREIGN_KEY_FAILED` where they previously executed or reported success — matching the pre-execution blocking semantics exactly.

## Tests

- xfail marker removed from `test_execution_failure_in_fk_parent_blocks_dependent_before_execution` (test body unchanged — it is the contract), implemented via strict red→green TDD.
- New black-box engine tests: transitive chain, partial parent failure, no-op dependent blocked (pins the uniform rule), diamond with one failure per FK, and healthy no-op parent *not* blocking (pins the inverse invariant).
- Full battery green: 497 passed (98.3% coverage), ruff, mypy, lint-imports, Sphinx `-W` docs build.

Design spec and per-task review notes in `docs/superpowers/` (untracked).