### PR TITLE
ci: add automated PyPI release workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,72 @@
+name: Release
+
+on:
+  push:
+    branches: [main]
+
+concurrency:
+  group: release
+  cancel-in-progress: false
+
+jobs:
+  release:
+    if: "!startsWith(github.event.head_commit.message, 'bump:')"
+    runs-on: ubuntu-latest
+    environment: pypi
+    permissions:
+      contents: write # push the bump commit + tag
+      id-token: write # OIDC for Trusted Publishing
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          fetch-depth: 0 # full history + tags for commitizen and hatch-vcs
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v8.2.0
+        with:
+          enable-cache: true
+          cache-dependency-glob: uv.lock
+
+      - name: Set up Python
+        run: uv python install 3.12
+
+      - name: Install dev dependencies
+        run: uv sync --locked --group dev
+
+      - name: Decide whether a release is needed
+        id: gate
+        run: |
+          if uv run cz bump --yes --dry-run > /dev/null 2>&1; then
+            echo "release=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "release=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Bump version, changelog, tag, and push
+        if: steps.gate.outputs.release == 'true'
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          uv run cz bump --yes --changelog
+          git push --follow-tags origin HEAD:main
+          echo "VERSION=$(uv run cz version --project)" >> "$GITHUB_ENV"
+
+      - name: Extract release notes for this version
+        if: steps.gate.outputs.release == 'true'
+        run: uv run cz changelog "v${VERSION}" --dry-run > body.md
+
+      - name: Build sdist and wheel
+        if: steps.gate.outputs.release == 'true'
+        run: uv build
+
+      - name: Publish to PyPI
+        if: steps.gate.outputs.release == 'true'
+        uses: pypa/gh-action-pypi-publish@release/v1
+
+      - name: Create GitHub Release
+        if: steps.gate.outputs.release == 'true'
+        uses: ncipollo/release-action@v1
+        with:
+          tag: v${{ env.VERSION }}
+          bodyFile: body.md
+          skipIfReleaseExists: true


### PR DESCRIPTION
## Summary

Adds `.github/workflows/release.yaml` — the automated release pipeline. On push to `main` it bumps the version (commitizen, from conventional commits), builds, publishes to PyPI via OIDC Trusted Publishing, and creates a GitHub Release. No stored tokens.

**Stacked on top of** the packaging PR (#166). Depends on the `commitizen`/`hatch-vcs` config landing there.

## ⚠️ Merge this LAST

`release.yaml` fires on every push to `main`. Only merge after:
1. The packaging PR (#166) is merged.
2. TestPyPI validation has passed.
3. The **PyPI** Trusted Publisher + `pypi` environment exist (✅ done) and workflow write permissions are enabled (✅ done).
4. The baseline `v0.1.0` tag exists on `main`.

Merging this PR is what makes the next release go live on real PyPI.

## Verification
YAML validated; the `cz bump --dry-run` gate was exercised locally (correctly computed `0.0.0 → 0.1.0`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
