### PR TITLE
refactor: tidy declaration-time validation (review follow-ups)

### DIFF
--- a/src/delta_engine/api/delta_table.py
+++ b/src/delta_engine/api/delta_table.py
@@ -1,4 +1,13 @@
-"""Schema declaration implementation for Delta tables and foreign keys."""
+"""
+Schema declaration implementation for Delta tables and foreign keys.
+
+Validation here is declaration-time deployability: rules Delta or Unity
+Catalog enforce when an author creates a table (layout key types, quotas,
+property-dependent naming rules). Structural coherence — columns exist,
+names are unique, at least one column — is the domain ``DesiredTable``'s
+job, enforced the moment a declaration is lowered; this module skips names
+it cannot resolve rather than re-checking existence.
+"""
 
 from __future__ import annotations
 
@@ -70,8 +79,10 @@ _CDF_RESERVED_COLUMN_NAMES: Final[frozenset[str]] = frozenset(
     {"_change_type", "_commit_version", "_commit_timestamp"}
 )
 
-# Complex types Delta cannot partition by (DELTA_INVALID_PARTITION_COLUMN_TYPE).
-_UNPARTITIONABLE_TYPES: Final[tuple[type[DataType], ...]] = (Array, Map, Struct, Variant)
+# Complex types Delta accepts neither as partition columns
+# (DELTA_INVALID_PARTITION_COLUMN_TYPE) nor as liquid-clustering keys.
+# Two distinct backend rules that happen to name the same types today.
+_TYPES_UNUSABLE_AS_LAYOUT_KEYS: Final[tuple[type[DataType], ...]] = (Array, Map, Struct, Variant)
 
 # Unity Catalog limits per securable object (a table and each of its
 # columns are separate securables).
@@ -125,34 +136,19 @@ def _nested_field_paths(path: str, data_type: DataType) -> tuple[str, ...]:
             return ()
 
 
-def _validate_delta_partitioning(
-    columns: tuple[Column, ...], partitioned_by: tuple[str, ...]
-) -> None:
-    columns_by_name = {column.name: column for column in columns}
-    if len(set(partitioned_by)) != len(partitioned_by):
-        return
-    if any(name not in columns_by_name for name in partitioned_by):
-        return
-
-    for name in partitioned_by:
-        data_type = columns_by_name[name].data_type
-        if isinstance(data_type, _UNPARTITIONABLE_TYPES):
-            raise ValueError(
-                f"Partition column {name!r} has type"
-                f" {type(data_type).__name__}, which Delta cannot partition by"
-            )
-
-    if partitioned_by and len(set(partitioned_by)) == len(columns):
-        raise ValueError(
-            "Cannot partition by every column: at least one non-partition column is required"
-        )
-
-
-def _validate_clustering(
+def _validate_layout(
     columns: tuple[Column, ...],
-    clustered_by: tuple[str, ...],
     partitioned_by: tuple[str, ...],
+    clustered_by: tuple[str, ...],
 ) -> None:
+    """
+    Reject physical layouts Delta cannot deploy.
+
+    Checks declaration-level deployability only: the partition/cluster
+    relationship, the clustering-key budget, and key data types. Whether the
+    named columns exist and are unique is a ``DesiredTable`` invariant, so
+    names that do not resolve are skipped here and the domain's error fires.
+    """
     if partitioned_by and clustered_by:
         raise ValueError(
             "A table cannot both partition and cluster: declare partitioned_by"
@@ -164,18 +160,29 @@ def _validate_clustering(
         )
 
     columns_by_name = {column.name: column for column in columns}
-    if len(set(clustered_by)) != len(clustered_by):
-        return
-    if any(name not in columns_by_name for name in clustered_by):
-        return
-
+    for name in partitioned_by:
+        column = columns_by_name.get(name)
+        if column is not None and isinstance(column.data_type, _TYPES_UNUSABLE_AS_LAYOUT_KEYS):
+            raise ValueError(
+                f"Partition column {name!r} has type"
+                f" {type(column.data_type).__name__}, which Delta cannot partition by"
+            )
     for name in clustered_by:
-        data_type = columns_by_name[name].data_type
-        if isinstance(data_type, _UNPARTITIONABLE_TYPES):
+        column = columns_by_name.get(name)
+        if column is not None and isinstance(column.data_type, _TYPES_UNUSABLE_AS_LAYOUT_KEYS):
             raise ValueError(
                 f"Clustering column {name!r} has type"
-                f" {type(data_type).__name__}, which cannot be a clustering key"
+                f" {type(column.data_type).__name__}, which cannot be a clustering key"
             )
+
+    if (
+        partitioned_by
+        and set(partitioned_by) <= columns_by_name.keys()
+        and len(set(partitioned_by)) == len(columns)
+    ):
+        raise ValueError(
+            "Cannot partition by every column: at least one non-partition column is required"
+        )
 
 
 def _validate_column_names(
@@ -443,8 +450,7 @@ class DeltaTable:
         columns = tuple(columns)
         partitioned_by = tuple(partitioned_by)
         clustered_by = tuple(clustered_by)
-        _validate_delta_partitioning(columns, partitioned_by)
-        _validate_clustering(columns, clustered_by, partitioned_by)
+        _validate_layout(columns, partitioned_by, clustered_by)
         _validate_column_names(columns, user_properties, managed_aspects)
 
         table_tags = dict(tags or {})

--- a/src/delta_engine/api/delta_table.py
+++ b/src/delta_engine/api/delta_table.py
@@ -14,7 +14,7 @@ from __future__ import annotations
 from collections.abc import Iterable, Mapping, Sequence
 from dataclasses import dataclass
 from types import MappingProxyType
-from typing import Final, Literal
+from typing import Final, Literal, NamedTuple
 
 from delta_engine.application.properties import DELTA_PROPERTY_REGISTRY, Property
 from delta_engine.domain.model import (
@@ -228,6 +228,14 @@ def _validate_column_names(
             )
 
 
+class _ReferencedSide(NamedTuple):
+    """The referenced side of a foreign key, resolved at lowering time."""
+
+    table: QualifiedName
+    key_columns: tuple[str, ...]
+    column_types: dict[str, DataType]
+
+
 @dataclass(frozen=True, slots=True)
 class ForeignKey:
     """
@@ -274,29 +282,27 @@ class ForeignKey:
         match its referenced column's. Local column existence is not checked
         here — the ``DesiredTable`` built right after enforces it.
         """
-        referenced_table, referenced_key_columns, referenced_types = self._resolve_reference(
-            owner_name, owner_columns, owner_primary_key
-        )
+        referenced = self._resolve_reference(owner_name, owner_columns, owner_primary_key)
 
-        if referenced_table.catalog != owner_name.catalog:
+        if referenced.table.catalog != owner_name.catalog:
             raise ValueError(
                 f"cross-catalog foreign key not supported: {owner_name} cannot"
-                f" reference {referenced_table}. information_schema is"
+                f" reference {referenced.table}. information_schema is"
                 " per-catalog, so the engine could create the constraint but"
                 " never observe it afterwards; declare both tables in the same"
                 " catalog."
             )
 
-        if not referenced_key_columns:
+        if not referenced.key_columns:
             raise ValueError(
-                f"foreign key references {referenced_table}, which declares no primary key"
+                f"foreign key references {referenced.table}, which declares no primary key"
             )
 
         local_columns = tuple(self.columns.keys())
         referenced_columns = tuple(self.columns.values())
 
         declared = set(referenced_columns)
-        key = set(referenced_key_columns)
+        key = set(referenced.key_columns)
         if declared != key:
             missing = sorted(key - declared)
             extra = sorted(declared - key)
@@ -306,8 +312,8 @@ class ForeignKey:
             if extra:
                 details.append(f"not in the key: {', '.join(extra)}")
             raise ValueError(
-                f"foreign key columns must reference {referenced_table}'s"
-                f" primary key ({', '.join(referenced_key_columns)}) exactly;"
+                f"foreign key columns must reference {referenced.table}'s"
+                f" primary key ({', '.join(referenced.key_columns)}) exactly;"
                 f" {'; '.join(details)}"
             )
 
@@ -316,18 +322,18 @@ class ForeignKey:
             local_type = local_types.get(local_name)
             if local_type is None:
                 continue  # local column existence is enforced when the DesiredTable is built
-            referenced_type = referenced_types[referenced_name]
+            referenced_type = referenced.column_types[referenced_name]
             if local_type != referenced_type:
                 raise ValueError(
                     f"foreign key column type mismatch: {owner_name}.{local_name}"
-                    f" is {local_type} but {referenced_table}.{referenced_name}"
+                    f" is {local_type} but {referenced.table}.{referenced_name}"
                     f" is {referenced_type}"
                 )
 
         return ForeignKeyConstraint.generate(
             owner_table_name=owner_name.name,
             local_columns=local_columns,
-            referenced_table=referenced_table,
+            referenced_table=referenced.table,
             referenced_columns=referenced_columns,
         )
 
@@ -336,27 +342,25 @@ class ForeignKey:
         owner_name: QualifiedName,
         owner_columns: tuple[Column, ...],
         owner_primary_key: tuple[str, ...],
-    ) -> tuple[QualifiedName, tuple[str, ...], dict[str, DataType]]:
+    ) -> _ReferencedSide:
         """
         Resolve ``references`` to the referenced side of the constraint.
 
-        Returns the referenced table's name, its primary-key columns (the
-        columns this key references), and its column types by name. For
-        :data:`Self` the enclosing table supplies all three — its own name,
-        ``owner_primary_key``, and ``owner_columns`` — because the owner's
-        ``DesiredTable`` does not exist yet while its foreign keys are being
-        lowered. The returned mapping always covers every referenced column:
-        primary-key columns are validated to exist on whichever table
-        declares them.
+        For :data:`Self` the enclosing table supplies every field — its own
+        name, ``owner_primary_key``, and ``owner_columns`` — because the
+        owner's ``DesiredTable`` does not exist yet while its foreign keys
+        are being lowered. ``column_types`` always covers every referenced
+        column: primary-key columns are validated to exist on whichever
+        table declares them.
         """
         match self.references:
             case _SelfReference():
                 types = {column.name: column.data_type for column in owner_columns}
-                return owner_name, owner_primary_key, types
+                return _ReferencedSide(owner_name, owner_primary_key, types)
             case DeltaTable() as target:
                 desired = target.to_desired_table()
                 types = {column.name: column.data_type for column in desired.columns}
-                return desired.qualified_name, desired.primary_key_columns, types
+                return _ReferencedSide(desired.qualified_name, desired.primary_key_columns, types)
             case _:
                 raise TypeError(
                     f"foreign key references must be a DeltaTable or Self; got {self.references!r}"

--- a/src/delta_engine/domain/model/table.py
+++ b/src/delta_engine/domain/model/table.py
@@ -198,10 +198,8 @@ class DesiredTable(TableSnapshot):
                 raise ValueError(
                     "Two foreign keys carry the same constraint name"
                     f" '{foreign_key.constraint_name}': local columns {collided}"
-                    f" and {foreign_key.local_columns}. Generated names join"
-                    " local columns with underscores, so underscore-adjacent"
-                    " tuples can collide; rename a local column so the names"
-                    " differ."
+                    f" and {foreign_key.local_columns}. Every foreign key on a"
+                    " table must have a distinct constraint name."
                 )
             local_columns_by_constraint_name[foreign_key.constraint_name] = (
                 foreign_key.local_columns

--- a/src/delta_engine/domain/model/table.py
+++ b/src/delta_engine/domain/model/table.py
@@ -15,6 +15,23 @@ from delta_engine.domain.model.constraints import (
 from delta_engine.domain.model.qualified_name import QualifiedName
 
 
+def _validate_key_column_list(kind: str, names: tuple[str, ...], column_names: set[str]) -> None:
+    """Rules shared by partition and clustering key lists: lowercase, existing, unique."""
+    for name in names:
+        if name != name.casefold():
+            raise ValueError(f"{kind} column name must be lowercase: {name!r}")
+
+    missing = [name for name in names if name not in column_names]
+    if missing:
+        raise ValueError(f"{kind} column not found: {', '.join(missing)}")
+
+    seen: set[str] = set()
+    for name in names:
+        if name in seen:
+            raise ValueError(f"Duplicate {kind.casefold()} column: {name}")
+        seen.add(name)
+
+
 class TableAspect(Enum):
     """One independently manageable dimension of a table's state."""
 
@@ -83,6 +100,7 @@ class TableSnapshot:
         object.__setattr__(self, "columns", tuple(self.columns))
         object.__setattr__(self, "tags", MappingProxyType(dict(self.tags)))
         object.__setattr__(self, "partitioned_by", tuple(self.partitioned_by))
+        object.__setattr__(self, "clustered_by", tuple(self.clustered_by))
         object.__setattr__(self, "foreign_keys", tuple(self.foreign_keys))
 
         if not self.columns:
@@ -94,33 +112,8 @@ class TableSnapshot:
                 raise ValueError(f"Duplicate column name: {column.name}")
             seen_names.add(column.name)
 
-        for name in self.partitioned_by:
-            if name != name.casefold():
-                raise ValueError(f"Partition column name must be lowercase: {name!r}")
-
-        missing_partitions = [name for name in self.partitioned_by if name not in seen_names]
-        if missing_partitions:
-            raise ValueError(f"Partition column not found: {missing_partitions[0]}")
-
-        seen_partitions: set[str] = set()
-        for name in self.partitioned_by:
-            if name in seen_partitions:
-                raise ValueError(f"Duplicate partition column: {name}")
-            seen_partitions.add(name)
-
-        for name in self.clustered_by:
-            if name != name.casefold():
-                raise ValueError(f"Clustering column name must be lowercase: {name!r}")
-
-        missing_clustering = [name for name in self.clustered_by if name not in seen_names]
-        if missing_clustering:
-            raise ValueError(f"Clustering column not found: {missing_clustering[0]}")
-
-        seen_clustering: set[str] = set()
-        for name in self.clustered_by:
-            if name in seen_clustering:
-                raise ValueError(f"Duplicate clustering column: {name}")
-            seen_clustering.add(name)
+        _validate_key_column_list("Partition", self.partitioned_by, seen_names)
+        _validate_key_column_list("Clustering", self.clustered_by, seen_names)
 
         if self.primary_key is not None:
             missing_pk = [name for name in self.primary_key.columns if name not in seen_names]

--- a/tests/domain/model/test_table.py
+++ b/tests/domain/model/test_table.py
@@ -502,6 +502,30 @@ def test_domain_tables_accept_backend_specific_partition_layouts() -> None:
     assert observed.partitioned_by == ("id", "day")
 
 
+def test_domain_tables_accept_backend_specific_clustering_layouts() -> None:
+    # The public API refuses to author these layouts (partitioning and
+    # clustering together, more than four clustering keys), but desired and
+    # observed state must stay representable: layout deployability is a
+    # declaration-time rule, not a snapshot invariant.
+    columns = tuple(Column(name, Integer()) for name in ("a", "b", "c", "d", "e"))
+    name = QualifiedName("dev", "silver", "orders")
+
+    five_keys = DesiredTable(
+        qualified_name=name, columns=columns, clustered_by=("a", "b", "c", "d", "e")
+    )
+    partitioned_and_clustered = DesiredTable(
+        qualified_name=name, columns=columns, partitioned_by=("a",), clustered_by=("b",)
+    )
+    observed = ObservedTable(
+        qualified_name=name, columns=columns, partitioned_by=("a",), clustered_by=("b",)
+    )
+
+    assert five_keys.clustered_by == ("a", "b", "c", "d", "e")
+    assert partitioned_and_clustered.partitioned_by == ("a",)
+    assert partitioned_and_clustered.clustered_by == ("b",)
+    assert observed.clustered_by == ("b",)
+
+
 # ---------- clustered_by ----------
 
 


### PR DESCRIPTION
Follow-ups from the 2026-07-10 delta_table.py / table.py design review. No rules added, removed, or moved between layers.

- Merge `_validate_delta_partitioning` + `_validate_clustering` into `_validate_layout`; per-entry name resolution replaces the silent early-return guards, and the module docstring now states the API/domain validation contract. `_UNPARTITIONABLE_TYPES` renamed `_TYPES_UNUSABLE_AS_LAYOUT_KEYS` (it gates clustering keys too). For declarations invalid in more than one way, which of the equally true errors fires first can differ from before; the set of rejected inputs is unchanged.
- `_resolve_reference` returns a named `_ReferencedSide` instead of an anonymous 3-tuple.
- `TableSnapshot.__post_init__`: partition/clustering key-list stanzas deduped into one helper; not-found errors now name every missing column; `clustered_by` gets the tuple normalization its sibling fields already had.
- `DesiredTable`'s FK name-collision error states the fact without explaining the API's name-generation scheme (advice would go stale with the parked constraint-name override; the remedy stays documented in how-to-configure-table.md).
- New pinning test: domain snapshots accept undeployable clustering layouts (partition+cluster together, >4 keys), the clustering twin of the existing partition-layout pin.

All existing tests pass unedited; error-message substrings asserted by tests are preserved verbatim.

Gate on HEAD: 669 passed, coverage 98.64%; ruff, mypy, lint-imports, sphinx -W all clean. Reviewed per-task and whole-branch (no Critical/Important findings).