### PR TITLE
feat(types): map TINYINT, SMALLINT, BINARY, TIMESTAMP_NTZ, VARIANT; normalise CHAR/VARCHAR to String on read

### DIFF
--- a/docs/explanation-architecture.md
+++ b/docs/explanation-architecture.md
@@ -121,6 +121,30 @@ domain data types, reads Unity Catalog constraints and tags, quotes SQL
 identifiers, and turns Spark/Py4J exceptions into `ReadFailure` or
 `ExecutionFailure` values.
 
+### Type-model fidelity
+
+The differ compares a declared table with an observed one, so every fact the
+domain type model carries must survive the round trip
+declaration → catalog → observation exactly. A fact that only one side can
+carry is worse than an unmodeled one. Declarable but not observable: every
+sync reports drift that is not there, and when the false drift is a blocked
+change (a column type change, say) the table fails validation forever.
+Observable but not declarable: the catalog permanently disagrees with the only
+spelling a declaration can use. Facts that cannot round-trip are therefore
+normalized out on both sides rather than modeled halfway.
+
+`CHAR(n)` and `VARCHAR(n)` are the worked example. Delta stores both as
+`STRING` and enforces the length bound as a write-time check, and Databricks
+recommends `STRING` for new tables. Mapping them to their own domain types on
+the read side only would make every observed varchar column drift against the
+only declarable spelling (`String`) and fail validation permanently; modeling
+them fully would mean owning length-transition safety rules for a type the
+platform steers users away from. The reader instead observes both as `String`:
+no drift, no `CHAR`/`VARCHAR` DDL is ever emitted, and the catalog keeps
+enforcing the length. The trade-off is deliberate: a declaration cannot create
+a varchar column, and an out-of-band length change is invisible to drift
+detection.
+
 ## Sync lifecycle
 
 `Engine.sync(...)` is a phase chain. Before the chain begins, user-facing table

--- a/docs/reference-data-types.md
+++ b/docs/reference-data-types.md
@@ -5,22 +5,29 @@ tags:
 
 # Data types
 
-| `delta_engine` type | Spark SQL type | Notes |
-|---|---|---|
-| `Integer()` | `INT` | |
-| `Long()` | `BIGINT` | |
-| `Float()` | `FLOAT` | |
-| `Double()` | `DOUBLE` | |
-| `Boolean()` | `BOOLEAN` | |
-| `String()` | `STRING` | |
-| `Date()` | `DATE` | |
-| `Timestamp()` | `TIMESTAMP` | |
-| `Decimal(precision, scale)` | `DECIMAL(p, s)` | Both arguments required |
-| `Array(element_type)` | `ARRAY<T>` | `element_type` must be a supported type |
-| `Map(key_type, value_type)` | `MAP<K, V>` | Both arguments must be supported types |
+| `delta_engine` type         | Spark SQL type  | Notes                                                               |
+| --------------------------- | --------------- | ------------------------------------------------------------------- |
+| `Integer()`                 | `INT`           |                                                                     |
+| `Long()`                    | `BIGINT`        |                                                                     |
+| `Float()`                   | `FLOAT`         |                                                                     |
+| `Double()`                  | `DOUBLE`        |                                                                     |
+| `Boolean()`                 | `BOOLEAN`       |                                                                     |
+| `String()`                  | `STRING`        |                                                                     |
+| `Date()`                    | `DATE`          |                                                                     |
+| `Timestamp()`               | `TIMESTAMP`     |                                                                     |
+| `Decimal(precision, scale)` | `DECIMAL(p, s)` | Both arguments required                                             |
+| `Array(element_type)`       | `ARRAY<T>`      | `element_type` must be a supported type                             |
+| `Map(key_type, value_type)` | `MAP<K, V>`     | Both arguments must be supported types                              |
+| `Byte()`                    | `TINYINT`       |                                                                     |
+| `Short()`                   | `SMALLINT`      |                                                                     |
+| `Binary()`                  | `BINARY`        |                                                                     |
+| `TimestampNtz()`            | `TIMESTAMP_NTZ` | No timezone; the table feature is enabled automatically on creation |
+| `Variant()`                 | `VARIANT`       | Requires a runtime with variant support                             |
 
 ## Unsupported types
 
-A column whose Spark type is outside this table (`STRUCT`, `BINARY`, `VARIANT`, `TIMESTAMP_NTZ`, etc.) is skipped with a logged warning. The engine leaves it unmanaged — it neither creates, alters, nor drops it. All other columns on the table are still managed normally.
+A column whose Spark type is outside this table (`STRUCT`, etc.) is skipped with a logged warning. The engine leaves it unmanaged — it neither creates, alters, nor drops it. All other columns on the table are still managed normally.
+
+Observed `CHAR(n)`/`VARCHAR(n)` columns are treated as `String`: the length bound is not modeled, produces no drift, and is never altered.
 
 A table where every column is unsupported surfaces as a `READ_FAILED` for that table alone.

--- a/docs/reference-data-types.md
+++ b/docs/reference-data-types.md
@@ -28,6 +28,6 @@ tags:
 
 A column whose Spark type is outside this table (`STRUCT`, etc.) is skipped with a logged warning. The engine leaves it unmanaged — it neither creates, alters, nor drops it. All other columns on the table are still managed normally.
 
-Observed `CHAR(n)`/`VARCHAR(n)` columns are treated as `String`: the length bound is not modeled, produces no drift, and is never altered.
+Observed `CHAR(n)`/`VARCHAR(n)` columns are treated as `String`: the length bound is not modeled, produces no drift, and is never altered. The reasoning — facts that cannot round-trip declaration → catalog → observation are normalized out on both sides — is explained in [explanation-architecture.md](explanation-architecture.md).
 
 A table where every column is unsupported surfaces as a `READ_FAILED` for that table alone.

--- a/docs/todo/todo.md
+++ b/docs/todo/todo.md
@@ -1,6 +1,7 @@
 # Open questions and decisions
 
 - [ ] Decide whether to create an enum for `Property` values as well as keys (currently only keys are enumerated)
+- [ ] Declarable `Char(n)`/`Varchar(n)` types, if length-bounded columns become a real need. Additive on the type-model side, but flipping the read-side normalisation (observed varchar currently maps to `String`) changes drift behaviour for every existing table with such columns — needs its own migration story. See the type-model fidelity section of explanation-architecture.md.
 - [ ] Figure out how to add existing tables (tables that already exist in the catalog but are not yet passed to `sync`)
 - [ ] Add support for clustering
 - [ ] make partitioned_by a Column-level thing on api DeltaTable

--- a/src/delta_engine/adapters/databricks/sql/types.py
+++ b/src/delta_engine/adapters/databricks/sql/types.py
@@ -14,7 +14,10 @@ ceremony here.
 
 from pyspark.sql.types import (
     ArrayType,
+    BinaryType,
     BooleanType,
+    ByteType,
+    CharType,
     DataType as SparkType,
     DateType,
     DecimalType,
@@ -23,13 +26,19 @@ from pyspark.sql.types import (
     IntegerType,
     LongType,
     MapType,
+    ShortType,
     StringType,
+    TimestampNTZType,
     TimestampType,
+    VarcharType,
+    VariantType,
 )
 
 from delta_engine.domain.model import (
     Array,
+    Binary,
     Boolean,
+    Byte,
     DataType,
     Date,
     Decimal,
@@ -38,8 +47,11 @@ from delta_engine.domain.model import (
     Integer,
     Long,
     Map,
+    Short,
     String,
     Timestamp,
+    TimestampNtz,
+    Variant,
 )
 
 
@@ -68,6 +80,16 @@ def sql_type_for_data_type(data_type: DataType) -> str:
             return f"ARRAY<{sql_type_for_data_type(element)}>"
         case Map(key, value):
             return f"MAP<{sql_type_for_data_type(key)},{sql_type_for_data_type(value)}>"
+        case Byte():
+            return "TINYINT"
+        case Short():
+            return "SMALLINT"
+        case Binary():
+            return "BINARY"
+        case TimestampNtz():
+            return "TIMESTAMP_NTZ"
+        case Variant():
+            return "VARIANT"
         case _:
             cls = data_type.__class__.__name__
             raise TypeError(f"Unsupported DataType variant: {cls}")
@@ -77,10 +99,10 @@ def domain_type_from_spark(spark_type: SparkType) -> DataType | None:
     """
     Map a ``pyspark`` type instance to a domain type.
 
-    Returns ``None`` when the type has no domain mapping (e.g. ``BINARY``,
-    ``STRUCT``, ``VARIANT``, ``TIMESTAMP_NTZ``). An unmappable element inside an
-    ``ARRAY`` or ``MAP`` makes the whole type unmappable. An unmappable type is a
-    routine, expected condition -- new Spark types appear over time -- so it is a
+    Returns ``None`` when the type has no domain mapping (e.g. ``VOID``,
+    ``INTERVAL``, ``STRUCT``). An unmappable element inside an ``ARRAY`` or
+    ``MAP`` makes the whole type unmappable. An unmappable type is a routine,
+    expected condition -- new Spark types appear over time -- so it is a
     ``None`` return, not an exception. Callers decide what to do with ``None``
     (the reader skips the column and logs a warning).
 
@@ -117,5 +139,20 @@ def domain_type_from_spark(spark_type: SparkType) -> DataType | None:
             if key is None or value is None:
                 return None
             return Map(key, value)
+        case ByteType():
+            return Byte()
+        case ShortType():
+            return Short()
+        case BinaryType():
+            return Binary()
+        case TimestampNTZType():
+            return TimestampNtz()
+        case VariantType():
+            return Variant()
+        case CharType() | VarcharType():
+            # Lossy normalization: the length bound is not modeled, so the
+            # engine sees these as plain strings, plans no change for them,
+            # and never emits CHAR/VARCHAR in DDL.
+            return String()
         case _:
             return None

--- a/src/delta_engine/domain/model/__init__.py
+++ b/src/delta_engine/domain/model/__init__.py
@@ -2,7 +2,9 @@ from delta_engine.domain.model.column import Column
 from delta_engine.domain.model.constraints import ForeignKeyConstraint, PrimaryKeyConstraint
 from delta_engine.domain.model.data_type import (
     Array,
+    Binary,
     Boolean,
+    Byte,
     DataType,
     Date,
     Decimal,
@@ -11,8 +13,11 @@ from delta_engine.domain.model.data_type import (
     Integer,
     Long,
     Map,
+    Short,
     String,
     Timestamp,
+    TimestampNtz,
+    Variant,
 )
 from delta_engine.domain.model.qualified_name import QualifiedName
 from delta_engine.domain.model.table import DesiredTable, ObservedTable, TableSnapshot
@@ -21,7 +26,9 @@ from delta_engine.domain.model.table_aspect import ALL_ASPECTS, TableAspect
 __all__ = [
     "ALL_ASPECTS",
     "Array",
+    "Binary",
     "Boolean",
+    "Byte",
     "Column",
     "DataType",
     "Date",
@@ -36,8 +43,11 @@ __all__ = [
     "ObservedTable",
     "PrimaryKeyConstraint",
     "QualifiedName",
+    "Short",
     "String",
     "TableAspect",
     "TableSnapshot",
     "Timestamp",
+    "TimestampNtz",
+    "Variant",
 ]

--- a/src/delta_engine/domain/model/data_type.py
+++ b/src/delta_engine/domain/model/data_type.py
@@ -75,6 +75,31 @@ class Decimal(DataType):
 
 
 @dataclass(frozen=True, slots=True)
+class Byte(DataType):
+    """8-bit signed integer type (TINYINT)."""
+
+
+@dataclass(frozen=True, slots=True)
+class Short(DataType):
+    """16-bit signed integer type (SMALLINT)."""
+
+
+@dataclass(frozen=True, slots=True)
+class Binary(DataType):
+    """Sequence-of-bytes type."""
+
+
+@dataclass(frozen=True, slots=True)
+class TimestampNtz(DataType):
+    """Timestamp with date and time, no timezone."""
+
+
+@dataclass(frozen=True, slots=True)
+class Variant(DataType):
+    """Semi-structured value type (Databricks VARIANT)."""
+
+
+@dataclass(frozen=True, slots=True)
 class Array(DataType):
     """Array of homogeneous ``element`` values."""
 

--- a/src/delta_engine/schema.py
+++ b/src/delta_engine/schema.py
@@ -9,7 +9,9 @@ from delta_engine.api.table import DeltaTable, ForeignKey, Self
 from delta_engine.application.properties import Property
 from delta_engine.domain.model import (
     Array,
+    Binary,
     Boolean,
+    Byte,
     Column,
     Date,
     Decimal,
@@ -18,13 +20,18 @@ from delta_engine.domain.model import (
     Integer,
     Long,
     Map,
+    Short,
     String,
     Timestamp,
+    TimestampNtz,
+    Variant,
 )
 
 __all__ = [
     "Array",
+    "Binary",
     "Boolean",
+    "Byte",
     "Column",
     "Date",
     "Decimal",
@@ -37,6 +44,9 @@ __all__ = [
     "Map",
     "Property",
     "Self",
+    "Short",
     "String",
     "Timestamp",
+    "TimestampNtz",
+    "Variant",
 ]

--- a/tests/adapters/databricks/sql/test_types.py
+++ b/tests/adapters/databricks/sql/test_types.py
@@ -7,7 +7,9 @@ from delta_engine.adapters.databricks.sql.types import (
 )
 from delta_engine.domain.model.data_type import (
     Array,
+    Binary,
     Boolean,
+    Byte,
     Date,
     Decimal,
     Double,
@@ -15,8 +17,11 @@ from delta_engine.domain.model.data_type import (
     Integer,
     Long,
     Map,
+    Short,
     String,
     Timestamp,
+    TimestampNtz,
+    Variant,
 )
 
 pyspark = pytest.importorskip("pyspark")  # TODO: create sparkSession fixture
@@ -42,10 +47,18 @@ def test_sql_type_for_decimal_array_map_recursive() -> None:
     assert sql_type_for_data_type(nested) == "ARRAY<MAP<STRING,DECIMAL(9,0)>>"
 
 
+def test_sql_type_for_new_leaf_types() -> None:
+    assert sql_type_for_data_type(Byte()) == "TINYINT"
+    assert sql_type_for_data_type(Short()) == "SMALLINT"
+    assert sql_type_for_data_type(Binary()) == "BINARY"
+    assert sql_type_for_data_type(TimestampNtz()) == "TIMESTAMP_NTZ"
+    assert sql_type_for_data_type(Variant()) == "VARIANT"
+
+
 def test_domain_type_from_spark_returns_none_for_unmappable_type() -> None:
     # Given a Spark type the engine does not map
     # Then the conversion returns None rather than raising
-    assert domain_type_from_spark(T.BinaryType()) is None
+    assert domain_type_from_spark(T.NullType()) is None
 
 
 def test_domain_type_from_spark_maps_primitives() -> None:
@@ -73,8 +86,23 @@ def test_domain_type_from_spark_maps_decimal_and_nested_collections() -> None:
     assert domain_type_from_spark(nested) == Array(Map(String(), Decimal(9, 0)))
 
 
+def test_domain_type_from_spark_maps_new_leaf_types() -> None:
+    assert domain_type_from_spark(T.ByteType()) == Byte()
+    assert domain_type_from_spark(T.ShortType()) == Short()
+    assert domain_type_from_spark(T.BinaryType()) == Binary()
+    assert domain_type_from_spark(T.TimestampNTZType()) == TimestampNtz()
+    assert domain_type_from_spark(T.VariantType()) == Variant()
+
+
+def test_domain_type_from_spark_normalises_char_and_varchar_to_string() -> None:
+    # CHAR/VARCHAR length limits are invisible to the engine: observed as
+    # String, they produce no drift and are never altered.
+    assert domain_type_from_spark(T.VarcharType(10)) == String()
+    assert domain_type_from_spark(T.CharType(5)) == String()
+
+
 def test_domain_type_from_spark_returns_none_when_collection_element_is_unmappable() -> None:
     # Given a collection whose element type has no domain mapping
     # Then the whole type is unmappable
-    assert domain_type_from_spark(T.ArrayType(T.BinaryType())) is None
-    assert domain_type_from_spark(T.MapType(T.StringType(), T.BinaryType())) is None
+    assert domain_type_from_spark(T.ArrayType(T.NullType())) is None
+    assert domain_type_from_spark(T.MapType(T.StringType(), T.NullType())) is None

--- a/tests/adapters/databricks/sql/test_types.py
+++ b/tests/adapters/databricks/sql/test_types.py
@@ -30,12 +30,17 @@ pyspark = pytest.importorskip("pyspark")  # TODO: create sparkSession fixture
 def test_sql_type_for_primitive_types() -> None:
     assert sql_type_for_data_type(Integer()) == "INT"
     assert sql_type_for_data_type(Long()) == "BIGINT"
+    assert sql_type_for_data_type(Byte()) == "TINYINT"
+    assert sql_type_for_data_type(Short()) == "SMALLINT"
     assert sql_type_for_data_type(Float()) == "FLOAT"
     assert sql_type_for_data_type(Double()) == "DOUBLE"
     assert sql_type_for_data_type(Boolean()) == "BOOLEAN"
     assert sql_type_for_data_type(String()) == "STRING"
+    assert sql_type_for_data_type(Binary()) == "BINARY"
     assert sql_type_for_data_type(Date()) == "DATE"
     assert sql_type_for_data_type(Timestamp()) == "TIMESTAMP"
+    assert sql_type_for_data_type(TimestampNtz()) == "TIMESTAMP_NTZ"
+    assert sql_type_for_data_type(Variant()) == "VARIANT"
 
 
 def test_sql_type_for_decimal_array_map_recursive() -> None:
@@ -45,14 +50,6 @@ def test_sql_type_for_decimal_array_map_recursive() -> None:
     # nested
     nested = Array(Map(String(), Decimal(9, 0)))
     assert sql_type_for_data_type(nested) == "ARRAY<MAP<STRING,DECIMAL(9,0)>>"
-
-
-def test_sql_type_for_new_leaf_types() -> None:
-    assert sql_type_for_data_type(Byte()) == "TINYINT"
-    assert sql_type_for_data_type(Short()) == "SMALLINT"
-    assert sql_type_for_data_type(Binary()) == "BINARY"
-    assert sql_type_for_data_type(TimestampNtz()) == "TIMESTAMP_NTZ"
-    assert sql_type_for_data_type(Variant()) == "VARIANT"
 
 
 def test_domain_type_from_spark_returns_none_for_unmappable_type() -> None:
@@ -66,12 +63,17 @@ def test_domain_type_from_spark_maps_primitives() -> None:
     # Then it maps to the matching domain type
     assert domain_type_from_spark(T.IntegerType()) == Integer()
     assert domain_type_from_spark(T.LongType()) == Long()
+    assert domain_type_from_spark(T.ByteType()) == Byte()
+    assert domain_type_from_spark(T.ShortType()) == Short()
     assert domain_type_from_spark(T.FloatType()) == Float()
     assert domain_type_from_spark(T.DoubleType()) == Double()
     assert domain_type_from_spark(T.BooleanType()) == Boolean()
     assert domain_type_from_spark(T.StringType()) == String()
+    assert domain_type_from_spark(T.BinaryType()) == Binary()
     assert domain_type_from_spark(T.DateType()) == Date()
     assert domain_type_from_spark(T.TimestampType()) == Timestamp()
+    assert domain_type_from_spark(T.TimestampNTZType()) == TimestampNtz()
+    assert domain_type_from_spark(T.VariantType()) == Variant()
 
 
 def test_domain_type_from_spark_maps_decimal_and_nested_collections() -> None:
@@ -84,14 +86,6 @@ def test_domain_type_from_spark_maps_decimal_and_nested_collections() -> None:
     )
     nested = T.ArrayType(T.MapType(T.StringType(), T.DecimalType(9, 0)))
     assert domain_type_from_spark(nested) == Array(Map(String(), Decimal(9, 0)))
-
-
-def test_domain_type_from_spark_maps_new_leaf_types() -> None:
-    assert domain_type_from_spark(T.ByteType()) == Byte()
-    assert domain_type_from_spark(T.ShortType()) == Short()
-    assert domain_type_from_spark(T.BinaryType()) == Binary()
-    assert domain_type_from_spark(T.TimestampNTZType()) == TimestampNtz()
-    assert domain_type_from_spark(T.VariantType()) == Variant()
 
 
 def test_domain_type_from_spark_normalises_char_and_varchar_to_string() -> None:

--- a/tests/adapters/databricks/test_reader.py
+++ b/tests/adapters/databricks/test_reader.py
@@ -261,7 +261,7 @@ def test_fetch_state_skips_unsupported_column_leaves_mappable_columns_intact(qn)
         columns_by_table={
             str(qn): [
                 make_catalog_col("id", dataType="int"),
-                make_catalog_col("blob", dataType="binary"),
+                make_catalog_col("nested", dataType="struct<x:int>"),
             ]
         }
     )
@@ -274,7 +274,9 @@ def test_fetch_state_skips_unsupported_column_leaves_mappable_columns_intact(qn)
 def test_fetch_state_returns_failed_when_all_columns_are_unsupported(qn):
     # An ObservedTable requires at least one column; a table whose every column
     # is unmappable cannot be honestly observed, so the read fails.
-    catalog = FakeCatalog(columns_by_table={str(qn): [make_catalog_col("blob", dataType="binary")]})
+    catalog = FakeCatalog(
+        columns_by_table={str(qn): [make_catalog_col("nested", dataType="struct<x:int>")]}
+    )
     result = DatabricksReader(routed_spark(qn, catalog=catalog)).fetch_state(qn)
 
     assert isinstance(result, ReadFailed)

--- a/tests/test_public_imports.py
+++ b/tests/test_public_imports.py
@@ -12,7 +12,9 @@ from delta_engine.application.properties import Property as PropertyImpl
 import delta_engine.databricks as databricks
 from delta_engine.domain.model import (
     Array,
+    Binary,
     Boolean,
+    Byte,
     Column,
     Date,
     Decimal,
@@ -21,14 +23,19 @@ from delta_engine.domain.model import (
     Integer,
     Long,
     Map,
+    Short,
     String,
     Timestamp,
+    TimestampNtz,
+    Variant,
 )
 import delta_engine.schema as schema
 
 _SCHEMA_EXPORTS = {
     "Array",
+    "Binary",
     "Boolean",
+    "Byte",
     "Column",
     "Date",
     "Decimal",
@@ -41,8 +48,11 @@ _SCHEMA_EXPORTS = {
     "Map",
     "Property",
     "Self",
+    "Short",
     "String",
     "Timestamp",
+    "TimestampNtz",
+    "Variant",
 }
 
 
@@ -54,7 +64,9 @@ def test_schema_import_path_matches_implementation_objects():
     # Given the preferred user-facing schema import path
     implementations = {
         "Array": Array,
+        "Binary": Binary,
         "Boolean": Boolean,
+        "Byte": Byte,
         "Column": Column,
         "Date": Date,
         "Decimal": Decimal,
@@ -67,8 +79,11 @@ def test_schema_import_path_matches_implementation_objects():
         "Map": Map,
         "Property": PropertyImpl,
         "Self": SelfImpl,
+        "Short": Short,
         "String": String,
         "Timestamp": Timestamp,
+        "TimestampNtz": TimestampNtz,
+        "Variant": Variant,
     }
 
     # Then it exposes exactly the supported declaration names


### PR DESCRIPTION
Part 2 of 15 — validation-hardening series (context in #142; previous: #143).

## What

The reader currently *skips* columns typed `TINYINT`, `SMALLINT`, `BINARY`, `TIMESTAMP_NTZ`, or `VARIANT` (logged warning, column invisible to the sync), making real tables half-invisible. This adds first-class domain types for all five with both mapping directions, and normalises observed `CHAR(n)`/`VARCHAR(n)` to `String` on the read side.

## Changes

- `domain/model/data_type.py`: new leaf types `Byte`, `Short`, `Binary`, `TimestampNtz`, `Variant`.
- `adapters/databricks/sql/types.py`: renderings (`TINYINT`, `SMALLINT`, `BINARY`, `TIMESTAMP_NTZ`, `VARIANT`) and reverse mappings; `CharType`/`VarcharType` → `String()` — deliberately lossy: the length bound is not modeled, produces no drift, and the engine never emits CHAR/VARCHAR in DDL (documented in the docstring and data-types reference).
- Exported from `delta_engine.domain.model` and the public `delta_engine.schema` facade; `tests/test_public_imports.py` updated in its three places.
- `tests/adapters/databricks/test_reader.py`: two tests that used `binary` as their "unsupported type" example now use `struct<x:int>` (still unmapped until Part 3).
- `docs/reference-data-types.md`: five new rows + the CHAR/VARCHAR note; STRUCT stays listed as unsupported until Part 3.

## Verification

Focused tests (types mapping, public imports, reader) pass; `ruff check .`, `mypy .`, and the sphinx `-W` docs build clean on the branch. Full gate ran green on the combined reference branch.