### PR TITLE
refactor: split desired and observed column types

### DIFF
--- a/src/delta_engine/adapters/databricks/spark/reader.py
+++ b/src/delta_engine/adapters/databricks/spark/reader.py
@@ -34,7 +34,7 @@ from delta_engine.application.ports import (
     TablePresent,
 )
 from delta_engine.domain.model import (
-    Column as DomainColumn,
+    ObservedColumn,
     ObservedTable,
     QualifiedName,
 )
@@ -51,7 +51,7 @@ _INFORMATION_SCHEMA_MISSING_CONDITIONS: Final[frozenset[str]] = frozenset(
 
 @dataclass(frozen=True, slots=True)
 class _ColumnMapping:
-    column: DomainColumn
+    column: ObservedColumn
     is_partition: bool
 
 

--- a/src/delta_engine/adapters/databricks/sql/rows.py
+++ b/src/delta_engine/adapters/databricks/sql/rows.py
@@ -28,9 +28,9 @@ from typing import Any
 from delta_engine.adapters.databricks.sql.parse import parse_data_type
 from delta_engine.application.properties import DELTA_PROPERTY_REGISTRY
 from delta_engine.domain.model import (
-    Column,
     ForeignKeyConstraint,
     ForeignKeyReference,
+    ObservedColumn,
     PrimaryKeyConstraint,
     QualifiedName,
 )
@@ -46,9 +46,9 @@ def column_from_catalog(
     comment: str,
     is_partition: bool,
     qualified_name: QualifiedName,
-) -> Column | None:
+) -> ObservedColumn | None:
     """
-    Build a domain ``Column`` from catalog-reported facts, or ``None``.
+    Build an ``ObservedColumn`` from catalog-reported facts, or ``None``.
 
     Owns the shared unmappable-type policy for both read backends, so the
     two readers cannot drift apart on it. A column whose type string has no
@@ -85,7 +85,7 @@ def column_from_catalog(
         )
         return None
 
-    return Column(
+    return ObservedColumn(
         name=name.casefold(),
         data_type=data_type,
         nullable=nullable,

--- a/src/delta_engine/adapters/databricks/warehouse/reader.py
+++ b/src/delta_engine/adapters/databricks/warehouse/reader.py
@@ -49,7 +49,7 @@ from delta_engine.application.ports import (
     TablePresent,
 )
 from delta_engine.domain.model import (
-    Column as DomainColumn,
+    ObservedColumn,
     ObservedTable,
     QualifiedName,
 )
@@ -150,8 +150,8 @@ def _describe_detail_row(cursor: Any, qualified_name: QualifiedName) -> Any:
 
 def _to_columns(
     column_rows: Sequence[Any], qualified_name: QualifiedName
-) -> tuple[DomainColumn, ...]:
-    """Map information_schema.columns rows to domain columns, skipping unmappable types."""
+) -> tuple[ObservedColumn, ...]:
+    """Map information_schema.columns rows to observed columns, skipping unmappable types."""
     columns = []
     for row in column_rows:
         column = column_from_catalog(

--- a/src/delta_engine/domain/model/__init__.py
+++ b/src/delta_engine/domain/model/__init__.py
@@ -1,4 +1,4 @@
-from delta_engine.domain.model.column import Column
+from delta_engine.domain.model.column import Column, ObservedColumn
 from delta_engine.domain.model.constraints import (
     ForeignKeyConstraint,
     ForeignKeyReference,
@@ -52,6 +52,7 @@ __all__ = [
     "Integer",
     "Long",
     "Map",
+    "ObservedColumn",
     "ObservedTable",
     "PrimaryKeyConstraint",
     "QualifiedName",

--- a/src/delta_engine/domain/model/column.py
+++ b/src/delta_engine/domain/model/column.py
@@ -7,10 +7,21 @@ from types import MappingProxyType
 from delta_engine.domain.model.data_type import DataType
 
 
+def _validate_column_fields(name: str, tags: Mapping[str, str]) -> None:
+    """Invariants shared by declared and observed columns."""
+    if not name.strip():
+        raise ValueError(f"Column name must not be blank: {name!r}")
+    if name != name.casefold():
+        raise ValueError(f"Column name must be lowercase: {name!r}")
+    for tag_key in tags:
+        if not tag_key.strip():
+            raise ValueError(f"Tag key must not be blank: {tag_key!r}")
+
+
 @dataclass(frozen=True, slots=True)
 class Column:
     """
-    Immutable, case-insensitive column definition.
+    Immutable, case-insensitive column declaration (desired state).
 
     Attributes:
         name: Column name (normalized to lowercase).
@@ -31,13 +42,25 @@ class Column:
 
     def __post_init__(self) -> None:
         object.__setattr__(self, "tags", MappingProxyType(dict(self.tags)))
+        _validate_column_fields(self.name, self.tags)
 
-        if not self.name.strip():
-            raise ValueError(f"Column name must not be blank: {self.name!r}")
 
-        if self.name != self.name.casefold():
-            raise ValueError(f"Column name must be lowercase: {self.name!r}")
+@dataclass(frozen=True, slots=True)
+class ObservedColumn:
+    """
+    Immutable column as observed in the catalog (current state).
 
-        for tag_key in self.tags:
-            if not tag_key.strip():
-                raise ValueError(f"Tag key must not be blank: {tag_key!r}")
+    The observed counterpart of :class:`Column`: the same observable fields,
+    and none of the declaration-only syntax, so catalog state cannot carry
+    declaration history by construction. Only reader adapters build these.
+    """
+
+    name: str
+    data_type: DataType
+    nullable: bool = True
+    comment: str = ""
+    tags: Mapping[str, str] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "tags", MappingProxyType(dict(self.tags)))
+        _validate_column_fields(self.name, self.tags)

--- a/src/delta_engine/domain/model/table.py
+++ b/src/delta_engine/domain/model/table.py
@@ -6,7 +6,7 @@ from enum import Enum, auto
 from types import MappingProxyType
 from typing import Final
 
-from delta_engine.domain.model.column import Column
+from delta_engine.domain.model.column import Column, ObservedColumn
 from delta_engine.domain.model.constraints import (
     ForeignKeyConstraint,
     ForeignKeyReference,
@@ -56,7 +56,7 @@ ALL_ASPECTS: Final[frozenset[TableAspect]] = frozenset(TableAspect)
 
 
 @dataclass(frozen=True, slots=True)
-class TableSnapshot:
+class TableSnapshot[ColumnT: (Column, ObservedColumn)]:
     """
     Immutable snapshot of a table schema.
 
@@ -76,7 +76,7 @@ class TableSnapshot:
     """
 
     qualified_name: QualifiedName
-    columns: tuple[Column, ...]
+    columns: tuple[ColumnT, ...]
     comment: str = ""
     tags: Mapping[str, str] = field(default_factory=dict)
     partitioned_by: tuple[str, ...] = ()
@@ -135,7 +135,7 @@ class TableSnapshot:
 
 
 @dataclass(frozen=True, slots=True)
-class DesiredTable(TableSnapshot):
+class DesiredTable(TableSnapshot[Column]):
     """
     Desired definition authored by users (target state).
 
@@ -221,7 +221,7 @@ class DesiredTable(TableSnapshot):
 
 
 @dataclass(frozen=True, slots=True)
-class ObservedTable(TableSnapshot):
+class ObservedTable(TableSnapshot[ObservedColumn]):
     """
     Observed definition derived from the catalog (current state).
 

--- a/src/delta_engine/domain/plan/changes.py
+++ b/src/delta_engine/domain/plan/changes.py
@@ -71,7 +71,7 @@ class ColumnAdded:
 class ColumnRemoved:
     """A column present in the catalog but absent from the declaration."""
 
-    column: Column
+    column: ObservedColumn
 
     aspect: ClassVar[TableAspect] = TableAspect.COLUMN_STRUCTURE
 

--- a/src/delta_engine/domain/plan/changes.py
+++ b/src/delta_engine/domain/plan/changes.py
@@ -25,7 +25,7 @@ Naming conventions:
 from dataclasses import dataclass
 from typing import ClassVar
 
-from delta_engine.domain.model import Column, TableAspect
+from delta_engine.domain.model import Column, ObservedColumn, TableAspect
 from delta_engine.domain.model.constraints import (
     ForeignKeyConstraint,
     ForeignKeyReference,

--- a/src/delta_engine/domain/plan/diff.py
+++ b/src/delta_engine/domain/plan/diff.py
@@ -161,13 +161,13 @@ def _diff_column_structure(desired: DesiredTable, observed: ObservedTable) -> li
     observed_by_name = {column.name: column for column in observed.columns}
     changes: list[Change] = []
 
-    for name, column in desired_by_name.items():
+    for name, desired_only_column in desired_by_name.items():
         if name not in observed_by_name:
-            changes.append(ColumnAdded(column=column))
+            changes.append(ColumnAdded(column=desired_only_column))
 
-    for name, column in observed_by_name.items():
+    for name, observed_only_column in observed_by_name.items():
         if name not in desired_by_name:
-            changes.append(ColumnRemoved(column=column))
+            changes.append(ColumnRemoved(column=observed_only_column))
 
     for name, desired_column in desired_by_name.items():
         observed_column = observed_by_name.get(name)

--- a/tests/application/test_ports.py
+++ b/tests/application/test_ports.py
@@ -10,7 +10,7 @@ from delta_engine.application.ports import (
     TableAbsent,
     TablePresent,
 )
-from delta_engine.domain.model import Column, Integer, ObservedTable, QualifiedName
+from delta_engine.domain.model import Integer, ObservedColumn, ObservedTable, QualifiedName
 
 # ---------- test builders
 
@@ -19,7 +19,7 @@ def _an_observed_table(partitioned_by=()):
     """Build a real ObservedTable, so reports are exercised against the domain type."""
     return ObservedTable(
         qualified_name=QualifiedName("cat", "schema", "observed"),
-        columns=(Column("id", Integer()),),
+        columns=(ObservedColumn("id", Integer()),),
         partitioned_by=partitioned_by,
     )
 

--- a/tests/application/test_report.py
+++ b/tests/application/test_report.py
@@ -21,7 +21,14 @@ from delta_engine.application.report import (
     TableRunReport,
     TableRunStatus,
 )
-from delta_engine.domain.model import Column, DesiredTable, Integer, ObservedTable, QualifiedName
+from delta_engine.domain.model import (
+    Column,
+    DesiredTable,
+    Integer,
+    ObservedColumn,
+    ObservedTable,
+    QualifiedName,
+)
 from delta_engine.domain.plan.actions import ActionPlan, SetTableComment
 
 # ---------- test builders
@@ -31,7 +38,7 @@ def _an_observed_table(partitioned_by=()):
     """Build a real ObservedTable, so reports are exercised against the domain type."""
     return ObservedTable(
         qualified_name=QualifiedName("cat", "schema", "observed"),
-        columns=(Column("id", Integer()),),
+        columns=(ObservedColumn("id", Integer()),),
         partitioned_by=partitioned_by,
     )
 

--- a/tests/application/test_validation.py
+++ b/tests/application/test_validation.py
@@ -20,6 +20,7 @@ from delta_engine.domain.model import (
     ForeignKeyReference,
     Integer,
     Long,
+    ObservedColumn,
     ObservedTable,
     PrimaryKeyConstraint,
     QualifiedName,
@@ -67,6 +68,17 @@ def _desired_table(
     )
 
 
+def _as_observed(column: Column | ObservedColumn) -> ObservedColumn:
+    """Coerce a column written as ``Column`` into the observed-state type."""
+    return ObservedColumn(
+        name=column.name,
+        data_type=column.data_type,
+        nullable=column.nullable,
+        comment=column.comment,
+        tags=column.tags,
+    )
+
+
 def _observed_table(
     *,
     columns: tuple[Column, ...] | None = None,
@@ -74,9 +86,10 @@ def _observed_table(
     partitioned_by: tuple[str, ...] = (),
     clustered_by: tuple[str, ...] = (),
 ) -> ObservedTable:
+    source = (Column("id", Integer()),) if columns is None else columns
     return ObservedTable(
         qualified_name=_QUALIFIED_NAME,
-        columns=(Column("id", Integer()),) if columns is None else columns,
+        columns=tuple(_as_observed(column) for column in source),
         properties={} if properties is None else properties,
         partitioned_by=partitioned_by,
         clustered_by=clustered_by,
@@ -972,7 +985,7 @@ def test_undeclared_rename_guard_blocks_same_type_drop_and_add():
     # Given a diff that drops one String column and adds another
     drift = _drift(
         ColumnAdded(column=Column("customer_name", String())),
-        ColumnRemoved(column=Column("customer_nm", String())),
+        ColumnRemoved(column=ObservedColumn("customer_nm", String())),
     )
 
     # When / Then the guard flags the pair as a possible rename
@@ -986,7 +999,7 @@ def test_undeclared_rename_guard_blocks_widenable_type_drop_and_add():
     # An undeclared rename-plus-widen (Integer -> Long) is just as destructive
     drift = _drift(
         ColumnAdded(column=Column("amount", Long())),
-        ColumnRemoved(column=Column("amt", Integer())),
+        ColumnRemoved(column=ObservedColumn("amt", Integer())),
     )
 
     assert _undeclared_rename_failures(validate_diff(drift))
@@ -996,14 +1009,14 @@ def test_undeclared_rename_guard_allows_incompatible_type_drop_and_add():
     # Integer removed, String added: cannot be a rename, so no guard failure
     drift = _drift(
         ColumnAdded(column=Column("label", String())),
-        ColumnRemoved(column=Column("amt", Integer())),
+        ColumnRemoved(column=ObservedColumn("amt", Integer())),
     )
 
     assert not _undeclared_rename_failures(validate_diff(drift))
 
 
 def test_undeclared_rename_guard_allows_lone_drop_and_lone_add():
-    drop_only = _drift(ColumnRemoved(column=Column("old", String())))
+    drop_only = _drift(ColumnRemoved(column=ObservedColumn("old", String())))
     add_only = _drift(ColumnAdded(column=Column("new", String())))
 
     for drift in (drop_only, add_only):

--- a/tests/domain/model/test_column.py
+++ b/tests/domain/model/test_column.py
@@ -1,6 +1,6 @@
 import pytest
 
-from delta_engine.domain.model.column import Column
+from delta_engine.domain.model.column import Column, ObservedColumn
 from delta_engine.domain.model.data_type import Integer
 
 
@@ -57,3 +57,16 @@ def test_raises_when_tag_key_is_blank(blank: str) -> None:
     # When/Then: constructing a Column fails
     with pytest.raises(ValueError, match="Tag key must not be blank"):
         Column("id", Integer(), tags={blank: "v"})
+
+
+def test_observed_column_enforces_the_same_field_invariants_as_column() -> None:
+    # Given/Then: blank and non-lowercase names are rejected, like Column
+    with pytest.raises(ValueError, match="blank"):
+        ObservedColumn("  ", Integer())
+    with pytest.raises(ValueError, match="lowercase"):
+        ObservedColumn("Amount", Integer())
+
+    # And a well-formed observed column carries the observable fields
+    column = ObservedColumn("amount", Integer(), nullable=False, comment="c", tags={"k": "v"})
+    assert (column.name, column.nullable, column.comment) == ("amount", False, "c")
+    assert dict(column.tags) == {"k": "v"}

--- a/tests/domain/plan/test_diff.py
+++ b/tests/domain/plan/test_diff.py
@@ -7,6 +7,7 @@ from delta_engine.domain.model import (
     ForeignKeyReference,
     Integer,
     Long,
+    ObservedColumn,
     ObservedTable,
     QualifiedName,
     String,
@@ -70,9 +71,22 @@ def _desired(**overrides) -> DesiredTable:
     return DesiredTable(**{**defaults, **overrides})
 
 
+def _as_observed(column: Column | ObservedColumn) -> ObservedColumn:
+    """Coerce a column written as ``Column`` into the observed-state type."""
+    return ObservedColumn(
+        name=column.name,
+        data_type=column.data_type,
+        nullable=column.nullable,
+        comment=column.comment,
+        tags=column.tags,
+    )
+
+
 def _observed(**overrides) -> ObservedTable:
-    defaults = dict(qualified_name=_QUALIFIED_NAME, columns=(Column("id", Integer()),))
-    return ObservedTable(**{**defaults, **overrides})
+    defaults = dict(qualified_name=_QUALIFIED_NAME, columns=(ObservedColumn("id", Integer()),))
+    merged = {**defaults, **overrides}
+    merged["columns"] = tuple(_as_observed(column) for column in merged["columns"])
+    return ObservedTable(**merged)
 
 
 def _foreign_key(constraint_name: str = "test_id_fk") -> ForeignKeyConstraint:
@@ -152,7 +166,7 @@ def test_observed_only_column_produces_column_removed_change():
 
     # Then a ColumnRemoved change is produced
     assert isinstance(diff, TableDrift)
-    assert diff.changes == (ColumnRemoved(Column("stale", String())),)
+    assert diff.changes == (ColumnRemoved(ObservedColumn("stale", String())),)
 
 
 def test_type_drift_produces_column_data_type_changed():
@@ -596,7 +610,9 @@ def test_column_added_produces_add_column_only():
 
 
 def test_column_removed_produces_drop_column():
-    assert ColumnRemoved(column=Column("stale", Integer())).actions() == (DropColumn("stale"),)
+    assert ColumnRemoved(column=ObservedColumn("stale", Integer())).actions() == (
+        DropColumn("stale"),
+    )
 
 
 def test_column_data_type_changed_lowers_to_alter_column_type():
@@ -943,7 +959,7 @@ def test_changed_foreign_key_signature_produces_remove_and_add_changes():
 
 def test_observed_only_column_tags_are_ignored_because_column_is_removed():
     # Given an observed-only column that also has catalog tags
-    observed_only_column = Column("stale", Integer(), tags={"old": "true"})
+    observed_only_column = ObservedColumn("stale", Integer(), tags={"old": "true"})
 
     # When diffing
     diff = diff_table(


### PR DESCRIPTION
Pure refactor (PR 2 of 3 for column renames; design in `docs/superpowers/specs/2026-07-12-column-renames-design.md`). **Stacked on #210** — review/merge that first.

Observed catalog state gets its own `ObservedColumn` type, so the declaration-only `renamed_from` field added in PR 3 is unrepresentable on catalog state by construction.

## What changed
- New `ObservedColumn` domain type; `TableSnapshot` becomes generic (`TableSnapshot[ColumnT: (Column, ObservedColumn)]`), with `DesiredTable` = `TableSnapshot[Column]` and `ObservedTable` = `TableSnapshot[ObservedColumn]`.
- `ColumnRemoved.column` retyped to `ObservedColumn`; shared field validation factored into `_validate_column_fields`.
- Both Databricks readers construct `ObservedColumn`. Reader tests are unchanged — they assert on attributes, not type identity.

No behaviour change.

## Scope note (fixtures)
Observed *builders* in the diff/validation/report/ports tests now emit `ObservedColumn`, as do all `ColumnRemoved` assertions. Inline fixtures that reuse a shared `Column` constant or a desired table's own `.columns` (to mean "observed already equals desired") are left as `Column`: mypy-clean and runtime-correct, and splitting them buys no type-safety.

## Verification
- `uv run pytest` — 761 passed, 98.46% coverage
- `uv run ruff check .`, `uv run mypy .`, `uv run lint-imports` — all clean
- docs build warning-clean