### PR TITLE
feat(domain): cap Decimal precision at the Delta/Spark limit of 38

### DIFF
--- a/src/delta_engine/domain/model/data_type.py
+++ b/src/delta_engine/domain/model/data_type.py
@@ -2,6 +2,8 @@
 
 from dataclasses import dataclass
 
+_MAX_DECIMAL_PRECISION = 38  # hard limit of Delta/Spark DecimalType
+
 
 class DataType:
     """Base class for all data types."""
@@ -53,7 +55,7 @@ class Decimal(DataType):
     Fixed-precision decimal type.
 
     Attributes:
-        precision: Total number of digits.
+        precision: Total number of digits (1–38, Delta/Spark limit).
         scale: Digits to the right of the decimal point.
 
     """
@@ -62,9 +64,14 @@ class Decimal(DataType):
     scale: int = 0
 
     def __post_init__(self) -> None:
-        """Validate that precision > 0 and 0 <= scale <= precision."""
+        """Validate that 0 < precision <= 38 and 0 <= scale <= precision."""
         if self.precision <= 0 or not (0 <= self.scale <= self.precision):
             raise ValueError("invalid decimal(precision, scale)")
+        if self.precision > _MAX_DECIMAL_PRECISION:
+            raise ValueError(
+                f"decimal precision must be at most {_MAX_DECIMAL_PRECISION}"
+                f" (Delta/Spark limit); got {self.precision}"
+            )
 
 
 @dataclass(frozen=True, slots=True)

--- a/src/delta_engine/domain/model/data_type.py
+++ b/src/delta_engine/domain/model/data_type.py
@@ -55,7 +55,7 @@ class Decimal(DataType):
     Fixed-precision decimal type.
 
     Attributes:
-        precision: Total number of digits (1–38, Delta/Spark limit).
+        precision: Total number of digits (1-38, Delta/Spark limit).
         scale: Digits to the right of the decimal point.
 
     """

--- a/tests/domain/model/test_data_type.py
+++ b/tests/domain/model/test_data_type.py
@@ -9,7 +9,7 @@ from delta_engine.domain.model.data_type import (
 @given(st.integers(min_value=-10, max_value=50), st.integers(min_value=-10, max_value=60))
 def test_decimal_accepts_valid_pairs_and_rejects_invalid_ones(precision: int, scale: int) -> None:
     # Given: an arbitrary (precision, scale) pair
-    valid = precision >= 1 and 0 <= scale <= precision
+    valid = 1 <= precision <= 38 and 0 <= scale <= precision
     if valid:
         # When: the pair is within bounds, construction succeeds and preserves the values
         d = Decimal(precision, scale)
@@ -19,3 +19,13 @@ def test_decimal_accepts_valid_pairs_and_rejects_invalid_ones(precision: int, sc
         # When: the pair violates any constraint, construction raises
         with pytest.raises(ValueError):
             Decimal(precision, scale)
+
+
+def test_decimal_rejects_precision_above_delta_maximum() -> None:
+    # Delta/Spark cap DECIMAL precision at 38
+    with pytest.raises(ValueError, match="38"):
+        Decimal(39, 0)
+
+
+def test_decimal_accepts_maximum_precision_and_scale() -> None:
+    assert Decimal(38, 38).precision == 38


### PR DESCRIPTION
Part 1 of 15 — validation-hardening series (split from #142 for per-task review; full context in that PR's description and `docs/superpowers/plans/2026-07-07-validation-hardening.md`).

## What

`Decimal(precision, scale)` now raises `ValueError` when `precision > 38`, the hard limit of Delta/Spark `DecimalType`. Previously `Decimal(50, 2)` validated clean at declaration time and failed at DDL execution — the exact failure mode this series exists to eliminate. Existing behaviour (`precision > 0`, `0 <= scale <= precision`) is unchanged; `Decimal(38, 38)` remains legal.

## Changes

- `src/delta_engine/domain/model/data_type.py`: `_MAX_DECIMAL_PRECISION = 38` + the cap in `Decimal.__post_init__`; docstring notes the 1-38 range.
- `tests/domain/model/test_data_type.py`: boundary tests (39 rejected, 38/38 accepted); the existing hypothesis property test's precision range already samples above 38, so the cap is also property-tested.

## Verification

Focused tests pass; `ruff check .` and `mypy .` clean on the branch. (The full suite ran green on the combined branch: 581 passed, 98.79% coverage.)

## Series plan

Each task lands as its own PR once the previous merges: 02 leaf Spark types → 03 Struct → 04 partition-type rules → 05 property value validation → 06 column-mapping character gate → 07 CDF reserved names → 08 tag limits → 09 FK type matching → 10-13 PK-referenced-by-FK rule (domain fact → reader query → diff → rule) → 14 reader partition guard → 15 docs.