### PR TITLE
docs: restrict the generated API reference to the public import surfaces

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,5 +1,7 @@
 from pathlib import Path
 
+from sphinx.application import Sphinx
+
 project = "delta-engine"
 author = "Tomos Corbin"
 release = "0.1.0"
@@ -49,7 +51,14 @@ _PUBLIC_MODULES = {
 _HIDDEN_MEMBERS = {"DeltaTable.to_desired_table"}
 
 
-def _skip_non_public(app, what, name, obj, skip, options):
+def _skip_non_public(
+    app: Sphinx,
+    what: str,
+    name: str,
+    obj: object,
+    skip: bool,
+    options: object,
+) -> bool | None:
     if what in ("module", "package") and name not in _PUBLIC_MODULES:
         return True
     if any(name.endswith(hidden) for hidden in _HIDDEN_MEMBERS):
@@ -57,7 +66,7 @@ def _skip_non_public(app, what, name, obj, skip, options):
     return None
 
 
-def setup(app):
+def setup(app: Sphinx) -> None:
     app.connect("autoapi-skip-member", _skip_non_public)
 
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -29,9 +29,37 @@ autoapi_options = [
     "undoc-members",
     "show-inheritance",
     "show-module-summary",
+    # The public surfaces are re-export facades; without this their pages
+    # would be empty and the docs would only exist on internal module pages.
+    "imported-members",
 ]
 autoapi_member_order = "bysource"
 autoapi_python_class_content = "class"
+
+# The published reference covers only the public import surfaces. Internal
+# layers (domain, application, adapters, api) are implementation detail;
+# documenting them would contradict the two-facade API story.
+_PUBLIC_MODULES = {
+    "delta_engine",
+    "delta_engine.schema",
+    "delta_engine.databricks",
+}
+
+# Public methods that are internal wiring, not user API.
+_HIDDEN_MEMBERS = {"DeltaTable.to_desired_table"}
+
+
+def _skip_non_public(app, what, name, obj, skip, options):
+    if what in ("module", "package") and name not in _PUBLIC_MODULES:
+        return True
+    if any(name.endswith(hidden) for hidden in _HIDDEN_MEMBERS):
+        return True
+    return None
+
+
+def setup(app):
+    app.connect("autoapi-skip-member", _skip_non_public)
+
 
 napoleon_use_ivar = True
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -225,3 +225,9 @@ exclude = ["^notebooks/"]
 [[tool.mypy.overrides]]
 module = ["tests.*"]
 ignore_errors = true
+
+# CI type-checks in the dev environment, where the docs group (and therefore
+# sphinx) is not installed; docs/conf.py imports Sphinx for its hook signatures.
+[[tool.mypy.overrides]]
+module = ["sphinx.*"]
+ignore_missing_imports = true


### PR DESCRIPTION
## What & why

The autoapi setup merged in #199 documented the entire source tree — 39 pages including `domain`, `application`, and `adapters` internals — which contradicts the two-facade API story the docs tell. This restricts the published reference to the three public import surfaces: `delta_engine`, `delta_engine.schema`, and `delta_engine.databricks`.

All in `docs/conf.py`:

- An `autoapi-skip-member` hook skips every module/package not on a `_PUBLIC_MODULES` allowlist (allowlist, not `autoapi_ignore` blocklist patterns, so a new internal module is hidden by default).
- `imported-members` added to `autoapi_options`: the facades are re-export surfaces, so without it their pages were empty — the classes were only documented on the internal pages. Objects now render under their canonical public names (`delta_engine.schema.DeltaTable`, not `delta_engine.api.delta_table.DeltaTable`). No duplicates: the top-level and `schema` `__all__` sets don't overlap, and `__all__` filters what each page shows.
- `DeltaTable.to_desired_table` (the internal API→domain lowering hook, flagged in #197/#199) is skipped via a `_HIDDEN_MEMBERS` set. It stays a public method — the application layer and the CI runtime-import check call it — this only removes it from user docs.

Verified on a clean build (`-W` passes): exactly 3 generated pages; 25 objects on the top-level page, 54 on `schema`, 2 on `databricks`; `to_desired_table` absent; the top-level page links only to the two facades.

## Checklist

- [x] PR title is a Conventional Commit (see comment above)
- [ ] Tests added or updated for behaviour changes (docs-only change)
- [x] Docs updated if public behaviour/architecture/validation changed
- [x] `uv run pytest`, `uv run ruff check .`, `uv run mypy .`, `uv run lint-imports` pass — docs-only; `sphinx-build -W` passes on a clean build