### PR TITLE
feat: block primary key changes while foreign keys reference the key

### DIFF
--- a/docs/reference-safe-change-rules.md
+++ b/docs/reference-safe-change-rules.md
@@ -15,6 +15,7 @@ The engine validates the computed diff before executing any SQL. These rules blo
 | `PartitioningChangeNotSupported` | Changing `partitioned_by` on an existing table | Drop and recreate the table out of band, then re-sync |
 | `PropertyTransitionNotSupported` | A property transition the catalog rejects — a value change (e.g. `delta.columnMapping.mode` `name` → `none`) or a removal of a key that cannot be unset | Update the declaration to match the catalog value |
 | `PropertyMustBeDeclared` | A managed property set on the table but missing from the declaration | Declare it (or declare it `None` to remove it, where removal is possible) |
+| `PrimaryKeyReferencedByForeignKeys` | Dropping or changing a primary key while foreign keys reference it (same-table FKs dropped in the same sync are exempt) | Sync the referencing tables without those foreign keys first, then change the key |
 
 Two further checks are scope invariants rather than rules — they define what a
 declaration is allowed to govern and always run, regardless of the rule set:

--- a/src/delta_engine/adapters/databricks/reader.py
+++ b/src/delta_engine/adapters/databricks/reader.py
@@ -19,6 +19,7 @@ from delta_engine.adapters.databricks.sql import (
     foreign_keys_query,
     information_schema_probe_query,
     primary_key_query,
+    referencing_foreign_keys_query,
     table_tags_query,
 )
 from delta_engine.application.failures import ReadFailure
@@ -32,6 +33,7 @@ from delta_engine.application.properties import DELTA_PROPERTY_REGISTRY
 from delta_engine.domain.model import (
     Column as DomainColumn,
     ForeignKeyConstraint,
+    ForeignKeyReference,
     ObservedTable,
     PrimaryKeyConstraint,
     QualifiedName,
@@ -146,6 +148,26 @@ def _foreign_key_from_rows(constraint_name: str, rows: list[Row]) -> ForeignKeyC
     )
 
 
+def _referencing_foreign_keys_from_rows(rows: Iterable[Row]) -> tuple[ForeignKeyReference, ...]:
+    """
+    Build the inbound foreign key references from information_schema rows.
+
+    Names are casefolded at the adapter boundary, consistent with the rest of
+    this reader.
+    """
+    return tuple(
+        ForeignKeyReference(
+            constraint_name=row.constraint_name.casefold(),
+            referencing_table=QualifiedName(
+                row.referencing_catalog.casefold(),
+                row.referencing_schema.casefold(),
+                row.referencing_table.casefold(),
+            ),
+        )
+        for row in rows
+    )
+
+
 def _table_tags_from_rows(rows: Iterable[Row]) -> MappingProxyType[str, str]:
     """Map table-tag rows to a read-only mapping; tag case is preserved verbatim."""
     return MappingProxyType({row.tag_name: row.tag_value for row in rows})
@@ -243,6 +265,11 @@ class DatabricksReader:
             ),
             foreign_keys=_foreign_keys_from_rows(
                 self._information_schema_rows(catalog, foreign_keys_query(qualified_name))
+            ),
+            referencing_foreign_keys=_referencing_foreign_keys_from_rows(
+                self._information_schema_rows(
+                    catalog, referencing_foreign_keys_query(qualified_name)
+                )
             ),
         )
         return TablePresent(table=observed)

--- a/src/delta_engine/adapters/databricks/sql/__init__.py
+++ b/src/delta_engine/adapters/databricks/sql/__init__.py
@@ -20,6 +20,7 @@ from delta_engine.adapters.databricks.sql.queries import (
     foreign_keys_query,
     information_schema_probe_query,
     primary_key_query,
+    referencing_foreign_keys_query,
     table_tags_query,
 )
 from delta_engine.adapters.databricks.sql.types import (
@@ -39,6 +40,7 @@ __all__ = [
     "information_schema_probe_query",
     "primary_key_query",
     "quote_literal",
+    "referencing_foreign_keys_query",
     "sql_type_for_data_type",
     "table_tags_query",
 ]

--- a/src/delta_engine/adapters/databricks/sql/queries.py
+++ b/src/delta_engine/adapters/databricks/sql/queries.py
@@ -120,6 +120,42 @@ def foreign_keys_query(qualified_name: QualifiedName) -> str:
     )
 
 
+def referencing_foreign_keys_query(qualified_name: QualifiedName) -> str:
+    """
+    Render the information_schema query for foreign keys referencing this table.
+
+    The inbound counterpart of :func:`foreign_keys_query`: it finds FKs owned
+    by *other* tables whose parent key lives on this table, joining
+    table_constraints twice — once to locate the parent key's table (the
+    WHERE filter) and once to name the referencing constraint's own table.
+    Column detail is not needed; validation only names what blocks a
+    primary-key change.
+
+    information_schema is per-catalog, so a foreign key owned by a table in a
+    different catalog is invisible here; such a drop still fails at execution.
+    """
+    catalog = backtick(qualified_name.catalog)
+    return (
+        f"SELECT rc.constraint_name,"
+        f" fk_tables.table_catalog AS referencing_catalog,"
+        f" fk_tables.table_schema AS referencing_schema,"
+        f" fk_tables.table_name AS referencing_table"
+        f" FROM {catalog}.information_schema.referential_constraints AS rc"
+        f" JOIN {catalog}.information_schema.table_constraints AS pk_tables"
+        f" ON rc.unique_constraint_catalog = pk_tables.constraint_catalog"
+        f" AND rc.unique_constraint_schema = pk_tables.constraint_schema"
+        f" AND rc.unique_constraint_name = pk_tables.constraint_name"
+        f" JOIN {catalog}.information_schema.table_constraints AS fk_tables"
+        f" ON rc.constraint_catalog = fk_tables.constraint_catalog"
+        f" AND rc.constraint_schema = fk_tables.constraint_schema"
+        f" AND rc.constraint_name = fk_tables.constraint_name"
+        f" WHERE pk_tables.table_schema = {quote_literal(qualified_name.schema)}"
+        f" AND pk_tables.table_name = {quote_literal(qualified_name.name)}"
+        f" ORDER BY fk_tables.table_catalog, fk_tables.table_schema,"
+        f" fk_tables.table_name, rc.constraint_name"
+    )
+
+
 def information_schema_probe_query(catalog: str) -> str:
     """
     Render a cheap query that succeeds exactly where information_schema exists.

--- a/src/delta_engine/application/validation.py
+++ b/src/delta_engine/application/validation.py
@@ -15,7 +15,10 @@ from delta_engine.domain.plan import (
     ColumnDataTypeChanged,
     ColumnNullabilityChanged,
     ColumnRemoved,
+    ForeignKeyRemoved,
     PartitioningChanged,
+    PrimaryKeyChanged,
+    PrimaryKeyRemoved,
     PropertySet,
     PropertyUndeclared,
     PropertyUnset,
@@ -269,6 +272,62 @@ class ColumnMappingRequiredForDrop:
         )
 
 
+class PrimaryKeyReferencedByForeignKeys:
+    """
+    Disallow dropping or changing a primary key while foreign keys reference it.
+
+    DROP PRIMARY KEY is RESTRICT by default: it fails while any FK references
+    the key. The referencing constraints ride on the primary-key change (an
+    observed fact), so this rule needs no second input. A referencing FK on
+    *this* table that this same sync also drops is exempt — DROP_FOREIGN_KEY
+    phases before DROP_PRIMARY_KEY, so that plan executes cleanly. FKs on
+    other tables cannot be exempted per-table: even when the other table's
+    declaration drops the FK in the same sync run, tables execute
+    parent-first, so the PK drop would still hit the live FK.
+
+    information_schema is per-catalog, so references from other catalogs are
+    not observed; those still fail at execution.
+    """
+
+    name: ClassVar[str] = "PrimaryKeyReferencedByForeignKeys"
+
+    def evaluate(self, drift: TableDrift) -> tuple[ValidationFailure, ...]:
+        """Flag every PK drop/change still referenced by a surviving foreign key."""
+        dropped_here = {
+            change.constraint.constraint_name
+            for change in drift.managed_changes
+            if isinstance(change, ForeignKeyRemoved)
+        }
+        failures: list[ValidationFailure] = []
+        for change in drift.managed_changes:
+            if not isinstance(change, PrimaryKeyRemoved | PrimaryKeyChanged):
+                continue
+            blockers = tuple(
+                reference
+                for reference in change.referencing_foreign_keys
+                if not (
+                    reference.referencing_table == drift.desired.qualified_name
+                    and reference.constraint_name in dropped_here
+                )
+            )
+            if blockers:
+                referenced_by = ", ".join(
+                    f"{ref.constraint_name} on {ref.referencing_table}" for ref in blockers
+                )
+                failures.append(
+                    ValidationFailure(
+                        rule_name=self.name,
+                        message=(
+                            "Operation not allowed: the primary key cannot be"
+                            f" dropped or changed while foreign keys reference it:"
+                            f" {referenced_by}. Sync the referencing tables without"
+                            " those foreign keys first, then change the key."
+                        ),
+                    )
+                )
+        return tuple(failures)
+
+
 DEFAULT_RULES: tuple[Rule, ...] = (
     NonNullableColumnAdd(),
     NullabilityTighteningOnExistingColumn(),
@@ -277,6 +336,7 @@ DEFAULT_RULES: tuple[Rule, ...] = (
     PropertyTransitionNotSupported(DELTA_PROPERTY_REGISTRY),
     PropertyMustBeDeclared(DELTA_PROPERTY_REGISTRY),
     ColumnMappingRequiredForDrop(),
+    PrimaryKeyReferencedByForeignKeys(),
 )
 
 

--- a/src/delta_engine/domain/model/__init__.py
+++ b/src/delta_engine/domain/model/__init__.py
@@ -1,5 +1,9 @@
 from delta_engine.domain.model.column import Column
-from delta_engine.domain.model.constraints import ForeignKeyConstraint, PrimaryKeyConstraint
+from delta_engine.domain.model.constraints import (
+    ForeignKeyConstraint,
+    ForeignKeyReference,
+    PrimaryKeyConstraint,
+)
 from delta_engine.domain.model.data_type import (
     Array,
     Binary,
@@ -39,6 +43,7 @@ __all__ = [
     "Double",
     "Float",
     "ForeignKeyConstraint",
+    "ForeignKeyReference",
     "Integer",
     "Long",
     "Map",

--- a/src/delta_engine/domain/model/constraints.py
+++ b/src/delta_engine/domain/model/constraints.py
@@ -106,3 +106,21 @@ class ForeignKeyConstraint:
         catalog's name) compare equal when they describe the same relationship.
         """
         return (self.local_columns, self.referenced_table, self.referenced_columns)
+
+
+@dataclass(frozen=True, slots=True)
+class ForeignKeyReference:
+    """
+    A foreign key on some table that references *this* table's key.
+
+    The inbound counterpart of :class:`ForeignKeyConstraint`: it identifies
+    the referencing constraint and its owner without carrying column detail —
+    enough for validation to name what blocks a primary-key change.
+    """
+
+    constraint_name: str
+    referencing_table: QualifiedName
+
+    def __post_init__(self) -> None:
+        if not self.constraint_name.strip():
+            raise ValueError("constraint_name must not be blank")

--- a/src/delta_engine/domain/model/table.py
+++ b/src/delta_engine/domain/model/table.py
@@ -4,7 +4,11 @@ from collections.abc import Mapping
 from dataclasses import dataclass, field
 
 from delta_engine.domain.model.column import Column
-from delta_engine.domain.model.constraints import ForeignKeyConstraint, PrimaryKeyConstraint
+from delta_engine.domain.model.constraints import (
+    ForeignKeyConstraint,
+    ForeignKeyReference,
+    PrimaryKeyConstraint,
+)
 from delta_engine.domain.model.data_type import Array, Map, Struct, Variant
 from delta_engine.domain.model.qualified_name import QualifiedName
 from delta_engine.domain.model.table_aspect import ALL_ASPECTS, TableAspect
@@ -177,3 +181,4 @@ class ObservedTable(TableSnapshot):
     """Observed definition derived from the catalog (current state)."""
 
     properties: Mapping[str, str] = field(default_factory=dict)
+    referencing_foreign_keys: tuple[ForeignKeyReference, ...] = ()

--- a/src/delta_engine/domain/model/table.py
+++ b/src/delta_engine/domain/model/table.py
@@ -178,7 +178,14 @@ class DesiredTable(TableSnapshot):
 
 @dataclass(frozen=True, slots=True)
 class ObservedTable(TableSnapshot):
-    """Observed definition derived from the catalog (current state)."""
+    """
+    Observed definition derived from the catalog (current state).
+
+    ``referencing_foreign_keys`` is the one field that is not about this
+    table's own schema: it lists inbound foreign keys owned by other tables,
+    read so primary-key changes can be judged for safety. Empty where
+    information_schema is unavailable (e.g. plain Spark).
+    """
 
     properties: Mapping[str, str] = field(default_factory=dict)
     referencing_foreign_keys: tuple[ForeignKeyReference, ...] = ()

--- a/src/delta_engine/domain/plan/diff.py
+++ b/src/delta_engine/domain/plan/diff.py
@@ -349,11 +349,13 @@ class PrimaryKeyRemoved:
     A primary key present in the catalog but absent from the declaration.
 
     ``referencing_foreign_keys`` rides along so validation can judge whether
-    the key can be dropped; it does not affect ``actions()``.
+    the key can be dropped; it does not affect ``actions()``. Required, not
+    defaulted: a producer must state what references the key, so the
+    protection cannot be disabled by omission.
     """
 
     observed_primary_key: PrimaryKeyConstraint
-    referencing_foreign_keys: tuple[ForeignKeyReference, ...] = ()
+    referencing_foreign_keys: tuple[ForeignKeyReference, ...]
 
     aspect: ClassVar[TableAspect] = TableAspect.PRIMARY_KEY
 
@@ -372,12 +374,14 @@ class PrimaryKeyChanged:
     added/removed changes would make an orphaned half representable.
 
     ``referencing_foreign_keys`` rides along so validation can judge whether
-    the key can be dropped; it does not affect ``actions()``.
+    the key can be dropped; it does not affect ``actions()``. Required, not
+    defaulted: a producer must state what references the key, so the
+    protection cannot be disabled by omission.
     """
 
     desired_primary_key: PrimaryKeyConstraint
     observed_primary_key: PrimaryKeyConstraint
-    referencing_foreign_keys: tuple[ForeignKeyReference, ...] = ()
+    referencing_foreign_keys: tuple[ForeignKeyReference, ...]
 
     aspect: ClassVar[TableAspect] = TableAspect.PRIMARY_KEY
 

--- a/src/delta_engine/domain/plan/diff.py
+++ b/src/delta_engine/domain/plan/diff.py
@@ -46,7 +46,11 @@ from dataclasses import dataclass
 from typing import ClassVar
 
 from delta_engine.domain.model import Column, DesiredTable, ObservedTable
-from delta_engine.domain.model.constraints import ForeignKeyConstraint, PrimaryKeyConstraint
+from delta_engine.domain.model.constraints import (
+    ForeignKeyConstraint,
+    ForeignKeyReference,
+    PrimaryKeyConstraint,
+)
 from delta_engine.domain.model.data_type import DataType
 from delta_engine.domain.model.table_aspect import TableAspect
 from delta_engine.domain.plan.actions import (
@@ -341,9 +345,15 @@ class PrimaryKeyAdded:
 
 @dataclass(frozen=True, slots=True)
 class PrimaryKeyRemoved:
-    """A primary key present in the catalog but absent from the declaration."""
+    """
+    A primary key present in the catalog but absent from the declaration.
+
+    ``referencing_foreign_keys`` rides along so validation can judge whether
+    the key can be dropped; it does not affect ``actions()``.
+    """
 
     observed_primary_key: PrimaryKeyConstraint
+    referencing_foreign_keys: tuple[ForeignKeyReference, ...] = ()
 
     aspect: ClassVar[TableAspect] = TableAspect.PRIMARY_KEY
 
@@ -360,10 +370,14 @@ class PrimaryKeyChanged:
     Both sides travel as one atomic pair so validation can report from/to and
     ``actions()`` can emit Drop then Set. Splitting into separate
     added/removed changes would make an orphaned half representable.
+
+    ``referencing_foreign_keys`` rides along so validation can judge whether
+    the key can be dropped; it does not affect ``actions()``.
     """
 
     desired_primary_key: PrimaryKeyConstraint
     observed_primary_key: PrimaryKeyConstraint
+    referencing_foreign_keys: tuple[ForeignKeyReference, ...] = ()
 
     aspect: ClassVar[TableAspect] = TableAspect.PRIMARY_KEY
 
@@ -717,7 +731,12 @@ def _diff_primary_key(desired: DesiredTable, observed: ObservedTable) -> list[Ch
         return [PrimaryKeyAdded(primary_key=desired_key)]
 
     if desired_key is None and observed_key is not None:
-        return [PrimaryKeyRemoved(observed_primary_key=observed_key)]
+        return [
+            PrimaryKeyRemoved(
+                observed_primary_key=observed_key,
+                referencing_foreign_keys=observed.referencing_foreign_keys,
+            )
+        ]
 
     if (
         desired_key is not None
@@ -725,7 +744,11 @@ def _diff_primary_key(desired: DesiredTable, observed: ObservedTable) -> list[Ch
         and set(desired_key.columns) != set(observed_key.columns)
     ):
         return [
-            PrimaryKeyChanged(desired_primary_key=desired_key, observed_primary_key=observed_key)
+            PrimaryKeyChanged(
+                desired_primary_key=desired_key,
+                observed_primary_key=observed_key,
+                referencing_foreign_keys=observed.referencing_foreign_keys,
+            )
         ]
 
     return []

--- a/tests/adapters/databricks/sql/test_queries.py
+++ b/tests/adapters/databricks/sql/test_queries.py
@@ -6,11 +6,34 @@ from delta_engine.adapters.databricks.sql import (
     foreign_keys_query,
     information_schema_probe_query,
     primary_key_query,
+    referencing_foreign_keys_query,
     table_tags_query,
 )
 from delta_engine.domain.model import QualifiedName
 
 QN = QualifiedName("cat", "sch", "tbl")
+
+
+def test_referencing_foreign_keys_query_golden():
+    assert referencing_foreign_keys_query(QN) == (
+        "SELECT rc.constraint_name,"
+        " fk_tables.table_catalog AS referencing_catalog,"
+        " fk_tables.table_schema AS referencing_schema,"
+        " fk_tables.table_name AS referencing_table"
+        " FROM `cat`.information_schema.referential_constraints AS rc"
+        " JOIN `cat`.information_schema.table_constraints AS pk_tables"
+        " ON rc.unique_constraint_catalog = pk_tables.constraint_catalog"
+        " AND rc.unique_constraint_schema = pk_tables.constraint_schema"
+        " AND rc.unique_constraint_name = pk_tables.constraint_name"
+        " JOIN `cat`.information_schema.table_constraints AS fk_tables"
+        " ON rc.constraint_catalog = fk_tables.constraint_catalog"
+        " AND rc.constraint_schema = fk_tables.constraint_schema"
+        " AND rc.constraint_name = fk_tables.constraint_name"
+        " WHERE pk_tables.table_schema = 'sch'"
+        " AND pk_tables.table_name = 'tbl'"
+        " ORDER BY fk_tables.table_catalog, fk_tables.table_schema,"
+        " fk_tables.table_name, rc.constraint_name"
+    )
 
 
 def test_describe_detail_query_backticks_the_table_name():

--- a/tests/adapters/databricks/test_reader.py
+++ b/tests/adapters/databricks/test_reader.py
@@ -22,10 +22,11 @@ from delta_engine.adapters.databricks.sql import (
     foreign_keys_query,
     information_schema_probe_query,
     primary_key_query,
+    referencing_foreign_keys_query,
     table_tags_query,
 )
 from delta_engine.application.ports import ReadFailed, TableAbsent, TablePresent
-from delta_engine.domain.model import QualifiedName
+from delta_engine.domain.model import ForeignKeyReference, QualifiedName
 from delta_engine.domain.model.constraints import ForeignKeyConstraint, PrimaryKeyConstraint
 
 # ---------- fakes & helpers ----------
@@ -103,6 +104,7 @@ def routed_spark(
     describe=None,
     pk=(),
     fks=(),
+    referencing_fks=(),
     tags=(),
     column_tags=(),
     probe=(),
@@ -112,6 +114,9 @@ def routed_spark(
         describe_detail_query(qn): describe if describe is not None else [{"properties": {}}],
         primary_key_query(qn): list(pk) if not isinstance(pk, Exception) else pk,
         foreign_keys_query(qn): list(fks) if not isinstance(fks, Exception) else fks,
+        referencing_foreign_keys_query(qn): (
+            list(referencing_fks) if not isinstance(referencing_fks, Exception) else referencing_fks
+        ),
         table_tags_query(qn): list(tags) if not isinstance(tags, Exception) else tags,
         column_tags_query(qn): (
             list(column_tags) if not isinstance(column_tags, Exception) else column_tags
@@ -168,6 +173,21 @@ def fk_row(
         ref_schema=ref_schema,
         ref_table=ref_table,
         ref_column=ref_column,
+    )
+
+
+def referencing_fk_row(
+    *,
+    constraint_name="orders_customer_fk",
+    referencing_catalog="c",
+    referencing_schema="s",
+    referencing_table="orders",
+):
+    return SimpleNamespace(
+        constraint_name=constraint_name,
+        referencing_catalog=referencing_catalog,
+        referencing_schema=referencing_schema,
+        referencing_table=referencing_table,
     )
 
 
@@ -405,6 +425,24 @@ def test_fetch_state_includes_single_column_foreign_key_in_observed_table(qn):
     )
 
 
+# ---------- referencing foreign keys ----------
+
+
+def test_fetch_state_includes_referencing_foreign_key_in_observed_table(qn):
+    spark = routed_spark(
+        qn, catalog=single_column_catalog(qn), referencing_fks=[referencing_fk_row()]
+    )
+    result = DatabricksReader(spark).fetch_state(qn)
+
+    assert isinstance(result, TablePresent)
+    assert result.table.referencing_foreign_keys == (
+        ForeignKeyReference(
+            constraint_name="orders_customer_fk",
+            referencing_table=QualifiedName("c", "s", "orders"),
+        ),
+    )
+
+
 # ---------- tags ----------
 
 
@@ -444,10 +482,12 @@ def test_fetch_state_skips_metadata_queries_when_information_schema_is_absent(qn
     assert isinstance(result, TablePresent)
     assert result.table.primary_key is None
     assert result.table.foreign_keys == ()
+    assert result.table.referencing_foreign_keys == ()
     assert dict(result.table.tags) == {}
     issued = set(spark.queries)
     assert primary_key_query(qn) not in issued
     assert foreign_keys_query(qn) not in issued
+    assert referencing_foreign_keys_query(qn) not in issued
     assert table_tags_query(qn) not in issued
     assert column_tags_query(qn) not in issued
 

--- a/tests/adapters/databricks/test_reader_mappers.py
+++ b/tests/adapters/databricks/test_reader_mappers.py
@@ -8,6 +8,7 @@ the real query results are accessed) and return domain values.
 
 from types import SimpleNamespace
 
+from pyspark.sql import Row
 import pytest
 
 from delta_engine.adapters.databricks.reader import (
@@ -15,9 +16,10 @@ from delta_engine.adapters.databricks.reader import (
     _foreign_keys_from_rows,
     _managed_properties_from_row,
     _primary_key_from_rows,
+    _referencing_foreign_keys_from_rows,
     _table_tags_from_rows,
 )
-from delta_engine.domain.model import QualifiedName
+from delta_engine.domain.model import ForeignKeyReference, QualifiedName
 from delta_engine.domain.model.constraints import ForeignKeyConstraint, PrimaryKeyConstraint
 
 
@@ -113,6 +115,33 @@ def test_foreign_keys_mapper_groups_contiguous_rows_per_constraint():
     assert first.local_columns == ("a_id",)
     assert second.constraint_name == "fk_b"
     assert second.local_columns == ("b_id",)
+
+
+# ---------- referencing foreign keys ----------
+
+
+def test_referencing_foreign_keys_rows_map_to_casefolded_references() -> None:
+    rows = [
+        Row(
+            constraint_name="Orders_Customer_FK",
+            referencing_catalog="Dev",
+            referencing_schema="Silver",
+            referencing_table="Orders",
+        ),
+    ]
+
+    result = _referencing_foreign_keys_from_rows(rows)
+
+    assert result == (
+        ForeignKeyReference(
+            constraint_name="orders_customer_fk",
+            referencing_table=QualifiedName("dev", "silver", "orders"),
+        ),
+    )
+
+
+def test_referencing_foreign_keys_empty_rows_map_to_empty_tuple() -> None:
+    assert _referencing_foreign_keys_from_rows([]) == ()
 
 
 # ---------- table tags ----------

--- a/tests/application/test_validation.py
+++ b/tests/application/test_validation.py
@@ -10,9 +10,12 @@ from delta_engine.domain.model import (
     ALL_ASPECTS,
     Column,
     DesiredTable,
+    ForeignKeyConstraint,
+    ForeignKeyReference,
     Integer,
     Long,
     ObservedTable,
+    PrimaryKeyConstraint,
     QualifiedName,
     String,
     TableAspect,
@@ -22,6 +25,9 @@ from delta_engine.domain.plan.diff import (
     ColumnAdded,
     ColumnDataTypeChanged,
     ColumnRemoved,
+    ForeignKeyRemoved,
+    PrimaryKeyChanged,
+    PrimaryKeyRemoved,
     TableCommentChanged,
     TableDrift,
     TableMissing,
@@ -117,6 +123,7 @@ def test_default_rules_cover_all_safety_policies():
         "PropertyTransitionNotSupported",
         "PropertyMustBeDeclared",
         "ColumnMappingRequiredForDrop",
+        "PrimaryKeyReferencedByForeignKeys",
     }
 
 
@@ -651,3 +658,80 @@ def test_multiple_column_drops_produce_one_column_mapping_failure():
 
     # Then the precondition is reported once for the table
     assert [failure.rule_name for failure in result.failures] == ["ColumnMappingRequiredForDrop"]
+
+
+# ---- primary key referenced by foreign keys
+
+
+def test_primary_key_drop_blocked_while_foreign_keys_reference_it():
+    # Given a PK removal observed to be referenced by another table's FK
+    reference = ForeignKeyReference(
+        constraint_name="orders_customer_id_fk",
+        referencing_table=QualifiedName("dev", "silver", "orders"),
+    )
+    change = PrimaryKeyRemoved(
+        observed_primary_key=PrimaryKeyConstraint(("id",), "customers_pk"),
+        referencing_foreign_keys=(reference,),
+    )
+
+    result = validate_diff(_drift(change))
+
+    # Then validation fails naming the referencing constraint
+    assert result.failed
+    assert any(
+        failure.rule_name == "PrimaryKeyReferencedByForeignKeys"
+        and "orders_customer_id_fk" in failure.message
+        for failure in result.failures
+    )
+
+
+def test_primary_key_drop_allowed_when_no_foreign_keys_reference_it():
+    change = PrimaryKeyRemoved(
+        observed_primary_key=PrimaryKeyConstraint(("id",), "customers_pk"),
+    )
+
+    result = validate_diff(_drift(change))
+
+    assert not result.failed
+
+
+def test_primary_key_drop_allowed_when_same_sync_drops_the_referencing_fk_on_this_table():
+    # Given a self-referential FK dropped in the same sync as the PK
+    # (DROP_FOREIGN_KEY phases before DROP_PRIMARY_KEY, so execution succeeds)
+    own_fk = ForeignKeyConstraint(
+        local_columns=("parent_id",),
+        referenced_table=_QUALIFIED_NAME,
+        referenced_columns=("id",),
+        constraint_name="test_parent_id_fk",
+    )
+    reference = ForeignKeyReference(
+        constraint_name="test_parent_id_fk",
+        referencing_table=_QUALIFIED_NAME,
+    )
+    pk_change = PrimaryKeyRemoved(
+        observed_primary_key=PrimaryKeyConstraint(("id",), "test_pk"),
+        referencing_foreign_keys=(reference,),
+    )
+    fk_change = ForeignKeyRemoved(constraint=own_fk)
+
+    result = validate_diff(_drift(pk_change, fk_change))
+
+    assert not any(
+        failure.rule_name == "PrimaryKeyReferencedByForeignKeys" for failure in result.failures
+    )
+
+
+def test_primary_key_change_blocked_while_foreign_keys_reference_it():
+    reference = ForeignKeyReference(
+        constraint_name="orders_customer_id_fk",
+        referencing_table=QualifiedName("dev", "silver", "orders"),
+    )
+    change = PrimaryKeyChanged(
+        desired_primary_key=PrimaryKeyConstraint(("id", "region"), "customers_pk"),
+        observed_primary_key=PrimaryKeyConstraint(("id",), "customers_pk"),
+        referencing_foreign_keys=(reference,),
+    )
+
+    result = validate_diff(_drift(change))
+
+    assert result.failed

--- a/tests/application/test_validation.py
+++ b/tests/application/test_validation.py
@@ -688,6 +688,7 @@ def test_primary_key_drop_blocked_while_foreign_keys_reference_it():
 def test_primary_key_drop_allowed_when_no_foreign_keys_reference_it():
     change = PrimaryKeyRemoved(
         observed_primary_key=PrimaryKeyConstraint(("id",), "customers_pk"),
+        referencing_foreign_keys=(),
     )
 
     result = validate_diff(_drift(change))

--- a/tests/domain/model/test_table.py
+++ b/tests/domain/model/test_table.py
@@ -5,6 +5,7 @@ from delta_engine.domain.model import (
     Column,
     Date,
     DesiredTable,
+    ForeignKeyReference,
     Integer,
     Map,
     ObservedTable,
@@ -484,3 +485,32 @@ def test_observed_table_accepts_layouts_desired_tables_reject() -> None:
         partitioned_by=("id", "day"),
     )
     assert observed.partitioned_by == ("id", "day")
+
+
+# ---------- referencing_foreign_keys ----------
+
+
+def test_observed_table_carries_referencing_foreign_keys() -> None:
+    # Given a ForeignKeyReference describing an inbound FK
+    reference = ForeignKeyReference(
+        constraint_name="orders_customer_id_fk",
+        referencing_table=QualifiedName("dev", "silver", "orders"),
+    )
+    # When building an ObservedTable with referencing_foreign_keys
+    observed = ObservedTable(
+        qualified_name=QualifiedName("dev", "silver", "customers"),
+        columns=(Column("id", Integer()),),
+        referencing_foreign_keys=(reference,),
+    )
+    # Then the field is readable and returns the value object
+    assert observed.referencing_foreign_keys == (reference,)
+
+
+def test_foreign_key_reference_rejects_blank_constraint_name() -> None:
+    # Given a blank constraint_name
+    # When / Then construction raises ValueError
+    with pytest.raises(ValueError):
+        ForeignKeyReference(
+            constraint_name="  ",
+            referencing_table=QualifiedName("dev", "silver", "orders"),
+        )

--- a/tests/domain/plan/test_actions.py
+++ b/tests/domain/plan/test_actions.py
@@ -4,6 +4,7 @@ import pytest
 from delta_engine.domain.model import Column, DesiredTable, Integer, QualifiedName
 from delta_engine.domain.plan.actions import (
     Action,
+    ActionPhase,
     ActionPlan,
     AddColumn,
     CreateTable,
@@ -268,3 +269,11 @@ def test_set_property_observed_value_defaults_to_none():
     action = SetProperty(name="delta.enableChangeDataFeed", value="true")
 
     assert action.observed_value is None
+
+
+def test_drop_foreign_key_phases_before_drop_primary_key():
+    # PrimaryKeyReferencedByForeignKeys exempts a same-table FK dropped in the
+    # same sync ONLY because the plan drops foreign keys before primary keys.
+    # Reordering these phases would make that exemption approve plans that
+    # fail at execution.
+    assert ActionPhase.DROP_FOREIGN_KEY < ActionPhase.DROP_PRIMARY_KEY

--- a/tests/domain/plan/test_diff.py
+++ b/tests/domain/plan/test_diff.py
@@ -4,6 +4,7 @@ from delta_engine.domain.model import (
     ALL_ASPECTS,
     Column,
     DesiredTable,
+    ForeignKeyReference,
     Integer,
     Long,
     ObservedTable,
@@ -743,6 +744,27 @@ def test_observed_only_primary_key_produces_removed_change():
     # Then the primary key is marked for removal
     assert isinstance(diff, TableDrift)
     assert diff.changes == (PrimaryKeyRemoved(observed_primary_key=primary_key),)
+
+
+def test_primary_key_removal_carries_observed_referencing_foreign_keys():
+    # Given a catalog primary key that other tables reference by foreign key
+    reference = ForeignKeyReference(
+        constraint_name="orders_customer_id_fk",
+        referencing_table=QualifiedName("dev", "silver", "orders"),
+    )
+    primary_key = PrimaryKeyConstraint(columns=("id",), constraint_name="customers_pk")
+
+    # When diffing a declaration that drops the primary key
+    diff = diff_table(
+        _desired(),
+        _observed(primary_key=primary_key, referencing_foreign_keys=(reference,)),
+    )
+
+    # Then the removal change carries the inbound reference for validation to judge
+    assert isinstance(diff, TableDrift)
+    (change,) = diff.changes
+    assert isinstance(change, PrimaryKeyRemoved)
+    assert change.referencing_foreign_keys == (reference,)
 
 
 def test_changed_primary_key_produces_changed_change():

--- a/tests/domain/plan/test_diff.py
+++ b/tests/domain/plan/test_diff.py
@@ -792,6 +792,37 @@ def test_changed_primary_key_produces_changed_change():
     )
 
 
+def test_primary_key_change_carries_observed_referencing_foreign_keys():
+    # Given desired and observed primary keys over different column sets, where
+    # another table references the observed key by foreign key
+    reference = ForeignKeyReference(
+        constraint_name="orders_customer_id_fk",
+        referencing_table=QualifiedName("dev", "silver", "orders"),
+    )
+    desired_primary_key = PrimaryKeyConstraint(columns=("id",), constraint_name="test_pk")
+    observed_primary_key = PrimaryKeyConstraint(columns=("other_id",), constraint_name="legacy_pk")
+    columns = (
+        Column("id", Integer(), nullable=False),
+        Column("other_id", Integer(), nullable=False),
+    )
+
+    # When diffing a declaration that changes the primary key
+    diff = diff_table(
+        _desired(columns=columns, primary_key=desired_primary_key),
+        _observed(
+            columns=columns,
+            primary_key=observed_primary_key,
+            referencing_foreign_keys=(reference,),
+        ),
+    )
+
+    # Then the changed fact carries the inbound reference for validation to judge
+    assert isinstance(diff, TableDrift)
+    (change,) = diff.changes
+    assert isinstance(change, PrimaryKeyChanged)
+    assert change.referencing_foreign_keys == (reference,)
+
+
 def test_observed_only_foreign_key_produces_removed_change():
     # Given a catalog foreign key that is absent from the declaration
     foreign_key = _foreign_key("legacy_fk")

--- a/tests/domain/plan/test_diff.py
+++ b/tests/domain/plan/test_diff.py
@@ -514,7 +514,9 @@ def test_primary_key_changed_rejects_equal_column_sets():
     pk_b = PrimaryKeyConstraint(columns=("b", "a"), constraint_name="y")
 
     with pytest.raises(ValueError, match="no difference"):
-        PrimaryKeyChanged(desired_primary_key=pk_a, observed_primary_key=pk_b)
+        PrimaryKeyChanged(
+            desired_primary_key=pk_a, observed_primary_key=pk_b, referencing_foreign_keys=()
+        )
 
 
 # ---------- change lowering: actions()
@@ -625,14 +627,20 @@ def test_primary_key_added_produces_set_primary_key():
 def test_primary_key_removed_produces_drop_primary_key():
     pk = PrimaryKeyConstraint(columns=("id",), constraint_name="legacy_pk")
 
-    assert PrimaryKeyRemoved(observed_primary_key=pk).actions() == (DropPrimaryKey(),)
+    assert PrimaryKeyRemoved(observed_primary_key=pk, referencing_foreign_keys=()).actions() == (
+        DropPrimaryKey(),
+    )
 
 
 def test_primary_key_changed_produces_drop_then_set():
     # Given a changed primary key (column set differs)
     desired_pk = PrimaryKeyConstraint(columns=("a",), constraint_name="test_pk")
     observed_pk = PrimaryKeyConstraint(columns=("b",), constraint_name="test_pk")
-    change = PrimaryKeyChanged(desired_primary_key=desired_pk, observed_primary_key=observed_pk)
+    change = PrimaryKeyChanged(
+        desired_primary_key=desired_pk,
+        observed_primary_key=observed_pk,
+        referencing_foreign_keys=(),
+    )
 
     # When the actions are sorted by ActionPlan (drop runs before set)
     plan = ActionPlan(change.actions())
@@ -743,7 +751,9 @@ def test_observed_only_primary_key_produces_removed_change():
 
     # Then the primary key is marked for removal
     assert isinstance(diff, TableDrift)
-    assert diff.changes == (PrimaryKeyRemoved(observed_primary_key=primary_key),)
+    assert diff.changes == (
+        PrimaryKeyRemoved(observed_primary_key=primary_key, referencing_foreign_keys=()),
+    )
 
 
 def test_primary_key_removal_carries_observed_referencing_foreign_keys():
@@ -788,6 +798,7 @@ def test_changed_primary_key_produces_changed_change():
         PrimaryKeyChanged(
             desired_primary_key=desired_primary_key,
             observed_primary_key=observed_primary_key,
+            referencing_foreign_keys=(),
         ),
     )
 


### PR DESCRIPTION
Parts 10-13 of 15, rolled into one PR for coherent review — validation-hardening series (context in #142; previous: #151).

## The problem

`ALTER TABLE ... DROP PRIMARY KEY` is RESTRICT by default: it fails while *any* foreign key references the key — including FKs owned by tables the engine has never been told about. The engine previously planned the drop and died at execution. Worse, even two *consistently declared* tables in one sync could fail: tables execute parent-first (so FK creation works), which means a parent's `DROP PRIMARY KEY` runs before its child's old FK is dropped.

## The mechanism, one commit per layer

1. **Domain fact** — `ForeignKeyReference(constraint_name, referencing_table)`, the inbound counterpart of `ForeignKeyConstraint`; `ObservedTable` gains `referencing_foreign_keys`. No column detail: validation only needs to name what blocks the change.
2. **Reader** — a new information_schema query finds FKs (owned by any table in the catalog) whose parent key lives on the table being read, by joining `table_constraints` twice through `referential_constraints`: once to locate the parent key's table, once to name the referencing constraint's owner. Names casefold at the adapter boundary as usual. Where information_schema is unavailable (plain Spark), the field is empty and behaviour is unchanged.
3. **Diff** — `PrimaryKeyRemoved` and `PrimaryKeyChanged` carry the observed `referencing_foreign_keys` (same pattern as `PropertySet.observed_value`: the fact rides on the change, validation stays a function of the drift alone). `actions()` unchanged.
4. **Rule** — `PrimaryKeyReferencedByForeignKeys` blocks the drop/change and names every blocker (`constraint on catalog.schema.table`). One exemption: a referencing FK on *this same table* that this same sync also drops — `DROP_FOREIGN_KEY` phases before `DROP_PRIMARY_KEY`, so that plan executes cleanly (e.g. removing a self-referential FK together with the PK). FKs on other tables cannot be exempted even when their declarations drop them in the same run: parent-first execution order means the PK drop still hits the live FK. Safe-change rules doc gains the row.

## Known limitations (deliberate, documented in code)

- information_schema is per-catalog, so an FK owned by a table in a *different* catalog is invisible; such a drop still fails at execution — the pre-series status quo.
- The referencing-FK query adds one information_schema round trip per table read (on the follow-ups list to watch, no latency evidence yet).

## Verification

209 focused tests across queries/reader-mappers/diff/validation/domain (query golden test, mapper casefolding, diff forwarding on both PK-change arms, rule block/allow/exemption cases); full non-e2e suite 536 passed; ruff, format, mypy, lint-imports, sphinx -W all clean.