### PR TITLE
refactor: tighten application layer constants and aliases

### DIFF
--- a/src/delta_engine/application/errors.py
+++ b/src/delta_engine/application/errors.py
@@ -30,7 +30,7 @@ class SyncFailedError(Exception):
 
 def _format_failure_detail(table_report: TableRunReport) -> list[str]:
     """Return the detail lines describing why a single table failed."""
-    lines = [f"\n❌ {table_report.qualified_name} [{table_report.status.value}]"]
+    lines = [f"\n{table_report.qualified_name} [{table_report.status.value}]"]
     for failure in table_report.failures:
         for line in failure.format_lines():
             lines.append(f"    {line}")

--- a/src/delta_engine/application/failures.py
+++ b/src/delta_engine/application/failures.py
@@ -10,7 +10,7 @@ together rather than being scattered across its producers.
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from enum import IntEnum, StrEnum
-from typing import ClassVar
+from typing import ClassVar, assert_never
 
 from delta_engine.domain.model import QualifiedName
 
@@ -44,6 +44,8 @@ class ForeignKeyFailureReason(StrEnum):
                 return "it references a table that failed to sync"
             case ForeignKeyFailureReason.REFERENCED_COLUMNS_NOT_A_KEY:
                 return "its referenced columns are not the primary key of the referenced table"
+            case _ as unreachable:
+                assert_never(unreachable)
 
 
 # ---------- Failure value objects ----------

--- a/src/delta_engine/application/ports.py
+++ b/src/delta_engine/application/ports.py
@@ -38,7 +38,7 @@ class ReadFailed:
 
 # The three answers a catalog can give about a table: it is there, it is not
 # there, or it could not be read.
-CatalogState = TablePresent | TableAbsent | ReadFailed
+type CatalogState = TablePresent | TableAbsent | ReadFailed
 
 
 class CatalogStateReader(Protocol):
@@ -96,7 +96,7 @@ class ExecutionFailed:
 # An executed action either succeeds or fails. The split makes "succeeded but
 # carries a failure" (and "failed but carries none") unrepresentable, so no
 # runtime invariant guard is needed.
-ExecutionResult = ExecutionSucceeded | ExecutionFailed
+type ExecutionResult = ExecutionSucceeded | ExecutionFailed
 
 
 @dataclass(frozen=True, slots=True)

--- a/src/delta_engine/application/rendering.py
+++ b/src/delta_engine/application/rendering.py
@@ -9,9 +9,12 @@ are the building blocks they compose.
 """
 
 from collections import Counter
+from collections.abc import Mapping
 from dataclasses import dataclass
 from enum import IntEnum
 import functools
+from types import MappingProxyType
+from typing import Final
 
 from delta_engine.application.ports import ReadFailed
 from delta_engine.application.report import SyncReport, TableRunReport
@@ -55,13 +58,24 @@ class DiffCategory(IntEnum):
 
 # (singular, plural) nouns per category: the plural names the diff group heading;
 # the singular is used in the grid's humanized detail count.
-_CATEGORY_NOUN: dict[DiffCategory, tuple[str, str]] = {
-    DiffCategory.COLUMNS: ("column", "columns"),
-    DiffCategory.KEYS: ("key", "keys"),
-    DiffCategory.PROPERTIES: ("property", "properties"),
-    DiffCategory.TAGS: ("tag", "tags"),
-    DiffCategory.COMMENTS: ("comment", "comments"),
-}
+_CATEGORY_NOUN: Final[Mapping[DiffCategory, tuple[str, str]]] = MappingProxyType(
+    {
+        DiffCategory.COLUMNS: ("column", "columns"),
+        DiffCategory.KEYS: ("key", "keys"),
+        DiffCategory.PROPERTIES: ("property", "properties"),
+        DiffCategory.TAGS: ("tag", "tags"),
+        DiffCategory.COMMENTS: ("comment", "comments"),
+    }
+)
+
+# Shown wherever a report has a readable state but no planned actions. One
+# spelling, two presentations: bare in the grid's DETAIL cell, parenthesised as
+# a standalone line in the diff block.
+_NO_CHANGES: Final[str] = "no changes"
+
+_DETAIL_MAX_CHARS: Final[int] = 60
+
+_GRID_HEADERS: Final[tuple[str, str, str, str]] = ("TABLE", "STATUS", "ACTIONS", "DETAIL")
 
 
 @dataclass(frozen=True, slots=True)
@@ -184,12 +198,6 @@ def _(action: DropForeignKey) -> tuple[DiffEntry, ...]:
     return (DiffEntry(DiffCategory.KEYS, "-", (f"foreign key {action.constraint_name}",)),)
 
 
-# Shown wherever a report has a readable state but no planned actions. One
-# spelling, two presentations: bare in the grid's DETAIL cell, parenthesised as
-# a standalone line in the diff block.
-_NO_CHANGES = "no changes"
-
-
 def _plan_creates_table(plan: ActionPlan) -> bool:
     return any(isinstance(action, CreateTable) for action in plan)
 
@@ -225,11 +233,6 @@ def render_diff_block(report: TableRunReport) -> str:
         header = f"{header}  (CREATE)"
     entries = [entry for action in report.plan for entry in _action_entries(action)]
     return "\n".join([header, *_render_entry_groups(entries)])
-
-
-_DETAIL_MAX_CHARS = 60
-
-_GRID_HEADERS = ("TABLE", "STATUS", "ACTIONS", "DETAIL")
 
 
 def _grid_actions_cell(report: TableRunReport) -> str:

--- a/src/delta_engine/application/report.py
+++ b/src/delta_engine/application/report.py
@@ -5,10 +5,12 @@ Run reports: per-table and run-level outcome aggregates.
 its status from the earliest failing phase; `SyncReport` aggregates a run.
 """
 
-from collections.abc import Iterator
+from collections.abc import Iterator, Mapping
 from dataclasses import dataclass, field
 from datetime import datetime
 from enum import StrEnum
+from types import MappingProxyType
+from typing import Final
 
 from delta_engine.application.failures import (
     Failure,
@@ -34,12 +36,14 @@ class TableRunStatus(StrEnum):
 # ---------- Reports ----------
 
 
-_STATUS_FOR_PHASE: dict[FailurePhase, TableRunStatus] = {
-    FailurePhase.READ: TableRunStatus.READ_FAILED,
-    FailurePhase.VALIDATION: TableRunStatus.VALIDATION_FAILED,
-    FailurePhase.FOREIGN_KEY: TableRunStatus.FOREIGN_KEY_FAILED,
-    FailurePhase.EXECUTION: TableRunStatus.EXECUTION_FAILED,
-}
+_STATUS_FOR_PHASE: Final[Mapping[FailurePhase, TableRunStatus]] = MappingProxyType(
+    {
+        FailurePhase.READ: TableRunStatus.READ_FAILED,
+        FailurePhase.VALIDATION: TableRunStatus.VALIDATION_FAILED,
+        FailurePhase.FOREIGN_KEY: TableRunStatus.FOREIGN_KEY_FAILED,
+        FailurePhase.EXECUTION: TableRunStatus.EXECUTION_FAILED,
+    }
+)
 
 
 @dataclass(frozen=True, slots=True)

--- a/src/delta_engine/application/validation.py
+++ b/src/delta_engine/application/validation.py
@@ -1,7 +1,7 @@
 """Validation rules judging the diff between desired and observed table state."""
 
 from dataclasses import dataclass
-from typing import ClassVar, Protocol, assert_never
+from typing import ClassVar, Final, Protocol, assert_never
 
 from delta_engine.application.failures import ValidationFailure
 from delta_engine.application.properties import (
@@ -330,7 +330,7 @@ class PrimaryKeyReferencedByForeignKeys:
         return tuple(failures)
 
 
-DEFAULT_RULES: tuple[Rule, ...] = (
+DEFAULT_RULES: Final[tuple[Rule, ...]] = (
     NonNullableColumnAdd(),
     NullabilityTighteningOnExistingColumn(),
     ColumnDataTypeChangeNotSupported(),
@@ -413,8 +413,8 @@ class MissingTableUnmanaged:
         )
 
 
-_SCOPE_INVARIANTS: tuple[Rule, ...] = (UnmanagedAspectDrift(),)
-_MISSING_TABLE_UNMANAGED = MissingTableUnmanaged()
+_SCOPE_INVARIANTS: Final[tuple[Rule, ...]] = (UnmanagedAspectDrift(),)
+_MISSING_TABLE_UNMANAGED: Final = MissingTableUnmanaged()
 
 
 def validate_diff(diff: TableDiff, rules: tuple[Rule, ...] = DEFAULT_RULES) -> ValidationResult:

--- a/tests/application/test_errors.py
+++ b/tests/application/test_errors.py
@@ -73,7 +73,8 @@ def test_message_renders_read_failure_detail():
     message = _message_for(report)
 
     # Then the table headline and the read error line are present
-    assert "❌ cat.sch.tbl [READ_FAILED]" in message
+    assert "cat.sch.tbl [READ_FAILED]" in message
+    assert "❌" not in message
     assert "Read error: AnalysisException - table not found" in message
 
 
@@ -88,7 +89,7 @@ def test_message_renders_validation_failure_detail():
     message = _message_for(report)
 
     # Then the validation failure line is present
-    assert "❌ cat.sch.tbl [VALIDATION_FAILED]" in message
+    assert "cat.sch.tbl [VALIDATION_FAILED]" in message
     assert "Validation failed: DisallowPartitioningChange - cannot repartition" in message
 
 
@@ -138,7 +139,7 @@ def test_message_renders_execution_failure_detail_with_sql_preview():
     message = _message_for(report)
 
     # Then both the failure line and the SQL preview are present
-    assert "❌ cat.sch.tbl [EXECUTION_FAILED]" in message
+    assert "cat.sch.tbl [EXECUTION_FAILED]" in message
     assert "Execution failed at action 2: SparkException - boom" in message
     assert "ALTER TABLE cat.sch.tbl ADD COLUMN x INT" in message
 
@@ -161,6 +162,6 @@ def test_message_renders_fk_failure_detail():
     message = _message_for(report)
 
     # Then the FK failure line is present with content-based description
-    assert "❌ cat.sch.tbl [FOREIGN_KEY_FAILED]" in message
+    assert "cat.sch.tbl [FOREIGN_KEY_FAILED]" in message
     assert "(ref_id)" in message
     assert "not registered" in message


### PR DESCRIPTION
## Summary

Tighten a few application-layer coding-practice details from the review pass:

- convert `CatalogState` and `ExecutionResult` to Python 3.12 `type` aliases
- mark application policy/display constants as `Final` and make lookup maps immutable
- group rendering display constants with the rendering vocabulary
- add an exhaustive fallback for `ForeignKeyFailureReason.detail`
- keep `SyncFailedError` messages plain-text by removing the emoji table marker

## Why

These changes make the application layer's constants and closed vocabularies more explicit without changing the engine flow. The exception text is now better suited for logs, CI, and API surfaces, while rich display formatting remains owned by report rendering.

## Validation

- `uv run ruff check src/delta_engine/application tests/application`
- `uv run mypy src/delta_engine/application tests/application`
- `uv run pytest tests/application -q --no-cov`
- `uv run ruff check .`
- `uv run mypy .`
- `uv run pytest -q`
- `uv run lint-imports`