### PR TITLE
docs: generate API reference pages with sphinx.ext.autosummary

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,4 @@ htmlcov/
 .superpowers/
 docs/superpowers/
 docs/_build/
+docs/generated/

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -9,6 +9,7 @@ release = "0.1.0"
 
 extensions = [
     "sphinx.ext.autodoc",
+    "sphinx.ext.autosummary",
     "sphinx.ext.napoleon",
     "sphinx_autodoc_typehints",
     "sphinx_copybutton",
@@ -22,6 +23,8 @@ myst_fence_as_directive = ["mermaid"]
 
 html_theme = "furo"
 html_title = "delta-engine"
+
+autosummary_generate = True
 
 autodoc_member_order = "bysource"
 autodoc_typehints = "description"

--- a/docs/reference-api.md
+++ b/docs/reference-api.md
@@ -10,15 +10,26 @@ for declaring tables (no PySpark required) and `delta_engine.databricks` for
 building an engine and running syncs. Result and error types are re-exported
 from the top-level `delta_engine` package.
 
+Each entry below links to a full page generated from the object's docstring.
+
 ## Schema declarations
 
-### DeltaTable
+```{eval-rst}
+.. autosummary::
+   :toctree: generated
+   :nosignatures:
+
+   delta_engine.schema.DeltaTable
+   delta_engine.schema.Column
+   delta_engine.schema.ForeignKey
+   delta_engine.schema.Property
+```
 
 ```{eval-rst}
-.. autoclass:: delta_engine.schema.DeltaTable
-   :members:
-   :undoc-members:
+.. autodata:: delta_engine.schema.Self
 ```
+
+### Notes on `DeltaTable`
 
 #### `scope` (str, default `"full"`)
 
@@ -38,93 +49,41 @@ sibling of `partitioned_by` and mutually exclusive with it; at most four keys.
 Key order is not significant. See
 [clustering](how-to-configure-table.md#clustering).
 
-### Column
-
-```{eval-rst}
-.. autoclass:: delta_engine.schema.Column
-   :members:
-   :undoc-members:
-```
-
-### ForeignKey
-
-```{eval-rst}
-.. autoclass:: delta_engine.schema.ForeignKey
-   :members:
-   :undoc-members:
-```
-
-### Self
-
-```{eval-rst}
-.. autodata:: delta_engine.schema.Self
-```
-
-### Property
-
-```{eval-rst}
-.. autoclass:: delta_engine.schema.Property
-   :members:
-```
-
 ## Engine
 
-### Engine
-
 ```{eval-rst}
-.. autoclass:: delta_engine.Engine
-   :members:
+.. autosummary::
+   :toctree: generated
+   :nosignatures:
+
+   delta_engine.Engine
 ```
 
 ## Results and errors
 
-### SyncReport
-
-```{eval-rst}
-.. autoclass:: delta_engine.SyncReport
-   :members:
-```
-
-### Rendering a report
-
 `SyncReport` is a pure data object. To turn one into human-readable text, pass
-it to one of these functions:
+it to `render_report` or `render_diff`.
 
 ```{eval-rst}
-.. autofunction:: delta_engine.render_report
-```
+.. autosummary::
+   :toctree: generated
+   :nosignatures:
 
-```{eval-rst}
-.. autofunction:: delta_engine.render_diff
-```
-
-### TableRunStatus
-
-```{eval-rst}
-.. autoclass:: delta_engine.TableRunStatus
-   :members:
-```
-
-### SyncFailedError
-
-```{eval-rst}
-.. autoexception:: delta_engine.SyncFailedError
-   :members:
-```
-
-### Failure
-
-```{eval-rst}
-.. autoclass:: delta_engine.Failure
-   :members:
+   delta_engine.SyncReport
+   delta_engine.render_report
+   delta_engine.render_diff
+   delta_engine.TableRunStatus
+   delta_engine.SyncFailedError
+   delta_engine.Failure
 ```
 
 ## Databricks adapter
 
 ```{eval-rst}
-.. autofunction:: delta_engine.databricks.build_engine
-```
+.. autosummary::
+   :toctree: generated
+   :nosignatures:
 
-```{eval-rst}
-.. autofunction:: delta_engine.databricks.configure_logging
+   delta_engine.databricks.build_engine
+   delta_engine.databricks.configure_logging
 ```


### PR DESCRIPTION
## What & why

Trial of Sphinx auto-generated API docs (option 2 of the survey: `sphinx.ext.autosummary`). Each section of the API reference now uses an `autosummary` directive with `:toctree: generated`, producing a summary table (name + first docstring line) that links to a generated per-object page, instead of hand-placed `autoclass` blocks on one long page.

- `docs/conf.py`: add `sphinx.ext.autosummary` with `autosummary_generate = True`; napoleon, typehints, and mock imports unchanged.
- `docs/reference-api.md`: autosummary tables per section; hand-written `scope`/`clustered_by` prose kept on the overview page. `Self` stays as a plain `autodata`.
- `.gitignore`: ignore `docs/generated/` (build artifact).

Known trade-offs to weigh in review:

1. The default class template lists all public members, so `DeltaTable`'s generated page shows `to_desired_table` (internal lowering hook). Fixable with a custom template in `docs/_templates/` or by making the method private.
2. The furo sidebar now nests 13 generated pages under the API reference instead of one long page.

Alternatives considered (sphinx-autoapi, sphinx-autodoc2) can be trialled as follow-up commits on request.

## Checklist

- [x] PR title is a Conventional Commit (see comment above)
- [ ] Tests added or updated for behaviour changes (docs-only change)
- [x] Docs updated if public behaviour/architecture/validation changed
- [x] `uv run pytest`, `uv run ruff check .`, `uv run mypy .`, `uv run lint-imports` pass — docs-only; `sphinx-build -W` passes