### PR TITLE
feat(api): accept any sequence or mapping in public declarations

### DIFF
--- a/docs/explanation-architecture.md
+++ b/docs/explanation-architecture.md
@@ -467,7 +467,7 @@ orders = DeltaTable(
     name="orders",
     columns=[...],
     foreign_keys=[
-        ForeignKey(local_columns=("customer_id",), references=customers),
+        ForeignKey(local_columns=["customer_id"], references=customers),
     ],
 )
 ```

--- a/docs/how-to-declare-foreign-keys.md
+++ b/docs/how-to-declare-foreign-keys.md
@@ -31,7 +31,7 @@ orders = DeltaTable(
     ],
     foreign_keys=[
         ForeignKey(
-            local_columns=("customer_id",),
+            local_columns=["customer_id"],
             references=customers,
         ),
     ],
@@ -58,7 +58,7 @@ employees = DeltaTable(
         Column("manager_id", Long()),
     ],
     foreign_keys=[
-        ForeignKey(local_columns=("manager_id",), references=Self),
+        ForeignKey(local_columns=["manager_id"], references=Self),
     ],
 )
 ```
@@ -89,7 +89,7 @@ order_lines = DeltaTable(
     ],
     foreign_keys=[
         ForeignKey(
-            local_columns=("tenant_id", "customer_id"),  # aligns with customer_accounts PK (tenant_id, id)
+            local_columns=["tenant_id", "customer_id"],  # aligns with customer_accounts PK (tenant_id, id)
             references=customer_accounts,
         ),
     ],

--- a/docs/reference-data-types.md
+++ b/docs/reference-data-types.md
@@ -23,7 +23,7 @@ tags:
 | `Binary()`                               | `BINARY`               |                                                                     |
 | `TimestampNtz()`                         | `TIMESTAMP_NTZ`        | No timezone; the table feature is enabled automatically on creation |
 | `Variant()`                              | `VARIANT`              | Requires a runtime with variant support                             |
-| `Struct((StructField(name, type), ...))` | `STRUCT<name: T, ...>` | Field nullability/comments not modeled; fields are created nullable |
+| `Struct([StructField(name, type), ...])` | `STRUCT<name: T, ...>` | Field nullability/comments not modeled; fields are created nullable |
 
 Any change to a struct's fields (adding, removing, renaming, or retyping a
 field) surfaces as a column type change on the owning column and is blocked

--- a/src/delta_engine/api/table.py
+++ b/src/delta_engine/api/table.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from collections.abc import Iterable, Mapping
+from collections.abc import Iterable, Mapping, Sequence
 from dataclasses import dataclass
 from typing import Final
 
@@ -120,8 +120,13 @@ class ForeignKey:
     reference is an object rather than a name.
     """
 
-    local_columns: tuple[str, ...]
+    local_columns: Sequence[str]
     references: DeltaTable | _SelfReference
+
+    def __post_init__(self) -> None:
+        # Accept any sequence at the public boundary (users naturally pass
+        # lists); store a tuple so the declaration stays immutable.
+        object.__setattr__(self, "local_columns", tuple(self.local_columns))
 
     def _to_constraint(
         self,
@@ -223,7 +228,7 @@ class DeltaTable:
         columns: Iterable[Column],
         comment: str = "",
         properties: Mapping[str, str | None] | None = None,
-        tags: dict[str, str] | None = None,
+        tags: Mapping[str, str] | None = None,
         partitioned_by: Iterable[str] = (),
         foreign_keys: Iterable[ForeignKey] | None = None,
         metadata_only: bool = False,

--- a/src/delta_engine/domain/model/data_type.py
+++ b/src/delta_engine/domain/model/data_type.py
@@ -1,5 +1,6 @@
 """Domain data type variants used to describe table schemas."""
 
+from collections.abc import Sequence
 from dataclasses import dataclass
 
 _MAX_DECIMAL_PRECISION = 38  # hard limit of Delta/Spark DecimalType
@@ -125,9 +126,12 @@ class StructField:
 class Struct(DataType):
     """Struct of named fields; identity is the ordered (name, type) tuple."""
 
-    fields: tuple[StructField, ...]
+    fields: Sequence[StructField]
 
     def __post_init__(self) -> None:
+        # Accept any sequence at the public boundary; store a tuple so
+        # equality and hashing stay structural.
+        object.__setattr__(self, "fields", tuple(self.fields))
         if not self.fields:
             raise ValueError("Struct requires at least one field")
         seen: set[str] = set()

--- a/tests/api/test_foreign_key.py
+++ b/tests/api/test_foreign_key.py
@@ -250,3 +250,21 @@ def test_foreign_key_with_matching_types_still_lowers():
 
     # Then the foreign key lowers normally
     assert orders.foreign_keys[0].local_columns == ("customer_id",)
+
+
+def test_foreign_key_accepts_local_columns_as_a_list():
+    # Given a foreign key declared with a plain list (the natural call style)
+    customers = _customers()
+    declaration = ForeignKey(local_columns=["customer_id"], references=customers)
+    orders = DeltaTable(
+        catalog="cat",
+        schema="sch",
+        name="orders",
+        columns=[Column("id", Integer()), Column("customer_id", Integer())],
+        foreign_keys=[declaration],
+    )
+
+    # Then the declaration and the lowered constraint both hold immutable tuples
+    assert declaration.local_columns == ("customer_id",)
+    [constraint] = orders.foreign_keys
+    assert constraint.local_columns == ("customer_id",)

--- a/tests/api/test_table.py
+++ b/tests/api/test_table.py
@@ -1,3 +1,5 @@
+from types import MappingProxyType
+
 import pytest
 
 from delta_engine.api.table import METADATA_ASPECTS
@@ -315,6 +317,20 @@ def test_delta_table_passes_tags_through_to_desired_table():
 
     # Then the tags carry through unchanged
     assert dict(desired.tags) == {"env": "prod", "domain": "sales"}
+
+
+def test_delta_table_accepts_tags_as_any_mapping():
+    # Given tags supplied as a read-only mapping rather than a dict
+    table = DeltaTable(
+        catalog="cat",
+        schema="sales",
+        name="orders",
+        columns=[Column("id", Integer())],
+        tags=MappingProxyType({"owner": "data"}),
+    )
+
+    # Then the declaration copies them into the desired table
+    assert dict(table.to_desired_table().tags) == {"owner": "data"}
 
 
 def test_delta_table_defaults_to_no_tags():

--- a/tests/domain/model/test_data_type.py
+++ b/tests/domain/model/test_data_type.py
@@ -58,3 +58,11 @@ def test_struct_equality_is_structural() -> None:
     left = Struct((StructField("a", Integer()), StructField("b", Array(String()))))
     right = Struct((StructField("a", Integer()), StructField("b", Array(String()))))
     assert left == right
+
+
+def test_struct_accepts_fields_as_a_list_and_compares_equal_to_tuple_form() -> None:
+    from_list = Struct([StructField("a", Integer())])
+    from_tuple = Struct((StructField("a", Integer()),))
+
+    assert from_list == from_tuple
+    assert from_list.fields == (StructField("a", Integer()),)


### PR DESCRIPTION
Task 1 of the review-polish sweep (docs/superpowers/plans/2026-07-08-review-polish-sweep.md).

## Summary
- `ForeignKey.local_columns` and `Struct.fields` accept any `Sequence` (lists are the natural call style) and normalize to tuples in `__post_init__`, so declarations stay immutable and structurally comparable under the hood
- `DeltaTable(tags=...)` accepts any `Mapping`, matching the `properties` parameter
- Docs examples switch to list syntax; `Struct` table row in reference-data-types updated

## Why
The annotations forced tuples on users while the lowering path quietly accepted lists — and a list-built `Struct` compared unequal to its tuple twin, which would have surfaced as spurious `ColumnDataTypeChanged` drift. Normalizing at construction closes that hole and makes the friendly call style official.

## Testing
- New regression tests: FK declared with a list lowers to tuples; `Struct([...]) == Struct((...))`; tags accept a read-only mapping
- Full suite green (591 passed, 98.71% coverage), mypy clean, ruff clean, `-W` docs build clean