### PR TITLE
ci: publish docs to GitHub Pages on push to main

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -1,0 +1,52 @@
+name: Docs
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v8.2.0
+        with:
+          enable-cache: true
+          cache-dependency-glob: uv.lock
+
+      - name: Set up Python
+        run: uv python install 3.12
+
+      - name: Install dependencies
+        run: uv sync --locked --group docs
+
+      - name: Build docs
+        run: uv run sphinx-build -W -b html docs docs/_build/html
+
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@v4
+        with:
+          path: docs/_build/html
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ pip install delta-engine
 The base package is pure Python with no runtime dependencies: declaring and
 planning schemas needs no PySpark. Running a sync needs a Databricks
 environment, which provides Spark and Delta. See the
-[installation guide](https://github.com/Tomoscorbin/delta-engine/blob/main/docs/installation.md)
+[installation guide](https://tomoscorbin.github.io/delta-engine/installation.html)
 for the `[databricks]` extra used for local development.
 
 ## Quickstart
@@ -56,35 +56,35 @@ a named rule before any SQL runs.
 
 ## Documentation
 
-Start with [how a sync works](https://github.com/Tomoscorbin/delta-engine/blob/main/docs/explanation-sync-lifecycle.md)
+Start with [how a sync works](https://tomoscorbin.github.io/delta-engine/explanation-sync-lifecycle.html)
 for the model, or jump to what you need:
 
 **Getting started**
 
-- [Installation](https://github.com/Tomoscorbin/delta-engine/blob/main/docs/installation.md)
-- [Getting started tutorial](https://github.com/Tomoscorbin/delta-engine/blob/main/docs/tutorial-getting-started.md) — define a table and run your first sync
+- [Installation](https://tomoscorbin.github.io/delta-engine/installation.html)
+- [Getting started tutorial](https://tomoscorbin.github.io/delta-engine/tutorial-getting-started.html) — define a table and run your first sync
 
 **Concepts**
 
-- [How a sync works](https://github.com/Tomoscorbin/delta-engine/blob/main/docs/explanation-sync-lifecycle.md) — the phases between calling `sync` and getting a report
-- [The safety model](https://github.com/Tomoscorbin/delta-engine/blob/main/docs/explanation-safety-model.md) — what the engine blocks, and why
+- [How a sync works](https://tomoscorbin.github.io/delta-engine/explanation-sync-lifecycle.html) — the phases between calling `sync` and getting a report
+- [The safety model](https://tomoscorbin.github.io/delta-engine/explanation-safety-model.html) — what the engine blocks, and why
 
 **How-to guides**
 
-- [Configure a table](https://github.com/Tomoscorbin/delta-engine/blob/main/docs/how-to-configure-table.md) — properties, tags, comments, keys, and partitioning
-- [Deploy metadata only](https://github.com/Tomoscorbin/delta-engine/blob/main/docs/how-to-deploy-metadata-only.md) — roll out governance metadata with no schema change
-- [Preview changes with a dry run](https://github.com/Tomoscorbin/delta-engine/blob/main/docs/how-to-preview-changes.md)
-- [Handle sync failures](https://github.com/Tomoscorbin/delta-engine/blob/main/docs/how-to-handle-sync-failures.md) — inspect `SyncReport` and act on each status
+- [Configure a table](https://tomoscorbin.github.io/delta-engine/how-to-configure-table.html) — properties, tags, comments, keys, and partitioning
+- [Deploy metadata only](https://tomoscorbin.github.io/delta-engine/how-to-deploy-metadata-only.html) — roll out governance metadata with no schema change
+- [Preview changes with a dry run](https://tomoscorbin.github.io/delta-engine/how-to-preview-changes.html)
+- [Handle sync failures](https://tomoscorbin.github.io/delta-engine/how-to-handle-sync-failures.html) — inspect `SyncReport` and act on each status
 
 **Reference**
 
-- [Capabilities and limitations](https://github.com/Tomoscorbin/delta-engine/blob/main/docs/reference-limitations.md) — what the engine can and cannot manage
-- [Data types](https://github.com/Tomoscorbin/delta-engine/blob/main/docs/reference-data-types.md) — supported types and Spark SQL equivalents
-- [Safe-change rules](https://github.com/Tomoscorbin/delta-engine/blob/main/docs/reference-safe-change-rules.md) — changes the engine blocks at validation
-- [API reference](https://github.com/Tomoscorbin/delta-engine/blob/main/docs/reference-api.md)
+- [Capabilities and limitations](https://tomoscorbin.github.io/delta-engine/reference-limitations.html) — what the engine can and cannot manage
+- [Data types](https://tomoscorbin.github.io/delta-engine/reference-data-types.html) — supported types and Spark SQL equivalents
+- [Safe-change rules](https://tomoscorbin.github.io/delta-engine/reference-safe-change-rules.html) — changes the engine blocks at validation
+- [API reference](https://tomoscorbin.github.io/delta-engine/reference-api.html)
 
 **Architecture**
 
-- [Architecture](https://github.com/Tomoscorbin/delta-engine/blob/main/docs/explanation-architecture.md) — layers, ports and adapters, design decisions
-- [Implement a custom adapter](https://github.com/Tomoscorbin/delta-engine/blob/main/docs/how-to-implement-adapter.md) — the `CatalogStateReader` and `PlanExecutor` ports
-- [Add a new action type](https://github.com/Tomoscorbin/delta-engine/blob/main/docs/how-to-add-action-type.md) — extend `Action`, `ActionPhase`, and the compiler
+- [Architecture](https://tomoscorbin.github.io/delta-engine/explanation-architecture.html) — layers, ports and adapters, design decisions
+- [Implement a custom adapter](https://tomoscorbin.github.io/delta-engine/how-to-implement-adapter.html) — the `CatalogStateReader` and `PlanExecutor` ports
+- [Add a new action type](https://tomoscorbin.github.io/delta-engine/how-to-add-action-type.html) — extend `Action`, `ActionPhase`, and the compiler

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ databricks = ["pyspark>=4.0.0", "delta-spark>=4.0.0"]
 [project.urls]
 Homepage = "https://github.com/Tomoscorbin/delta-engine"
 Repository = "https://github.com/Tomoscorbin/delta-engine"
-Documentation = "https://github.com/Tomoscorbin/delta-engine/tree/main/docs"
+Documentation = "https://tomoscorbin.github.io/delta-engine/"
 Issues = "https://github.com/Tomoscorbin/delta-engine/issues"
 
 [dependency-groups]


### PR DESCRIPTION
## What & why

Makes the docs publicly readable. Until now the Sphinx docs existed only as source in `docs/` — no Read the Docs, no Pages — so users had to clone and build locally.

- `.github/workflows/docs.yaml`: on push to `main` (and manual dispatch), build with the same `sphinx-build -W` command the CI docs job uses, then deploy via `actions/upload-pages-artifact` + `actions/deploy-pages`. The CI docs job keeps gating PRs; this workflow only publishes.
- GitHub Pages is already enabled on the repo with `build_type: workflow` (done via API), so the first push to `main` after merge deploys to **https://tomoscorbin.github.io/delta-engine/**.
- `pyproject.toml`: `Documentation` project URL now points at the site (shows on PyPI).
- `README.md`: the 17 doc links now point at rendered pages instead of raw markdown on GitHub; every rewritten link verified against a local `sphinx-build` output.

Versioned-per-release docs (Read the Docs) can come later if needed; this publishes latest `main` only.

## Checklist

- [x] PR title is a Conventional Commit (see comment above)
- [ ] Tests added or updated for behaviour changes (CI/docs-only change)
- [x] Docs updated if public behaviour/architecture/validation changed
- [x] `uv run pytest`, `uv run ruff check .`, `uv run mypy .`, `uv run lint-imports` pass — no Python changes; `sphinx-build -W` passes locally