### PR TITLE
feat(api): require column mapping for special-character column and struct field names

### DIFF
--- a/src/delta_engine/api/table.py
+++ b/src/delta_engine/api/table.py
@@ -9,11 +9,15 @@ from typing import Final
 from delta_engine.application.properties import DELTA_PROPERTY_REGISTRY, Property
 from delta_engine.domain.model import (
     ALL_ASPECTS,
+    Array,
     Column,
+    DataType,
     DesiredTable,
     ForeignKeyConstraint,
+    Map,
     PrimaryKeyConstraint,
     QualifiedName,
+    Struct,
     TableAspect,
 )
 
@@ -42,6 +46,38 @@ METADATA_ASPECTS: Final[frozenset[TableAspect]] = frozenset(
 
 # Delta permits these characters in column names only under column mapping.
 _CHARACTERS_REQUIRING_COLUMN_MAPPING: Final[frozenset[str]] = frozenset(" ,;{}()\n\t=")
+
+
+def _column_declared_names(column: Column) -> tuple[str, ...]:
+    """
+    Return every name a column declares under Delta's naming rules.
+
+    This is the column's own name, plus every struct field name reachable
+    through nested ``Struct``/``Array``/``Map`` types (struct-in-array,
+    struct-in-struct, and so on). The column's own name is returned bare;
+    nested field names are returned as dotted paths from the column, e.g.
+    ``"payload.order id"`` for a field named ``"order id"`` inside a struct
+    column named ``"payload"``.
+    """
+    return (column.name, *_nested_field_paths(column.name, column.data_type))
+
+
+def _nested_field_paths(path: str, data_type: DataType) -> tuple[str, ...]:
+    """Recursively collect dotted struct-field paths reachable from `data_type`."""
+    match data_type:
+        case Struct(fields):
+            paths: list[str] = []
+            for field in fields:
+                field_path = f"{path}.{field.name}"
+                paths.append(field_path)
+                paths.extend(_nested_field_paths(field_path, field.data_type))
+            return tuple(paths)
+        case Array(element):
+            return _nested_field_paths(path, element)
+        case Map(key, value):
+            return _nested_field_paths(path, key) + _nested_field_paths(path, value)
+        case _:
+            return ()
 
 
 @dataclass(frozen=True, slots=True)
@@ -171,13 +207,14 @@ class DeltaTable:
 
         if not metadata_only and user_properties.get(Property.COLUMN_MAPPING_MODE) != "name":
             offending = [
-                column.name
+                name
                 for column in columns
-                if set(column.name) & _CHARACTERS_REQUIRING_COLUMN_MAPPING
+                for name in _column_declared_names(column)
+                if set(name) & _CHARACTERS_REQUIRING_COLUMN_MAPPING
             ]
             if offending:
                 raise ValueError(
-                    f"Column names {offending} contain characters Delta only"
+                    f"Column or struct field names {offending} contain characters Delta only"
                     " permits with column mapping. Declare"
                     f" properties={{'{Property.COLUMN_MAPPING_MODE}': 'name'}}"
                     " or rename the columns."

--- a/src/delta_engine/api/table.py
+++ b/src/delta_engine/api/table.py
@@ -6,7 +6,7 @@ from collections.abc import Iterable, Mapping
 from dataclasses import dataclass
 from typing import Final
 
-from delta_engine.application.properties import DELTA_PROPERTY_REGISTRY
+from delta_engine.application.properties import DELTA_PROPERTY_REGISTRY, Property
 from delta_engine.domain.model import (
     ALL_ASPECTS,
     Column,
@@ -39,6 +39,9 @@ METADATA_ASPECTS: Final[frozenset[TableAspect]] = frozenset(
         TableAspect.FOREIGN_KEYS,
     }
 )
+
+# Delta permits these characters in column names only under column mapping.
+_CHARACTERS_REQUIRING_COLUMN_MAPPING: Final[frozenset[str]] = frozenset(" ,;{}()\n\t=")
 
 
 @dataclass(frozen=True, slots=True)
@@ -165,6 +168,21 @@ class DeltaTable:
                 raise ValueError(rejection)
 
         columns = tuple(columns)
+
+        if not metadata_only and user_properties.get(Property.COLUMN_MAPPING_MODE) != "name":
+            offending = [
+                column.name
+                for column in columns
+                if set(column.name) & _CHARACTERS_REQUIRING_COLUMN_MAPPING
+            ]
+            if offending:
+                raise ValueError(
+                    f"Column names {offending} contain characters Delta only"
+                    " permits with column mapping. Declare"
+                    f" properties={{'{Property.COLUMN_MAPPING_MODE}': 'name'}}"
+                    " or rename the columns."
+                )
+
         primary_key_columns = tuple(column.name for column in columns if column.primary_key)
         primary_key = (
             PrimaryKeyConstraint.generate(table_name=name, columns=primary_key_columns)

--- a/tests/api/test_table.py
+++ b/tests/api/test_table.py
@@ -8,7 +8,17 @@ from delta_engine.domain.model import (
     TableAspect,
 )
 from delta_engine.domain.model.constraints import PrimaryKeyConstraint
-from delta_engine.schema import Column, DeltaTable, ForeignKey, Integer, Property, String
+from delta_engine.schema import (
+    Array,
+    Column,
+    DeltaTable,
+    ForeignKey,
+    Integer,
+    Property,
+    String,
+    Struct,
+    StructField,
+)
 
 
 @pytest.mark.parametrize(
@@ -515,6 +525,48 @@ def test_delta_table_accepts_special_character_column_names_with_column_mapping(
         properties={"delta.columnMapping.mode": "name"},
     )
     assert table.to_desired_table().columns[0].name == "order id"
+
+
+def test_delta_table_rejects_special_character_struct_field_names_without_column_mapping() -> None:
+    with pytest.raises(ValueError, match="columnMapping"):
+        DeltaTable(
+            catalog="dev",
+            schema="silver",
+            name="orders",
+            columns=[
+                Column("payload", Struct((StructField("order id", Integer()),))),
+            ],
+        )
+
+
+def test_delta_table_accepts_special_character_struct_field_names_with_column_mapping() -> None:
+    table = DeltaTable(
+        catalog="dev",
+        schema="silver",
+        name="orders",
+        columns=[
+            Column("payload", Struct((StructField("order id", Integer()),))),
+        ],
+        properties={"delta.columnMapping.mode": "name"},
+    )
+    [column] = table.to_desired_table().columns
+    assert column.data_type == Struct((StructField("order id", Integer()),))
+
+
+def test_delta_table_rejects_special_character_field_names_in_struct_nested_in_array() -> None:
+    # Proves the gate recurses through container types, not just direct struct columns.
+    with pytest.raises(ValueError, match="columnMapping"):
+        DeltaTable(
+            catalog="dev",
+            schema="silver",
+            name="orders",
+            columns=[
+                Column(
+                    "items",
+                    Array(Struct((StructField("order id", Integer()),))),
+                ),
+            ],
+        )
 
 
 def test_metadata_only_table_mirrors_special_character_columns_without_the_property() -> None:

--- a/tests/api/test_table.py
+++ b/tests/api/test_table.py
@@ -494,3 +494,37 @@ def test_metadata_aspects_excludes_structure_properties_and_partitioning():
             TableAspect.PARTITIONING,
         }
     )
+
+
+def test_delta_table_rejects_special_character_column_names_without_column_mapping() -> None:
+    with pytest.raises(ValueError, match="columnMapping"):
+        DeltaTable(
+            catalog="dev",
+            schema="silver",
+            name="orders",
+            columns=[Column("order id", Integer())],
+        )
+
+
+def test_delta_table_accepts_special_character_column_names_with_column_mapping() -> None:
+    table = DeltaTable(
+        catalog="dev",
+        schema="silver",
+        name="orders",
+        columns=[Column("order id", Integer())],
+        properties={"delta.columnMapping.mode": "name"},
+    )
+    assert table.to_desired_table().columns[0].name == "order id"
+
+
+def test_metadata_only_table_mirrors_special_character_columns_without_the_property() -> None:
+    # metadata_only never creates or adds columns; the catalog already
+    # accepted this name, so the declaration must be able to mirror it.
+    table = DeltaTable(
+        catalog="dev",
+        schema="silver",
+        name="orders",
+        columns=[Column("order id", Integer())],
+        metadata_only=True,
+    )
+    assert table.to_desired_table().columns[0].name == "order id"


### PR DESCRIPTION
Part 6 of 15 — validation-hardening series (context in #142; previous: #147).

## What

Delta only permits spaces and the characters `,;{}()=` (plus tabs/newlines) in column names when `delta.columnMapping.mode = 'name'`. Nothing checked this at declaration time, so such names failed at CREATE/ADD COLUMN execution. Two commits:

1. **Top-level gate** — `DeltaTable` rejects offending column names unless the declaration also carries `delta.columnMapping.mode: 'name'`. Gated on `not metadata_only`: a metadata-only declaration mirrors an existing table whose names the catalog already accepted, and must stay declarable without the property (test pins this).
2. **Nested extension** (from the whole-branch review) — the gate walks each column's *declared names*: struct field names, including structs nested in arrays, maps, and other structs, reported as dotted paths (`payload.order id`). Without this, a struct field could reach execution ungated even though Part 3 renders it correctly backtick-quoted.

## Adaptation from the reviewed branch

The original commits used the `COLUMN_MAPPING_MODE_KEY` alias, which #147's `PropertyDefinition` deepening deleted — this slice uses `Property.COLUMN_MAPPING_MODE` directly. No behavioural difference; error messages are identical.

## Verification

38 api-table tests (6 new: reject/accept/metadata-only at top level; struct field, struct-in-array, struct-with-mapping nested); 248 across tests/api + tests/application; `ruff check .`, `ruff format --check`, `mypy .` all clean.