### PR TITLE
feat(properties): validate declared property values at declaration time

### DIFF
--- a/docs/how-to-configure-properties.md
+++ b/docs/how-to-configure-properties.md
@@ -60,6 +60,11 @@ changes.
 A key declared `None` asserts absence, not a value, so it is exempt from
 this check.
 
+Retention durations accept a single `interval <n> <unit>` term only.
+Compound intervals such as `interval 1 hour 30 minutes` are rejected at
+declaration even though the catalog itself accepts them; declare a
+single-unit equivalent instead (e.g. `interval 90 minutes`).
+
 ## Declaring and removing properties
 
 ```python

--- a/docs/how-to-configure-properties.md
+++ b/docs/how-to-configure-properties.md
@@ -22,13 +22,13 @@ the complete list of the properties you manage on that table.
 
 ## The managed keys
 
-| `Property` member | Delta table property key | Restrictions |
-|---|---|---|
-| `CHANGE_DATA_FEED` | `delta.enableChangeDataFeed` | none |
-| `DELETED_FILE_RETENTION_DURATION` | `delta.deletedFileRetentionDuration` | none |
-| `LOG_RETENTION_DURATION` | `delta.logRetentionDuration` | none |
-| `DATA_SKIPPING_NUM_INDEXED_COLS` | `delta.dataSkippingNumIndexedCols` | none |
-| `COLUMN_MAPPING_MODE` | `delta.columnMapping.mode` | only `none → name`; cannot be removed |
+| `Property` member                 | Delta table property key             | Restrictions                          |
+| --------------------------------- | ------------------------------------ | ------------------------------------- |
+| `CHANGE_DATA_FEED`                | `delta.enableChangeDataFeed`         | none                                  |
+| `DELETED_FILE_RETENTION_DURATION` | `delta.deletedFileRetentionDuration` | none                                  |
+| `LOG_RETENTION_DURATION`          | `delta.logRetentionDuration`         | none                                  |
+| `DATA_SKIPPING_NUM_INDEXED_COLS`  | `delta.dataSkippingNumIndexedCols`   | none                                  |
+| `COLUMN_MAPPING_MODE`             | `delta.columnMapping.mode`           | only `none → name`; cannot be removed |
 
 Passing a key outside this set raises `ValueError` at `DeltaTable`
 construction (for `None` assertions too). This prevents typos from silently
@@ -37,6 +37,28 @@ doing nothing.
 Deletion vectors (`delta.enableDeletionVectors`) are deliberately **not**
 managed: Databricks enables them automatically on new tables, so the engine
 leaves that key entirely to the platform.
+
+## Value validation
+
+Declared values are validated at `DeltaTable` construction, before a first
+write can ever reach the catalog. Each managed key has an expected format:
+
+| `Property` member                 | Expected value                                 |
+| --------------------------------- | ---------------------------------------------- |
+| `CHANGE_DATA_FEED`                | lowercase `true` or `false`                    |
+| `DELETED_FILE_RETENTION_DURATION` | `interval <n> <unit>`, e.g. `interval 7 days`  |
+| `LOG_RETENTION_DURATION`          | `interval <n> <unit>`, e.g. `interval 30 days` |
+| `DATA_SKIPPING_NUM_INDEXED_COLS`  | an integer `>= -1` (`-1` indexes all columns)  |
+| `COLUMN_MAPPING_MODE`             | `none` or `name`                               |
+
+A value outside its key's format raises `ValueError` naming the key, the
+rejected value, and the expected format. Booleans must be lowercase because
+the catalog stores `true`/`false`; any other casing (`"True"`, `"yes"`)
+would re-diff as drift on every sync even though the underlying value never
+changes.
+
+A key declared `None` asserts absence, not a value, so it is exempt from
+this check.
 
 ## Declaring and removing properties
 

--- a/src/delta_engine/api/table.py
+++ b/src/delta_engine/api/table.py
@@ -157,6 +157,18 @@ class DeltaTable:
                     f"Properties not managed by this engine: {', '.join(sorted(unmanaged))}"
                 )
 
+        # Fast-fail on malformed values. Declared None asserts absence, not a
+        # value, so it is exempt from this check.
+        for key, declared_value in user_properties.items():
+            if declared_value is None:
+                continue
+            definition = DELTA_PROPERTY_REGISTRY[key]
+            if not definition.is_valid_value(declared_value):
+                raise ValueError(
+                    f"Invalid value for {key}: {declared_value!r}."
+                    f" Expected {definition.value_description}."
+                )
+
         columns = tuple(columns)
         primary_key_columns = tuple(column.name for column in columns if column.primary_key)
         primary_key = (

--- a/src/delta_engine/api/table.py
+++ b/src/delta_engine/api/table.py
@@ -157,17 +157,12 @@ class DeltaTable:
                     f"Properties not managed by this engine: {', '.join(sorted(unmanaged))}"
                 )
 
-        # Fast-fail on malformed values. Declared None asserts absence, not a
-        # value, so it is exempt from this check.
+        # Fast-fail on malformed values; the definition owns the judgment
+        # (including the exemption for None, which asserts absence).
         for key, declared_value in user_properties.items():
-            if declared_value is None:
-                continue
-            definition = DELTA_PROPERTY_REGISTRY[key]
-            if not definition.is_valid_value(declared_value):
-                raise ValueError(
-                    f"Invalid value for {key}: {declared_value!r}."
-                    f" Expected {definition.value_description}."
-                )
+            rejection = DELTA_PROPERTY_REGISTRY[key].reject_declared_value(declared_value)
+            if rejection is not None:
+                raise ValueError(rejection)
 
         columns = tuple(columns)
         primary_key_columns = tuple(column.name for column in columns if column.primary_key)

--- a/src/delta_engine/application/properties.py
+++ b/src/delta_engine/application/properties.py
@@ -25,9 +25,10 @@ DETAIL's properties: if the platform auto-writes the key, do not register
 it. Additions are called out in release notes.
 """
 
-from collections.abc import Mapping
+from collections.abc import Callable, Mapping
 from dataclasses import dataclass, field
 from enum import StrEnum
+import re
 from types import MappingProxyType
 from typing import Final
 
@@ -44,11 +45,45 @@ class Property(StrEnum):
 
 COLUMN_MAPPING_MODE_KEY: Final[str] = Property.COLUMN_MAPPING_MODE.value
 
+_INTERVAL_FORMAT = re.compile(
+    r"interval\s+\d+\s+(nanosecond|microsecond|millisecond|second|minute|hour|day|week)s?",
+    re.IGNORECASE,
+)
+
+
+def _is_lowercase_boolean(value: str) -> bool:
+    # The catalog stores 'true'/'false'; any other casing would re-diff
+    # as drift on every sync.
+    return value in {"true", "false"}
+
+
+def _is_interval(value: str) -> bool:
+    return _INTERVAL_FORMAT.fullmatch(value.strip()) is not None
+
+
+def _is_integer_at_least_minus_one(value: str) -> bool:
+    try:
+        return int(value) >= -1
+    except ValueError:
+        return False
+
+
+def _is_column_mapping_mode(value: str) -> bool:
+    return value in {"none", "name"}
+
 
 @dataclass(frozen=True, slots=True)
 class PropertyDefinition:
     """
-    One manageable property key and its restrictions.
+    One manageable property key, its value constraints, and its restrictions.
+
+    ``value_description``: a human phrase describing the expected value
+    format, used in error messages when a declared value fails
+    ``is_valid_value``.
+
+    ``is_valid_value``: the predicate a declared value must satisfy. Declared
+    ``None`` asserts absence rather than a value, so it is exempt from this
+    check — the caller must not invoke it for ``None``.
 
     ``permitted_transitions``: the ``(observed_value, desired_value)`` pairs
     that are legal in-place changes, where a ``desired_value`` of ``None``
@@ -58,18 +93,38 @@ class PropertyDefinition:
     """
 
     key: str
+    value_description: str
+    is_valid_value: Callable[[str], bool]
     permitted_transitions: frozenset[tuple[str, str | None]] = field(default_factory=frozenset)
 
 
 type PropertyRegistry = Mapping[str, PropertyDefinition]
 
 _DEFINITIONS: Final[tuple[PropertyDefinition, ...]] = (
-    PropertyDefinition(key=Property.CHANGE_DATA_FEED),
-    PropertyDefinition(key=Property.DELETED_FILE_RETENTION_DURATION),
-    PropertyDefinition(key=Property.LOG_RETENTION_DURATION),
-    PropertyDefinition(key=Property.DATA_SKIPPING_NUM_INDEXED_COLS),
+    PropertyDefinition(
+        key=Property.CHANGE_DATA_FEED,
+        value_description="'true' or 'false' (lowercase, as the catalog stores it)",
+        is_valid_value=_is_lowercase_boolean,
+    ),
+    PropertyDefinition(
+        key=Property.DELETED_FILE_RETENTION_DURATION,
+        value_description="an interval string such as 'interval 7 days'",
+        is_valid_value=_is_interval,
+    ),
+    PropertyDefinition(
+        key=Property.LOG_RETENTION_DURATION,
+        value_description="an interval string such as 'interval 30 days'",
+        is_valid_value=_is_interval,
+    ),
+    PropertyDefinition(
+        key=Property.DATA_SKIPPING_NUM_INDEXED_COLS,
+        value_description="an integer >= -1 (-1 indexes all columns)",
+        is_valid_value=_is_integer_at_least_minus_one,
+    ),
     PropertyDefinition(
         key=Property.COLUMN_MAPPING_MODE,
+        value_description="'none' or 'name'",
+        is_valid_value=_is_column_mapping_mode,
         # The protocol upgrade (minReader 2 / minWriter 5, physical column
         # names) is permanent: only none -> name is a legal change. The
         # absence of any (value, None) pair blocks removal by the same

--- a/src/delta_engine/application/properties.py
+++ b/src/delta_engine/application/properties.py
@@ -62,10 +62,12 @@ def _is_interval(value: str) -> bool:
 
 
 def _is_integer_at_least_minus_one(value: str) -> bool:
-    try:
-        return int(value) >= -1
-    except ValueError:
+    # Canonical digits only: bare int() also accepts "1_000", "+5", or " 5 ",
+    # forms the catalog would not normalize and that can fail Java-side
+    # parsing at execution instead of at declaration.
+    if re.fullmatch(r"-?\d+", value) is None:
         return False
+    return int(value) >= -1
 
 
 def _is_column_mapping_mode(value: str) -> bool:

--- a/src/delta_engine/application/properties.py
+++ b/src/delta_engine/application/properties.py
@@ -43,8 +43,10 @@ class Property(StrEnum):
     DATA_SKIPPING_NUM_INDEXED_COLS = "delta.dataSkippingNumIndexedCols"
 
 
-COLUMN_MAPPING_MODE_KEY: Final[str] = Property.COLUMN_MAPPING_MODE.value
-
+# A single `interval <n> <unit>` term only — deliberately stricter than the
+# catalog, which also accepts compound intervals ("interval 1 hour 30
+# minutes"). One canonical spelling keeps declared and observed values
+# comparable; see docs/how-to-configure-properties.md.
 _INTERVAL_FORMAT = re.compile(
     r"interval\s+\d+\s+(nanosecond|microsecond|millisecond|second|minute|hour|day|week)s?",
     re.IGNORECASE,
@@ -77,27 +79,46 @@ def _is_column_mapping_mode(value: str) -> bool:
 @dataclass(frozen=True, slots=True)
 class PropertyDefinition:
     """
-    One manageable property key, its value constraints, and its restrictions.
+    One manageable property key, and the judgments the engine needs about it.
 
-    ``value_description``: a human phrase describing the expected value
-    format, used in error messages when a declared value fails
-    ``is_valid_value``.
+    The fields are ingredients; consumers ask the two questions below rather
+    than interpreting the fields themselves, so the semantics — a declared
+    ``None`` asserts absence, a first write is always legal, an empty
+    transition set is unrestricted — live here and nowhere else.
 
-    ``is_valid_value``: the predicate a declared value must satisfy. Declared
-    ``None`` asserts absence rather than a value, so it is exempt from this
-    check — the caller must not invoke it for ``None``.
-
-    ``permitted_transitions``: the ``(observed_value, desired_value)`` pairs
-    that are legal in-place changes, where a ``desired_value`` of ``None``
-    means removal (the key declared absent). Empty means unrestricted; a
-    non-empty set blocks any pair not in it. A first write (key absent from
-    the catalog) is always legal and is never looked up here.
+    ``value_description`` is the human phrase for the expected value format,
+    used verbatim in rejection messages; ``permitted_transitions`` holds the
+    ``(observed_value, desired_value)`` pairs that are legal in-place
+    changes, where a ``desired_value`` of ``None`` means removal.
     """
 
-    key: str
+    key: Property
     value_description: str
     is_valid_value: Callable[[str], bool]
     permitted_transitions: frozenset[tuple[str, str | None]] = field(default_factory=frozenset)
+
+    def reject_declared_value(self, value: str | None) -> str | None:
+        """
+        Return the error message for an unacceptable declared value, or ``None``.
+
+        A declared ``None`` asserts the key's absence, not a value, and is
+        never rejected.
+        """
+        if value is None or self.is_valid_value(value):
+            return None
+        return f"Invalid value for {self.key}: {value!r}. Expected {self.value_description}."
+
+    def permits_transition(self, observed: str | None, desired: str | None) -> bool:
+        """
+        Whether the catalog accepts moving this key from observed to desired.
+
+        A first write (``observed`` is ``None``) is always legal; an empty
+        restriction set permits everything; ``desired`` ``None`` means
+        removal (the key declared absent).
+        """
+        if observed is None or not self.permitted_transitions:
+            return True
+        return (observed, desired) in self.permitted_transitions
 
 
 type PropertyRegistry = Mapping[str, PropertyDefinition]

--- a/src/delta_engine/application/validation.py
+++ b/src/delta_engine/application/validation.py
@@ -5,8 +5,8 @@ from typing import ClassVar, Protocol, assert_never
 
 from delta_engine.application.failures import ValidationFailure
 from delta_engine.application.properties import (
-    COLUMN_MAPPING_MODE_KEY,
     DELTA_PROPERTY_REGISTRY,
+    Property,
     PropertyRegistry,
 )
 from delta_engine.domain.model import TableAspect
@@ -194,9 +194,9 @@ class PropertyTransitionNotSupported:
 
     def _is_blocked(self, name: str, observed_value: str, desired_value: str | None) -> bool:
         definition = self.property_registry.get(name)
-        if definition is None or not definition.permitted_transitions:
+        if definition is None:
             return False
-        return (observed_value, desired_value) not in definition.permitted_transitions
+        return not definition.permits_transition(observed_value, desired_value)
 
 
 @dataclass(frozen=True, slots=True)
@@ -231,9 +231,7 @@ class PropertyMustBeDeclared:
 
     def _removal_permitted(self, name: str, observed_value: str) -> bool:
         definition = self.property_registry.get(name)
-        if definition is None or not definition.permitted_transitions:
-            return True
-        return (observed_value, None) in definition.permitted_transitions
+        return definition is None or definition.permits_transition(observed_value, None)
 
 
 class ColumnMappingRequiredForDrop:
@@ -257,15 +255,15 @@ class ColumnMappingRequiredForDrop:
         drops_a_column = any(isinstance(change, ColumnRemoved) for change in drift.managed_changes)
         if not drops_a_column:
             return ()
-        if drift.desired.properties.get(COLUMN_MAPPING_MODE_KEY) == "name":
+        if drift.desired.properties.get(Property.COLUMN_MAPPING_MODE) == "name":
             return ()
         return (
             ValidationFailure(
                 rule_name=self.name,
                 message=(
                     "Operation not allowed: dropping a column requires"
-                    f" {COLUMN_MAPPING_MODE_KEY}='name'. Declare"
-                    f" properties={{'{COLUMN_MAPPING_MODE_KEY}': 'name'}} on this table."
+                    f" {Property.COLUMN_MAPPING_MODE}='name'. Declare"
+                    f" properties={{'{Property.COLUMN_MAPPING_MODE}': 'name'}} on this table."
                 ),
             ),
         )

--- a/tests/api/test_table.py
+++ b/tests/api/test_table.py
@@ -446,6 +446,29 @@ def test_rejects_unregistered_key_declared_as_none():
         )
 
 
+def test_delta_table_rejects_invalid_property_value() -> None:
+    with pytest.raises(ValueError, match=r"delta\.enableChangeDataFeed"):
+        DeltaTable(
+            "dev",
+            "silver",
+            "orders",
+            columns=[Column("id", Integer())],
+            properties={"delta.enableChangeDataFeed": "yes"},
+        )
+
+
+def test_delta_table_accepts_none_property_value_without_value_check() -> None:
+    # None asserts absence; it is not a value and must not be validated as one.
+    table = DeltaTable(
+        "dev",
+        "silver",
+        "orders",
+        columns=[Column("id", Integer())],
+        properties={"delta.enableChangeDataFeed": None},
+    )
+    assert table.to_desired_table().properties["delta.enableChangeDataFeed"] is None
+
+
 def test_metadata_only_table_still_lowers_the_full_schema():
     # Given a metadata-only declaration with full schema detail
     table = DeltaTable(

--- a/tests/application/test_properties.py
+++ b/tests/application/test_properties.py
@@ -77,6 +77,9 @@ def test_registry_accepts_valid_property_values(key: str, value: str) -> None:
         (Property.LOG_RETENTION_DURATION, "interval thirty days"),
         (Property.DATA_SKIPPING_NUM_INDEXED_COLS, "-2"),
         (Property.DATA_SKIPPING_NUM_INDEXED_COLS, "many"),
+        (Property.DATA_SKIPPING_NUM_INDEXED_COLS, "1_000"),
+        (Property.DATA_SKIPPING_NUM_INDEXED_COLS, "+5"),
+        (Property.DATA_SKIPPING_NUM_INDEXED_COLS, " 5 "),
     ],
 )
 def test_registry_rejects_invalid_property_values(key: str, value: str) -> None:

--- a/tests/application/test_properties.py
+++ b/tests/application/test_properties.py
@@ -1,3 +1,5 @@
+import pytest
+
 from delta_engine.application.properties import DELTA_PROPERTY_REGISTRY, Property
 
 
@@ -45,3 +47,37 @@ def test_every_other_key_is_unrestricted():
     }
 
     assert unrestricted == set(DELTA_PROPERTY_REGISTRY) - {"delta.columnMapping.mode"}
+
+
+@pytest.mark.parametrize(
+    ("key", "value"),
+    [
+        (Property.CHANGE_DATA_FEED, "true"),
+        (Property.CHANGE_DATA_FEED, "false"),
+        (Property.COLUMN_MAPPING_MODE, "name"),
+        (Property.COLUMN_MAPPING_MODE, "none"),
+        (Property.LOG_RETENTION_DURATION, "interval 30 days"),
+        (Property.LOG_RETENTION_DURATION, "INTERVAL 1 WEEK"),
+        (Property.DELETED_FILE_RETENTION_DURATION, "interval 7 days"),
+        (Property.DATA_SKIPPING_NUM_INDEXED_COLS, "-1"),
+        (Property.DATA_SKIPPING_NUM_INDEXED_COLS, "32"),
+    ],
+)
+def test_registry_accepts_valid_property_values(key: str, value: str) -> None:
+    assert DELTA_PROPERTY_REGISTRY[key].is_valid_value(value)
+
+
+@pytest.mark.parametrize(
+    ("key", "value"),
+    [
+        (Property.CHANGE_DATA_FEED, "True"),  # catalog stores lowercase; drift churn otherwise
+        (Property.CHANGE_DATA_FEED, "yes"),
+        (Property.COLUMN_MAPPING_MODE, "id"),
+        (Property.LOG_RETENTION_DURATION, "30 days"),
+        (Property.LOG_RETENTION_DURATION, "interval thirty days"),
+        (Property.DATA_SKIPPING_NUM_INDEXED_COLS, "-2"),
+        (Property.DATA_SKIPPING_NUM_INDEXED_COLS, "many"),
+    ],
+)
+def test_registry_rejects_invalid_property_values(key: str, value: str) -> None:
+    assert not DELTA_PROPERTY_REGISTRY[key].is_valid_value(value)

--- a/tests/application/test_properties.py
+++ b/tests/application/test_properties.py
@@ -27,26 +27,35 @@ def test_registry_covers_the_five_managed_keys():
 def test_column_mapping_mode_permits_only_the_upgrade_transition():
     definition = DELTA_PROPERTY_REGISTRY["delta.columnMapping.mode"]
 
-    assert definition.permitted_transitions == frozenset({("none", "name")})
+    # The protocol upgrade is one-way
+    assert definition.permits_transition("none", "name")
+    assert not definition.permits_transition("name", "none")
 
 
 def test_column_mapping_mode_permits_no_removal():
     # Given the protocol upgrade is permanent — removal is a transition to
-    # absence, and no (value, None) pair is permitted
-    transitions = DELTA_PROPERTY_REGISTRY["delta.columnMapping.mode"].permitted_transitions
+    # absence, and no absence transition is permitted
+    definition = DELTA_PROPERTY_REGISTRY["delta.columnMapping.mode"]
 
-    assert not any(desired is None for _, desired in transitions)
+    assert not definition.permits_transition("name", None)
+    assert not definition.permits_transition("none", None)
 
 
-def test_every_other_key_is_unrestricted():
+def test_first_write_is_always_permitted():
+    # Given a key absent from the catalog, any declared value may be written,
+    # even for the most restricted key
+    definition = DELTA_PROPERTY_REGISTRY["delta.columnMapping.mode"]
+
+    assert definition.permits_transition(None, "name")
+
+
+def test_every_other_key_permits_any_transition_and_removal():
     # Given the four pure-configuration keys
-    unrestricted = {
-        key
-        for key, definition in DELTA_PROPERTY_REGISTRY.items()
-        if definition.permitted_transitions == frozenset()
-    }
-
-    assert unrestricted == set(DELTA_PROPERTY_REGISTRY) - {"delta.columnMapping.mode"}
+    for key, definition in DELTA_PROPERTY_REGISTRY.items():
+        if key == "delta.columnMapping.mode":
+            continue
+        assert definition.permits_transition("anything", "else"), key
+        assert definition.permits_transition("anything", None), key
 
 
 @pytest.mark.parametrize(
@@ -64,7 +73,7 @@ def test_every_other_key_is_unrestricted():
     ],
 )
 def test_registry_accepts_valid_property_values(key: str, value: str) -> None:
-    assert DELTA_PROPERTY_REGISTRY[key].is_valid_value(value)
+    assert DELTA_PROPERTY_REGISTRY[key].reject_declared_value(value) is None
 
 
 @pytest.mark.parametrize(
@@ -83,4 +92,15 @@ def test_registry_accepts_valid_property_values(key: str, value: str) -> None:
     ],
 )
 def test_registry_rejects_invalid_property_values(key: str, value: str) -> None:
-    assert not DELTA_PROPERTY_REGISTRY[key].is_valid_value(value)
+    rejection = DELTA_PROPERTY_REGISTRY[key].reject_declared_value(value)
+
+    # The message names the key and the expected format
+    assert rejection is not None
+    assert str(key) in rejection
+    assert "Expected" in rejection
+
+
+def test_declared_none_is_never_rejected():
+    # Given None asserts a key's absence, not a value
+    for definition in DELTA_PROPERTY_REGISTRY.values():
+        assert definition.reject_declared_value(None) is None


### PR DESCRIPTION
Part 5 of 15 — validation-hardening series (context in #142; previous: #146).

## What

The property registry models managed keys and permitted transitions, but nothing validates declared *values* — and the transition rule only judges changes against an observed value, so a **first write** of a junk value (`delta.enableChangeDataFeed: "yes"`) passed validation and died at DDL execution. Values are now validated per key when the `DeltaTable` is constructed.

## Changes

- `application/properties.py`: `PropertyDefinition` gains `value_description` (for error messages) and `is_valid_value`. Per-key validators:
  - `delta.enableChangeDataFeed`: lowercase `true`/`false` only — the catalog stores lowercase, so any other casing would re-diff as drift on every sync.
  - retention durations: `interval <n> <unit>` (nanosecond…week, optional plural, case-insensitive). Single-unit only; compound intervals are rejected even though the catalog accepts them — documented in the how-to with the workaround (`interval 90 minutes`).
  - `delta.dataSkippingNumIndexedCols`: canonical digits only, `>= -1`. Bare `int()` would admit `"1_000"`, `"+5"`, `" 5 "` — forms that can die in Java-side parsing at execution (second commit, from the whole-branch review).
  - `delta.columnMapping.mode`: `none`/`name`; the `none → name` permitted-transition set is unchanged.
- `api/table.py`: enforcement in `DeltaTable.__init__` directly after the unmanaged-keys check. A key declared `None` asserts absence, not a value, and is exempt.
- `docs/how-to-configure-properties.md`: value-validation section + the single-unit interval restriction note.

## Compatibility note

Stricter than before by design: previously-accepted declarations like `"True"` or `"1_000"` now fail at declaration time with a message naming the expected format. Worth a release-note line when this ships.

## Verification

93 focused tests pass (properties registry, api table, validation); `ruff check .`, `mypy .`, sphinx `-W` build clean. Full gate ran green on the combined reference branch.