### PR TITLE
docs: fix stale docs version and shorten API object titles

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,10 +1,11 @@
+from importlib.metadata import version as _version
 from pathlib import Path
 
 from sphinx.application import Sphinx
 
 project = "delta-engine"
 author = "Tomos Corbin"
-release = "0.1.0"
+release = _version("delta-engine")
 
 extensions = [
     "autoapi.extension",
@@ -20,6 +21,11 @@ myst_fence_as_directive = ["mermaid"]
 
 html_theme = "furo"
 html_title = "delta-engine"
+
+# Show object titles as short names (build_engine, class Engine) rather than
+# the fully-qualified definition path. This does not shorten type annotations
+# that resolve to hidden internal modules; those still show their full path.
+add_module_names = False
 
 # sphinx-autoapi documents the package by static analysis: nothing is
 # imported at build time, so pyspark/delta need no mocking.


### PR DESCRIPTION
## What & why

Two quick fixes to the generated API reference, following the site review.

**1. Stale version.** `docs/conf.py` hard-coded `release = "0.1.0"` while the package is at 0.3.x — so the docs metadata (`documentation_options.js`, and anywhere `|release|` is used) advertised the wrong version. Now read dynamically from installed package metadata via `importlib.metadata.version`, matching how `delta_engine.__version__` already works. Release builds from a tag render a clean version; local dev builds show the hatch-vcs dev version.

**2. Fully-qualified object titles.** autoapi rendered object headings with their full definition path (`class delta_engine.Engine`, `delta_engine.databricks.build_engine`). `add_module_names = False` shortens these to `class Engine` / `build_engine`.

### Known remaining leak (not fixed here)

Type *annotations* that reference hidden internal modules still show their full path, e.g. `build_engine(...) -> delta_engine.application.engine.Engine` and `Engine(reader: delta_engine.application.ports.CatalogStateReader, ...)`. `python_use_unqualified_type_names` only shortens annotations that resolve to *documented* objects, and we deliberately hid those internal modules — so it's a no-op here and I left it out rather than ship dead config. Fixing this properly needs the annotations to resolve to public re-export paths, which is a deeper change; it pairs naturally with the upcoming docstring sweep. These leaks are on constructor signatures users don't typically call by hand (`build_engine` is the entry point, not `Engine(...)`).

Verified: clean `sphinx-build -W` passes; object titles shortened; version metadata now `0.3.x`; `mypy docs/conf.py` clean.

## Checklist

- [x] PR title is a Conventional Commit (see comment above)
- [ ] Tests added or updated for behaviour changes (docs-only change)
- [x] Docs updated if public behaviour/architecture/validation changed
- [x] `uv run pytest`, `uv run ruff check .`, `uv run mypy .`, `uv run lint-imports` pass — docs-only; `sphinx-build -W` and `mypy docs/conf.py` pass