### PR TITLE
Classify CYCLE per FK edge and clarify dependency resolution

### DIFF
--- a/src/delta_engine/application/dependency_resolution.py
+++ b/src/delta_engine/application/dependency_resolution.py
@@ -9,9 +9,27 @@ classifies which of one table's foreign keys reference already-failed tables.
 engine reuses it while executing, so both phases block dependents by the
 same rule.
 
+For example, given these declared foreign keys (child ──► parent)::
+
+    order_items ──► orders ──► customers      invoices ◄──► ledger
+    payments ──► invoices                     refunds ──► archive (not registered)
+
+`resolve` orders every table dependency-first and classifies the failures::
+
+    ordered_names: customers, orders, order_items, ...  (parents before
+                   children; failed tables keep their place in the order)
+    fk_failures:
+        invoices  CYCLE                         (references ledger)
+        ledger    CYCLE                         (references invoices)
+        payments  BLOCKED_BY_FAILED_DEPENDENCY  (references invoices)
+        refunds   UNRESOLVABLE_REFERENCE        (references archive)
+
+Healthy tables execute in that order; the engine gates failed tables out by
+their recorded failures.
+
 All graph-traversal implementation details (adjacency map, Tarjan's
-strongly-connected-components algorithm, reverse-reachability propagation) are
-hidden behind that interface.
+strongly-connected-components algorithm, fixpoint propagation of blocked
+dependents) are hidden behind that interface.
 """
 
 from __future__ import annotations
@@ -74,12 +92,12 @@ def resolve(
 
     """
     registered_names = {table.qualified_name for table in tables}
-    graph = _build_dependency_graph(tables, registered_names)
-    components = _strongly_connected_components(graph)
+    dependencies_by_table = _build_dependency_graph(tables, registered_names)
+    components = _strongly_connected_components(dependencies_by_table)
 
-    cycle_members = {name for component in components if _is_cycle(component) for name in component}
+    cycle_partners = _cycle_partners_by_table(components)
     ordered = _order_tables(tables, components)
-    failures_by_table = _classify_failures(tables, registered_names, cycle_members, set(blocked))
+    failures_by_table = _classify_failures(tables, registered_names, cycle_partners, set(blocked))
 
     ordered_names = tuple(table.qualified_name for table in ordered)
     return ResolveResult(ordered_names=ordered_names, fk_failures=failures_by_table)
@@ -123,7 +141,7 @@ def _build_dependency_graph(
     create the table, then add the constraint. Excluding the self-edge
     keeps the table a non-cyclic single-node component.
     """
-    graph: dict[QualifiedName, set[QualifiedName]] = {
+    dependencies_by_table: dict[QualifiedName, set[QualifiedName]] = {
         table.qualified_name: set() for table in tables
     }
     for table in tables:
@@ -131,25 +149,34 @@ def _build_dependency_graph(
         for foreign_key in table.foreign_keys:
             referenced_table = foreign_key.referenced_table
             if referenced_table in registered_names and referenced_table != table_name:
-                graph[table_name].add(referenced_table)
-    return graph
+                dependencies_by_table[table_name].add(referenced_table)
+    return dependencies_by_table
 
 
 def _strongly_connected_components(
-    graph: dict[QualifiedName, set[QualifiedName]],
+    dependencies_by_table: dict[QualifiedName, set[QualifiedName]],
 ) -> list[list[QualifiedName]]:
     """
     Return the graph's strongly-connected components in dependency-first order.
 
     Uses Tarjan's algorithm, which emits each component only after every
     component it depends on has been emitted — so a referenced table's component
-    always precedes its dependents'. Neighbours are visited in sorted order and
-    nodes in graph insertion order, making the result deterministic
+    always precedes its dependents'. Dependencies are visited in sorted order
+    and nodes in graph insertion order, making the result deterministic
     regardless of set-iteration order or hash seed.
 
     A component of more than one node is a true dependency cycle. (Self-loops are
     excluded from the graph, so a single node is never cyclic.)
+
+    Reference:
+    https://en.wikipedia.org/wiki/Tarjan%27s_strongly_connected_components_algorithm
+    The implementation matches the reference pseudocode, with one deliberate
+    divergence: the sorted dependency visits described above.
     """
+    # Tarjan's bookkeeping: `indices` numbers nodes in DFS visit order, and
+    # `low_links[node]` tracks the smallest index reachable from the node's
+    # DFS subtree without leaving the stack. A node whose low-link stays equal
+    # to its own index is the root of a strongly-connected component.
     index_counter = 0
     indices: dict[QualifiedName, int] = {}
     low_links: dict[QualifiedName, int] = {}
@@ -165,14 +192,18 @@ def _strongly_connected_components(
         stack.append(node)
         on_stack.add(node)
 
-        for neighbour in sorted(graph[node], key=str):
-            if neighbour not in indices:
-                strong_connect(neighbour)
-                low_links[node] = min(low_links[node], low_links[neighbour])
-            elif neighbour in on_stack:
-                low_links[node] = min(low_links[node], indices[neighbour])
+        for dependency in sorted(dependencies_by_table[node], key=str):
+            if dependency not in indices:
+                strong_connect(dependency)
+                low_links[node] = min(low_links[node], low_links[dependency])
+            elif dependency in on_stack:
+                # A dependency still on the stack is a back-edge into the
+                # component being built; one already popped belongs to a
+                # completed component and cannot lower this low-link.
+                low_links[node] = min(low_links[node], indices[dependency])
 
         if low_links[node] == indices[node]:
+            # This node roots a component: pop the stack down to it to collect its members.
             component: list[QualifiedName] = []
             while True:
                 member = stack.pop()
@@ -182,7 +213,7 @@ def _strongly_connected_components(
                     break
             components.append(component)
 
-    for node in graph:
+    for node in dependencies_by_table:
         if node not in indices:
             strong_connect(node)
 
@@ -192,6 +223,25 @@ def _strongly_connected_components(
 def _is_cycle(component: list[QualifiedName]) -> bool:
     """Return True if the component is a true multi-node dependency cycle."""
     return len(component) > 1
+
+
+def _cycle_partners_by_table(
+    components: list[list[QualifiedName]],
+) -> dict[QualifiedName, frozenset[QualifiedName]]:
+    """
+    Map each member of a cyclic component to the other members of its component.
+
+    A foreign key is part of a cycle exactly when its referenced table is one
+    of the owning table's cycle partners; a cycle member's FK to a table
+    outside its component is not itself cyclic.
+    """
+    partners: dict[QualifiedName, frozenset[QualifiedName]] = {}
+    for component in components:
+        if _is_cycle(component):
+            members = frozenset(component)
+            for name in component:
+                partners[name] = members - {name}
+    return partners
 
 
 def _order_tables(
@@ -213,7 +263,7 @@ def _order_tables(
 def _classify_failures(
     tables: tuple[DesiredTable, ...],
     registered_names: set[QualifiedName],
-    cycle_members: set[QualifiedName],
+    cycle_partners_by_table: dict[QualifiedName, frozenset[QualifiedName]],
     already_failed: set[QualifiedName],
 ) -> dict[QualifiedName, tuple[ForeignKeyFailure, ...]]:
     """
@@ -222,12 +272,20 @@ def _classify_failures(
     Two passes:
 
     1. Direct failures — a foreign key to an unregistered table
-       (UNRESOLVABLE_REFERENCE) or any foreign key on a cycle member (CYCLE).
+       (UNRESOLVABLE_REFERENCE) or a foreign key into the owning table's own
+       dependency cycle (CYCLE).
     2. Propagation — a table that references a table which will not be built
        cannot be built either (its foreign key would target a missing table).
        This repeats to a fixpoint so the block flows along chains of dependents.
        `already_failed` seeds this pass with names that failed for external
        reasons (e.g. validation), so their FK dependents are also blocked.
+
+    For example, with `archive` not registered::
+
+        c ──► b ──► a ──► archive
+
+    pass 1 fails `a` (UNRESOLVABLE_REFERENCE) and pass 2 blocks `b` and `c`
+    (BLOCKED_BY_FAILED_DEPENDENCY).
     """
     failures: dict[QualifiedName, list[ForeignKeyFailure]] = {}
 
@@ -257,11 +315,11 @@ def _classify_failures(
             referenced_table = foreign_key.referenced_table
             if referenced_table not in registered_names:
                 record(table, foreign_key, ForeignKeyFailureReason.UNRESOLVABLE_REFERENCE)
-            # Checked before cycle membership so that a structural FK-target problem is
+            # Checked before the cycle test so that a structural FK-target problem is
             # reported per-FK even when the table also participates in a cycle.
             elif set(foreign_key.referenced_columns) != primary_key_by_name[referenced_table]:
                 record(table, foreign_key, ForeignKeyFailureReason.REFERENCED_COLUMNS_NOT_A_KEY)
-            elif table_name in cycle_members:
+            elif referenced_table in cycle_partners_by_table.get(table_name, frozenset()):
                 record(table, foreign_key, ForeignKeyFailureReason.CYCLE)
 
     # Pass 2 — propagate to dependents until no new table is blocked.

--- a/src/delta_engine/application/engine.py
+++ b/src/delta_engine/application/engine.py
@@ -205,6 +205,7 @@ class Engine:
         for run in runs:
             if isinstance(run.read, ReadFailed):
                 continue
+            # An absent table diffs against None, which yields TableMissing — a create.
             observed = run.read.table if isinstance(run.read, TablePresent) else None
             run.diff = diff_table(desired=run.desired, observed=observed)
         return runs
@@ -216,6 +217,8 @@ class Engine:
                 continue
             result = validate_diff(run.diff)
             run.failures.extend(result.failures)
+            # A run that has a diff passed its read, so any failures counted
+            # here are validation's own.
             if run.failures:
                 logger.error(
                     "Validation failed for %s (%d failure(s))",
@@ -229,6 +232,8 @@ class Engine:
     def _plan(self, runs: tuple[_TableRun, ...]) -> tuple[_TableRun, ...]:
         """Build the action plan for each run by delegating to the diff."""
         for run in runs:
+            # Only validated drift is lowered into actions: a run that failed
+            # read or validation keeps its empty plan.
             if run.diff is None or run.failures:
                 continue
             run.plan = run.diff.plan()
@@ -277,6 +282,9 @@ class Engine:
             if run.failures:
                 failed.add(run.qualified_name)
                 continue
+            # _resolve propagated failures known before execution; a parent can
+            # also fail while executing, so re-apply the same blocking rule as
+            # the walk reaches each run.
             blocking = blocking_failures(run.desired, failed)
             if blocking:
                 logger.error(
@@ -287,6 +295,8 @@ class Engine:
                 run.failures.extend(blocking)
                 failed.add(run.qualified_name)
                 continue
+            # Checked after blocking, so a no-op dependent of a failed parent is
+            # still blocked; a healthy no-op run counts as a healthy parent.
             if not run.plan:
                 continue
             summary = self.executor.execute(run.qualified_name, run.plan)

--- a/tests/application/test_dependency_resolution.py
+++ b/tests/application/test_dependency_resolution.py
@@ -105,6 +105,39 @@ def _table_with_fk(
     ).to_desired_table()
 
 
+def _fk_column_name(referenced_fqn: str) -> str:
+    """Derive the local FK column name for a reference: cat.sch.orders -> orders_id."""
+    _, _, referenced_table_name = _split_fqn(referenced_fqn)
+    return f"{referenced_table_name}_id"
+
+
+def _table_with_fks(fqn: str, *references: str) -> DesiredTable:
+    """
+    Build a table with one single-column foreign key per referenced table.
+
+    Each foreign key's local column is named after its referenced table:
+    a reference to cat.sch.orders uses local column orders_id.
+    """
+    catalog, schema, table_name = _split_fqn(fqn)
+
+    return DeltaTable(
+        catalog,
+        schema,
+        table_name,
+        columns=(
+            Column("id", String(), nullable=False, primary_key=True),
+            *(Column(_fk_column_name(reference), String()) for reference in references),
+        ),
+        foreign_keys=[
+            ForeignKey(
+                local_columns=(_fk_column_name(reference),),
+                references=_referenced_table(reference),
+            )
+            for reference in references
+        ],
+    ).to_desired_table()
+
+
 def _names(result: ResolveResult) -> list[str]:
     return [str(name) for name in result.ordered_names]
 
@@ -212,29 +245,8 @@ def test_resolve_handles_chain_of_dependencies():
 
 def test_resolve_orders_table_after_all_fk_parents():
     # Given order_items depends on both orders and products
-    order_items = DeltaTable(
-        "cat",
-        "sch",
-        "order_items",
-        columns=(
-            Column("id", String(), nullable=False, primary_key=True),
-            Column("order_id", String()),
-            Column("product_id", String()),
-        ),
-        foreign_keys=[
-            ForeignKey(
-                local_columns=("order_id",),
-                references=_referenced_table("cat.sch.orders"),
-            ),
-            ForeignKey(
-                local_columns=("product_id",),
-                references=_referenced_table("cat.sch.products"),
-            ),
-        ],
-    ).to_desired_table()
-
     tables = (
-        order_items,
+        _table_with_fks("cat.sch.order_items", "cat.sch.orders", "cat.sch.products"),
         _table("cat.sch.products"),
         _table("cat.sch.orders"),
     )
@@ -270,26 +282,7 @@ def test_resolve_fails_table_with_unresolvable_reference():
 
 def test_resolve_records_one_failure_per_unresolvable_fk():
     # Given a table has two FKs to missing tables
-    shipments = DeltaTable(
-        "cat",
-        "sch",
-        "shipments",
-        columns=(
-            Column("id", String(), nullable=False, primary_key=True),
-            Column("order_id", String()),
-            Column("customer_id", String()),
-        ),
-        foreign_keys=[
-            ForeignKey(
-                local_columns=("order_id",),
-                references=_referenced_table("cat.sch.orders"),
-            ),
-            ForeignKey(
-                local_columns=("customer_id",),
-                references=_referenced_table("cat.sch.customers"),
-            ),
-        ],
-    ).to_desired_table()
+    shipments = _table_with_fks("cat.sch.shipments", "cat.sch.orders", "cat.sch.customers")
 
     # When resolving dependencies
     result = resolve((shipments,))
@@ -301,12 +294,12 @@ def test_resolve_records_one_failure_per_unresolvable_fk():
         (failure.local_columns, failure.references, failure.reason) for failure in failures
     } == {
         (
-            ("order_id",),
+            ("orders_id",),
             _qualified_name("cat.sch.orders"),
             ForeignKeyFailureReason.UNRESOLVABLE_REFERENCE,
         ),
         (
-            ("customer_id",),
+            ("customers_id",),
             _qualified_name("cat.sch.customers"),
             ForeignKeyFailureReason.UNRESOLVABLE_REFERENCE,
         ),
@@ -419,6 +412,36 @@ def test_resolve_propagates_block_along_a_chain():
         )
 
 
+def test_resolve_records_cycle_failure_only_for_fk_inside_the_cycle():
+    # Given a <-> b form a cycle, and a also references healthy table c
+    tables = (
+        _table_with_fks("cat.sch.a", "cat.sch.b", "cat.sch.c"),
+        _table_with_fk("cat.sch.b", "cat.sch.a"),
+        _table("cat.sch.c"),
+    )
+
+    # When resolving dependencies
+    result = resolve(tables)
+
+    # Then a's FK into the cycle fails, but its FK to the healthy table does not
+    failures_for_a = _failures_for(result, "cat.sch.a")
+
+    assert len(failures_for_a) == 1
+    _assert_has_failure(
+        result,
+        "cat.sch.a",
+        reason=ForeignKeyFailureReason.CYCLE,
+        references="cat.sch.b",
+    )
+    _assert_has_failure(
+        result,
+        "cat.sch.b",
+        reason=ForeignKeyFailureReason.CYCLE,
+        references="cat.sch.a",
+    )
+    assert _failures_for(result, "cat.sch.c") == ()
+
+
 def test_resolve_blocks_table_that_depends_on_a_cycle():
     # Given b <-> c form a cycle, and a depends on b
     tables = (
@@ -499,29 +522,8 @@ def test_resolve_treats_self_referential_fk_as_applicable():
 
 def test_resolve_propagates_block_through_a_diamond():
     # Given d depends on b and c; both b and c depend on a; a is missing a parent
-    table_d = DeltaTable(
-        "cat",
-        "sch",
-        "d",
-        columns=(
-            Column("id", String(), nullable=False, primary_key=True),
-            Column("b_id", String()),
-            Column("c_id", String()),
-        ),
-        foreign_keys=[
-            ForeignKey(
-                local_columns=("b_id",),
-                references=_referenced_table("cat.sch.b"),
-            ),
-            ForeignKey(
-                local_columns=("c_id",),
-                references=_referenced_table("cat.sch.c"),
-            ),
-        ],
-    ).to_desired_table()
-
     tables = (
-        table_d,
+        _table_with_fks("cat.sch.d", "cat.sch.b", "cat.sch.c"),
         _table_with_fk("cat.sch.b", "cat.sch.a"),
         _table_with_fk("cat.sch.c", "cat.sch.a"),
         _table_with_fk("cat.sch.a", "cat.sch.missing"),
@@ -727,25 +729,9 @@ def test_resolve_blocks_dependents_of_table_with_invalid_fk_target():
 
 def test_resolve_valid_chain_where_middle_table_has_pk_and_fk_executes():
     # Given c -> a -> b, and a has both its own PK and an FK to b
-    table_a = DeltaTable(
-        "cat",
-        "sch",
-        "a",
-        columns=(
-            Column("id", String(), nullable=False, primary_key=True),
-            Column("ref_id", String()),
-        ),
-        foreign_keys=[
-            ForeignKey(
-                local_columns=("ref_id",),
-                references=_referenced_table("cat.sch.b"),
-            )
-        ],
-    ).to_desired_table()
-
     tables = (
         _table_with_fk("cat.sch.c", "cat.sch.a"),
-        table_a,
+        _table_with_fk("cat.sch.a", "cat.sch.b"),
         _table("cat.sch.b"),
     )
 


### PR DESCRIPTION
## Summary

- **Fix:** a cycle member's foreign key to a healthy table outside its component was reported as `CYCLE` ("it is part of a foreign key dependency cycle"), misdescribing that edge. Classification now maps each cyclic-component member to its cycle partners and records `CYCLE` only for FKs pointing inside the owning table's own cycle. Tables fail exactly as before — every cycle member necessarily keeps at least one intra-cycle FK — so only the reported edges change, and they are now truthful.
- **Docs/readability:** worked input→output example in the resolver module docstring, propagation sketch on `_classify_failures`, Tarjan reference link (with the one deliberate divergence from the reference pseudocode noted), `dependencies_by_table`/`dependency` domain renames for the graph bindings, corrected propagation wording (fixpoint, not reverse reachability), and a few inline comments on the `Engine` phase invariants.
- **Tests:** new pinning test for the per-edge behaviour; new `_table_with_fks` builder collapses the four ~20-line inline `DeltaTable` constructions to one line each.

## Test plan

- `uv run pytest` — 498 passed (incl. local Spark e2e), coverage 98.3%
- `uv run ruff check src tests` / `uv run ruff format` — clean
- `uv run mypy src` — clean
- `uv run lint-imports` — both contracts kept
- `uv run --group docs sphinx-build -b html docs docs/_build/html -W` — build succeeded