### PR TITLE
ci: on-demand release workflow (fix changelog, manual trigger)

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -16,6 +16,11 @@ on:
   push:
     branches: [main]
   workflow_dispatch:
+    inputs:
+      tag:
+        description: "Existing tag to build and publish, e.g. v0.1.0 (manual recovery/re-publish)"
+        required: true
+        type: string
 
 concurrency:
   group: release
@@ -36,6 +41,12 @@ jobs:
       - uses: actions/checkout@v5
         with:
           fetch-depth: 0 # full history + tags for commitizen and hatch-vcs
+
+      - name: Check out the tag to publish (manual run)
+        # Detach onto the exact tag so hatch-vcs builds that clean version rather
+        # than a dev version derived from later commits on main.
+        if: github.event_name == 'workflow_dispatch'
+        run: git checkout "refs/tags/${{ inputs.tag }}"
 
       - name: Install uv
         uses: astral-sh/setup-uv@v8.2.0

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,52 +1,43 @@
 name: Release
 
-# On push to main: commitizen decides the bump from conventional commits, tags,
-# builds, and (after approval of the `pypi` environment) publishes to PyPI.
+# Releases are on-demand. Commits accumulate on main between releases; cutting a
+# release rolls up everything since the last one into a single version bump.
 #
-# Manual run (workflow_dispatch): skip the bump and publish whatever version the
-# current commit's tag resolves to. Use this to recover/re-publish a version that
-# was tagged but not published.
-#
-# build and publish are split into two jobs on purpose: GitHub environment
-# protection gates a whole job, so only `publish` carries `environment: pypi`.
-# That lets the bump + build run automatically while the PyPI upload waits for
-# approval.
+# Run this workflow from the Actions tab:
+#   - "tag" blank        -> cut a NEW release: commitizen bumps from accumulated
+#                           commits, tags, updates the changelog, builds, and
+#                           publishes to PyPI + GitHub Releases.
+#   - "tag" set          -> publish an EXISTING tag as-is (recovery / re-publish),
+#                           with no bump (e.g. tag = v0.1.0).
+#   - "dry_run" checked  -> preview the new-release version without publishing.
 
 on:
-  push:
-    branches: [main]
   workflow_dispatch:
     inputs:
       tag:
-        description: "Existing tag to build and publish, e.g. v0.1.0 (manual recovery/re-publish)"
-        required: true
-        type: string
+        description: "Existing tag to publish as-is, e.g. v0.1.0. Blank = cut a new release."
+        required: false
+        default: ""
+      dry_run:
+        description: "Preview the new-release version bump without publishing."
+        type: boolean
+        default: false
 
 concurrency:
   group: release
   cancel-in-progress: false
 
 jobs:
-  build:
-    # On push, skip commitizen's own bump commit to avoid re-triggering.
-    # Manual runs always proceed.
-    if: ${{ github.event_name == 'workflow_dispatch' || !startsWith(github.event.head_commit.message, 'bump:') }}
+  release:
     runs-on: ubuntu-latest
+    environment: pypi # OIDC binding for Trusted Publishing (approval optional)
     permissions:
       contents: write # push the bump commit + tag
-    outputs:
-      released: ${{ steps.decide.outputs.released }}
-      version: ${{ steps.notes.outputs.version }}
+      id-token: write # OIDC for Trusted Publishing
     steps:
       - uses: actions/checkout@v5
         with:
           fetch-depth: 0 # full history + tags for commitizen and hatch-vcs
-
-      - name: Check out the tag to publish (manual run)
-        # Detach onto the exact tag so hatch-vcs builds that clean version rather
-        # than a dev version derived from later commits on main.
-        if: github.event_name == 'workflow_dispatch'
-        run: git checkout "refs/tags/${{ inputs.tag }}"
 
       - name: Install uv
         uses: astral-sh/setup-uv@v8.2.0
@@ -60,23 +51,34 @@ jobs:
       - name: Install dev dependencies
         run: uv sync --locked --group dev
 
-      - name: Decide what to do
-        id: decide
+      - name: Determine mode
+        id: mode
         run: |
-          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
-            # Publish the current tag as-is, no bump.
-            echo "released=true" >> "$GITHUB_OUTPUT"
-            echo "bump=false" >> "$GITHUB_OUTPUT"
-          elif uv run cz bump --yes --dry-run > /dev/null 2>&1; then
-            echo "released=true" >> "$GITHUB_OUTPUT"
-            echo "bump=true" >> "$GITHUB_OUTPUT"
+          if [ -n "${{ inputs.tag }}" ]; then
+            echo "publish=true"  >> "$GITHUB_OUTPUT"   # re-publish an existing tag
+            echo "bump=false"    >> "$GITHUB_OUTPUT"
+          elif [ "${{ inputs.dry_run }}" = "true" ]; then
+            echo "publish=false" >> "$GITHUB_OUTPUT"   # preview only
+            echo "bump=false"    >> "$GITHUB_OUTPUT"
           else
-            echo "released=false" >> "$GITHUB_OUTPUT"
-            echo "bump=false" >> "$GITHUB_OUTPUT"
+            echo "publish=true"  >> "$GITHUB_OUTPUT"   # cut a new release
+            echo "bump=true"     >> "$GITHUB_OUTPUT"
           fi
 
+      - name: Check out the tag to publish
+        # Detach onto the exact tag so hatch-vcs builds that clean version rather
+        # than a dev version derived from later commits on main.
+        if: inputs.tag != ''
+        run: git checkout "refs/tags/${{ inputs.tag }}"
+
+      - name: Preview bump (dry run)
+        if: inputs.tag == '' && inputs.dry_run
+        run: |
+          uv run cz bump --yes --dry-run
+          echo "Dry run only — nothing was published."
+
       - name: Bump version, changelog, tag, and push
-        if: steps.decide.outputs.bump == 'true'
+        if: steps.mode.outputs.bump == 'true'
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
@@ -84,53 +86,30 @@ jobs:
           git push --follow-tags origin HEAD:main
 
       - name: Resolve version and release notes
-        if: steps.decide.outputs.released == 'true'
+        if: steps.mode.outputs.publish == 'true'
         id: notes
         run: |
           VERSION="$(uv run cz version --project)"
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
           # Slice the newest CHANGELOG.md section (between the first two `## `
-          # headers) for the GitHub Release body. Never fatal — the publish must
-          # not depend on release-note formatting.
+          # headers) for the GitHub Release body. Never fatal.
           if [ -f CHANGELOG.md ]; then
             awk '/^## /{c++} c==1{print} c==2{exit}' CHANGELOG.md > body.md || true
           fi
           [ -s body.md ] || echo "Release $VERSION" > body.md
 
       - name: Build sdist and wheel
-        if: steps.decide.outputs.released == 'true'
+        if: steps.mode.outputs.publish == 'true'
         run: uv build
 
-      - name: Upload build artifacts
-        if: steps.decide.outputs.released == 'true'
-        uses: actions/upload-artifact@v4
-        with:
-          name: release-dist
-          path: |
-            dist/
-            body.md
-          if-no-files-found: error
-
-  publish:
-    needs: build
-    if: needs.build.outputs.released == 'true'
-    runs-on: ubuntu-latest
-    environment: pypi # deployment approval gate applies to this job only
-    permissions:
-      id-token: write # OIDC for Trusted Publishing
-      contents: write # create the GitHub Release
-    steps:
-      - name: Download build artifacts
-        uses: actions/download-artifact@v4
-        with:
-          name: release-dist
-
       - name: Publish to PyPI
+        if: steps.mode.outputs.publish == 'true'
         uses: pypa/gh-action-pypi-publish@release/v1
 
       - name: Create GitHub Release
+        if: steps.mode.outputs.publish == 'true'
         uses: ncipollo/release-action@v1
         with:
-          tag: v${{ needs.build.outputs.version }}
+          tag: v${{ steps.notes.outputs.version }}
           bodyFile: body.md
           skipIfReleaseExists: true

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,21 +1,37 @@
 name: Release
 
+# On push to main: commitizen decides the bump from conventional commits, tags,
+# builds, and (after approval of the `pypi` environment) publishes to PyPI.
+#
+# Manual run (workflow_dispatch): skip the bump and publish whatever version the
+# current commit's tag resolves to. Use this to recover/re-publish a version that
+# was tagged but not published.
+#
+# build and publish are split into two jobs on purpose: GitHub environment
+# protection gates a whole job, so only `publish` carries `environment: pypi`.
+# That lets the bump + build run automatically while the PyPI upload waits for
+# approval.
+
 on:
   push:
     branches: [main]
+  workflow_dispatch:
 
 concurrency:
   group: release
   cancel-in-progress: false
 
 jobs:
-  release:
-    if: "!startsWith(github.event.head_commit.message, 'bump:')"
+  build:
+    # On push, skip commitizen's own bump commit to avoid re-triggering.
+    # Manual runs always proceed.
+    if: ${{ github.event_name == 'workflow_dispatch' || !startsWith(github.event.head_commit.message, 'bump:') }}
     runs-on: ubuntu-latest
-    environment: pypi
     permissions:
       contents: write # push the bump commit + tag
-      id-token: write # OIDC for Trusted Publishing
+    outputs:
+      released: ${{ steps.decide.outputs.released }}
+      version: ${{ steps.notes.outputs.version }}
     steps:
       - uses: actions/checkout@v5
         with:
@@ -33,40 +49,77 @@ jobs:
       - name: Install dev dependencies
         run: uv sync --locked --group dev
 
-      - name: Decide whether a release is needed
-        id: gate
+      - name: Decide what to do
+        id: decide
         run: |
-          if uv run cz bump --yes --dry-run > /dev/null 2>&1; then
-            echo "release=true" >> "$GITHUB_OUTPUT"
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            # Publish the current tag as-is, no bump.
+            echo "released=true" >> "$GITHUB_OUTPUT"
+            echo "bump=false" >> "$GITHUB_OUTPUT"
+          elif uv run cz bump --yes --dry-run > /dev/null 2>&1; then
+            echo "released=true" >> "$GITHUB_OUTPUT"
+            echo "bump=true" >> "$GITHUB_OUTPUT"
           else
-            echo "release=false" >> "$GITHUB_OUTPUT"
+            echo "released=false" >> "$GITHUB_OUTPUT"
+            echo "bump=false" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Bump version, changelog, tag, and push
-        if: steps.gate.outputs.release == 'true'
+        if: steps.decide.outputs.bump == 'true'
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           uv run cz bump --yes --changelog
           git push --follow-tags origin HEAD:main
-          echo "VERSION=$(uv run cz version --project)" >> "$GITHUB_ENV"
 
-      - name: Extract release notes for this version
-        if: steps.gate.outputs.release == 'true'
-        run: uv run cz changelog "v${VERSION}" --dry-run > body.md
+      - name: Resolve version and release notes
+        if: steps.decide.outputs.released == 'true'
+        id: notes
+        run: |
+          VERSION="$(uv run cz version --project)"
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          # Slice the newest CHANGELOG.md section (between the first two `## `
+          # headers) for the GitHub Release body. Never fatal — the publish must
+          # not depend on release-note formatting.
+          if [ -f CHANGELOG.md ]; then
+            awk '/^## /{c++} c==1{print} c==2{exit}' CHANGELOG.md > body.md || true
+          fi
+          [ -s body.md ] || echo "Release $VERSION" > body.md
 
       - name: Build sdist and wheel
-        if: steps.gate.outputs.release == 'true'
+        if: steps.decide.outputs.released == 'true'
         run: uv build
 
+      - name: Upload build artifacts
+        if: steps.decide.outputs.released == 'true'
+        uses: actions/upload-artifact@v4
+        with:
+          name: release-dist
+          path: |
+            dist/
+            body.md
+          if-no-files-found: error
+
+  publish:
+    needs: build
+    if: needs.build.outputs.released == 'true'
+    runs-on: ubuntu-latest
+    environment: pypi # deployment approval gate applies to this job only
+    permissions:
+      id-token: write # OIDC for Trusted Publishing
+      contents: write # create the GitHub Release
+    steps:
+      - name: Download build artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: release-dist
+
       - name: Publish to PyPI
-        if: steps.gate.outputs.release == 'true'
         uses: pypa/gh-action-pypi-publish@release/v1
 
       - name: Create GitHub Release
-        if: steps.gate.outputs.release == 'true'
         uses: ncipollo/release-action@v1
         with:
-          tag: v${{ env.VERSION }}
+          tag: v${{ needs.build.outputs.version }}
           bodyFile: body.md
           skipIfReleaseExists: true


### PR DESCRIPTION
## Why

Two changes in one:

1. **Fix the broken release run.** The first `Release` bumped/tagged `v0.1.0` on `main` but failed before publishing (`cz changelog <rev>` clashed with `changelog_incremental = true`, and notes ran before publish). So `0.1.0` is tagged but not on PyPI.
2. **Switch to on-demand releases.** Auto-publishing on every merge means a tiny fix ships immediately with no way to batch. Releases are now a deliberate manual action.

## New model: on-demand

`release.yaml` now triggers only via **`workflow_dispatch`** (no more `on: push`). Commits accumulate on `main`; you cut a release when ready, and commitizen rolls up everything since the last release into one version bump.

Run it from **Actions → Release → Run workflow**:
- **`tag` blank** → cut a NEW release: bump from accumulated commits → tag → changelog → build → publish to PyPI + GitHub Release.
- **`tag` set** (e.g. `v0.1.0`) → publish an EXISTING tag as-is, no bump (recovery / re-publish). Checks out the tag so the build is a clean version.
- **`dry_run` checked** → preview the next version without publishing.

Since releasing is now a deliberate button press, the `pypi` environment's required reviewer is optional — the manual trigger is already the gate. Keep it if you want a second confirmation before the PyPI upload.

## Recover 0.1.0 after merge
1. Merge this PR (no `on: push` trigger, so merging publishes nothing).
2. Actions → **Release** → Run workflow → **tag = `v0.1.0`** → Run → (approve if you kept the reviewer) → `0.1.0` publishes to PyPI + GitHub Release.
3. Future releases: Run workflow with `tag` blank when you're ready to ship the accumulated fixes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
