### PR TITLE
refactor: reintroduce _SelfReference class in delta_table.py

### DIFF
--- a/src/delta_engine/api/delta_table.py
+++ b/src/delta_engine/api/delta_table.py
@@ -32,7 +32,6 @@ from delta_engine.domain.model import (
     Variant,
 )
 
-
 METADATA_ASPECTS: Final[frozenset[TableAspect]] = frozenset(
     {
         TableAspect.TABLE_COMMENT,

--- a/src/delta_engine/api/delta_table.py
+++ b/src/delta_engine/api/delta_table.py
@@ -33,17 +33,6 @@ from delta_engine.domain.model import (
 )
 
 
-class _SelfReference:
-    """Sentinel marking a foreign key that references its own table."""
-
-    __slots__ = ()
-
-    def __repr__(self) -> str:
-        return "Self"
-
-
-Self: Final = _SelfReference()
-
 METADATA_ASPECTS: Final[frozenset[TableAspect]] = frozenset(
     {
         TableAspect.TABLE_COMMENT,
@@ -88,6 +77,18 @@ _TYPES_UNUSABLE_AS_LAYOUT_KEYS: Final[tuple[type[DataType], ...]] = (Array, Map,
 # columns are separate securables).
 _MAX_TAGS_PER_SECURABLE: Final[int] = 50
 _MAX_TAG_VALUE_LENGTH: Final[int] = 1000
+
+
+class _SelfReference:
+    """Sentinel marking a foreign key that references its own table."""
+
+    __slots__ = ()
+
+    def __repr__(self) -> str:
+        return "Self"
+
+
+Self: Final = _SelfReference()
 
 
 def _validate_tags(subject: str, tags: Mapping[str, str]) -> None:


### PR DESCRIPTION
<!--
The PR TITLE becomes the squash-commit message on main and drives the
automatic version bump and changelog. It MUST be a Conventional Commit:

  feat: ...      -> minor release
  fix: ...       -> patch release
  feat!: ... / BREAKING CHANGE -> handled as a 0.x minor while pre-1.0
  docs/chore/refactor/test/ci/build/style: ... -> no release

Scope is optional, e.g. `feat(api): ...`.
-->

## What & why

<!-- Describe the change and the motivation. -->

## Checklist

- [ ] PR title is a Conventional Commit (see comment above)
- [ ] Tests added or updated for behaviour changes
- [ ] Docs updated if public behaviour/architecture/validation changed
- [ ] `uv run pytest`, `uv run ruff check .`, `uv run mypy .`, `uv run lint-imports` pass
