### PR TITLE
feat(domain): reject unpartitionable column types and all-column partitioning

### DIFF
--- a/src/delta_engine/domain/model/table.py
+++ b/src/delta_engine/domain/model/table.py
@@ -5,8 +5,12 @@ from dataclasses import dataclass, field
 
 from delta_engine.domain.model.column import Column
 from delta_engine.domain.model.constraints import ForeignKeyConstraint, PrimaryKeyConstraint
+from delta_engine.domain.model.data_type import Array, Map, Struct, Variant
 from delta_engine.domain.model.qualified_name import QualifiedName
 from delta_engine.domain.model.table_aspect import ALL_ASPECTS, TableAspect
+
+# Complex types Delta cannot partition by (DELTA_INVALID_PARTITION_COLUMN_TYPE).
+_UNPARTITIONABLE_TYPES = (Array, Map, Struct, Variant)
 
 
 @dataclass(frozen=True, slots=True)
@@ -119,6 +123,9 @@ class DesiredTable(TableSnapshot):
         free of column-nullability lookups. Both checks live on DesiredTable,
         not the shared base: an observed table may legitimately carry such a
         layout (a legacy catalog schema) and must stay representable.
+
+        Partition columns must not have complex types (Array, Map, Struct, Variant)
+        and at least one non-partition column must exist.
         """
         TableSnapshot.__post_init__(self)
         if not self.managed_aspects:
@@ -149,6 +156,20 @@ class DesiredTable(TableSnapshot):
                     f" {nullable_key_columns[0]}. Set nullable=False on every"
                     " primary key column."
                 )
+
+        columns_by_name = {column.name: column for column in self.columns}
+        for name in self.partitioned_by:
+            data_type = columns_by_name[name].data_type
+            if isinstance(data_type, _UNPARTITIONABLE_TYPES):
+                raise ValueError(
+                    f"Partition column {name!r} has type"
+                    f" {type(data_type).__name__}, which Delta cannot"
+                    " partition by"
+                )
+        if self.partitioned_by and len(self.partitioned_by) == len(self.columns):
+            raise ValueError(
+                "Cannot partition by every column: at least one non-partition column is required"
+            )
 
 
 @dataclass(frozen=True, slots=True)

--- a/src/delta_engine/domain/model/table.py
+++ b/src/delta_engine/domain/model/table.py
@@ -166,7 +166,7 @@ class DesiredTable(TableSnapshot):
                     f" {type(data_type).__name__}, which Delta cannot"
                     " partition by"
                 )
-        if self.partitioned_by and len(self.partitioned_by) == len(self.columns):
+        if self.partitioned_by and (len(self.partitioned_by) == len(self.columns)):
             raise ValueError(
                 "Cannot partition by every column: at least one non-partition column is required"
             )

--- a/tests/application/test_validation.py
+++ b/tests/application/test_validation.py
@@ -363,9 +363,11 @@ def test_rejects_existing_column_type_change():
 
 
 def test_rejects_partitioning_change():
-    # Given a declaration that changes table partitioning
-    desired = _desired_table(partitioned_by=("id",))
-    observed = _observed_table()
+    # Given a declaration that changes table partitioning (identical columns on
+    # both sides so partitioning is the only drift)
+    columns = (Column("id", Integer()), Column("value", Integer()))
+    desired = _desired_table(columns=columns, partitioned_by=("id",))
+    observed = _observed_table(columns=columns)
 
     # When validating the diff
     result = _validate(desired, observed)

--- a/tests/domain/model/test_table.py
+++ b/tests/domain/model/test_table.py
@@ -6,6 +6,7 @@ from delta_engine.domain.model import (
     Date,
     DesiredTable,
     Integer,
+    Map,
     ObservedTable,
     QualifiedName,
     String,
@@ -452,3 +453,34 @@ def test_observed_table_properties_carry_values_only():
     )
 
     assert observed.properties == {"delta.enableChangeDataFeed": "true"}
+
+
+def test_desired_table_rejects_complex_typed_partition_column() -> None:
+    with pytest.raises(ValueError, match="partition"):
+        DesiredTable(
+            qualified_name=QualifiedName("dev", "silver", "orders"),
+            columns=(
+                Column("id", Integer()),
+                Column("attrs", Map(String(), String())),
+            ),
+            partitioned_by=("attrs",),
+        )
+
+
+def test_desired_table_rejects_partitioning_by_every_column() -> None:
+    with pytest.raises(ValueError, match="every column"):
+        DesiredTable(
+            qualified_name=QualifiedName("dev", "silver", "orders"),
+            columns=(Column("id", Integer()), Column("day", Date())),
+            partitioned_by=("id", "day"),
+        )
+
+
+def test_observed_table_accepts_layouts_desired_tables_reject() -> None:
+    # Observed state must stay representable even when it is not declarable.
+    observed = ObservedTable(
+        qualified_name=QualifiedName("dev", "silver", "orders"),
+        columns=(Column("id", Integer()), Column("day", Date())),
+        partitioned_by=("id", "day"),
+    )
+    assert observed.partitioned_by == ("id", "day")

--- a/tests/domain/plan/test_diff.py
+++ b/tests/domain/plan/test_diff.py
@@ -414,7 +414,12 @@ def test_table_tag_drift_produces_set_and_unset_changes():
 
 
 def test_partitioning_drift_produces_change_with_both_sides():
-    diff = diff_table(_desired(partitioned_by=("id",)), _observed())
+    # Given identical columns on both sides so partitioning is the only drift
+    columns = (Column("id", Integer()), Column("value", Integer()))
+    diff = diff_table(
+        _desired(columns=columns, partitioned_by=("id",)),
+        _observed(columns=columns),
+    )
 
     assert isinstance(diff, TableDrift)
     assert diff.changes == (


### PR DESCRIPTION
Part 4 of 15 — validation-hardening series (context in #142; previous: #145).

## What

Two partition rules Delta enforces at DDL time (`DELTA_INVALID_PARTITION_COLUMN_TYPE`, and the requirement that at least one non-partition column remains) now fail at declaration time on `DesiredTable`:

- A partition column cannot be complex-typed: `Array`, `Map`, `Struct`, or `Variant`.
- Partitioning by every column is rejected; empty partitioning stays legal.

`ObservedTable` deliberately stays permissive — observed catalog state must remain representable even when it is not declarable (a test pins this asymmetry, mirroring the primary-key-nullability precedent).

## Changes

- `domain/model/table.py`: `_UNPARTITIONABLE_TYPES` + two checks appended to `DesiredTable.__post_init__` (after the PK-nullability check). The base class already guarantees partition columns exist, so the type lookup cannot `KeyError`.
- `tests/domain/model/test_table.py`: complex-type rejection, all-column rejection, observed-side permissiveness.
- Second commit: two pre-existing tests in `test_diff.py`/`test_validation.py` built a single-column table partitioned by that column — legal before, rejected now. Their fixtures gain an identical second column on both desired and observed sides, keeping `PartitioningChanged` as the only drift each test exercises (assertions unchanged).

## Verification

134 focused tests pass (domain table model, diff, validation); `ruff check .` and `mypy .` clean. Full gate ran green on the combined reference branch.
