### PR TITLE
docs: generate API reference with sphinx-autoapi

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,17 +1,12 @@
 from pathlib import Path
-import sys
-
-sys.path.insert(0, str(Path(__file__).parent.parent / "src"))
 
 project = "delta-engine"
 author = "Tomos Corbin"
 release = "0.1.0"
 
 extensions = [
-    "sphinx.ext.autodoc",
-    "sphinx.ext.autosummary",
+    "autoapi.extension",
     "sphinx.ext.napoleon",
-    "sphinx_autodoc_typehints",
     "sphinx_copybutton",
     "sphinxcontrib.mermaid",
     "myst_parser",
@@ -24,11 +19,20 @@ myst_fence_as_directive = ["mermaid"]
 html_theme = "furo"
 html_title = "delta-engine"
 
-autosummary_generate = True
+# sphinx-autoapi documents the package by static analysis: nothing is
+# imported at build time, so pyspark/delta need no mocking.
+autoapi_dirs = [str(Path(__file__).parent.parent / "src" / "delta_engine")]
+autoapi_root = "autoapi"
+autoapi_add_toctree_entry = False
+autoapi_options = [
+    "members",
+    "undoc-members",
+    "show-inheritance",
+    "show-module-summary",
+]
+autoapi_member_order = "bysource"
+autoapi_python_class_content = "class"
 
-autodoc_member_order = "bysource"
-autodoc_typehints = "description"
-autodoc_mock_imports = ["pyspark", "delta"]
 napoleon_use_ivar = True
 
 exclude_patterns = ["_build", "superpowers", "todo"]

--- a/docs/index.md
+++ b/docs/index.md
@@ -104,6 +104,7 @@ reference-limitations
 reference-data-types
 reference-safe-change-rules
 reference-api
+autoapi/delta_engine/index
 ```
 
 ```{toctree}

--- a/docs/reference-api.md
+++ b/docs/reference-api.md
@@ -10,28 +10,18 @@ for declaring tables (no PySpark required) and `delta_engine.databricks` for
 building an engine and running syncs. Result and error types are re-exported
 from the top-level `delta_engine` package.
 
-Each entry below links to a full page generated from the object's docstring.
+The full per-module reference is generated from the source tree; see
+{doc}`autoapi/delta_engine/index`. The entry points:
 
-## Schema declarations
+| You want to…                  | Start at                                                                |
+| ----------------------------- | ----------------------------------------------------------------------- |
+| Declare tables, columns, keys | {doc}`delta_engine.schema <autoapi/delta_engine/schema/index>`          |
+| Build an engine and sync      | {doc}`delta_engine.databricks <autoapi/delta_engine/databricks/index>`  |
+| Inspect results and errors    | {doc}`delta_engine <autoapi/delta_engine/index>` (top-level re-exports) |
 
-```{eval-rst}
-.. autosummary::
-   :toctree: generated
-   :nosignatures:
+## Notes on `DeltaTable`
 
-   delta_engine.schema.DeltaTable
-   delta_engine.schema.Column
-   delta_engine.schema.ForeignKey
-   delta_engine.schema.Property
-```
-
-```{eval-rst}
-.. autodata:: delta_engine.schema.Self
-```
-
-### Notes on `DeltaTable`
-
-#### `scope` (str, default `"full"`)
+### `scope` (str, default `"full"`)
 
 Selects what the declaration manages. `"full"` manages the whole table.
 `"metadata"` restricts the sync to catalog metadata: comments, tags, and
@@ -41,49 +31,10 @@ the scope are never changed, and any unmanaged drift causes validation to
 fail. Properties are the exception: a declaration that does not manage
 properties never compares them at all.
 
-#### `clustered_by` (read-only accessor)
+### `clustered_by` (read-only accessor)
 
 The tuple of liquid clustering key column names, in declaration order,
 reflecting the `clustered_by` constructor argument. A table-level list, the
 sibling of `partitioned_by` and mutually exclusive with it; at most four keys.
 Key order is not significant. See
 [clustering](how-to-configure-table.md#clustering).
-
-## Engine
-
-```{eval-rst}
-.. autosummary::
-   :toctree: generated
-   :nosignatures:
-
-   delta_engine.Engine
-```
-
-## Results and errors
-
-`SyncReport` is a pure data object. To turn one into human-readable text, pass
-it to `render_report` or `render_diff`.
-
-```{eval-rst}
-.. autosummary::
-   :toctree: generated
-   :nosignatures:
-
-   delta_engine.SyncReport
-   delta_engine.render_report
-   delta_engine.render_diff
-   delta_engine.TableRunStatus
-   delta_engine.SyncFailedError
-   delta_engine.Failure
-```
-
-## Databricks adapter
-
-```{eval-rst}
-.. autosummary::
-   :toctree: generated
-   :nosignatures:
-
-   delta_engine.databricks.build_engine
-   delta_engine.databricks.configure_logging
-```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,6 +52,7 @@ docs = [
   "sphinx-copybutton>=0.5",
   "sphinx-autodoc-typehints>=2.0",
   "sphinxcontrib-mermaid>=1.0",
+  "sphinx-autoapi>=3.8.0",
 ]
 
 [build-system]

--- a/uv.lock
+++ b/uv.lock
@@ -77,6 +77,15 @@ wheels = [
 ]
 
 [[package]]
+name = "astroid"
+version = "4.1.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/da/fd/24475b7cfb70298e8921bc077adb46a3fe77887422545d8a061573e130ee/astroid-4.1.2.tar.gz", hash = "sha256:d6c4a52bfcda4bbeb7359dead642b0248b90f7d9a07e690230bd86fefd6d37f1", size = 414896, upload-time = "2026-03-22T19:16:42.075Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/97/4ee9b0438e85bf0a808a89ef0be357319252ab27e1b313ae0aef7aeaa5a6/astroid-4.1.2-py3-none-any.whl", hash = "sha256:21312e682c0866dc5a309ee57e4b88ea92751b9955a58b1c31371cbbeb088707", size = 279956, upload-time = "2026-03-22T19:16:40.062Z" },
+]
+
+[[package]]
 name = "babel"
 version = "2.18.0"
 source = { registry = "https://pypi.org/simple" }
@@ -353,6 +362,7 @@ docs = [
     { name = "furo" },
     { name = "myst-parser" },
     { name = "sphinx" },
+    { name = "sphinx-autoapi" },
     { name = "sphinx-autodoc-typehints" },
     { name = "sphinx-copybutton" },
     { name = "sphinxcontrib-mermaid" },
@@ -382,6 +392,7 @@ docs = [
     { name = "furo", specifier = ">=2024.1.29" },
     { name = "myst-parser", specifier = ">=4.0" },
     { name = "sphinx", specifier = ">=8.0" },
+    { name = "sphinx-autoapi", specifier = ">=3.8.0" },
     { name = "sphinx-autodoc-typehints", specifier = ">=2.0" },
     { name = "sphinx-copybutton", specifier = ">=0.5" },
     { name = "sphinxcontrib-mermaid", specifier = ">=1.0" },
@@ -1148,6 +1159,21 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/cd/bd/f08eb0f4eed5c83f1ba2a3bd18f7745a2b1525fad70660a1c00224ec468a/sphinx-9.1.0.tar.gz", hash = "sha256:7741722357dd75f8190766926071fed3bdc211c74dd2d7d4df5404da95930ddb", size = 8718324, upload-time = "2025-12-31T15:09:27.646Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/73/f7/b1884cb3188ab181fc81fa00c266699dab600f927a964df02ec3d5d1916a/sphinx-9.1.0-py3-none-any.whl", hash = "sha256:c84fdd4e782504495fe4f2c0b3413d6c2bf388589bb352d439b2a3bb99991978", size = 3921742, upload-time = "2025-12-31T15:09:25.561Z" },
+]
+
+[[package]]
+name = "sphinx-autoapi"
+version = "3.8.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "astroid" },
+    { name = "jinja2" },
+    { name = "pyyaml" },
+    { name = "sphinx" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f8/25/386d851320bc306e9d7d41b8cecf113f638e205a99595c481c146622de94/sphinx_autoapi-3.8.0.tar.gz", hash = "sha256:9f8ac7d43baf28a0831ac0e392fab6a095b875af07e52d135a5f716cc3cf1142", size = 58418, upload-time = "2026-03-08T03:49:52.931Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2f/3a/8923a543fa2422d32be4c5311f488e4f275acde263c811e4d5d22bb544cb/sphinx_autoapi-3.8.0-py3-none-any.whl", hash = "sha256:245aefdeab85609ae4aa3576b0d99f69676aa6333dda438761bd125755b3c42d", size = 35994, upload-time = "2026-03-08T03:49:51.383Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## What & why

Trial of option 3 in the auto-generated docs survey: `sphinx-autoapi`. Documents the package by **static analysis** — nothing is imported at build time, so the `autodoc_mock_imports = ["pyspark", "delta"]` workaround and the `sys.path` insert are gone entirely.

- `pyproject.toml` / `uv.lock`: add `sphinx-autoapi` to the docs group.
- `docs/conf.py`: replace autodoc/autosummary/typehints config with `autoapi.extension` pointed at `src/delta_engine`.
- `docs/reference-api.md`: now a curated entry-point page (facade table + `scope`/`clustered_by` notes) linking into the generated tree; the autodoc directives are removed since autoapi documents the same objects and `-W` would fail on duplicates.
- `docs/index.md`: autoapi root added under the Reference sidebar caption.

The trade-off to weigh (this is the honest demo of the option): autoapi generates **39 pages covering the entire source tree** — `domain`, `application`, and `adapters` internals included. Great for contributors, but it buries the deliberate two-facade public surface unless we aggressively prune with `autoapi_ignore`, at which point we're re-doing curation by exclusion. The no-import build is the standout win.

`sphinx-build -W` passes. Compare against the autosummary approach merged in #197.

## Checklist

- [x] PR title is a Conventional Commit (see comment above)
- [ ] Tests added or updated for behaviour changes (docs-only change)
- [x] Docs updated if public behaviour/architecture/validation changed
- [x] `uv run pytest`, `uv run ruff check .`, `uv run mypy .`, `uv run lint-imports` pass — docs-only; `sphinx-build -W` passes