### PR TITLE
feat(api): enforce Unity Catalog tag count and value-length limits at declaration time

### DIFF
--- a/docs/how-to-configure-tags.md
+++ b/docs/how-to-configure-tags.md
@@ -34,7 +34,7 @@ Tag keys are free-form strings — there is no enum allowlist (unlike properties
 The engine owns the complete set of tags on a table. On each sync it:
 
 - **sets** any declared tag that is missing from the catalog or has a different value, and
-- **unsets** any tag found on the table that is _not_ in your declaration.
+- **unsets** any tag found on the table that is *not* in your declaration.
 
 This means a tag applied outside delta-engine (in the Databricks UI, by another job, or by a tag policy) **will be removed** on the next sync unless you also declare it. This is deliberate — it keeps the table's tags exactly as declared — but declare every tag you want to keep.
 
@@ -44,7 +44,7 @@ This means a tag applied outside delta-engine (in the Databricks UI, by another 
 
 Tags require Unity Catalog on Databricks Runtime 13.3 LTS or later, and the `APPLY TAG` privilege on the table (plus `USE SCHEMA` / `USE CATALOG`). On non-Unity-Catalog environments the engine observes no tags and emits no tag changes.
 
-Databricks limits: up to 50 tags per table; keys and values up to 256 characters; tag keys cannot contain `. , - = / :` or leading/trailing spaces. Delta-engine enforces the 50-tag limit and 1000-character value limit at declaration time; declarations that violate these limits fail immediately with a `ValueError`.
+Databricks limits: up to 50 tags per table; keys up to 256 characters and values up to 1,000 characters; tag keys cannot contain `. , - = / :` or leading/trailing spaces. Delta-engine enforces the 50-tag limit and the 1,000-character value limit at declaration time; declarations that violate these limits fail immediately with a `ValueError`.
 
 ## Column tags
 
@@ -81,5 +81,7 @@ As with table tags, keys are **case-sensitive** (`PII` and `pii` are distinct).
 
 Column tags require Unity Catalog on Databricks Runtime 13.3 LTS or later and the
 `APPLY TAG` privilege. Databricks limits: up to 50 tags per column, at most 1,000
-column tags per table across all columns, keys and values up to 256 characters,
-and tag keys cannot contain `. , - = / :` or leading/trailing spaces.
+column tags per table across all columns, keys up to 256 characters and values up
+to 1,000 characters, and tag keys cannot contain `. , - = / :` or leading/trailing
+spaces. Delta-engine enforces the 50-tags-per-column limit and the 1,000-character
+value limit at declaration time; violations fail immediately with a `ValueError`.

--- a/docs/how-to-configure-tags.md
+++ b/docs/how-to-configure-tags.md
@@ -34,7 +34,7 @@ Tag keys are free-form strings — there is no enum allowlist (unlike properties
 The engine owns the complete set of tags on a table. On each sync it:
 
 - **sets** any declared tag that is missing from the catalog or has a different value, and
-- **unsets** any tag found on the table that is *not* in your declaration.
+- **unsets** any tag found on the table that is _not_ in your declaration.
 
 This means a tag applied outside delta-engine (in the Databricks UI, by another job, or by a tag policy) **will be removed** on the next sync unless you also declare it. This is deliberate — it keeps the table's tags exactly as declared — but declare every tag you want to keep.
 
@@ -44,7 +44,7 @@ This means a tag applied outside delta-engine (in the Databricks UI, by another 
 
 Tags require Unity Catalog on Databricks Runtime 13.3 LTS or later, and the `APPLY TAG` privilege on the table (plus `USE SCHEMA` / `USE CATALOG`). On non-Unity-Catalog environments the engine observes no tags and emits no tag changes.
 
-Databricks limits: up to 50 tags per table; keys and values up to 256 characters; tag keys cannot contain `. , - = / :` or leading/trailing spaces.
+Databricks limits: up to 50 tags per table; keys and values up to 256 characters; tag keys cannot contain `. , - = / :` or leading/trailing spaces. Delta-engine enforces the 50-tag limit and 1000-character value limit at declaration time; declarations that violate these limits fail immediately with a `ValueError`.
 
 ## Column tags
 

--- a/src/delta_engine/api/table.py
+++ b/src/delta_engine/api/table.py
@@ -52,6 +52,25 @@ _CDF_RESERVED_COLUMN_NAMES: Final[frozenset[str]] = frozenset(
     {"_change_type", "_commit_version", "_commit_timestamp"}
 )
 
+# Unity Catalog limits per securable object (a table and each of its
+# columns are separate securables).
+_MAX_TAGS_PER_SECURABLE: Final[int] = 50
+_MAX_TAG_VALUE_LENGTH: Final[int] = 1000
+
+
+def _validate_tags(subject: str, tags: Mapping[str, str]) -> None:
+    if len(tags) > _MAX_TAGS_PER_SECURABLE:
+        raise ValueError(
+            f"{subject} declares {len(tags)} tags; Unity Catalog allows at"
+            f" most {_MAX_TAGS_PER_SECURABLE} per securable"
+        )
+    for key, value in tags.items():
+        if len(value) > _MAX_TAG_VALUE_LENGTH:
+            raise ValueError(
+                f"Tag {key!r} on {subject} has a {len(value)}-character"
+                f" value; Unity Catalog allows at most {_MAX_TAG_VALUE_LENGTH}"
+            )
+
 
 def _column_declared_names(column: Column) -> tuple[str, ...]:
     """
@@ -236,6 +255,11 @@ class DeltaTable:
                     f" {Property.CHANGE_DATA_FEED}."
                 )
 
+        table_tags = dict(tags or {})
+        _validate_tags(f"table '{name}'", table_tags)
+        for column in columns:
+            _validate_tags(f"column '{column.name}'", column.tags)
+
         primary_key_columns = tuple(column.name for column in columns if column.primary_key)
         primary_key = (
             PrimaryKeyConstraint.generate(table_name=name, columns=primary_key_columns)
@@ -258,7 +282,7 @@ class DeltaTable:
             columns=columns,
             comment=comment,
             properties=user_properties,
-            tags=dict(tags or {}),
+            tags=table_tags,
             partitioned_by=tuple(partitioned_by),
             primary_key=primary_key,
             foreign_keys=lowered_foreign_keys,

--- a/tests/api/test_table.py
+++ b/tests/api/test_table.py
@@ -601,3 +601,40 @@ def test_delta_table_accepts_cdf_reserved_column_names_when_cdf_not_enabled() ->
         columns=[Column("id", Integer()), Column("_change_type", String())],
     )
     assert len(table.to_desired_table().columns) == 2
+
+
+# ---- tag limits (Unity Catalog) ----
+
+
+def test_delta_table_rejects_more_than_fifty_table_tags() -> None:
+    too_many = {f"tag_{i}": "v" for i in range(51)}
+    with pytest.raises(ValueError, match="50"):
+        DeltaTable(
+            catalog="dev",
+            schema="silver",
+            name="orders",
+            columns=[Column("id", Integer())],
+            tags=too_many,
+        )
+
+
+def test_delta_table_rejects_overlong_tag_value_on_a_column() -> None:
+    with pytest.raises(ValueError, match="1000"):
+        DeltaTable(
+            catalog="dev",
+            schema="silver",
+            name="orders",
+            columns=[Column("id", Integer(), tags={"note": "x" * 1001})],
+        )
+
+
+def test_delta_table_accepts_tags_at_the_limits() -> None:
+    at_limit = {f"tag_{i}": "x" * 1000 for i in range(50)}
+    table = DeltaTable(
+        catalog="dev",
+        schema="silver",
+        name="orders",
+        columns=[Column("id", Integer())],
+        tags=at_limit,
+    )
+    assert len(table.to_desired_table().tags) == 50


### PR DESCRIPTION
Part 8 of 15 — validation-hardening series (context in #142; previous: #149).

## What

Unity Catalog allows at most **50 tags per securable** (a table and each of its columns are separate securables) and tag **values up to 1,000 characters**. Because tags apply as one `SET TAG` statement each, an over-limit declaration previously failed *partway through the sequence* — partial application, the worst failure mode in the series. Both limits are now checked when the `DeltaTable` is constructed.

Boundary semantics: exactly 50 tags with exactly 1,000-character values are accepted (test pins it). The checks are NOT gated on `metadata_only` — tags are managed in both modes. The checks live in the api layer only; domain `Column`/`TableSnapshot` stay unconstrained so observed state remains representable whatever the catalog holds.

Second commit reconciles the tags how-to: the pre-existing text claimed "keys and values up to 256 characters", which is stale for values (Databricks raised the value limit to 1,000 in May 2024); both the table-tags and column-tags sections now state keys ≤ 256 / values ≤ 1,000 and document the declaration-time enforcement.

## Known limitation (deliberate)

Databricks also caps a table at 1,000 column tags *in aggregate*. That is declaration-knowable but not enforced here — a table with 21+ columns at 50 tags each can still fail server-side. On the follow-ups list rather than this slice.

## Verification

253 tests across tests/api + tests/application (3 new); `ruff check .`, `mypy .`, sphinx `-W` docs build clean.
