### PR TITLE
docs: slim the getting-started tutorial to the basic happy path

### DIFF
--- a/docs/how-to-configure-table.md
+++ b/docs/how-to-configure-table.md
@@ -17,10 +17,11 @@ partitioned. This page is the practical reference for configuring each aspect.
 | Comments          | Table and column documentation                        | [Comments](#comments), below                                                          |
 | Primary keys      | The table's primary key                               | [Primary keys](how-to-declare-primary-keys.md)                                        |
 | Foreign keys      | Cross-table references and sync ordering              | [Foreign keys](how-to-declare-foreign-keys.md)                                        |
-| Partitioning      | Partition columns, fixed at creation                  | [Getting started](tutorial-getting-started.md)                                        |
+| Partitioning      | Partition columns, fixed at creation                  | [Partitioning](#partitioning), below                                                  |
 
-Tags and comments are covered here in full. The other aspects have their own
-pages for now and will move into this one as the documentation grows.
+Tags, comments, and partitioning are covered here in full. Properties and keys
+have their own pages for now and will move into this one as the documentation
+grows.
 
 ## Tags
 
@@ -138,3 +139,39 @@ without a comment (the default is the empty string) asserts that the column has
 no comment — so removing a comment from the declaration clears it on the table
 at the next sync, and a comment added to the table outside the declaration is
 drift that the sync overwrites.
+
+## Partitioning
+
+Pass `partitioned_by` to set the columns a table is partitioned by when it is
+created:
+
+```python
+from delta_engine.schema import Column, Date, DeltaTable, String
+
+events = DeltaTable(
+    catalog="dev",
+    schema="silver",
+    name="events",
+    columns=[
+        Column("event_date", Date()),
+        Column("event_type", String()),
+        Column("payload", String()),
+    ],
+    partitioned_by=["event_date"],
+)
+```
+
+Every name in `partitioned_by` must also appear in `columns`. Partition columns
+are still regular columns: `partitioned_by` names them, and `columns` defines
+their types and other metadata.
+
+### Partitioning is fixed at creation
+
+Partitioning can only be set when the table is created. Declaring a different
+`partitioned_by` for an existing table fails validation before any SQL runs — to
+change it, drop and recreate the table out of band, then re-sync. Partition
+columns also cannot be of complex type (`Array`, `Map`, `Struct`, `Variant`),
+and a table cannot be partitioned by every column; both are rejected when the
+`DeltaTable` is constructed. See
+[safe-change rules](reference-safe-change-rules.md) for the full set of changes
+the engine rejects.

--- a/docs/how-to-configure-table.md
+++ b/docs/how-to-configure-table.md
@@ -167,11 +167,21 @@ their types and other metadata.
 
 ### Partitioning is fixed at creation
 
-Partitioning can only be set when the table is created. Declaring a different
-`partitioned_by` for an existing table fails validation before any SQL runs — to
-change it, drop and recreate the table out of band, then re-sync. Partition
-columns also cannot be of complex type (`Array`, `Map`, `Struct`, `Variant`),
-and a table cannot be partitioned by every column; both are rejected when the
-`DeltaTable` is constructed. See
+Partitioning can only be set when the table is created. Partition columns
+determine how the table's data files are physically laid out on storage, and
+Delta Lake has no `ALTER TABLE` that repartitions an existing table in place.
+Changing the partition columns means rewriting every data file into the new
+layout — a full table rewrite (for example `REPLACE TABLE ... PARTITIONED BY`,
+or an overwrite with a new partitioning), not the in-place DDL delta-engine
+issues.
+
+Because that rewrite is a data operation outside the engine's remit, declaring
+a different `partitioned_by` for an existing table fails validation before any
+SQL runs. To change partitioning, rewrite the table out of band, then re-sync
+against the new layout.
+
+Partition columns also cannot be of complex type (`Array`, `Map`, `Struct`,
+`Variant`), and a table cannot be partitioned by every column; both are
+rejected when the `DeltaTable` is constructed. See
 [safe-change rules](reference-safe-change-rules.md) for the full set of changes
 the engine rejects.

--- a/docs/tutorial-getting-started.md
+++ b/docs/tutorial-getting-started.md
@@ -5,7 +5,9 @@ tags:
 
 # Getting started with delta-engine
 
-This tutorial walks you through defining your first Delta table, registering it, and syncing it to Databricks. By the end you will have a table created in your Unity Catalog and a sync report confirming success.
+This tutorial walks you through defining your first Delta table and syncing it
+to Databricks. By the end you will have created a table in Unity Catalog and
+seen the sync report that confirms it.
 
 ## Prerequisites
 
@@ -33,37 +35,6 @@ customers = DeltaTable(
 
 `DeltaTable` describes what you want. No SQL runs yet.
 
-### Declare partitioning
-
-Pass `partitioned_by` to `DeltaTable` to set partition columns when the table is
-created:
-
-```python
-from delta_engine.schema import Column, Date, DeltaTable, String
-
-events = DeltaTable(
-    catalog="dev",
-    schema="silver",
-    name="events",
-    columns=[
-        Column("event_date", Date()),
-        Column("event_type", String()),
-        Column("payload", String()),
-    ],
-    partitioned_by=["event_date"],
-)
-```
-
-Every name in `partitioned_by` must also appear in `columns`. Partition columns
-are still regular columns: `partitioned_by` names them, and `columns` defines
-their types and other column metadata.
-
-Partitioning is fixed after table creation. Declaring a different
-`partitioned_by` for an existing table fails validation before any SQL runs. To
-change partitioning, drop and recreate the table out of band, then re-sync. See
-[reference-safe-change-rules.md](reference-safe-change-rules.md) for the full
-list of changes the engine rejects at validation.
-
 ## Sync
 
 Build an engine and pass your table definitions straight to `sync`. The engine reads the current catalog state, computes a plan, validates it, and executes any DDL needed:
@@ -76,6 +47,22 @@ engine.sync(customers)
 ```
 
 If the table does not exist, the engine creates it. If it already matches your declaration, `sync` is a no-op.
+
+## Check the result
+
+`sync` returns a `SyncReport` describing what happened to each table. Render it
+to see the outcome:
+
+```python
+from delta_engine import render_report
+
+report = engine.sync(customers)
+print(render_report(report))
+```
+
+On the first run the report shows the `customers` table being created. Run it
+again and the report shows no changes — the declaration and the catalog now
+agree.
 
 ## Enable logging (optional)
 
@@ -90,4 +77,10 @@ engine.sync(customers)
 
 ## What to do when sync fails
 
-If any table fails validation or execution, `sync` raises `SyncFailedError`. The exception message shows which tables failed and why. See [how-to-handle-sync-failures.md](how-to-handle-sync-failures.md) for how to inspect the report programmatically.
+If any table fails validation or execution, `sync` raises `SyncFailedError`. The exception message shows which tables failed and why. See [how to handle sync failures](how-to-handle-sync-failures.md) for how to inspect the report programmatically.
+
+## Next steps
+
+- [How a sync works](explanation-sync-lifecycle.md) — what happens between calling `sync` and getting a report back.
+- [How to configure a table](how-to-configure-table.md) — properties, tags, comments, keys, and partitioning.
+- [Preview changes with a dry run](how-to-preview-changes.md) — see what a sync would do before it touches anything.


### PR DESCRIPTION
## Summary

First page of the page-by-page documentation pass (following the structural restructure in #170). This PR covers the **getting-started tutorial**, and will collect subsequent page reviews as the pass continues.

### Tutorial

- Trimmed to a strictly basic happy path: define → sync → check the result → optional logging → what to do on failure → next steps.
- Fixed an inaccuracy: the intro said the tutorial "registers" a table; there is no registration step, so that framing is gone.
- Added a **Check the result** step that renders the returned `SyncReport` with `render_report` — the old intro promised a report the tutorial never showed.
- Added a **Next steps** section linking into the new structure (how a sync works, configure a table, dry runs).
- Removed the partitioning detour entirely (see below).

### Configure-a-table hub

- Relocated partitioning out of the tutorial into a full `## Partitioning` section on the hub: declaration example, the `partitioned_by` ⊆ `columns` rule, and the "fixed at creation" limits (complex-type partition columns and partition-by-every-column both rejected at construction).
- Updated the hub's aspect map and "covered here in full" note — the hub now fully covers tags, comments, and partitioning; properties and keys remain separate pages until their turns.

### Checks

- `uv run --group docs sphinx-build -b html docs docs/_build/html -W` passes (warnings as errors).