### PR TITLE
test: close the review-minor gaps from the validation-hardening series

### DIFF
--- a/src/delta_engine/domain/model/constraints.py
+++ b/src/delta_engine/domain/model/constraints.py
@@ -116,6 +116,13 @@ class ForeignKeyReference:
     The inbound counterpart of :class:`ForeignKeyConstraint`: it identifies
     the referencing constraint and its owner without carrying column detail —
     enough for validation to name what blocks a primary-key change.
+
+    Attributes:
+        constraint_name: The referencing constraint's name, as read from the
+            catalog.
+        referencing_table: Fully qualified name of the table that owns the
+            referencing constraint.
+
     """
 
     constraint_name: str

--- a/src/delta_engine/domain/model/data_type.py
+++ b/src/delta_engine/domain/model/data_type.py
@@ -65,13 +65,15 @@ class Decimal(DataType):
 
     def __post_init__(self) -> None:
         """Validate that 0 < precision <= 38 and 0 <= scale <= precision."""
-        if self.precision <= 0 or not (0 <= self.scale <= self.precision):
-            raise ValueError("invalid decimal(precision, scale)")
+        # The cap is checked first so an over-limit precision always gets the
+        # message naming the limit, even when the scale is also out of range.
         if self.precision > _MAX_DECIMAL_PRECISION:
             raise ValueError(
                 f"decimal precision must be at most {_MAX_DECIMAL_PRECISION}"
                 f" (Delta/Spark limit); got {self.precision}"
             )
+        if self.precision <= 0 or not (0 <= self.scale <= self.precision):
+            raise ValueError("invalid decimal(precision, scale)")
 
 
 @dataclass(frozen=True, slots=True)

--- a/tests/adapters/databricks/sql/test_types.py
+++ b/tests/adapters/databricks/sql/test_types.py
@@ -126,9 +126,7 @@ def test_domain_type_from_spark_returns_none_for_struct_with_unmappable_field() 
     assert domain_type_from_spark(spark_struct) is None
 
 
-def test_domain_type_from_spark_returns_none_for_struct_with_casefold_colliding_field_names() -> (
-    None
-):
+def test_struct_with_casefold_colliding_field_names_is_unmappable() -> None:
     spark_struct = T.StructType(
         [
             T.StructField("Amount", T.IntegerType()),
@@ -136,3 +134,30 @@ def test_domain_type_from_spark_returns_none_for_struct_with_casefold_colliding_
         ]
     )
     assert domain_type_from_spark(spark_struct) is None
+
+
+def test_leaf_types_round_trip_inside_collections() -> None:
+    # Given leaf types nested in Array/Map, both mapping directions agree
+    assert domain_type_from_spark(T.ArrayType(T.BinaryType())) == Array(Binary())
+    assert domain_type_from_spark(T.MapType(T.ShortType(), T.TimestampNTZType())) == Map(
+        Short(), TimestampNtz()
+    )
+    assert sql_type_for_data_type(Array(Binary())) == "ARRAY<BINARY>"
+    assert sql_type_for_data_type(Map(Short(), TimestampNtz())) == "MAP<SMALLINT,TIMESTAMP_NTZ>"
+
+
+def test_struct_maps_when_nested_in_structs_and_maps() -> None:
+    # Given struct-in-struct and struct-in-map-value shapes
+    inner = T.StructType([T.StructField("x", T.IntegerType())])
+    spark_nested = T.StructType([T.StructField("inner", inner)])
+    spark_in_map = T.MapType(T.StringType(), inner)
+
+    domain_inner = Struct((StructField("x", Integer()),))
+
+    # Then the mapping recurses in both directions
+    assert domain_type_from_spark(spark_nested) == Struct((StructField("inner", domain_inner),))
+    assert domain_type_from_spark(spark_in_map) == Map(String(), domain_inner)
+    assert (
+        sql_type_for_data_type(Struct((StructField("inner", domain_inner),)))
+        == "STRUCT<`inner`: STRUCT<`x`: INT>>"
+    )

--- a/tests/adapters/databricks/test_reader_mappers.py
+++ b/tests/adapters/databricks/test_reader_mappers.py
@@ -17,6 +17,7 @@ from pyspark.sql.catalog import Column as SparkColumn
 import pytest
 
 from delta_engine.adapters.databricks.reader import (
+    DatabricksReader,
     _column_tags_from_rows,
     _foreign_keys_from_rows,
     _managed_properties_from_row,
@@ -25,6 +26,7 @@ from delta_engine.adapters.databricks.reader import (
     _table_tags_from_rows,
     _to_column_mapping,
 )
+from delta_engine.application.ports import ReadFailed
 from delta_engine.domain.model import ForeignKeyReference, QualifiedName
 from delta_engine.domain.model.constraints import ForeignKeyConstraint, PrimaryKeyConstraint
 
@@ -244,3 +246,21 @@ def test_unmappable_non_partition_column_is_still_skipped(spark) -> None:
     column = spark_column(name="extra", dataType="void", isPartition=False)
 
     assert _to_column_mapping(column, QualifiedName("dev", "silver", "orders")) is None
+
+
+def test_fetch_state_returns_read_failed_for_unmappable_partition_column(spark) -> None:
+    # Given a catalog whose table has a partition column the engine cannot map
+    bad_column = spark_column(name="part", dataType="void", isPartition=True)
+    stub_spark = SimpleNamespace(
+        catalog=SimpleNamespace(
+            tableExists=lambda name: True,
+            listColumns=lambda name: [bad_column],
+        )
+    )
+
+    # When fetching state through the port
+    state = DatabricksReader(stub_spark).fetch_state(QualifiedName("dev", "silver", "orders"))
+
+    # Then the mapper's refusal surfaces as a typed ReadFailed, not an exception
+    assert isinstance(state, ReadFailed)
+    assert "partition" in state.failure.message.lower()

--- a/tests/api/test_foreign_key.py
+++ b/tests/api/test_foreign_key.py
@@ -196,6 +196,39 @@ def test_self_referential_foreign_key_rejects_type_mismatch():
         )
 
 
+def test_composite_foreign_key_rejects_a_single_mismatched_column_pair():
+    # Given a composite referenced primary key where only the second local
+    # column's type differs
+    customers = DeltaTable(
+        catalog="cat",
+        schema="sch",
+        name="customers",
+        columns=[
+            Column("tenant_id", Integer(), nullable=False, primary_key=True),
+            Column("id", Long(), nullable=False, primary_key=True),
+        ],
+    )
+
+    # When / Then construction fails naming the mismatched pair
+    with pytest.raises(ValueError, match=r"orders\.customer_id"):
+        DeltaTable(
+            catalog="cat",
+            schema="sch",
+            name="orders",
+            columns=[
+                Column("id", Long(), nullable=False, primary_key=True),
+                Column("customer_tenant_id", Integer()),
+                Column("customer_id", String()),
+            ],
+            foreign_keys=[
+                ForeignKey(
+                    local_columns=("customer_tenant_id", "customer_id"),
+                    references=customers,
+                )
+            ],
+        )
+
+
 def test_foreign_key_with_matching_types_still_lowers():
     # Given a referenced primary key and local column that share the same type
     customers = DeltaTable(

--- a/tests/api/test_table.py
+++ b/tests/api/test_table.py
@@ -459,9 +459,9 @@ def test_rejects_unregistered_key_declared_as_none():
 def test_delta_table_rejects_invalid_property_value() -> None:
     with pytest.raises(ValueError, match=r"delta\.enableChangeDataFeed"):
         DeltaTable(
-            "dev",
-            "silver",
-            "orders",
+            catalog="dev",
+            schema="silver",
+            name="orders",
             columns=[Column("id", Integer())],
             properties={"delta.enableChangeDataFeed": "yes"},
         )
@@ -470,13 +470,39 @@ def test_delta_table_rejects_invalid_property_value() -> None:
 def test_delta_table_accepts_none_property_value_without_value_check() -> None:
     # None asserts absence; it is not a value and must not be validated as one.
     table = DeltaTable(
-        "dev",
-        "silver",
-        "orders",
+        catalog="dev",
+        schema="silver",
+        name="orders",
         columns=[Column("id", Integer())],
         properties={"delta.enableChangeDataFeed": None},
     )
     assert table.to_desired_table().properties["delta.enableChangeDataFeed"] is None
+
+
+def test_metadata_only_table_mirrors_cdf_reserved_columns_with_cdf_declared() -> None:
+    # metadata_only declarations do not manage properties, so the declaration
+    # is a mirror of existing state, not an attempt to enable CDF.
+    table = DeltaTable(
+        catalog="dev",
+        schema="silver",
+        name="orders",
+        columns=[Column("id", Integer()), Column("_change_type", String())],
+        properties={"delta.enableChangeDataFeed": "true"},
+        metadata_only=True,
+    )
+    assert len(table.to_desired_table().columns) == 2
+
+
+def test_delta_table_accepts_column_tags_at_the_limits() -> None:
+    # A column is its own securable: 50 tags of 1,000 characters are accepted
+    at_limit = {f"tag_{i}": "x" * 1000 for i in range(50)}
+    table = DeltaTable(
+        catalog="dev",
+        schema="silver",
+        name="orders",
+        columns=[Column("id", Integer(), tags=at_limit)],
+    )
+    assert len(table.to_desired_table().columns[0].tags) == 50
 
 
 def test_metadata_only_table_still_lowers_the_full_schema():

--- a/tests/domain/model/test_data_type.py
+++ b/tests/domain/model/test_data_type.py
@@ -31,6 +31,10 @@ def test_decimal_rejects_precision_above_delta_maximum() -> None:
     with pytest.raises(ValueError, match="38"):
         Decimal(39, 0)
 
+    # The limit message wins even when the scale is also out of range
+    with pytest.raises(ValueError, match="38"):
+        Decimal(40, 45)
+
 
 def test_decimal_accepts_maximum_precision_and_scale() -> None:
     assert Decimal(38, 38).precision == 38


### PR DESCRIPTION
The Minors pass — closing out the per-task review findings that were logged rather than fixed during the series (#143–#154).

## What's here (8 items)

| Origin | Item |
|---|---|
| Part 1 review | `Decimal(40, 45)` now gets the 38-limit message, not the generic one — the cap check runs first (+ test) |
| Part 2 review | Leaf types round-trip inside `Array`/`Map`, both directions |
| Part 3 review | Struct-in-struct and struct-in-map mapping covered both directions |
| Part 3 review | Casefold-collision test renamed so its signature no longer line-wraps |
| Part 5 review | The two property-value tests use keyword construction like the rest of the file |
| Part 7 review | `metadata_only` + declared CDF + reserved column names pinned as legal (the three-way case the reviewer verified by hand) |
| Part 8 review | Column-securable tag boundary: 50 × 1,000-char tags on a column accepted |
| Part 9 review | Composite FK with one mismatched pair raises naming that specific pair |
| Part 14 review | `fetch_state`-boundary test: unmappable partition column → typed `ReadFailed`, driven through `DatabricksReader` with a stub catalog (mock at the Spark boundary only) |

Plus the `ForeignKeyReference` docstring gains the `Attributes:` section its sibling constraints have (Part 10 review).

## Dropped, with reasons

- *Why-comment on the union-isinstance in `PrimaryKeyReferencedByForeignKeys`* — it would restate the code; project comment rules say no.
- *Diff-reflow and report-labelling notes* — process observations about already-merged diffs; nothing to change in the repo.

Everything else from the reviews was already retired inside the series itself (integer validator, `_to_constraint` docstring, `ObservedTable` field doc, changed-arm forwarding test, boolean-key doc row, compile-test assertion).

## Verification

93 tests across the five touched files (10 new/renamed); full non-e2e suite 542 passed; ruff, format, mypy clean. Net: +1 behaviourally-visible change (the Decimal error message), everything else is tests and docstrings.