### PR TITLE
refactor: honest AbstractSet annotations and drop redundant guards

### DIFF
--- a/src/delta_engine/adapters/databricks/log_config.py
+++ b/src/delta_engine/adapters/databricks/log_config.py
@@ -69,8 +69,7 @@ def configure_logging(level: int = logging.INFO, stream: TextIO | None = None) -
     """
     root = logging.getLogger()
 
-    if root.handlers:
-        root.handlers.clear()
+    root.handlers.clear()
     root.setLevel(level)
 
     handler = SafeStreamHandler(stream=stream if stream is not None else sys.__stderr__)

--- a/src/delta_engine/api/table.py
+++ b/src/delta_engine/api/table.py
@@ -259,12 +259,11 @@ class DeltaTable:
         # Fast-fail on property keys this engine does not manage (e.g. typos).
         # None-valued assertions are validated too: asserting absence of an
         # unmanaged key is as meaningless as declaring it.
-        if user_properties:
-            unmanaged = [k for k in user_properties if k not in DELTA_PROPERTY_REGISTRY]
-            if unmanaged:
-                raise ValueError(
-                    f"Properties not managed by this engine: {', '.join(sorted(unmanaged))}"
-                )
+        unmanaged = [key for key in user_properties if key not in DELTA_PROPERTY_REGISTRY]
+        if unmanaged:
+            raise ValueError(
+                f"Properties not managed by this engine: {', '.join(sorted(unmanaged))}"
+            )
 
         # Fast-fail on malformed values; the definition owns the judgment
         # (including the exemption for None, which asserts absence).

--- a/src/delta_engine/application/dependency_resolution.py
+++ b/src/delta_engine/application/dependency_resolution.py
@@ -93,7 +93,7 @@ def resolve(
 
     cycle_partners = _cycle_partners_by_table(components)
     ordered = _order_tables(tables, components)
-    failures_by_table = _classify_failures(tables, registered_names, cycle_partners, set(blocked))
+    failures_by_table = _classify_failures(tables, registered_names, cycle_partners, blocked)
 
     ordered_names = tuple(table.qualified_name for table in ordered)
     return ResolveResult(ordered_names=ordered_names, fk_failures=failures_by_table)
@@ -126,7 +126,7 @@ def blocking_failures(
 
 def _build_dependency_graph(
     tables: tuple[DesiredTable, ...],
-    registered_names: set[QualifiedName],
+    registered_names: AbstractSet[QualifiedName],
 ) -> dict[QualifiedName, set[QualifiedName]]:
     """
     Build an adjacency map from table name to the set of table names it depends on.
@@ -258,9 +258,9 @@ def _order_tables(
 
 def _classify_failures(
     tables: tuple[DesiredTable, ...],
-    registered_names: set[QualifiedName],
+    registered_names: AbstractSet[QualifiedName],
     cycle_partners_by_table: dict[QualifiedName, frozenset[QualifiedName]],
-    already_failed: set[QualifiedName],
+    already_failed: AbstractSet[QualifiedName],
 ) -> dict[QualifiedName, tuple[ForeignKeyFailure, ...]]:
     """
     Classify every table as buildable or failed because of a foreign key.
@@ -320,7 +320,9 @@ def _classify_failures(
 
     # Pass 2 — propagate to dependents until no new table is blocked.
     # Seed with both FK direct failures and any externally supplied failed names.
-    failed_names = set(failures) | already_failed
+    # Materialize a builtin set: the fixpoint loop below mutates it, and
+    # already_failed may be any read-only AbstractSet.
+    failed_names = set(failures) | set(already_failed)
     changed = True
     while changed:
         changed = False

--- a/src/delta_engine/domain/model/table.py
+++ b/src/delta_engine/domain/model/table.py
@@ -70,9 +70,9 @@ class TableSnapshot:
             if name != name.casefold():
                 raise ValueError(f"Partition column name must be lowercase: {name!r}")
 
-        missing = [name for name in self.partitioned_by if name not in seen_names]
-        if missing:
-            raise ValueError(f"Partition column not found: {missing[0]}")
+        missing_partitions = [name for name in self.partitioned_by if name not in seen_names]
+        if missing_partitions:
+            raise ValueError(f"Partition column not found: {missing_partitions[0]}")
 
         seen_partitions: set[str] = set()
         for name in self.partitioned_by:
@@ -86,9 +86,13 @@ class TableSnapshot:
                 raise ValueError(f"Primary key column not found in columns: {missing_pk[0]}")
 
         for foreign_key in self.foreign_keys:
-            missing = [col for col in foreign_key.local_columns if col not in seen_names]
-            if missing:
-                raise ValueError(f"Foreign key local column not found in columns: {missing[0]}")
+            missing_fk_columns = [
+                name for name in foreign_key.local_columns if name not in seen_names
+            ]
+            if missing_fk_columns:
+                raise ValueError(
+                    f"Foreign key local column not found in columns: {missing_fk_columns[0]}"
+                )
 
         for tag_key in self.tags:
             if not tag_key.strip():


### PR DESCRIPTION
Task 6 of the review-polish sweep (docs/superpowers/plans/2026-07-08-review-polish-sweep.md).

## Summary
- `_build_dependency_graph` and `_classify_failures` accept `AbstractSet` — they only read; the `set(blocked)` copy in `resolve` goes away, and `_classify_failures` materializes its own builtin set where the fixpoint loop actually needs mutability (with a comment saying why)
- `DeltaTable.__init__` drops the redundant `if user_properties:` wrapper (the comprehension over an empty dict is already empty) and renames `k` → `key`
- `configure_logging` drops the redundant `if root.handlers:` guard before `.clear()`
- `TableSnapshot.__post_init__` no longer reuses one `missing` variable for two different things: `missing_partitions` and `missing_fk_columns` (error messages unchanged); `col` → `name` in the FK comprehension

## Behaviour
None.

## Testing
- Dependency-resolution, table, and adapter suites (239 passed) and full suite (591 passed, 98.75% coverage) green; mypy and whole-repo ruff clean