### PR TITLE
docs: be honest about Delta/Databricks coupling in the application layer

### DIFF
--- a/docs/explanation-architecture.md
+++ b/docs/explanation-architecture.md
@@ -22,8 +22,12 @@ The important separation is this:
 - The **public API** gives users a convenient way to describe desired tables
   without exposing the internal planning model directly.
 
-That split keeps the planning code backend-free. Databricks is the first
-adapter, not the center of the design.
+That split keeps the planning code free of backend _imports_. It does not yet
+make it free of backend _knowledge_: Delta and Databricks semantics are still
+encoded in the application layer, so Databricks is the first adapter but, today,
+also the only one the rest of the engine is written for. See
+[Import purity versus semantic coupling](#import-purity-versus-semantic-coupling)
+for what that means for adding a new backend.
 
 ```mermaid
 flowchart TB
@@ -166,6 +170,36 @@ snapshot stays honest about everything else), but an unmappable partition
 column fails the whole read — an incomplete `partitioned_by` would fabricate
 partitioning drift, and a false blocked change is worse than an honest
 `READ_FAILED`.
+
+### Import purity versus semantic coupling
+
+The layering is enforced by import-linter: `domain` and `application` cannot
+import `pyspark` or `delta`, and a new adapter adds no backend imports to them.
+That is the _hard_ form of the hexagonal boundary, and it holds.
+
+The _soft_ form — that the domain and application layers know nothing about any
+particular backend — does not fully hold today. Delta and Databricks semantics
+are encoded as ordinary Python in the application layer:
+
+- `application/properties.py` is a registry of Delta table properties
+  (`delta.columnMapping.mode`, `delta.enableChangeDataFeed`, retention
+  durations, …), with Delta-specific value formats and transition rules.
+- Several rules in `application/validation.py` encode Delta behaviour directly.
+  `ColumnMappingRequiredForDrop` exists only because Delta permits
+  `DROP COLUMN` solely under `delta.columnMapping.mode='name'`;
+  `PropertyTransitionNotSupported` and `PropertyMustBeDeclared` operate on that
+  Delta property registry.
+
+import-linter cannot catch this, because it is backend _knowledge_ expressed in
+ordinary types, not a forbidden import.
+
+The practical consequence is about what a new backend costs. A backend that
+shares Delta's semantics — another Delta-on-Spark or Unity Catalog surface — can
+be added by implementing the two ports alone. A genuinely different table
+format, such as Iceberg, would first need this Delta-specific policy lifted out
+of the application layer (or made selectable per backend) so its own property
+model and safety rules could take its place. Until then, delta-engine is a
+Delta/Databricks engine with a clean adapter seam, not a format-neutral one.
 
 ## Sync lifecycle
 

--- a/docs/how-to-implement-adapter.md
+++ b/docs/how-to-implement-adapter.md
@@ -5,7 +5,9 @@ tags:
 
 # How to implement a custom adapter
 
-delta-engine ships with a Databricks adapter. To target a different backend, implement the two port protocols: `CatalogStateReader` and `PlanExecutor`. These are the ports of the hexagonal architecture — see [the hexagonal boundary](explanation-architecture.md#the-hexagonal-boundary) for how they fit — and implementing them is all a new backend needs; the planning core is untouched.
+delta-engine ships with a single backend today: Delta Lake on Databricks. A backend is defined by two port protocols — `CatalogStateReader` and `PlanExecutor`, in `delta_engine.application.ports` — and this guide shows how to implement them. See [the hexagonal boundary](explanation-architecture.md#the-hexagonal-boundary) for how the ports fit.
+
+Implementing the two ports is enough for a backend that shares Delta's semantics. A genuinely different table format needs more — see [Adding a genuinely different backend](#adding-a-genuinely-different-backend) below before you start.
 
 ## The two protocols
 
@@ -100,3 +102,14 @@ for action in plan.actions:
 ```
 
 See `delta_engine/adapters/databricks/sql/compile.py` for a complete example using `functools.singledispatch`.
+
+## Adding a genuinely different backend
+
+The two ports are import-clean: the `domain` and `application` layers never import `pyspark` or `delta`, and your adapter adds no backend imports to them. But import purity is not the whole story. The application layer still encodes Delta-specific policy in ordinary Python — the Delta table-property registry in `application/properties.py`, and validation rules such as `ColumnMappingRequiredForDrop` that exist only because of how Delta handles column drops.
+
+The consequence for a new backend:
+
+- **A Delta-compatible backend** — another Delta-on-Spark or Unity Catalog surface with the same property and safety semantics — can be added with the two ports alone.
+- **A different table format**, such as Iceberg, would first need that Delta-specific policy lifted out of the application layer (or made selectable per backend) so its own property model and safety rules could take its place. Implementing the ports is necessary but not sufficient.
+
+See [Import purity versus semantic coupling](explanation-architecture.md#import-purity-versus-semantic-coupling) for the full picture.


### PR DESCRIPTION
## Summary

The docs claimed the planning core is backend-free and that implementing the two ports is all a new backend needs. That is true at the *import* level but not the *semantic* level, and the adapter guide oversold it (a line I added in #177). This makes the real boundary honest.

### The reality, verified in code

- import-linter enforces that `domain` and `application` never import `pyspark` or `delta` — the **hard** form of the hexagonal boundary holds.
- But Delta/Databricks semantics are encoded as ordinary Python in the application layer, which import-linter cannot catch:
  - `application/properties.py` is a registry of Delta table properties (`delta.columnMapping.mode`, `delta.enableChangeDataFeed`, …) — its own header cites the Delta docs.
  - `application/validation.py` rules encode Delta behaviour: `ColumnMappingRequiredForDrop` exists only because Delta permits `DROP COLUMN` solely under `delta.columnMapping.mode='name'`; `PropertyTransitionNotSupported` / `PropertyMustBeDeclared` operate on that Delta registry.

### Changes

- **explanation-architecture.md:** new "Import purity versus semantic coupling" subsection spelling out the hard/soft distinction and what it costs a new backend; qualified the "Databricks is not the center of the design" claim to match.
- **how-to-implement-adapter.md:** corrected the lead (the two ports are enough only for a Delta-compatible backend); added an "Adding a genuinely different backend" section — a format like Iceberg would first need the Delta policy lifted out of the application layer. Links the architecture detail.

Net message: a Delta-compatible backend needs only the two ports; a genuinely different table format needs the application-layer Delta coupling resolved first.

### Checks

- `sphinx-build -W` passes; new cross-reference anchors resolve.