### PR TITLE
chore: trim restating docstrings and fix lint-config typos

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -91,19 +91,21 @@ ban-relative-imports = "all" # enforce absolute imports (TID252)
   "N803", # allow non-PEP8 argument names
   "N806", # allow non-PEP8 variable names
   "D101", # don't require docstring in public classes
-  "D102", # don't require docstrings in public methods 
+  "D102", # don't require docstrings in public methods
   "D103", # don't require docstrings in public
-  "D105", # don't require docstrings in magig methods 
+  "D105", # don't require docstrings in magic methods
   "D100", # don't require module docstrings
   "D205", # don't require 1 blank line between summary line and description
   "N815", # allow variables in class scope to be mixedCase
   "N812", # allow uppercase variable names
 ]
 # Value-object modules: each class is documented and the contract lives on the
-# abstract method (Action.subject, Failure.format_lines). Concrete overrides
-# only restate it, so we don't require a docstring on every override.
+# abstract method (Action.subject, Failure.format_lines) or, for diff changes,
+# on the module docstring's description of actions(). Concrete overrides only
+# restate it, so we don't require a docstring on every override.
 "src/delta_engine/domain/plan/actions.py" = ["D102"]
 "src/delta_engine/application/failures.py" = ["D102"]
+"src/delta_engine/domain/plan/diff.py" = ["D102"]
 # Example notebooks in Databricks source format. Databricks injects `spark`,
 # `dbutils`, and `display` at runtime; the first line must be the notebook
 # header (so no module docstring); imports follow cell markers, not the file top.

--- a/src/delta_engine/adapters/databricks/executor.py
+++ b/src/delta_engine/adapters/databricks/executor.py
@@ -32,7 +32,6 @@ class DatabricksExecutor:
     """Plan executor that runs compiled statements via a Spark session."""
 
     def __init__(self, spark: SparkSession) -> None:
-        """Initialize the executor with the Spark session it runs statements on."""
         self.spark = spark
 
     def execute(self, qualified_name: QualifiedName, plan: ActionPlan) -> ExecutionSummary:

--- a/src/delta_engine/adapters/databricks/reader.py
+++ b/src/delta_engine/adapters/databricks/reader.py
@@ -227,7 +227,6 @@ class DatabricksReader:
     """Catalog state reader backed by a Databricks/Spark session."""
 
     def __init__(self, spark: SparkSession) -> None:
-        """Initialize the reader with a `SparkSession`."""
         self.spark = spark
         self._information_schema_availability: dict[str, bool] = {}
 

--- a/src/delta_engine/application/engine.py
+++ b/src/delta_engine/application/engine.py
@@ -102,7 +102,6 @@ class Engine:
         reader: CatalogStateReader,
         executor: PlanExecutor,
     ) -> None:
-        """Initialize the engine with the catalog adapters it orchestrates."""
         self.reader = reader
         self.executor = executor
 

--- a/src/delta_engine/application/ports.py
+++ b/src/delta_engine/application/ports.py
@@ -72,7 +72,13 @@ class CatalogStateReader(Protocol):
 
 @dataclass(frozen=True, slots=True)
 class ExecutionSucceeded:
-    """A single plan action that executed without error."""
+    """
+    A single plan action that executed without error.
+
+    ``action_index`` and ``statement_preview`` are not rendered by the
+    engine's own reports; they are carried for callers that inspect
+    ``ExecutionSummary.results`` directly.
+    """
 
     action: str
     action_index: int

--- a/src/delta_engine/domain/model/column.py
+++ b/src/delta_engine/domain/model/column.py
@@ -32,7 +32,6 @@ class Column:
     tags: Mapping[str, str] = field(default_factory=dict)
 
     def __post_init__(self) -> None:
-        """Raise if the name is blank/uppercase, or a tag key is blank."""
         if not self.name.strip():
             raise ValueError(f"Column name must not be blank: {self.name!r}")
         if self.name != self.name.casefold():

--- a/src/delta_engine/domain/model/qualified_name.py
+++ b/src/delta_engine/domain/model/qualified_name.py
@@ -21,7 +21,6 @@ class QualifiedName:
     name: str
 
     def __post_init__(self) -> None:
-        """Raise if any part is blank or contains uppercase characters."""
         for field_name, value in (
             ("catalog", self.catalog),
             ("schema", self.schema),

--- a/src/delta_engine/domain/plan/diff.py
+++ b/src/delta_engine/domain/plan/diff.py
@@ -101,7 +101,6 @@ class ColumnRemoved:
     aspect: ClassVar[TableAspect] = TableAspect.COLUMN_STRUCTURE
 
     def actions(self) -> tuple[Action, ...]:
-        """DropColumn for the removed column."""
         return (DropColumn(column_name=self.column.name),)
 
 
@@ -141,7 +140,6 @@ class ColumnNullabilityChanged:
             )
 
     def actions(self) -> tuple[Action, ...]:
-        """SetColumnNullability to the desired value."""
         return (SetColumnNullability(column_name=self.column_name, nullable=self.desired_nullable),)
 
 
@@ -162,7 +160,6 @@ class ColumnCommentChanged:
             )
 
     def actions(self) -> tuple[Action, ...]:
-        """SetColumnComment to the desired value."""
         return (SetColumnComment(column_name=self.column_name, comment=self.desired_comment),)
 
 
@@ -177,7 +174,6 @@ class ColumnTagSet:
     aspect: ClassVar[TableAspect] = TableAspect.COLUMN_TAGS
 
     def actions(self) -> tuple[Action, ...]:
-        """SetColumnTag with the desired value."""
         return (
             SetColumnTag(column_name=self.column_name, name=self.tag_name, value=self.tag_value),
         )
@@ -193,7 +189,6 @@ class ColumnTagUnset:
     aspect: ClassVar[TableAspect] = TableAspect.COLUMN_TAGS
 
     def actions(self) -> tuple[Action, ...]:
-        """UnsetColumnTag for the undeclared tag."""
         return (UnsetColumnTag(column_name=self.column_name, name=self.tag_name),)
 
 
@@ -211,7 +206,6 @@ class TableCommentChanged:
             raise ValueError(f"TableCommentChanged carries no difference: {self.desired_comment!r}")
 
     def actions(self) -> tuple[Action, ...]:
-        """SetTableComment to the desired value."""
         return (SetTableComment(comment=self.desired_comment),)
 
 
@@ -255,7 +249,6 @@ class PropertyUnset:
     aspect: ClassVar[TableAspect] = TableAspect.PROPERTIES
 
     def actions(self) -> tuple[Action, ...]:
-        """UnsetProperty for the asserted-absent key."""
         return (UnsetProperty(name=self.name),)
 
 
@@ -288,7 +281,6 @@ class TableTagSet:
     aspect: ClassVar[TableAspect] = TableAspect.TABLE_TAGS
 
     def actions(self) -> tuple[Action, ...]:
-        """SetTableTag with the desired value."""
         return (SetTableTag(name=self.name, value=self.value),)
 
 
@@ -301,7 +293,6 @@ class TableTagUnset:
     aspect: ClassVar[TableAspect] = TableAspect.TABLE_TAGS
 
     def actions(self) -> tuple[Action, ...]:
-        """UnsetTableTag for the undeclared tag."""
         return (UnsetTableTag(name=self.name),)
 
 
@@ -334,7 +325,6 @@ class PrimaryKeyAdded:
     aspect: ClassVar[TableAspect] = TableAspect.PRIMARY_KEY
 
     def actions(self) -> tuple[Action, ...]:
-        """SetPrimaryKey for the declared key."""
         return (
             SetPrimaryKey(
                 columns=self.primary_key.columns,
@@ -360,7 +350,6 @@ class PrimaryKeyRemoved:
     aspect: ClassVar[TableAspect] = TableAspect.PRIMARY_KEY
 
     def actions(self) -> tuple[Action, ...]:
-        """DropPrimaryKey for the undeclared key."""
         return (DropPrimaryKey(),)
 
 
@@ -411,7 +400,6 @@ class ForeignKeyAdded:
     aspect: ClassVar[TableAspect] = TableAspect.FOREIGN_KEYS
 
     def actions(self) -> tuple[Action, ...]:
-        """SetForeignKey for the declared constraint."""
         return (
             SetForeignKey(
                 local_columns=self.constraint.local_columns,


### PR DESCRIPTION
Task 8 of the review-polish sweep (docs/superpowers/plans/2026-07-08-review-polish-sweep.md).

## Summary
- diff.py joins the existing D102 per-file-ignore for value-object modules (same rationale as actions.py/failures.py: the actions() contract lives in the module docstring; per-change one-liners only restated the returned action). The 12 pure restaters are deleted; the 7 docstrings that carry real information stay (e.g. ColumnAdded's tag-arrival note, PrimaryKeyChanged's ordering note, the "no actions — validation blocks this" cross-references)
- Five voluntary restating docstrings removed: the three adapter/engine `__init__`s and the `QualifiedName`/`Column` `__post_init__` one-liners that restated the checks directly below them. The `__post_init__` docstrings that carry invariants or rationale (TableSnapshot, DesiredTable, ActionPlan, Decimal) stay
- `ExecutionSucceeded` now documents why it carries fields the reports never render: they're the introspection surface for callers reading `ExecutionSummary.results`
- pyproject comment typos fixed ("magig", trailing spaces)

## Behaviour
None — comment/config only.

## Testing
- Whole-repo ruff clean (proves the ignore covers the deletions); diff+ports suites (74 passed); full suite (591 passed, 98.75% coverage); mypy clean