### PR TITLE
fix: reconcile duplicate-signature observed foreign keys instead of collapsing them

### DIFF
--- a/src/delta_engine/domain/plan/diff.py
+++ b/src/delta_engine/domain/plan/diff.py
@@ -45,7 +45,7 @@ from collections.abc import Mapping
 from dataclasses import dataclass
 from typing import ClassVar
 
-from delta_engine.domain.model import Column, DesiredTable, ObservedTable
+from delta_engine.domain.model import Column, DesiredTable, ObservedTable, QualifiedName
 from delta_engine.domain.model.constraints import (
     ForeignKeyConstraint,
     ForeignKeyReference,
@@ -753,17 +753,33 @@ def _diff_foreign_keys(desired: DesiredTable, observed: ObservedTable) -> list[C
     Identity is content (local columns, referenced table, referenced columns):
     an FK present on both sides under different constraint names produces
     nothing, so a sync over an unchanged catalog stays idempotent.
+
+    The observed side is grouped rather than dict-keyed: current Databricks
+    DDL rejects two FKs over the same column set, but a legacy catalog or
+    another backend may hold equivalent constraints under different names,
+    and ``ObservedTable`` deliberately keeps such states representable. A
+    signature the declaration matches keeps exactly one constraint — the
+    lowest name, for determinism — and removes the rest by their catalog
+    names; an unmatched signature removes them all. The desired side needs
+    no grouping: ``DesiredTable`` rejects duplicate local-column sets.
     """
     desired_by_signature = {fk.signature: fk for fk in desired.foreign_keys}
-    observed_by_signature = {fk.signature: fk for fk in observed.foreign_keys}
+    observed_by_signature: dict[
+        tuple[tuple[str, ...], QualifiedName, tuple[str, ...]], list[ForeignKeyConstraint]
+    ] = {}
+    for fk in observed.foreign_keys:
+        observed_by_signature.setdefault(fk.signature, []).append(fk)
+
     changes: list[Change] = []
 
     for signature, fk in desired_by_signature.items():
         if signature not in observed_by_signature:
             changes.append(ForeignKeyAdded(constraint=fk))
 
-    for signature, fk in observed_by_signature.items():
-        if signature not in desired_by_signature:
+    for signature, group in observed_by_signature.items():
+        keep = 1 if signature in desired_by_signature else 0
+        ordered = sorted(group, key=lambda constraint: constraint.constraint_name)
+        for fk in ordered[keep:]:
             changes.append(ForeignKeyRemoved(constraint=fk))
 
     return changes

--- a/tests/domain/plan/test_diff.py
+++ b/tests/domain/plan/test_diff.py
@@ -481,6 +481,36 @@ def test_equal_foreign_keys_by_signature_produce_no_change():
     assert diff.changes == ()
 
 
+def test_observed_duplicate_equivalent_foreign_keys_remove_extras_only():
+    # Given one desired FK and two observed FKs with the same signature under
+    # different names (current Databricks DDL rejects the duplicate, but a
+    # legacy catalog or another backend may hold it)
+    diff = diff_table(
+        _desired(foreign_keys=(_foreign_key("engine_name"),)),
+        _observed(foreign_keys=(_foreign_key("b_fk"), _foreign_key("a_fk"))),
+    )
+
+    # Then one constraint keeps satisfying the declaration (lowest name, for
+    # determinism) and the duplicate is dropped by its catalog name
+    assert isinstance(diff, TableDrift)
+    assert diff.changes == (ForeignKeyRemoved(constraint=_foreign_key("b_fk")),)
+
+
+def test_observed_duplicate_equivalent_foreign_keys_are_all_removed_when_undeclared():
+    # Given no desired FK and two observed FKs with the same signature
+    diff = diff_table(
+        _desired(),
+        _observed(foreign_keys=(_foreign_key("b_fk"), _foreign_key("a_fk"))),
+    )
+
+    # Then both catalog constraints are removed by their observed names
+    assert isinstance(diff, TableDrift)
+    assert diff.changes == (
+        ForeignKeyRemoved(constraint=_foreign_key("a_fk")),
+        ForeignKeyRemoved(constraint=_foreign_key("b_fk")),
+    )
+
+
 # ---------- no-difference changes are unrepresentable
 
 


### PR DESCRIPTION
## What

The observed side of `_diff_foreign_keys` is now grouped by signature instead of dict-keyed. A signature the declaration matches keeps exactly one constraint (lowest name, for determinism) and plans `ForeignKeyRemoved` for the extras by their catalog names; an unmatched signature removes all members. The desired side stays a plain dict — `DesiredTable` already guarantees unique signatures.

## Why

Two observed FKs with the same content under different names silently collapsed in the dict: matched → the duplicate constraint survived every sync while the report said converged; unmatched → only one of the two was removed per… forever, since each sync reports success. Current Databricks DDL forbids two FKs over the same column set ("foreign key constraints which only differ in the permutation of the foreign key columns are not allowed"), so this is hardening for legacy catalogs and future backends rather than a live Databricks bug — `ObservedTable` deliberately keeps such states representable, and the diff must not erase what the model can express.

## Testing

- New: one declared + two equivalent observed → exactly the extra is removed; none declared + two equivalent observed → both removed, deterministically ordered.
- Full gate: 594 passed (98.68% coverage), ruff, mypy, lint-imports clean.