### PR TITLE
refactor: import-facade hygiene + report/rendering re-layering

### DIFF
--- a/docs/reference-api.md
+++ b/docs/reference-api.md
@@ -70,6 +70,19 @@ exactly — any structural drift causes validation to fail.
    :members:
 ```
 
+### Rendering a report
+
+`SyncReport` is a pure data object. To turn one into human-readable text, pass
+it to one of these functions:
+
+```{eval-rst}
+.. autofunction:: delta_engine.render_report
+```
+
+```{eval-rst}
+.. autofunction:: delta_engine.render_diff
+```
+
 ### TableRunStatus
 
 ```{eval-rst}

--- a/src/delta_engine/__init__.py
+++ b/src/delta_engine/__init__.py
@@ -17,6 +17,8 @@ from delta_engine.application import (
     SyncFailedError,
     SyncReport,
     TableRunStatus,
+    render_diff,
+    render_report,
 )
 
 __all__ = [
@@ -25,4 +27,6 @@ __all__ = [
     "SyncFailedError",
     "SyncReport",
     "TableRunStatus",
+    "render_diff",
+    "render_report",
 ]

--- a/src/delta_engine/adapters/databricks/executor.py
+++ b/src/delta_engine/adapters/databricks/executor.py
@@ -25,7 +25,7 @@ from delta_engine.application.ports import (
     ExecutionSummary,
 )
 from delta_engine.domain.model import QualifiedName
-from delta_engine.domain.plan.actions import Action, ActionPlan
+from delta_engine.domain.plan import Action, ActionPlan
 
 logger = logging.getLogger(__name__)
 

--- a/src/delta_engine/adapters/databricks/reader.py
+++ b/src/delta_engine/adapters/databricks/reader.py
@@ -31,8 +31,13 @@ from delta_engine.application.ports import (
     TablePresent,
 )
 from delta_engine.application.properties import DELTA_PROPERTY_REGISTRY
-from delta_engine.domain.model import Column as DomainColumn, ObservedTable, QualifiedName
-from delta_engine.domain.model.constraints import ForeignKeyConstraint, PrimaryKeyConstraint
+from delta_engine.domain.model import (
+    Column as DomainColumn,
+    ForeignKeyConstraint,
+    ObservedTable,
+    PrimaryKeyConstraint,
+    QualifiedName,
+)
 
 logger = logging.getLogger(__name__)
 

--- a/src/delta_engine/adapters/databricks/sql/compile.py
+++ b/src/delta_engine/adapters/databricks/sql/compile.py
@@ -19,7 +19,7 @@ from delta_engine.adapters.databricks.sql.dialect import (
 )
 from delta_engine.adapters.databricks.sql.types import sql_type_for_data_type
 from delta_engine.domain.model import Column, QualifiedName
-from delta_engine.domain.plan.actions import (
+from delta_engine.domain.plan import (
     Action,
     ActionPlan,
     AddColumn,

--- a/src/delta_engine/api/table.py
+++ b/src/delta_engine/api/table.py
@@ -7,8 +7,15 @@ from dataclasses import dataclass
 from typing import Final
 
 from delta_engine.application.properties import DELTA_PROPERTY_REGISTRY
-from delta_engine.domain.model import ALL_ASPECTS, Column, DesiredTable, QualifiedName, TableAspect
-from delta_engine.domain.model.constraints import ForeignKeyConstraint, PrimaryKeyConstraint
+from delta_engine.domain.model import (
+    ALL_ASPECTS,
+    Column,
+    DesiredTable,
+    ForeignKeyConstraint,
+    PrimaryKeyConstraint,
+    QualifiedName,
+    TableAspect,
+)
 
 
 class _SelfReference:

--- a/src/delta_engine/application/__init__.py
+++ b/src/delta_engine/application/__init__.py
@@ -9,6 +9,15 @@ users. The per-phase result types (`CatalogState`, `ExecutionSummary`,
 from delta_engine.application.engine import Engine
 from delta_engine.application.errors import SyncFailedError
 from delta_engine.application.failures import Failure
+from delta_engine.application.rendering import render_diff, render_report
 from delta_engine.application.report import SyncReport, TableRunStatus
 
-__all__ = ["Engine", "Failure", "SyncFailedError", "SyncReport", "TableRunStatus"]
+__all__ = [
+    "Engine",
+    "Failure",
+    "SyncFailedError",
+    "SyncReport",
+    "TableRunStatus",
+    "render_diff",
+    "render_report",
+]

--- a/src/delta_engine/application/dependency_resolution.py
+++ b/src/delta_engine/application/dependency_resolution.py
@@ -38,9 +38,7 @@ from collections.abc import Mapping, Set as AbstractSet
 from dataclasses import dataclass
 
 from delta_engine.application.failures import ForeignKeyFailure, ForeignKeyFailureReason
-from delta_engine.domain.model import QualifiedName
-from delta_engine.domain.model.constraints import ForeignKeyConstraint
-from delta_engine.domain.model.table import DesiredTable
+from delta_engine.domain.model import DesiredTable, ForeignKeyConstraint, QualifiedName
 
 # A table dependency graph is small (tens of tables, shallow chains), so the
 # recursion depth of the SCC traversal below stays far under Python's limit.

--- a/src/delta_engine/application/engine.py
+++ b/src/delta_engine/application/engine.py
@@ -51,10 +51,8 @@ from delta_engine.application.report import (
     TableRunReport,
 )
 from delta_engine.application.validation import validate_diff
-from delta_engine.domain.model import QualifiedName
-from delta_engine.domain.model.table import DesiredTable
-from delta_engine.domain.plan.actions import ActionPlan
-from delta_engine.domain.plan.diff import TableDiff, diff_table
+from delta_engine.domain.model import DesiredTable, QualifiedName
+from delta_engine.domain.plan import ActionPlan, TableDiff, diff_table
 
 logger = logging.getLogger(__name__)
 

--- a/src/delta_engine/application/ports.py
+++ b/src/delta_engine/application/ports.py
@@ -14,7 +14,7 @@ from typing import Protocol
 
 from delta_engine.application.failures import ExecutionFailure, ReadFailure
 from delta_engine.domain.model import ObservedTable, QualifiedName
-from delta_engine.domain.plan.actions import ActionPlan
+from delta_engine.domain.plan import ActionPlan
 
 # ---------- CatalogState ----------
 

--- a/src/delta_engine/application/rendering.py
+++ b/src/delta_engine/application/rendering.py
@@ -1,18 +1,20 @@
 """
 Diff and grid rendering for table and sync run reports.
 
-Separates display logic from the result/report value types in report.py.
-The three public entry points are render_diff_block, render_grid, and
-run_summary_footer; action_diff_line handles per-action diff lines via
-singledispatch.
+The report value types in report.py are pure data; all human-readable
+formatting lives here. The public entry points are render_report (status
+grid plus summary footer) and render_diff (per-table change blocks);
+render_grid, render_diff_block, run_summary_footer, and action_diff_line
+are the building blocks they compose.
 """
 
 from __future__ import annotations
 
 import functools
-from typing import TYPE_CHECKING
 
-from delta_engine.domain.plan.actions import (
+from delta_engine.application.ports import ReadFailed
+from delta_engine.application.report import SyncReport, TableRunReport
+from delta_engine.domain.plan import (
     Action,
     AddColumn,
     CreateTable,
@@ -31,9 +33,6 @@ from delta_engine.domain.plan.actions import (
     UnsetProperty,
     UnsetTableTag,
 )
-
-if TYPE_CHECKING:
-    from delta_engine.application.report import SyncReport, TableRunReport
 
 
 def _type_name(data_type: object) -> str:
@@ -143,8 +142,6 @@ _NO_CHANGES = "no changes"
 
 def render_diff_block(report: TableRunReport) -> str:
     """Render one table's change block: its name then one line per planned action."""
-    from delta_engine.application.ports import ReadFailed
-
     header = str(report.qualified_name)
     if isinstance(report.read, ReadFailed):
         return f"{header}\n  (could not read — no diff)"
@@ -211,3 +208,13 @@ def run_summary_footer(report: SyncReport) -> str:
         f"{total} tables: {changed} changed, {unchanged} unchanged, "
         f"{failed} failed ({seconds:.1f}s)"
     )
+
+
+def render_report(report: SyncReport) -> str:
+    """Render a run's aligned status grid followed by its one-line summary footer."""
+    return f"{render_grid(report.table_reports)}\n\n{run_summary_footer(report)}"
+
+
+def render_diff(report: SyncReport) -> str:
+    """Render every table's planned changes as +/-/~ blocks, in report order."""
+    return "\n\n".join(render_diff_block(table_report) for table_report in report.table_reports)

--- a/src/delta_engine/application/report.py
+++ b/src/delta_engine/application/report.py
@@ -17,9 +17,8 @@ from delta_engine.application.failures import (
     FailurePhase,
 )
 from delta_engine.application.ports import CatalogState, ExecutionSummary
-from delta_engine.domain.model import QualifiedName
-from delta_engine.domain.model.table import DesiredTable
-from delta_engine.domain.plan.actions import ActionPlan
+from delta_engine.domain.model import DesiredTable, QualifiedName
+from delta_engine.domain.plan import ActionPlan
 
 # ---------- Status enums ----------
 
@@ -68,18 +67,6 @@ class TableRunReport:
         """True if the table did not fully succeed."""
         return bool(self.failures)
 
-    def diff(self) -> str:
-        """Render this table's planned changes as a +/-/~ change list."""
-        from delta_engine.application.rendering import render_diff_block
-
-        return render_diff_block(self)
-
-    def __str__(self) -> str:
-        """Render this report as the grid header plus its single row."""
-        from delta_engine.application.rendering import render_grid
-
-        return render_grid((self,))
-
 
 @dataclass(frozen=True, slots=True)
 class SyncReport:
@@ -101,15 +88,3 @@ class SyncReport:
 
     def __iter__(self) -> Iterator[TableRunReport]:
         return iter(self.table_reports)
-
-    def diff(self) -> str:
-        """Render every table's planned changes, in report order."""
-        from delta_engine.application.rendering import render_diff_block
-
-        return "\n\n".join(render_diff_block(report) for report in self.table_reports)
-
-    def __str__(self) -> str:
-        """Render the run as an aligned grid followed by a summary footer."""
-        from delta_engine.application.rendering import render_grid, run_summary_footer
-
-        return f"{render_grid(self.table_reports)}\n\n{run_summary_footer(self)}"

--- a/src/delta_engine/application/validation.py
+++ b/src/delta_engine/application/validation.py
@@ -11,8 +11,8 @@ from delta_engine.application.properties import (
     DELTA_PROPERTY_REGISTRY,
     PropertyRegistry,
 )
-from delta_engine.domain.model.table_aspect import TableAspect
-from delta_engine.domain.plan.diff import (
+from delta_engine.domain.model import TableAspect
+from delta_engine.domain.plan import (
     ColumnAdded,
     ColumnDataTypeChanged,
     ColumnNullabilityChanged,

--- a/tests/application/test_public_api.py
+++ b/tests/application/test_public_api.py
@@ -12,10 +12,16 @@ def test_public_api_exposes_the_intended_names():
         SyncFailedError,
         SyncReport,
         TableRunStatus,
+        render_diff,
+        render_report,
     )
     from delta_engine.application.engine import Engine as EngineImpl
     from delta_engine.application.errors import SyncFailedError as SyncFailedErrorImpl
     from delta_engine.application.failures import Failure as FailureImpl
+    from delta_engine.application.rendering import (
+        render_diff as render_diff_impl,
+        render_report as render_report_impl,
+    )
     from delta_engine.application.report import (
         SyncReport as SyncReportImpl,
         TableRunStatus as TableRunStatusImpl,
@@ -27,6 +33,8 @@ def test_public_api_exposes_the_intended_names():
         "SyncReport",
         "Failure",
         "TableRunStatus",
+        "render_diff",
+        "render_report",
     }
     # And each name resolves to the real type (single identity, not a shadow copy)
     assert Engine is EngineImpl
@@ -34,3 +42,5 @@ def test_public_api_exposes_the_intended_names():
     assert SyncReport is SyncReportImpl
     assert Failure is FailureImpl
     assert TableRunStatus is TableRunStatusImpl
+    assert render_diff is render_diff_impl
+    assert render_report is render_report_impl

--- a/tests/application/test_rendering.py
+++ b/tests/application/test_rendering.py
@@ -7,8 +7,10 @@ from delta_engine.application.failures import ReadFailure, ValidationFailure
 from delta_engine.application.ports import ReadFailed, TablePresent
 from delta_engine.application.rendering import (
     action_diff_line,
+    render_diff,
     render_diff_block,
     render_grid,
+    render_report,
     run_summary_footer,
 )
 from delta_engine.application.report import SyncReport, TableRunReport
@@ -338,3 +340,59 @@ def test_diff_block_reports_a_read_failure_instead_of_a_diff():
 
     # Then it says the table could not be read rather than showing a diff
     assert block == "cat.sch.orders\n  (could not read — no diff)"
+
+
+# ---------- whole-report rendering ----------
+
+
+def test_render_report_is_the_status_grid_followed_by_the_summary_footer():
+    # Given a run over one changed and one failed table
+    changed = _grid_report("a", plan=ActionPlan((SetTableComment(comment="c"),)))
+    failed = _grid_report("b", failures=(ValidationFailure(rule_name="R", message="m"),))
+    sync = SyncReport(
+        started_at=datetime(2025, 1, 1, 0, 0, 0),
+        ended_at=datetime(2025, 1, 1, 0, 0, 3),
+        table_reports=(changed, failed),
+    )
+
+    # When rendering the whole report
+    rendered = render_report(sync)
+
+    # Then it opens with the grid header and ends with the summary footer
+    assert rendered.splitlines()[0].split() == ["TABLE", "STATUS", "ACTIONS", "DETAIL"]
+    assert rendered.endswith("2 tables: 1 changed, 0 unchanged, 1 failed (3.0s)")
+
+
+def test_render_report_of_an_empty_run_is_a_header_and_zero_footer():
+    # Given a run over no tables
+    sync = SyncReport(
+        started_at=datetime(2025, 1, 1, 0, 0, 0),
+        ended_at=datetime(2025, 1, 1, 0, 0, 3),
+        table_reports=(),
+    )
+
+    # When rendering the whole report
+    rendered = render_report(sync)
+
+    # Then the grid header and a zero-count footer are shown -- no empty-run sentinel
+    assert rendered.splitlines()[0].split() == ["TABLE", "STATUS", "ACTIONS", "DETAIL"]
+    assert rendered.endswith("0 tables: 0 changed, 0 unchanged, 0 failed (3.0s)")
+
+
+def test_render_diff_joins_each_tables_change_block_in_report_order():
+    # Given a run over two tables with plans
+    first = _grid_report("a", plan=ActionPlan((SetTableComment(comment="c"),)))
+    second = _grid_report("b", plan=ActionPlan((AddColumn(Column("age", Integer())),)))
+    sync = SyncReport(
+        started_at=datetime(2025, 1, 1, 0, 0, 0),
+        ended_at=datetime(2025, 1, 1, 0, 0, 3),
+        table_reports=(first, second),
+    )
+
+    # When rendering the run's diff
+    rendered = render_diff(sync)
+
+    # Then each table's change block appears, in report order
+    assert rendered.index("cat.sch.a") < rendered.index("cat.sch.b")
+    assert "~ comment on table" in rendered
+    assert "+ column age Integer" in rendered

--- a/tests/application/test_report.py
+++ b/tests/application/test_report.py
@@ -88,18 +88,6 @@ def test_table_status_success_when_all_actions_succeed():
     assert report.execution.failures == ()
 
 
-def test_sync_report_with_no_tables_renders_grid_header_and_zero_footer():
-    # Given a run over no tables
-    sr = SyncReport(started_at=_t0(), ended_at=_t1(), table_reports=())
-
-    # When rendered
-    # Then the general grid+footer path produces a header row and a zero-count
-    # footer -- no dedicated empty-run sentinel string
-    rendered = str(sr)
-    assert rendered.splitlines()[0].split() == ["TABLE", "STATUS", "ACTIONS", "DETAIL"]
-    assert rendered.endswith("0 tables: 0 changed, 0 unchanged, 0 failed (300.0s)")
-
-
 def test_sync_report_any_failures_true_if_any_table_has_failures():
     # Given two tables: one success, one with execution failure
     t_ok = TableRunReport(

--- a/tests/test_public_api.py
+++ b/tests/test_public_api.py
@@ -16,19 +16,31 @@ _EAGER = {
     "SyncFailedError",
     "Failure",
     "TableRunStatus",
+    "render_diff",
+    "render_report",
 }
 
 
 def test_eager_names_are_importable_and_identical_to_their_source():
     # Given the curated root namespace
     # Then every pyspark-free name resolves to the same object as its source module
-    from delta_engine import Engine, Failure, SyncFailedError, SyncReport, TableRunStatus
+    from delta_engine import (
+        Engine,
+        Failure,
+        SyncFailedError,
+        SyncReport,
+        TableRunStatus,
+        render_diff,
+        render_report,
+    )
     from delta_engine.application import (
         Engine as EngineImpl,
         Failure as FailureImpl,
         SyncFailedError as SyncFailedErrorImpl,
         SyncReport as SyncReportImpl,
         TableRunStatus as TableRunStatusImpl,
+        render_diff as render_diff_impl,
+        render_report as render_report_impl,
     )
 
     assert Engine is EngineImpl
@@ -36,6 +48,8 @@ def test_eager_names_are_importable_and_identical_to_their_source():
     assert SyncFailedError is SyncFailedErrorImpl
     assert SyncReport is SyncReportImpl
     assert TableRunStatus is TableRunStatusImpl
+    assert render_diff is render_diff_impl
+    assert render_report is render_report_impl
 
 
 def test_all_advertises_eager_and_lazy_names():


### PR DESCRIPTION
## Summary

Two related module-boundary cleanups, split into one commit each for reviewability:

1. **`refactor: route internal imports through domain package facades`** — behaviour-preserving import hygiene.
2. **`refactor(report): make reports pure data behind a render seam`** — a public-API change (see Breaking below).

## 1. Import-facade routing (behaviour-preserving)

Consumers of `domain.model` and `domain.plan` now import from the package namespace instead of reaching into concrete submodules (`.constraints`, `.table`, `.table_aspect`, `.actions`, `.diff`). This applies the facade convention already used by `adapters/databricks/sql` uniformly:

- **External callers** import from the package (`from delta_engine.domain.plan import ActionPlan`).
- **Sibling modules inside a package** still import each other directly, to avoid init-time cycles.

The `domain.plan` facade was previously dead — every caller dug into `.actions`/`.diff`; it's now the single import path.

## 2. Reports are pure data behind a render seam

`TableRunReport`/`SyncReport` no longer depend on the presentation layer. Their `__str__`/`diff()` methods (which delegated to `rendering`, creating a data→presentation dependency edge) are removed. Display now lives entirely in `application/rendering.py`, exposed as a public seam:

- `render_report(report)` — status grid + summary footer (was `str(sync_report)`)
- `render_diff(report)` — per-table change blocks (was `sync_report.diff()`)

Both are re-exported from `delta_engine`. `rendering.py` now imports `report` normally at top level (was `TYPE_CHECKING` to break the cycle), so the dependency graph is a clean DAG: `rendering → report`, never the reverse.

### ⚠️ Breaking

`str(sync_report)` and `sync_report.diff()` are removed. Migrate:

```python
from delta_engine import render_report, render_diff
print(render_report(sync_report))   # was: print(sync_report)
print(render_diff(sync_report))     # was: sync_report.diff()
```

Pre-1.0 (`0.1.0`), no changelog in the repo, so no changelog entry.

## Verification

All green on the final tree:

- `pytest` — 504 passed, 98.67% coverage
- `ruff check src tests` — clean
- `mypy src` — clean
- `lint-imports` — contracts kept (confirms the `report → rendering` edge is gone)
- `sphinx-build -b html docs -W` — build succeeded

## Follow-up (not in this PR)

The `from __future__ import annotations` policy is still undecided. This PR removed `rendering.py`'s only real _need_ for it, leaving `databricks.py` (the `SparkSession` optional-dependency case) as the sole load-bearing user.
