### PR TITLE
fix(reader): fail reads when a partition column type is unmappable

### DIFF
--- a/docs/explanation-architecture.md
+++ b/docs/explanation-architecture.md
@@ -154,6 +154,18 @@ fields are created nullable, nested comments are unmanaged, and modeling
 field nullability waits until the reader observes a real `StructType` rather
 than DDL text.
 
+The model is also a pinned vocabulary while the catalog's keeps growing:
+`TIMESTAMP_NTZ` and `VARIANT` both went from nonexistent to real column
+types within the life of running tools, and the next addition will reach
+tables before it reaches engines that pin a type model. An observed type
+outside the model is therefore a routine lifecycle condition, not a defect,
+and the reader handles it by how much the omission would distort the
+snapshot: an ordinary unmappable column is skipped and left unmanaged (the
+snapshot stays honest about everything else), but an unmappable partition
+column fails the whole read — an incomplete `partitioned_by` would fabricate
+partitioning drift, and a false blocked change is worse than an honest
+`READ_FAILED`.
+
 ## Sync lifecycle
 
 `Engine.sync(...)` is a phase chain. Before the chain begins, user-facing table

--- a/docs/reference-data-types.md
+++ b/docs/reference-data-types.md
@@ -38,4 +38,4 @@ Observed `CHAR(n)`/`VARCHAR(n)` columns are treated as `String`: the length boun
 
 A table where every column is unsupported surfaces as a `READ_FAILED` for that table alone.
 
-A table whose partition column has an unsupported type also surfaces as `READ_FAILED`, rather than being skipped: silently dropping a partition column would leave the observed partitioning incomplete, and the engine would report a false partitioning change instead of an honest "could not determine state".
+A table whose partition column has an unsupported type also surfaces as `READ_FAILED`, rather than being skipped: silently dropping a partition column would leave the observed partitioning incomplete, and the engine would report a false partitioning change instead of an honest "could not determine state". Hitting this usually means the catalog's type vocabulary is ahead of this engine version — new Spark types (recent precedents: `TIMESTAMP_NTZ`, `VARIANT`) reach tables before tools that pin a type model — or the name resolves to a non-Delta relation (a federated or legacy Hive table) with a broader partitioning vocabulary.

--- a/docs/reference-data-types.md
+++ b/docs/reference-data-types.md
@@ -37,3 +37,5 @@ A column whose Spark type is outside this table (`VOID`, `INTERVAL`, geospatial 
 Observed `CHAR(n)`/`VARCHAR(n)` columns are treated as `String`: the length bound is not modeled, produces no drift, and is never altered. The reasoning — facts that cannot round-trip declaration → catalog → observation are normalized out on both sides — is explained in [explanation-architecture.md](explanation-architecture.md).
 
 A table where every column is unsupported surfaces as a `READ_FAILED` for that table alone.
+
+A table whose partition column has an unsupported type also surfaces as `READ_FAILED`, rather than being skipped: silently dropping a partition column would leave the observed partitioning incomplete, and the engine would report a false partitioning change instead of an honest "could not determine state".

--- a/src/delta_engine/adapters/databricks/reader.py
+++ b/src/delta_engine/adapters/databricks/reader.py
@@ -78,7 +78,9 @@ def _to_column_mapping(
         if bool(getattr(spark_column, "isPartition", False)):
             raise RuntimeError(
                 f"Partition column {spark_column.name!r} in {qualified_name} has"
-                f" unsupported type {spark_column.dataType!r}; the observed"
+                f" type {spark_column.dataType!r}, which this version of"
+                " delta-engine has no mapping for (catalogs gain new types"
+                " before engines that pin a type model); the observed"
                 " partitioning cannot be determined, so the table cannot be"
                 " read safely."
             )

--- a/src/delta_engine/adapters/databricks/reader.py
+++ b/src/delta_engine/adapters/databricks/reader.py
@@ -56,6 +56,11 @@ def _to_column_mapping(
 
     Returns ``None`` for columns whose Spark type has no domain mapping yet,
     logging a warning so operators can track gaps as new Spark types are released.
+    A partition column with no domain mapping instead raises: skipping it would
+    leave ``ObservedTable.partitioned_by`` silently incomplete, and the differ
+    would fabricate a false ``PartitioningChanged`` from the gap. Raising here
+    lets ``fetch_state``'s exception boundary turn it into ``ReadFailed`` — the
+    honest "could not determine state" — rather than a wrong diff.
 
     The column name is lowercased here: the domain model requires lowercase
     identifiers, and case-preserving catalogs (e.g. Hive Metastore) can return
@@ -70,6 +75,13 @@ def _to_column_mapping(
     """
     domain_data_type = domain_type_from_spark(SparkType.fromDDL(spark_column.dataType))
     if domain_data_type is None:
+        if bool(getattr(spark_column, "isPartition", False)):
+            raise RuntimeError(
+                f"Partition column {spark_column.name!r} in {qualified_name} has"
+                f" unsupported type {spark_column.dataType!r}; the observed"
+                " partitioning cannot be determined, so the table cannot be"
+                " read safely."
+            )
         logger.warning(
             "Skipping column %r in %s: unrecognised Spark type %r"
             " — the column is invisible to this sync; if a declaration includes"

--- a/tests/adapters/databricks/test_reader_mappers.py
+++ b/tests/adapters/databricks/test_reader_mappers.py
@@ -4,11 +4,16 @@ Direct tests for the reader's pure row->domain mappers.
 No Spark session, no fakes: mappers take plain rows (dicts for primary-key and
 DESCRIBE DETAIL rows, attribute-style objects for FK/tag rows — matching how
 the real query results are accessed) and return domain values.
+
+The column-mapping tests below are the exception: ``_to_column_mapping`` parses
+each Spark DDL type string through ``SparkType.fromDDL``, which needs a live
+SparkSession, so those tests request the ``spark`` fixture directly.
 """
 
 from types import SimpleNamespace
 
 from pyspark.sql import Row
+from pyspark.sql.catalog import Column as SparkColumn
 import pytest
 
 from delta_engine.adapters.databricks.reader import (
@@ -18,6 +23,7 @@ from delta_engine.adapters.databricks.reader import (
     _primary_key_from_rows,
     _referencing_foreign_keys_from_rows,
     _table_tags_from_rows,
+    _to_column_mapping,
 )
 from delta_engine.domain.model import ForeignKeyReference, QualifiedName
 from delta_engine.domain.model.constraints import ForeignKeyConstraint, PrimaryKeyConstraint
@@ -199,3 +205,42 @@ def test_properties_mapper_returns_empty_read_only_mapping_for_empty_map():
     assert dict(properties) == {}
     with pytest.raises(TypeError):
         properties["x"] = "y"  # type: ignore[index]
+
+
+# ---------- column mapping ----------
+
+
+def spark_column(
+    *,
+    name: str,
+    dataType: str,
+    isPartition: bool,
+    description: str | None = None,
+    nullable: bool = True,
+    isBucket: bool = False,
+) -> SparkColumn:
+    """Build a real pyspark catalog ``Column``, matching what Unity Catalog returns."""
+    return SparkColumn(
+        name=name,
+        description=description,
+        dataType=dataType,
+        nullable=nullable,
+        isPartition=isPartition,
+        isBucket=isBucket,
+        isCluster=False,
+    )
+
+
+def test_unmappable_partition_column_fails_the_read(spark) -> None:
+    # A skipped partition column would fabricate PartitioningChanged drift,
+    # so the read must fail loudly instead.
+    column = spark_column(name="part", dataType="void", isPartition=True)
+
+    with pytest.raises(RuntimeError, match="partition"):
+        _to_column_mapping(column, QualifiedName("dev", "silver", "orders"))
+
+
+def test_unmappable_non_partition_column_is_still_skipped(spark) -> None:
+    column = spark_column(name="extra", dataType="void", isPartition=False)
+
+    assert _to_column_mapping(column, QualifiedName("dev", "silver", "orders")) is None


### PR DESCRIPTION
Part 14 of 15 — validation-hardening series (context in #142; previous: #152).

## What

An unmappable column type gets skip-and-warn treatment in the reader — sound for ordinary columns (the engine simply leaves them unmanaged), but silently wrong for **partition** columns: skipping one leaves `ObservedTable.partitioned_by` incomplete, and the differ then reports a **false `PartitioningChanged`** that blocks the sync with a misleading message. The reader now raises for that case, and `fetch_state`'s existing total-port boundary converts it to `READ_FAILED` — the honest "could not determine state".

With Parts 2–3 merged, the unmappable set is down to exotic types (`VOID`, `INTERVAL`, geospatial, future Spark types), so this guard is a rare-path correctness fix, not a common-path behaviour change. Non-partition unmappable columns keep today's skip-and-warn.

## Changes

- `reader.py::_to_column_mapping`: unmappable + `isPartition` → raise (caught at the `fetch_state` boundary → typed `ReadFailure`); docstring updated.
- Mapper tests for both branches (partition column fails the read; ordinary column still skips).
- `docs/reference-data-types.md`: the partition-column `READ_FAILED` note alongside the existing all-columns-unsupported one.

## Verification

38 reader tests pass; `ruff check .`, `mypy .`, sphinx `-W` build clean. (Known gap, on the Minors list: coverage is at the mapper level; no integration test drives an unmappable partition column through `fetch_state` itself.)