### PR TITLE
ci: push release tags explicitly so they reach origin

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -83,7 +83,11 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           uv run cz bump --yes --changelog
-          git push --follow-tags origin HEAD:main
+          # Push the branch, then the new tag explicitly. `--follow-tags` only
+          # pushes annotated tags and silently drops lightweight ones, which
+          # previously left the tag off the remote.
+          git push origin HEAD:main
+          git push origin "v$(uv run cz version --project)"
 
       - name: Resolve version and release notes
         if: steps.mode.outputs.publish == 'true'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,6 +70,7 @@ tag_format = "v$version"
 major_version_zero = true
 update_changelog_on_bump = true
 changelog_incremental = true
+annotated_tag = true
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/delta_engine"]


### PR DESCRIPTION
## Why

The first automated release created the `v0.1.0` tag but it never reached `origin`, so the recovery run failed with `pathspec 'refs/tags/v0.1.0' did not match`. Cause: commitizen creates a **lightweight** tag by default, and `git push --follow-tags` only pushes **annotated** tags — so it silently dropped the tag while pushing the bump commit.

(The `v0.1.0` tag has since been created and pushed manually to unblock the 0.1.0 recovery. This PR prevents a recurrence on future releases.)

## What changed
- **Push the tag explicitly** after the bump: `git push origin HEAD:main` then `git push origin "v$(cz version --project)"`. Can't silently drop a tag anymore.
- **`annotated_tag = true`** in `[tool.commitizen]` — annotated tags are better practice for releases and also work with tag-following tooling.

No behaviour change to the on-demand trigger or the modes; only the tag-push reliability.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
