### PR TITLE
docs: polish metadata-only and sync-failures how-to guides

### DIFF
--- a/docs/how-to-deploy-metadata-only.md
+++ b/docs/how-to-deploy-metadata-only.md
@@ -11,7 +11,11 @@ Column structure, table properties, and partitioning are read for context but
 never changed — a metadata-only sync can never add, drop, or alter a column.
 
 Use it to roll out governance metadata with a hard guarantee that no schema
-change can slip in.
+change can slip in — for example, applying tags and comments across tables
+whose schemas are owned by another team. `metadata_only=True` is a
+managed-aspects scope: see
+[the safety model](explanation-safety-model.md#managed-aspects-what-a-declaration-is-responsible-for)
+for how managed aspects decide what a declaration is responsible for.
 
 ## Declare a metadata-only table
 
@@ -43,13 +47,18 @@ metadata is applied.
 - **Reconciles** table comment, column comments, table tags, column tags, and
   PK/FK constraints, exactly as a fully managed sync would.
 - **Requires** the live schema to match the declaration exactly. Any unmanaged
-  aspect (column structure or partitioning) that has drifted causes the sync
-  to fail at validation before any SQL executes. Catalog properties are never
-  compared for a metadata-only table — it declares none, and undeclared
-  properties (for example those written by a previous fully managed sync) are
-  not drift.
+  aspect (column structure or partitioning) that has drifted fails the sync at
+  validation (`UnmanagedAspectDrift`) before any SQL executes. Catalog
+  properties are never compared for a metadata-only table — it declares none,
+  and undeclared properties (for example those written by a previous fully
+  managed sync) are not drift.
 - **Cannot create** a missing table. If the table does not exist, the sync
-  fails at validation.
+  fails at validation (`MissingTableUnmanaged`) — a metadata-only declaration
+  does not manage column structure, so it has no shape to create the table
+  from.
+
+Both failures are scope invariants, listed in
+[safe-change rules](reference-safe-change-rules.md).
 
 ## Mixing modes in one sync
 

--- a/docs/how-to-handle-sync-failures.md
+++ b/docs/how-to-handle-sync-failures.md
@@ -5,7 +5,9 @@ tags:
 
 # How to handle sync failures
 
-`engine.sync(...)` raises `SyncFailedError` when one or more tables fail. This guide shows how to catch it and act on the structured report it carries.
+On a real run, `engine.sync(...)` raises `SyncFailedError` when one or more tables fail; the exception carries the full `SyncReport`. (A [dry run](how-to-preview-changes.md) never raises — it returns the same report for you to inspect.) This guide shows how to catch it and act on the report.
+
+A table's status names the [phase](explanation-sync-lifecycle.md) at which it failed, so handling a failure is mostly a matter of mapping status to cause.
 
 ## Catch the error
 


### PR DESCRIPTION
## Summary

Page-by-page pass over the two remaining standalone how-to guides. Both were already accurate against the code (verified `METADATA_ASPECTS`, `TableRunStatus`, `SyncReport.any_failures` / `failures_by_table` / `__iter__`, `Failure.format_lines`), so this is light polish to tie them into the new concept pages and sharpen precision.

### metadata-only

- Linked the safety model's **managed aspects** concept — `metadata_only=True` is a managed-aspects scope.
- Named the two validation failures it can raise (`UnmanagedAspectDrift`, `MissingTableUnmanaged`) and explained *why* a missing table can't be created (a metadata-only declaration doesn't manage column structure, so there's no shape to create from).
- Pointed to safe-change rules for both invariants.

### sync-failures

- Clarified that `SyncFailedError` is raised **on a real run**; a dry run never raises and returns the same report (links the preview guide).
- Added a one-line frame: a table's status names the **phase** at which it failed (links the lifecycle page), so handling a failure is mostly mapping status to cause.

### Checks

- `sphinx-build -W` passes; new cross-reference anchors resolve.