### PR TITLE
refactor: split desired and observed column types

### DIFF
--- a/src/delta_engine/adapters/databricks/spark/reader.py
+++ b/src/delta_engine/adapters/databricks/spark/reader.py
@@ -59,7 +59,7 @@ def _to_column_mapping(
     spark_column: SparkColumn, qualified_name: QualifiedName
 ) -> _ColumnMapping | None:
     """
-    Convert a Spark catalog column into a domain ``Column`` and its partition flag.
+    Convert a Spark catalog column into an ``ObservedColumn`` and its partition flag.
 
     Unity Catalog reports a column's type as a DDL string (e.g. ``"array<int>"``),
     the same shape information_schema gives the warehouse backend, so both

--- a/src/delta_engine/adapters/databricks/spark/reader.py
+++ b/src/delta_engine/adapters/databricks/spark/reader.py
@@ -34,7 +34,7 @@ from delta_engine.application.ports import (
     TablePresent,
 )
 from delta_engine.domain.model import (
-    Column as DomainColumn,
+    ObservedColumn,
     ObservedTable,
     QualifiedName,
 )
@@ -51,7 +51,7 @@ _INFORMATION_SCHEMA_MISSING_CONDITIONS: Final[frozenset[str]] = frozenset(
 
 @dataclass(frozen=True, slots=True)
 class _ColumnMapping:
-    column: DomainColumn
+    column: ObservedColumn
     is_partition: bool
 
 

--- a/src/delta_engine/adapters/databricks/sql/rows.py
+++ b/src/delta_engine/adapters/databricks/sql/rows.py
@@ -28,9 +28,9 @@ from typing import Any
 from delta_engine.adapters.databricks.sql.parse import parse_data_type
 from delta_engine.application.properties import DELTA_PROPERTY_REGISTRY
 from delta_engine.domain.model import (
-    Column,
     ForeignKeyConstraint,
     ForeignKeyReference,
+    ObservedColumn,
     PrimaryKeyConstraint,
     QualifiedName,
 )
@@ -46,9 +46,9 @@ def column_from_catalog(
     comment: str,
     is_partition: bool,
     qualified_name: QualifiedName,
-) -> Column | None:
+) -> ObservedColumn | None:
     """
-    Build a domain ``Column`` from catalog-reported facts, or ``None``.
+    Build an ``ObservedColumn`` from catalog-reported facts, or ``None``.
 
     Owns the shared unmappable-type policy for both read backends, so the
     two readers cannot drift apart on it. A column whose type string has no
@@ -85,7 +85,7 @@ def column_from_catalog(
         )
         return None
 
-    return Column(
+    return ObservedColumn(
         name=name.casefold(),
         data_type=data_type,
         nullable=nullable,

--- a/src/delta_engine/adapters/databricks/warehouse/reader.py
+++ b/src/delta_engine/adapters/databricks/warehouse/reader.py
@@ -49,7 +49,7 @@ from delta_engine.application.ports import (
     TablePresent,
 )
 from delta_engine.domain.model import (
-    Column as DomainColumn,
+    ObservedColumn,
     ObservedTable,
     QualifiedName,
 )
@@ -150,8 +150,8 @@ def _describe_detail_row(cursor: Any, qualified_name: QualifiedName) -> Any:
 
 def _to_columns(
     column_rows: Sequence[Any], qualified_name: QualifiedName
-) -> tuple[DomainColumn, ...]:
-    """Map information_schema.columns rows to domain columns, skipping unmappable types."""
+) -> tuple[ObservedColumn, ...]:
+    """Map information_schema.columns rows to observed columns, skipping unmappable types."""
     columns = []
     for row in column_rows:
         column = column_from_catalog(

--- a/src/delta_engine/domain/model/__init__.py
+++ b/src/delta_engine/domain/model/__init__.py
@@ -1,4 +1,4 @@
-from delta_engine.domain.model.column import Column
+from delta_engine.domain.model.column import Column, ObservedColumn
 from delta_engine.domain.model.constraints import (
     ForeignKeyConstraint,
     ForeignKeyReference,
@@ -52,6 +52,7 @@ __all__ = [
     "Integer",
     "Long",
     "Map",
+    "ObservedColumn",
     "ObservedTable",
     "PrimaryKeyConstraint",
     "QualifiedName",

--- a/src/delta_engine/domain/model/column.py
+++ b/src/delta_engine/domain/model/column.py
@@ -7,10 +7,21 @@ from types import MappingProxyType
 from delta_engine.domain.model.data_type import DataType
 
 
+def _validate_column_fields(name: str, tags: Mapping[str, str]) -> None:
+    """Invariants shared by declared and observed columns."""
+    if not name.strip():
+        raise ValueError(f"Column name must not be blank: {name!r}")
+    if name != name.casefold():
+        raise ValueError(f"Column name must be lowercase: {name!r}")
+    for tag_key in tags:
+        if not tag_key.strip():
+            raise ValueError(f"Tag key must not be blank: {tag_key!r}")
+
+
 @dataclass(frozen=True, slots=True)
 class Column:
     """
-    Immutable, case-insensitive column definition.
+    Immutable, case-insensitive column declaration (desired state).
 
     Attributes:
         name: Column name (normalized to lowercase).
@@ -31,13 +42,25 @@ class Column:
 
     def __post_init__(self) -> None:
         object.__setattr__(self, "tags", MappingProxyType(dict(self.tags)))
+        _validate_column_fields(self.name, self.tags)
 
-        if not self.name.strip():
-            raise ValueError(f"Column name must not be blank: {self.name!r}")
 
-        if self.name != self.name.casefold():
-            raise ValueError(f"Column name must be lowercase: {self.name!r}")
+@dataclass(frozen=True, slots=True)
+class ObservedColumn:
+    """
+    Immutable column as observed in the catalog (current state).
 
-        for tag_key in self.tags:
-            if not tag_key.strip():
-                raise ValueError(f"Tag key must not be blank: {tag_key!r}")
+    The observed counterpart of :class:`Column`: the same observable fields,
+    and none of the declaration-only syntax, so catalog state cannot carry
+    declaration history by construction. Only reader adapters build these.
+    """
+
+    name: str
+    data_type: DataType
+    nullable: bool = True
+    comment: str = ""
+    tags: Mapping[str, str] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "tags", MappingProxyType(dict(self.tags)))
+        _validate_column_fields(self.name, self.tags)

--- a/src/delta_engine/domain/model/table.py
+++ b/src/delta_engine/domain/model/table.py
@@ -6,7 +6,7 @@ from enum import Enum, auto
 from types import MappingProxyType
 from typing import Final
 
-from delta_engine.domain.model.column import Column
+from delta_engine.domain.model.column import Column, ObservedColumn
 from delta_engine.domain.model.constraints import (
     ForeignKeyConstraint,
     ForeignKeyReference,
@@ -56,7 +56,7 @@ ALL_ASPECTS: Final[frozenset[TableAspect]] = frozenset(TableAspect)
 
 
 @dataclass(frozen=True, slots=True)
-class TableSnapshot:
+class TableSnapshot[ColumnT: (Column, ObservedColumn)]:
     """
     Immutable snapshot of a table schema.
 
@@ -76,7 +76,7 @@ class TableSnapshot:
     """
 
     qualified_name: QualifiedName
-    columns: tuple[Column, ...]
+    columns: tuple[ColumnT, ...]
     comment: str = ""
     tags: Mapping[str, str] = field(default_factory=dict)
     partitioned_by: tuple[str, ...] = ()
@@ -135,7 +135,7 @@ class TableSnapshot:
 
 
 @dataclass(frozen=True, slots=True)
-class DesiredTable(TableSnapshot):
+class DesiredTable(TableSnapshot[Column]):
     """
     Desired definition authored by users (target state).
 
@@ -221,7 +221,7 @@ class DesiredTable(TableSnapshot):
 
 
 @dataclass(frozen=True, slots=True)
-class ObservedTable(TableSnapshot):
+class ObservedTable(TableSnapshot[ObservedColumn]):
     """
     Observed definition derived from the catalog (current state).
 

--- a/src/delta_engine/domain/model/table.py
+++ b/src/delta_engine/domain/model/table.py
@@ -62,7 +62,8 @@ class TableSnapshot[ColumnT: (Column, ObservedColumn)]:
 
     Attributes:
         qualified_name: Fully qualified table name.
-        columns: Ordered tuple of ``Column`` definitions.
+        columns: Ordered tuple of column definitions — ``Column`` on desired
+            tables, ``ObservedColumn`` on observed tables.
         comment: Optional table-level comment (empty string when unset).
         tags: Read-only mapping of Unity Catalog tag keys to values.
         partitioned_by: Ordered tuple of partition column names.

--- a/src/delta_engine/domain/plan/changes.py
+++ b/src/delta_engine/domain/plan/changes.py
@@ -71,7 +71,7 @@ class ColumnAdded:
 class ColumnRemoved:
     """A column present in the catalog but absent from the declaration."""
 
-    column: Column
+    column: ObservedColumn
 
     aspect: ClassVar[TableAspect] = TableAspect.COLUMN_STRUCTURE
 

--- a/src/delta_engine/domain/plan/changes.py
+++ b/src/delta_engine/domain/plan/changes.py
@@ -25,7 +25,7 @@ Naming conventions:
 from dataclasses import dataclass
 from typing import ClassVar
 
-from delta_engine.domain.model import Column, TableAspect
+from delta_engine.domain.model import Column, ObservedColumn, TableAspect
 from delta_engine.domain.model.constraints import (
     ForeignKeyConstraint,
     ForeignKeyReference,

--- a/src/delta_engine/domain/plan/diff.py
+++ b/src/delta_engine/domain/plan/diff.py
@@ -161,13 +161,13 @@ def _diff_column_structure(desired: DesiredTable, observed: ObservedTable) -> li
     observed_by_name = {column.name: column for column in observed.columns}
     changes: list[Change] = []
 
-    for name, column in desired_by_name.items():
+    for name, desired_only_column in desired_by_name.items():
         if name not in observed_by_name:
-            changes.append(ColumnAdded(column=column))
+            changes.append(ColumnAdded(column=desired_only_column))
 
-    for name, column in observed_by_name.items():
+    for name, observed_only_column in observed_by_name.items():
         if name not in desired_by_name:
-            changes.append(ColumnRemoved(column=column))
+            changes.append(ColumnRemoved(column=observed_only_column))
 
     for name, desired_column in desired_by_name.items():
         observed_column = observed_by_name.get(name)

--- a/tests/api/test_foreign_key.py
+++ b/tests/api/test_foreign_key.py
@@ -468,10 +468,11 @@ def test_reordering_the_parent_primary_key_produces_no_foreign_key_drift():
     assert before.foreign_keys == after.foreign_keys
 
     from delta_engine.domain.model import ObservedTable
+    from tests.builders import as_observed_columns
 
     observed = ObservedTable(
         qualified_name=before.qualified_name,
-        columns=before.columns,
+        columns=as_observed_columns(before.columns),
         foreign_keys=before.foreign_keys,
     )
     diff = diff_table(after, observed)

--- a/tests/application/test_engine.py
+++ b/tests/application/test_engine.py
@@ -24,7 +24,7 @@ from delta_engine.application.report import (
     TableRunReport,
     TableRunStatus,
 )
-from delta_engine.domain.model import ObservedTable, QualifiedName
+from delta_engine.domain.model import ObservedColumn, ObservedTable, QualifiedName
 from delta_engine.domain.model.constraints import PrimaryKeyConstraint
 from delta_engine.domain.plan import ActionPlan
 from delta_engine.domain.plan.actions import (
@@ -37,6 +37,7 @@ from delta_engine.domain.plan.actions import (
     UnsetTableTag,
 )
 from delta_engine.schema import Column, DeltaTable, ForeignKey, String
+from tests.builders import as_observed_columns
 
 # ---------------------------------------------------------------------------
 # Helpers and fakes
@@ -137,7 +138,7 @@ def _existing_id_table(fqn: str) -> TablePresent:
     return TablePresent(
         table=ObservedTable(
             qualified_name=QualifiedName(catalog, schema, table_name),
-            columns=(Column("id", String()),),
+            columns=(ObservedColumn("id", String()),),
         )
     )
 
@@ -149,7 +150,7 @@ def _existing_id_table_synced(fqn: str) -> TablePresent:
     return TablePresent(
         table=ObservedTable(
             qualified_name=QualifiedName(catalog, schema, table_name),
-            columns=(Column("id", String(), nullable=False),),
+            columns=(ObservedColumn("id", String(), nullable=False),),
             primary_key=PrimaryKeyConstraint.generate(
                 table_name=table_name,
                 columns=("id",),
@@ -165,7 +166,7 @@ def _existing_fk_table_synced(fqn: str, references: str) -> TablePresent:
     return TablePresent(
         table=ObservedTable(
             qualified_name=desired.qualified_name,
-            columns=desired.columns,
+            columns=as_observed_columns(desired.columns),
             primary_key=desired.primary_key,
             foreign_keys=desired.foreign_keys,
         )
@@ -207,7 +208,7 @@ def _existing_matching_table(fqn: str) -> TablePresent:
     return TablePresent(
         table=ObservedTable(
             qualified_name=QualifiedName(catalog, schema, table_name),
-            columns=(Column("id", String()),),
+            columns=(ObservedColumn("id", String()),),
         )
     )
 
@@ -219,7 +220,7 @@ def _existing_tag_drifted_table(fqn: str) -> TablePresent:
     return TablePresent(
         table=ObservedTable(
             qualified_name=QualifiedName(catalog, schema, table_name),
-            columns=(Column("id", String(), tags={"stale": "true"}),),
+            columns=(ObservedColumn("id", String(), tags={"stale": "true"}),),
             tags={"legacy": "yes"},
         )
     )
@@ -1290,7 +1291,7 @@ def test_sync_fails_at_validation_when_dropping_column_without_column_mapping():
             fqn: TablePresent(
                 table=ObservedTable(
                     qualified_name=QualifiedName(catalog, schema, name),
-                    columns=(Column("id", String()), Column("stale", String())),
+                    columns=(ObservedColumn("id", String()), ObservedColumn("stale", String())),
                 )
             )
         }
@@ -1317,7 +1318,7 @@ def test_sync_fails_loud_on_undeclared_registered_property():
             fqn: TablePresent(
                 table=ObservedTable(
                     qualified_name=QualifiedName(catalog, schema, name),
-                    columns=(Column("id", String()),),
+                    columns=(ObservedColumn("id", String()),),
                     properties={"delta.columnMapping.mode": "name"},
                 )
             )
@@ -1344,7 +1345,7 @@ def test_metadata_scoped_column_removal_fails_without_drop_precondition():
             fqn: TablePresent(
                 table=ObservedTable(
                     qualified_name=QualifiedName(catalog, schema, name),
-                    columns=(Column("id", String()), Column("extra", String())),
+                    columns=(ObservedColumn("id", String()), ObservedColumn("extra", String())),
                 )
             )
         }

--- a/tests/application/test_ports.py
+++ b/tests/application/test_ports.py
@@ -10,7 +10,7 @@ from delta_engine.application.ports import (
     TableAbsent,
     TablePresent,
 )
-from delta_engine.domain.model import Column, Integer, ObservedTable, QualifiedName
+from delta_engine.domain.model import Integer, ObservedColumn, ObservedTable, QualifiedName
 
 # ---------- test builders
 
@@ -19,7 +19,7 @@ def _an_observed_table(partitioned_by=()):
     """Build a real ObservedTable, so reports are exercised against the domain type."""
     return ObservedTable(
         qualified_name=QualifiedName("cat", "schema", "observed"),
-        columns=(Column("id", Integer()),),
+        columns=(ObservedColumn("id", Integer()),),
         partitioned_by=partitioned_by,
     )
 

--- a/tests/application/test_rendering.py
+++ b/tests/application/test_rendering.py
@@ -30,6 +30,7 @@ from delta_engine.domain.model import (
     DesiredTable,
     Integer,
     Long,
+    ObservedColumn,
     ObservedTable,
     PrimaryKeyConstraint,
     QualifiedName,
@@ -257,7 +258,9 @@ def test_every_action_type_has_registered_diff_entries():
 def _report_with_empty_plan_and_failure() -> TableRunReport:
     qualified_name = QualifiedName("dev", "silver", "orders")
     desired = DesiredTable(qualified_name=qualified_name, columns=(Column("id", Integer()),))
-    observed = ObservedTable(qualified_name=qualified_name, columns=(Column("id", Integer()),))
+    observed = ObservedTable(
+        qualified_name=qualified_name, columns=(ObservedColumn("id", Integer()),)
+    )
     return TableRunReport(
         qualified_name=qualified_name,
         desired=desired,
@@ -347,7 +350,11 @@ def _grid_report(name, *, plan=None, failures=()):
     return TableRunReport(
         qualified_name=qualified_name,
         desired=DesiredTable(qualified_name=qualified_name, columns=columns),
-        read=TablePresent(table=ObservedTable(qualified_name=qualified_name, columns=columns)),
+        read=TablePresent(
+            table=ObservedTable(
+                qualified_name=qualified_name, columns=(ObservedColumn("id", Integer()),)
+            )
+        ),
         plan=plan,
         # One fake statement per action, as the engine would have compiled.
         planned_sql_statements=tuple(f"SQL {index}" for index in range(len(plan))),

--- a/tests/application/test_report.py
+++ b/tests/application/test_report.py
@@ -21,7 +21,14 @@ from delta_engine.application.report import (
     TableRunReport,
     TableRunStatus,
 )
-from delta_engine.domain.model import Column, DesiredTable, Integer, ObservedTable, QualifiedName
+from delta_engine.domain.model import (
+    Column,
+    DesiredTable,
+    Integer,
+    ObservedColumn,
+    ObservedTable,
+    QualifiedName,
+)
 from delta_engine.domain.plan.actions import ActionPlan, SetTableComment
 
 # ---------- test builders
@@ -31,7 +38,7 @@ def _an_observed_table(partitioned_by=()):
     """Build a real ObservedTable, so reports are exercised against the domain type."""
     return ObservedTable(
         qualified_name=QualifiedName("cat", "schema", "observed"),
-        columns=(Column("id", Integer()),),
+        columns=(ObservedColumn("id", Integer()),),
         partitioned_by=partitioned_by,
     )
 

--- a/tests/application/test_validation.py
+++ b/tests/application/test_validation.py
@@ -46,6 +46,7 @@ from delta_engine.domain.plan.diff import (
     TableMissing,
     diff_table,
 )
+from tests.builders import as_observed_columns
 
 _QUALIFIED_NAME = QualifiedName("dev", "silver", "test")
 
@@ -68,17 +69,6 @@ def _desired_table(
     )
 
 
-def _as_observed(column: Column | ObservedColumn) -> ObservedColumn:
-    """Coerce a column written as ``Column`` into the observed-state type."""
-    return ObservedColumn(
-        name=column.name,
-        data_type=column.data_type,
-        nullable=column.nullable,
-        comment=column.comment,
-        tags=column.tags,
-    )
-
-
 def _observed_table(
     *,
     columns: tuple[Column, ...] | None = None,
@@ -89,7 +79,7 @@ def _observed_table(
     source = (Column("id", Integer()),) if columns is None else columns
     return ObservedTable(
         qualified_name=_QUALIFIED_NAME,
-        columns=tuple(_as_observed(column) for column in source),
+        columns=as_observed_columns(source),
         properties={} if properties is None else properties,
         partitioned_by=partitioned_by,
         clustered_by=clustered_by,
@@ -692,7 +682,7 @@ def test_tag_only_scope_passes_when_only_table_and_column_tags_drift():
     )
     observed = ObservedTable(
         qualified_name=_QUALIFIED_NAME,
-        columns=(Column("id", Integer(), tags={"pii": "true"}),),
+        columns=(ObservedColumn("id", Integer(), tags={"pii": "true"}),),
         tags={"legacy": "yes"},
     )
 

--- a/tests/application/test_validation.py
+++ b/tests/application/test_validation.py
@@ -20,6 +20,7 @@ from delta_engine.domain.model import (
     ForeignKeyReference,
     Integer,
     Long,
+    ObservedColumn,
     ObservedTable,
     PrimaryKeyConstraint,
     QualifiedName,
@@ -67,6 +68,17 @@ def _desired_table(
     )
 
 
+def _as_observed(column: Column | ObservedColumn) -> ObservedColumn:
+    """Coerce a column written as ``Column`` into the observed-state type."""
+    return ObservedColumn(
+        name=column.name,
+        data_type=column.data_type,
+        nullable=column.nullable,
+        comment=column.comment,
+        tags=column.tags,
+    )
+
+
 def _observed_table(
     *,
     columns: tuple[Column, ...] | None = None,
@@ -74,9 +86,10 @@ def _observed_table(
     partitioned_by: tuple[str, ...] = (),
     clustered_by: tuple[str, ...] = (),
 ) -> ObservedTable:
+    source = (Column("id", Integer()),) if columns is None else columns
     return ObservedTable(
         qualified_name=_QUALIFIED_NAME,
-        columns=(Column("id", Integer()),) if columns is None else columns,
+        columns=tuple(_as_observed(column) for column in source),
         properties={} if properties is None else properties,
         partitioned_by=partitioned_by,
         clustered_by=clustered_by,

--- a/tests/builders.py
+++ b/tests/builders.py
@@ -1,0 +1,26 @@
+"""Shared test builders for observed catalog state."""
+
+from collections.abc import Iterable
+
+from delta_engine.domain.model import Column, ObservedColumn
+
+
+def as_observed_columns(
+    columns: Iterable[Column | ObservedColumn],
+) -> tuple[ObservedColumn, ...]:
+    """
+    Project columns to their observed catalog image.
+
+    Mirrors what a catalog read-back reports: the observable fields only.
+    Declaration-only syntax on ``Column`` does not survive the projection.
+    """
+    return tuple(
+        ObservedColumn(
+            name=column.name,
+            data_type=column.data_type,
+            nullable=column.nullable,
+            comment=column.comment,
+            tags=column.tags,
+        )
+        for column in columns
+    )

--- a/tests/domain/model/test_column.py
+++ b/tests/domain/model/test_column.py
@@ -1,6 +1,6 @@
 import pytest
 
-from delta_engine.domain.model.column import Column
+from delta_engine.domain.model.column import Column, ObservedColumn
 from delta_engine.domain.model.data_type import Integer
 
 
@@ -57,3 +57,16 @@ def test_raises_when_tag_key_is_blank(blank: str) -> None:
     # When/Then: constructing a Column fails
     with pytest.raises(ValueError, match="Tag key must not be blank"):
         Column("id", Integer(), tags={blank: "v"})
+
+
+def test_observed_column_enforces_the_same_field_invariants_as_column() -> None:
+    # Given/Then: blank and non-lowercase names are rejected, like Column
+    with pytest.raises(ValueError, match="blank"):
+        ObservedColumn("  ", Integer())
+    with pytest.raises(ValueError, match="lowercase"):
+        ObservedColumn("Amount", Integer())
+
+    # And a well-formed observed column carries the observable fields
+    column = ObservedColumn("amount", Integer(), nullable=False, comment="c", tags={"k": "v"})
+    assert (column.name, column.nullable, column.comment) == ("amount", False, "c")
+    assert dict(column.tags) == {"k": "v"}

--- a/tests/domain/model/test_table.py
+++ b/tests/domain/model/test_table.py
@@ -7,6 +7,7 @@ from delta_engine.domain.model import (
     DesiredTable,
     ForeignKeyReference,
     Integer,
+    ObservedColumn,
     ObservedTable,
     QualifiedName,
     String,
@@ -14,10 +15,12 @@ from delta_engine.domain.model import (
     TableSnapshot,
 )
 from delta_engine.domain.model.constraints import ForeignKeyConstraint, PrimaryKeyConstraint
+from tests.builders import as_observed_columns
 
 _QUALIFIED_NAME = QualifiedName("dev", "silver", "orders")
 _QN = QualifiedName("c", "s", "orders")
 _COL = Column("id", Integer(), nullable=False)
+_OBSERVED_COL = ObservedColumn("id", Integer(), nullable=False)
 
 
 def test_fails_when_no_columns_defined():
@@ -87,7 +90,7 @@ def test_primary_key_columns_returns_the_constraint_columns():
     # Given a table with a two-column primary key
     table = ObservedTable(
         qualified_name=_QN,
-        columns=(Column("id", Integer()), Column("tenant_id", Integer())),
+        columns=(ObservedColumn("id", Integer()), ObservedColumn("tenant_id", Integer())),
         primary_key=PrimaryKeyConstraint(columns=("id", "tenant_id"), constraint_name="t_pk"),
     )
 
@@ -112,7 +115,7 @@ def test_observed_table_has_primary_key_field():
     # Given an ObservedTable constructed with a primary key
     table = ObservedTable(
         qualified_name=_QN,
-        columns=(_COL,),
+        columns=(_OBSERVED_COL,),
         primary_key=PrimaryKeyConstraint(columns=("id",), constraint_name="t_pk"),
     )
 
@@ -151,7 +154,7 @@ def test_observed_table_allows_a_nullable_primary_key_column():
     # Given an ObservedTable read from a legacy catalog where a PK column is nullable
     table = ObservedTable(
         qualified_name=_QN,
-        columns=(Column("id", Integer(), nullable=True),),
+        columns=(ObservedColumn("id", Integer(), nullable=True),),
         primary_key=PrimaryKeyConstraint(columns=("id",), constraint_name="t_pk"),
     )
 
@@ -359,7 +362,7 @@ def test_observed_table_allows_two_foreign_keys_over_the_same_local_columns():
     # When building an ObservedTable with both
     observed = ObservedTable(
         qualified_name=QualifiedName("cat", "sch", "orders"),
-        columns=(Column("customer_id", Integer()),),
+        columns=(ObservedColumn("customer_id", Integer()),),
         foreign_keys=(fk_one, fk_two),
     )
 
@@ -417,7 +420,7 @@ def test_observed_table_stores_tags():
     # Given an ObservedTable read from a catalog carrying a tag
     table = ObservedTable(
         qualified_name=_QN,
-        columns=(_COL,),
+        columns=(_OBSERVED_COL,),
         tags={"env": "prod"},
     )
 
@@ -478,7 +481,7 @@ def test_observed_table_properties_carry_values_only():
     # Given an observed table — the catalog has values, never assertions
     observed = ObservedTable(
         qualified_name=_QUALIFIED_NAME,
-        columns=(_COL,),
+        columns=(_OBSERVED_COL,),
         properties={"delta.enableChangeDataFeed": "true"},
     )
 
@@ -495,7 +498,7 @@ def test_domain_tables_accept_backend_specific_partition_layouts() -> None:
     )
     observed = ObservedTable(
         qualified_name=QualifiedName("dev", "silver", "orders"),
-        columns=(Column("id", Integer()), Column("day", Date())),
+        columns=(ObservedColumn("id", Integer()), ObservedColumn("day", Date())),
         partitioned_by=("id", "day"),
     )
     assert desired.partitioned_by == ("id", "day")
@@ -517,7 +520,10 @@ def test_domain_tables_accept_backend_specific_clustering_layouts() -> None:
         qualified_name=name, columns=columns, partitioned_by=("a",), clustered_by=("b",)
     )
     observed = ObservedTable(
-        qualified_name=name, columns=columns, partitioned_by=("a",), clustered_by=("b",)
+        qualified_name=name,
+        columns=as_observed_columns(columns),
+        partitioned_by=("a",),
+        clustered_by=("b",),
     )
 
     assert five_keys.clustered_by == ("a", "b", "c", "d", "e")
@@ -563,7 +569,7 @@ def test_table_snapshot_rejects_duplicate_clustering_column():
 
 
 def test_observed_table_accepts_clustering():
-    columns = (Column("id", Integer()), Column("region", String()))
+    columns = (ObservedColumn("id", Integer()), ObservedColumn("region", String()))
     table = ObservedTable(_QUALIFIED_NAME, columns, clustered_by=("region",))
     assert table.clustered_by == ("region",)
 
@@ -580,7 +586,7 @@ def test_observed_table_carries_referencing_foreign_keys() -> None:
     # When building an ObservedTable with referencing_foreign_keys
     observed = ObservedTable(
         qualified_name=QualifiedName("dev", "silver", "customers"),
-        columns=(Column("id", Integer()),),
+        columns=(ObservedColumn("id", Integer()),),
         referencing_foreign_keys=(reference,),
     )
     # Then the field is readable and returns the value object

--- a/tests/domain/plan/test_diff.py
+++ b/tests/domain/plan/test_diff.py
@@ -62,6 +62,7 @@ from delta_engine.domain.plan.diff import (
     TableMissing,
     diff_table,
 )
+from tests.builders import as_observed_columns
 
 _QUALIFIED_NAME = QualifiedName("dev", "silver", "test")
 
@@ -71,21 +72,10 @@ def _desired(**overrides) -> DesiredTable:
     return DesiredTable(**{**defaults, **overrides})
 
 
-def _as_observed(column: Column | ObservedColumn) -> ObservedColumn:
-    """Coerce a column written as ``Column`` into the observed-state type."""
-    return ObservedColumn(
-        name=column.name,
-        data_type=column.data_type,
-        nullable=column.nullable,
-        comment=column.comment,
-        tags=column.tags,
-    )
-
-
 def _observed(**overrides) -> ObservedTable:
     defaults = dict(qualified_name=_QUALIFIED_NAME, columns=(ObservedColumn("id", Integer()),))
     merged = {**defaults, **overrides}
-    merged["columns"] = tuple(_as_observed(column) for column in merged["columns"])
+    merged["columns"] = as_observed_columns(merged["columns"])
     return ObservedTable(**merged)
 
 

--- a/tests/domain/plan/test_diff.py
+++ b/tests/domain/plan/test_diff.py
@@ -7,6 +7,7 @@ from delta_engine.domain.model import (
     ForeignKeyReference,
     Integer,
     Long,
+    ObservedColumn,
     ObservedTable,
     QualifiedName,
     String,
@@ -70,9 +71,22 @@ def _desired(**overrides) -> DesiredTable:
     return DesiredTable(**{**defaults, **overrides})
 
 
+def _as_observed(column: Column | ObservedColumn) -> ObservedColumn:
+    """Coerce a column written as ``Column`` into the observed-state type."""
+    return ObservedColumn(
+        name=column.name,
+        data_type=column.data_type,
+        nullable=column.nullable,
+        comment=column.comment,
+        tags=column.tags,
+    )
+
+
 def _observed(**overrides) -> ObservedTable:
-    defaults = dict(qualified_name=_QUALIFIED_NAME, columns=(Column("id", Integer()),))
-    return ObservedTable(**{**defaults, **overrides})
+    defaults = dict(qualified_name=_QUALIFIED_NAME, columns=(ObservedColumn("id", Integer()),))
+    merged = {**defaults, **overrides}
+    merged["columns"] = tuple(_as_observed(column) for column in merged["columns"])
+    return ObservedTable(**merged)
 
 
 def _foreign_key(constraint_name: str = "test_id_fk") -> ForeignKeyConstraint:
@@ -152,7 +166,7 @@ def test_observed_only_column_produces_column_removed_change():
 
     # Then a ColumnRemoved change is produced
     assert isinstance(diff, TableDrift)
-    assert diff.changes == (ColumnRemoved(Column("stale", String())),)
+    assert diff.changes == (ColumnRemoved(ObservedColumn("stale", String())),)
 
 
 def test_type_drift_produces_column_data_type_changed():
@@ -596,7 +610,9 @@ def test_column_added_produces_add_column_only():
 
 
 def test_column_removed_produces_drop_column():
-    assert ColumnRemoved(column=Column("stale", Integer())).actions() == (DropColumn("stale"),)
+    assert ColumnRemoved(column=ObservedColumn("stale", Integer())).actions() == (
+        DropColumn("stale"),
+    )
 
 
 def test_column_data_type_changed_lowers_to_alter_column_type():
@@ -943,7 +959,7 @@ def test_changed_foreign_key_signature_produces_remove_and_add_changes():
 
 def test_observed_only_column_tags_are_ignored_because_column_is_removed():
     # Given an observed-only column that also has catalog tags
-    observed_only_column = Column("stale", Integer(), tags={"old": "true"})
+    observed_only_column = ObservedColumn("stale", Integer(), tags={"old": "true"})
 
     # When diffing
     diff = diff_table(


### PR DESCRIPTION
Pure refactor (1 of 2 for column renames; design in `docs/superpowers/specs/2026-07-12-column-renames-design.md`).

Observed catalog state gets its own `ObservedColumn` type, so the declaration-only `renamed_from` field added in the follow-up PR is unrepresentable on catalog state by construction.

## What changed
- New `ObservedColumn` domain type; `TableSnapshot` becomes generic (`TableSnapshot[ColumnT: (Column, ObservedColumn)]`), with `DesiredTable` = `TableSnapshot[Column]` and `ObservedTable` = `TableSnapshot[ObservedColumn]`.
- `ColumnRemoved.column` retyped to `ObservedColumn`; shared field validation factored into `_validate_column_fields`.
- Both Databricks readers construct `ObservedColumn`. Reader tests unchanged — they assert on attributes, not type identity.

No behaviour change.

## Verification
- `uv run pytest` — 757 passed, 98.45% coverage
- `uv run ruff check .`, `uv run mypy .`, `uv run lint-imports` — all clean

_Replaces the earlier stacked PRs #210/#211/#212, which included a rename-detection guard that has been dropped (it guessed at renames from column types — inconsistent with the explicit `renamed_from` feature)._