### PR TITLE
feat(api): reject foreign keys whose column types do not match the referenced primary key

### DIFF
--- a/docs/how-to-declare-foreign-keys.md
+++ b/docs/how-to-declare-foreign-keys.md
@@ -40,6 +40,8 @@ orders = DeltaTable(
 
 The engine derives the constraint name as `{table_name}_{local_columns}_fk` — `orders_customer_id_fk` above. This name is internal; `constraint_name` is not part of the public API.
 
+Each local column's data type must match its corresponding referenced primary-key column's data type. A mismatch raises `ValueError` when the `DeltaTable` is constructed, before any sync runs.
+
 ## Self-referential foreign keys
 
 Use the `Self` sentinel when a table references itself:

--- a/src/delta_engine/api/table.py
+++ b/src/delta_engine/api/table.py
@@ -133,10 +133,13 @@ class ForeignKey:
         Lower this declaration into a domain constraint.
 
         Resolves ``references`` to a concrete table and infers the referenced
-        columns from that table's primary key. ``owner_name``, ``owner_columns``,
-        and ``owner_primary_key`` describe the enclosing table, used when
-        ``references`` is :data:`Self`. Each local column's data type must match
-        its corresponding referenced primary-key column's data type.
+        columns from that table's primary key. ``owner_name`` and
+        ``owner_columns`` describe the enclosing table and are used
+        unconditionally, for error messages and local column types;
+        ``owner_primary_key`` is used only when ``references`` is
+        :data:`Self`, to supply the enclosing table's own primary key as the
+        referenced columns. Each local column's data type must match its
+        corresponding referenced primary-key column's data type.
         """
         match self.references:
             case _SelfReference():

--- a/src/delta_engine/api/table.py
+++ b/src/delta_engine/api/table.py
@@ -132,28 +132,15 @@ class ForeignKey:
         """
         Lower this declaration into a domain constraint.
 
-        Resolves ``references`` to a concrete table and infers the referenced
-        columns from that table's primary key. ``owner_name`` and
-        ``owner_columns`` describe the enclosing table and are used
-        unconditionally, for error messages and local column types;
-        ``owner_primary_key`` is used only when ``references`` is
-        :data:`Self`, to supply the enclosing table's own primary key as the
-        referenced columns. Each local column's data type must match its
-        corresponding referenced primary-key column's data type.
+        Applies the lowering rules in order: the referenced table must declare
+        a primary key, the local column count must match it, and each local
+        column's data type must match its referenced column's. Local column
+        existence is not checked here — the ``DesiredTable`` built right
+        after enforces it.
         """
-        match self.references:
-            case _SelfReference():
-                referenced_table, referenced_columns = owner_name, owner_primary_key
-                referenced_table_columns = owner_columns
-            case DeltaTable() as target:
-                desired = target.to_desired_table()
-                referenced_table = desired.qualified_name
-                referenced_columns = desired.primary_key_columns
-                referenced_table_columns = desired.columns
-            case _:
-                raise TypeError(
-                    f"foreign key references must be a DeltaTable or Self; got {self.references!r}"
-                )
+        referenced_table, referenced_columns, referenced_types = self._resolve_reference(
+            owner_name, owner_columns, owner_primary_key
+        )
 
         if not referenced_columns:
             raise ValueError(
@@ -165,25 +152,57 @@ class ForeignKey:
                 f" {owner_name} declares {len(self.local_columns)} local column(s)"
                 f" but {referenced_table}'s primary key has {len(referenced_columns)}"
             )
+
         local_types = {column.name: column.data_type for column in owner_columns}
-        referenced_types = {column.name: column.data_type for column in referenced_table_columns}
         for local_name, referenced_name in zip(self.local_columns, referenced_columns, strict=True):
             local_type = local_types.get(local_name)
-            referenced_type = referenced_types.get(referenced_name)
-            if local_type is None or referenced_type is None:
-                continue  # column existence is enforced when the DesiredTable is built
+            if local_type is None:
+                continue  # local column existence is enforced when the DesiredTable is built
+            referenced_type = referenced_types[referenced_name]
             if local_type != referenced_type:
                 raise ValueError(
                     f"foreign key column type mismatch: {owner_name}.{local_name}"
                     f" is {local_type} but {referenced_table}.{referenced_name}"
                     f" is {referenced_type}"
                 )
+
         return ForeignKeyConstraint.generate(
             owner_table_name=owner_name.name,
             local_columns=tuple(self.local_columns),
             referenced_table=referenced_table,
             referenced_columns=tuple(referenced_columns),
         )
+
+    def _resolve_reference(
+        self,
+        owner_name: QualifiedName,
+        owner_columns: tuple[Column, ...],
+        owner_primary_key: tuple[str, ...],
+    ) -> tuple[QualifiedName, tuple[str, ...], dict[str, DataType]]:
+        """
+        Resolve ``references`` to the referenced side of the constraint.
+
+        Returns the referenced table's name, its primary-key columns (the
+        columns this key references), and its column types by name. For
+        :data:`Self` the enclosing table supplies all three — its own name,
+        ``owner_primary_key``, and ``owner_columns`` — because the owner's
+        ``DesiredTable`` does not exist yet while its foreign keys are being
+        lowered. The returned mapping always covers every referenced column:
+        primary-key columns are validated to exist on whichever table
+        declares them.
+        """
+        match self.references:
+            case _SelfReference():
+                types = {column.name: column.data_type for column in owner_columns}
+                return owner_name, owner_primary_key, types
+            case DeltaTable() as target:
+                desired = target.to_desired_table()
+                types = {column.name: column.data_type for column in desired.columns}
+                return desired.qualified_name, desired.primary_key_columns, types
+            case _:
+                raise TypeError(
+                    f"foreign key references must be a DeltaTable or Self; got {self.references!r}"
+                )
 
 
 class DeltaTable:

--- a/src/delta_engine/api/table.py
+++ b/src/delta_engine/api/table.py
@@ -124,23 +124,29 @@ class ForeignKey:
     references: DeltaTable | _SelfReference
 
     def _to_constraint(
-        self, owner_name: QualifiedName, owner_primary_key: tuple[str, ...]
+        self,
+        owner_name: QualifiedName,
+        owner_columns: tuple[Column, ...],
+        owner_primary_key: tuple[str, ...],
     ) -> ForeignKeyConstraint:
         """
         Lower this declaration into a domain constraint.
 
         Resolves ``references`` to a concrete table and infers the referenced
-        columns from that table's primary key. ``owner_name`` and
-        ``owner_primary_key`` describe the enclosing table, used when
-        ``references`` is :data:`Self`.
+        columns from that table's primary key. ``owner_name``, ``owner_columns``,
+        and ``owner_primary_key`` describe the enclosing table, used when
+        ``references`` is :data:`Self`. Each local column's data type must match
+        its corresponding referenced primary-key column's data type.
         """
         match self.references:
             case _SelfReference():
                 referenced_table, referenced_columns = owner_name, owner_primary_key
+                referenced_table_columns = owner_columns
             case DeltaTable() as target:
                 desired = target.to_desired_table()
                 referenced_table = desired.qualified_name
                 referenced_columns = desired.primary_key_columns
+                referenced_table_columns = desired.columns
             case _:
                 raise TypeError(
                     f"foreign key references must be a DeltaTable or Self; got {self.references!r}"
@@ -156,6 +162,19 @@ class ForeignKey:
                 f" {owner_name} declares {len(self.local_columns)} local column(s)"
                 f" but {referenced_table}'s primary key has {len(referenced_columns)}"
             )
+        local_types = {column.name: column.data_type for column in owner_columns}
+        referenced_types = {column.name: column.data_type for column in referenced_table_columns}
+        for local_name, referenced_name in zip(self.local_columns, referenced_columns, strict=True):
+            local_type = local_types.get(local_name)
+            referenced_type = referenced_types.get(referenced_name)
+            if local_type is None or referenced_type is None:
+                continue  # column existence is enforced when the DesiredTable is built
+            if local_type != referenced_type:
+                raise ValueError(
+                    f"foreign key column type mismatch: {owner_name}.{local_name}"
+                    f" is {local_type} but {referenced_table}.{referenced_name}"
+                    f" is {referenced_type}"
+                )
         return ForeignKeyConstraint.generate(
             owner_table_name=owner_name.name,
             local_columns=tuple(self.local_columns),
@@ -269,7 +288,7 @@ class DeltaTable:
 
         qualified_name = QualifiedName(catalog, schema, name)
         lowered_foreign_keys = tuple(
-            declaration._to_constraint(qualified_name, primary_key_columns)
+            declaration._to_constraint(qualified_name, columns, primary_key_columns)
             for declaration in (foreign_keys or ())
         )
 

--- a/tests/api/test_foreign_key.py
+++ b/tests/api/test_foreign_key.py
@@ -1,7 +1,7 @@
 import pytest
 
 from delta_engine.domain.model import QualifiedName
-from delta_engine.schema import Column, DeltaTable, ForeignKey, Integer, Self
+from delta_engine.schema import Column, DeltaTable, ForeignKey, Integer, Long, Self, String
 
 
 def _customers() -> DeltaTable:
@@ -155,3 +155,65 @@ def test_delta_table_rejects_non_table_reference():
                 ForeignKey(local_columns=("customer_id",), references="cat.sch.customers")  # type: ignore[arg-type]
             ],
         )
+
+
+def test_foreign_key_rejects_local_column_type_mismatch_with_target_primary_key():
+    # Given a referenced primary key of type Long and a local column of type String
+    customers = DeltaTable(
+        catalog="cat",
+        schema="sch",
+        name="customers",
+        columns=[Column("id", Long(), nullable=False, primary_key=True)],
+    )
+
+    # When / Then construction fails because the local column type does not match
+    with pytest.raises(ValueError, match="type mismatch"):
+        DeltaTable(
+            catalog="cat",
+            schema="sch",
+            name="orders",
+            columns=[
+                Column("id", Long(), nullable=False, primary_key=True),
+                Column("customer_id", String()),
+            ],
+            foreign_keys=[ForeignKey(local_columns=("customer_id",), references=customers)],
+        )
+
+
+def test_self_referential_foreign_key_rejects_type_mismatch():
+    # Given a self-referential foreign key whose local column type differs from the primary key
+    # When / Then construction fails because the local column type does not match
+    with pytest.raises(ValueError, match="type mismatch"):
+        DeltaTable(
+            catalog="cat",
+            schema="sch",
+            name="employees",
+            columns=[
+                Column("id", Long(), nullable=False, primary_key=True),
+                Column("manager_id", Integer()),
+            ],
+            foreign_keys=[ForeignKey(local_columns=("manager_id",), references=Self)],
+        )
+
+
+def test_foreign_key_with_matching_types_still_lowers():
+    # Given a referenced primary key and local column that share the same type
+    customers = DeltaTable(
+        catalog="cat",
+        schema="sch",
+        name="customers",
+        columns=[Column("id", Long(), nullable=False, primary_key=True)],
+    )
+    orders = DeltaTable(
+        catalog="cat",
+        schema="sch",
+        name="orders",
+        columns=[
+            Column("id", Long(), nullable=False, primary_key=True),
+            Column("customer_id", Long()),
+        ],
+        foreign_keys=[ForeignKey(local_columns=("customer_id",), references=customers)],
+    )
+
+    # Then the foreign key lowers normally
+    assert orders.foreign_keys[0].local_columns == ("customer_id",)


### PR DESCRIPTION
Part 9 of 15 — validation-hardening series (context in #142; previous: #150).

## What

Databricks requires FK columns to "match the data type and number of parent columns". The lowering checked count but never types, so `orders.customer_id: String → customers.id: Long` validated clean and died at DDL execution. Both tables' declarations are in hand at lowering (the FK references the `DeltaTable` object), so the check is exact and free.

## Changes

- `ForeignKey._to_constraint` gains `owner_columns` as its second parameter; after the existing count check, each local/referenced column pair is compared by domain-type equality, raising with both sides named (`Decimal(precision=10, scale=2)` vs `Decimal(precision=10, scale=0)` render distinguishably). Missing columns are skipped — existence is enforced by `DesiredTable` construction right after.
- Self-referential keys (`references=Self`) get the same check against the owner's own columns.
- Second commit: docstring correction from the whole-branch review — `owner_name`/`owner_columns` are used unconditionally (error messages, local types); only `owner_primary_key` is Self-specific.
- `docs/how-to-declare-foreign-keys.md` notes the type-match requirement.

## Verification

54 api tests (3 new: cross-table mismatch, self-referential mismatch, matching-types acceptance); `ruff check .`, `mypy .`, sphinx `-W` build clean. The `_to_constraint` region is byte-identical to the fully-reviewed reference branch.