### PR TITLE
fix: read primary key columns in key order

### DIFF
--- a/src/delta_engine/adapters/databricks/reader.py
+++ b/src/delta_engine/adapters/databricks/reader.py
@@ -117,8 +117,9 @@ def _primary_key_from_rows(rows: Sequence[Row]) -> PrimaryKeyConstraint | None:
     """
     Build the primary key from its information_schema rows, or ``None``.
 
-    Constraint and column names are normalised to lowercase at the adapter
-    boundary.
+    The query orders rows by ordinal_position, so the columns tuple is in
+    key order. Constraint and column names are normalised to lowercase at
+    the adapter boundary.
     """
     columns = tuple(row["column_name"].casefold() for row in rows)
     if not columns:

--- a/src/delta_engine/adapters/databricks/sql/queries.py
+++ b/src/delta_engine/adapters/databricks/sql/queries.py
@@ -38,21 +38,29 @@ def describe_detail_query(qualified_name: QualifiedName) -> str:
 
 
 def primary_key_query(qualified_name: QualifiedName) -> str:
-    """Render the information_schema query for a table's primary key columns."""
+    """
+    Render the information_schema query for a table's primary key columns.
+
+    Reads from key_column_usage, whose ordinal_position puts a composite
+    key's columns in key order — constraint_column_usage has no ordinal and
+    returns rows in arbitrary order, which would scramble the observed
+    ``PrimaryKeyConstraint.columns`` tuple.
+    """
     catalog = backtick(qualified_name.catalog)
     return (
         f"SELECT table_constraints_info.constraint_name,"
-        f" constraint_columns.column_name"
-        f" FROM {catalog}.information_schema.constraint_column_usage"
-        f" AS constraint_columns"
+        f" key_columns.column_name"
+        f" FROM {catalog}.information_schema.key_column_usage"
+        f" AS key_columns"
         f" JOIN {catalog}.information_schema.table_constraints"
         f" AS table_constraints_info"
         f" USING (constraint_catalog, constraint_schema, constraint_name)"
-        f" WHERE constraint_columns.table_schema ="
+        f" WHERE key_columns.table_schema ="
         f" {quote_literal(qualified_name.schema)}"
-        f" AND constraint_columns.table_name ="
+        f" AND key_columns.table_name ="
         f" {quote_literal(qualified_name.name)}"
         f" AND table_constraints_info.constraint_type = 'PRIMARY KEY'"
+        f" ORDER BY key_columns.ordinal_position"
     )
 
 

--- a/tests/adapters/databricks/sql/test_queries.py
+++ b/tests/adapters/databricks/sql/test_queries.py
@@ -43,16 +43,26 @@ def test_describe_detail_query_backticks_the_table_name():
 def test_primary_key_query_golden():
     assert primary_key_query(QN) == (
         "SELECT table_constraints_info.constraint_name,"
-        " constraint_columns.column_name"
-        " FROM `cat`.information_schema.constraint_column_usage"
-        " AS constraint_columns"
+        " key_columns.column_name"
+        " FROM `cat`.information_schema.key_column_usage"
+        " AS key_columns"
         " JOIN `cat`.information_schema.table_constraints"
         " AS table_constraints_info"
         " USING (constraint_catalog, constraint_schema, constraint_name)"
-        " WHERE constraint_columns.table_schema = 'sch'"
-        " AND constraint_columns.table_name = 'tbl'"
+        " WHERE key_columns.table_schema = 'sch'"
+        " AND key_columns.table_name = 'tbl'"
         " AND table_constraints_info.constraint_type = 'PRIMARY KEY'"
+        " ORDER BY key_columns.ordinal_position"
     )
+
+
+def test_primary_key_query_orders_columns_by_key_position():
+    # A composite primary key's columns must come back in key order;
+    # constraint_column_usage has no ordinal, so the query reads
+    # key_column_usage instead.
+    query = primary_key_query(QN)
+    assert "ORDER BY key_columns.ordinal_position" in query
+    assert "constraint_column_usage" not in query
 
 
 def test_table_tags_query_golden():


### PR DESCRIPTION
## What

`primary_key_query` now reads from `key_column_usage` (which carries `ordinal_position`) instead of `constraint_column_usage` (which has no ordinal), with `ORDER BY key_columns.ordinal_position`. Output column names are unchanged, so the row mapper is untouched.

## Why

Observed composite-PK column order was whatever the join happened to return. Planning is unaffected — PK identity is deliberately set-based — but `PrimaryKeyConstraint.columns` is documented as an ordered tuple, reports rendered a nondeterministic order, and any future code trusting observed PK order would inherit a trap. The FK query already reads kcu with an ordinal for exactly this reason.

## Testing

- Golden test updated; new behaviour test pins the ordinal ordering and the move off `constraint_column_usage`.
- Full gate: 593 passed (98.68% coverage), ruff, mypy, lint-imports clean.