### PR TITLE
style: apply ruff format to errors.py

### DIFF
--- a/src/delta_engine/application/errors.py
+++ b/src/delta_engine/application/errors.py
@@ -16,7 +16,9 @@ class SyncFailedError(Exception):
         """Build a rich error message from the supplied sync `report`."""
         self.report = report
 
-        failed_tables = [report for report in report.table_reports if report.has_failures]
+        failed_tables = [
+            table_report for table_report in report.table_reports if table_report.has_failures
+        ]
         header = f"Sync failed: {len(failed_tables)}/{len(report.table_reports)} tables failed"
 
         details: list[str] = []

--- a/src/delta_engine/application/errors.py
+++ b/src/delta_engine/application/errors.py
@@ -16,9 +16,7 @@ class SyncFailedError(Exception):
         """Build a rich error message from the supplied sync `report`."""
         self.report = report
 
-        failed_tables = [
-            report for report in report.table_reports if report.has_failures
-        ]
+        failed_tables = [report for report in report.table_reports if report.has_failures]
         header = f"Sync failed: {len(failed_tables)}/{len(report.table_reports)} tables failed"
 
         details: list[str] = []


### PR DESCRIPTION
Closing item from the review-polish sweep's final validation (Task 9): `ruff format --check` flagged errors.py after be86f5d — the comprehension fits within the 100-char limit, so the formatter collapses it to one line. Mechanical `uv run ruff format src tests` output, no other files affected.

Side observation, your call whether to act on it: `report for report in report.table_reports` shadows the `report` parameter inside the comprehension. It's functionally correct (the iterable is evaluated in the enclosing scope), but if you'd rather avoid the shadow, `table_report for table_report in report.table_reports if table_report.has_failures` doesn't fit on one line and would stay in the multi-line form — happy to switch it on this branch.

Full suite, ruff check/format, mypy, lint-imports, and the -W docs build are otherwise all green on merged main.