### PR TITLE
fix: only treat a missing information_schema as unavailable in the probe

### DIFF
--- a/src/delta_engine/adapters/databricks/reader.py
+++ b/src/delta_engine/adapters/databricks/reader.py
@@ -5,6 +5,7 @@ from dataclasses import dataclass, replace
 from itertools import groupby
 import logging
 from types import MappingProxyType
+from typing import Final
 
 from pyspark.errors.exceptions.base import AnalysisException
 from pyspark.sql import Row, SparkSession
@@ -40,6 +41,15 @@ from delta_engine.domain.model import (
 )
 
 logger = logging.getLogger(__name__)
+
+# AnalysisException conditions that mean a catalog has no information_schema
+# (plain Spark, Hive metastore). TABLE_OR_VIEW_NOT_FOUND is what Spark raises
+# for the probe; SCHEMA_NOT_FOUND covers resolvers that report the missing
+# schema instead. Anything else — a permission error, a transient failure — is
+# not evidence of absence and must propagate.
+_INFORMATION_SCHEMA_MISSING_CONDITIONS: Final[frozenset[str]] = frozenset(
+    {"TABLE_OR_VIEW_NOT_FOUND", "SCHEMA_NOT_FOUND"}
+)
 
 
 @dataclass(frozen=True, slots=True)
@@ -349,11 +359,22 @@ class DatabricksReader:
         return self.spark.sql(query).collect()
 
     def _information_schema_available(self, catalog: str) -> bool:
-        """Probe (once per catalog) whether information_schema is queryable."""
+        """
+        Probe (once per catalog) whether information_schema is queryable.
+
+        Only the missing-view conditions may conclude "unavailable" — a
+        permission error or transient failure on the probe propagates to
+        ``fetch_state``'s boundary as ``ReadFailed`` rather than reading the
+        whole catalog as constraint- and tag-free (the same policy
+        ``_information_schema_rows`` applies to the metadata queries). An
+        unexpected failure is not cached, so the next read probes again.
+        """
         if catalog not in self._information_schema_availability:
             try:
                 self.spark.sql(information_schema_probe_query(catalog)).collect()
-            except AnalysisException:
+            except AnalysisException as exception:
+                if exception.getCondition() not in _INFORMATION_SCHEMA_MISSING_CONDITIONS:
+                    raise
                 self._information_schema_availability[catalog] = False
             else:
                 self._information_schema_availability[catalog] = True

--- a/tests/adapters/databricks/test_reader.py
+++ b/tests/adapters/databricks/test_reader.py
@@ -475,7 +475,11 @@ def test_fetch_state_skips_metadata_queries_when_information_schema_is_absent(qn
     spark = routed_spark(
         qn,
         catalog=single_column_catalog(qn),
-        probe=AnalysisException("no information_schema"),
+        probe=AnalysisException(
+            message="no information_schema",
+            errorClass="TABLE_OR_VIEW_NOT_FOUND",
+            messageParameters={},
+        ),
     )
     result = DatabricksReader(spark).fetch_state(qn)
 
@@ -490,6 +494,50 @@ def test_fetch_state_skips_metadata_queries_when_information_schema_is_absent(qn
     assert referencing_foreign_keys_query(qn) not in issued
     assert table_tags_query(qn) not in issued
     assert column_tags_query(qn) not in issued
+
+
+@pytest.mark.parametrize(
+    "probe_error",
+    [
+        AnalysisException(
+            message="permission denied",
+            errorClass="INSUFFICIENT_PERMISSIONS",
+            messageParameters={},
+        ),
+        AnalysisException("boom"),
+    ],
+    ids=["permission-error", "no-error-condition"],
+)
+def test_fetch_state_fails_when_the_probe_raises_an_unexpected_error(qn, probe_error):
+    # Only the missing-view conditions mean "no information_schema". Anything
+    # else (a permission error, an exception with no condition at all) must
+    # surface as ReadFailed rather than silently reading the whole catalog as
+    # constraint- and tag-free.
+    spark = routed_spark(qn, catalog=single_column_catalog(qn), probe=probe_error)
+    result = DatabricksReader(spark).fetch_state(qn)
+
+    assert isinstance(result, ReadFailed)
+    assert result.failure.exception_type == "AnalysisException"
+
+
+def test_probe_availability_is_not_cached_when_the_probe_fails_unexpectedly(qn):
+    # A transient probe failure must not poison the catalog for the reader's
+    # lifetime: the next read probes again instead of trusting a failed answer.
+    spark = routed_spark(
+        qn,
+        catalog=single_column_catalog(qn),
+        probe=AnalysisException(
+            message="permission denied",
+            errorClass="INSUFFICIENT_PERMISSIONS",
+            messageParameters={},
+        ),
+    )
+    reader = DatabricksReader(spark)
+    assert isinstance(reader.fetch_state(qn), ReadFailed)
+    assert isinstance(reader.fetch_state(qn), ReadFailed)
+
+    probe = information_schema_probe_query(qn.catalog)
+    assert spark.queries.count(probe) == 2
 
 
 def test_fetch_state_fails_when_a_metadata_query_fails_on_unity_catalog(qn):


### PR DESCRIPTION
## What

`_information_schema_available` now inspects `AnalysisException.getCondition()`: only `TABLE_OR_VIEW_NOT_FOUND` / `SCHEMA_NOT_FOUND` mean "this catalog has no information_schema" (plain Spark, Hive metastore). Any other condition — or an exception with no condition — propagates to `fetch_state`'s boundary and becomes `ReadFailed`. An unexpected probe failure is not cached, so the next read probes again.

## Why

The probe's bare `except AnalysisException` contradicted the policy `_information_schema_rows` documents and honours for the metadata queries ("a permission error must not masquerade as 'no constraints, no tags'"). A mis-granted principal silently degraded the entire catalog for the reader's lifetime: missed constraint/tag drift, the PK-drop guard disabled, and declared keys re-planned as adds that fail at execution.

`TABLE_OR_VIEW_NOT_FOUND` is pinned empirically — it is what Spark 4 raises for the probe on a catalog without information_schema (verified against local Spark; the local e2e suite exercises the same path).

## Testing

- New: probe permission error → `ReadFailed`; probe exception with no error condition → `ReadFailed`; failed probe is re-probed on the next read (no caching).
- Existing absent-path test upgraded to carry the real `TABLE_OR_VIEW_NOT_FOUND` condition.
- Full gate: 595 passed (98.68% coverage) incl. local-Spark e2e, ruff, mypy, lint-imports clean.