### PR TITLE
feat(api): reject CDF-reserved column names when change data feed is declared

### DIFF
--- a/src/delta_engine/api/table.py
+++ b/src/delta_engine/api/table.py
@@ -47,6 +47,11 @@ METADATA_ASPECTS: Final[frozenset[TableAspect]] = frozenset(
 # Delta permits these characters in column names only under column mapping.
 _CHARACTERS_REQUIRING_COLUMN_MAPPING: Final[frozenset[str]] = frozenset(" ,;{}()\n\t=")
 
+# Column names change data feed reserves for its own output columns.
+_CDF_RESERVED_COLUMN_NAMES: Final[frozenset[str]] = frozenset(
+    {"_change_type", "_commit_version", "_commit_timestamp"}
+)
+
 
 def _column_declared_names(column: Column) -> tuple[str, ...]:
     """
@@ -218,6 +223,17 @@ class DeltaTable:
                     " permits with column mapping. Declare"
                     f" properties={{'{Property.COLUMN_MAPPING_MODE}': 'name'}}"
                     " or rename the columns."
+                )
+
+        if not metadata_only and user_properties.get(Property.CHANGE_DATA_FEED) == "true":
+            reserved = [
+                column.name for column in columns if column.name in _CDF_RESERVED_COLUMN_NAMES
+            ]
+            if reserved:
+                raise ValueError(
+                    f"Column names {reserved} are reserved by change data feed."
+                    " Rename them or do not enable"
+                    f" {Property.CHANGE_DATA_FEED}."
                 )
 
         primary_key_columns = tuple(column.name for column in columns if column.primary_key)

--- a/tests/api/test_table.py
+++ b/tests/api/test_table.py
@@ -580,3 +580,24 @@ def test_metadata_only_table_mirrors_special_character_columns_without_the_prope
         metadata_only=True,
     )
     assert table.to_desired_table().columns[0].name == "order id"
+
+
+def test_delta_table_rejects_cdf_reserved_column_names_when_cdf_enabled() -> None:
+    with pytest.raises(ValueError, match="_change_type"):
+        DeltaTable(
+            catalog="dev",
+            schema="silver",
+            name="orders",
+            columns=[Column("id", Integer()), Column("_change_type", String())],
+            properties={"delta.enableChangeDataFeed": "true"},
+        )
+
+
+def test_delta_table_accepts_cdf_reserved_column_names_when_cdf_not_enabled() -> None:
+    table = DeltaTable(
+        catalog="dev",
+        schema="silver",
+        name="orders",
+        columns=[Column("id", Integer()), Column("_change_type", String())],
+    )
+    assert len(table.to_desired_table().columns) == 2


### PR DESCRIPTION
Part 7 of 15 — validation-hardening series (context in #142; previous: #148).

## What

Enabling change data feed fails on tables with columns named `_change_type`, `_commit_version`, or `_commit_timestamp` — CDF reserves them for its own output columns. Nothing checked this at declaration time. `DeltaTable` now rejects the combination of a reserved column name and a declared `delta.enableChangeDataFeed: "true"`.

The reserved names *without* CDF stay legal (a test pins it), and the check is gated on `not metadata_only` — a metadata-only declaration does not manage properties, so it cannot be enabling CDF.

By the time this check runs, Part 5's value validation has already guaranteed a declared value is exactly `"true"` or `"false"`, so there is no casing edge case.

## Adaptation from the reviewed branch

Same as Part 6: the original commit touched the import line that carried the now-deleted `COLUMN_MAPPING_MODE_KEY` alias; resolved to the current `DELTA_PROPERTY_REGISTRY, Property` import. No code difference beyond that line.

## Verification

40 api-table tests (2 new); 250 across tests/api + tests/application; `ruff check .` and `mypy .` clean.