### PR TITLE
refactor: split table drift into actions and findings

### DIFF
--- a/docs/explanation-architecture.md
+++ b/docs/explanation-architecture.md
@@ -57,22 +57,22 @@ flowchart TB
 The architecture is easiest to follow if you start with the data that moves
 through a sync.
 
-| Concept            | Role                                                                                                                                                         |
-| ------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `DeltaTable`       | Public user declaration. It is the object users write in notebooks, scripts, and Python modules.                                                             |
-| `DesiredTable`     | Immutable domain snapshot of the target table state. `DeltaTable.to_desired_table()` lowers the public declaration into this shape.                          |
-| `ObservedTable`    | Immutable domain snapshot of the current catalog state. Reader adapters produce this after normalizing backend details.                                      |
-| `CatalogState`     | The result of reading one table: `TablePresent`, `TableAbsent`, or `ReadFailed`.                                                                             |
-| `TableDiff`        | Typed desired/observed drift. It is either `TableMissing` or `TableDrift`, whose members are executable actions or non-action differences.                  |
-| `Change`           | One member of a `TableDrift`: an `Action`, `ColumnRenameConflict`, `PropertyUndeclared`, or `PartitioningChanged`.                                           |
-| `TableAspect`      | One managed aspect of a table: existence, columns, comments, properties, tags, partitioning, clustering, primary key, or foreign keys. Internal enum.        |
-| `ValidationResult` | Lower-level validation verdict used to test policy rules in isolation.                                                                                       |
-| `PlanningResult`   | The total application boundary: either `PlanningSucceeded(ActionPlan)` or `PlanningFailed(validation failures)`.                                             |
-| `ActionPlan`       | The ordered, table-local actions that should be executed if the table is allowed to run.                                                                     |
-| `ResolveResult`    | The foreign-key dependency order plus any FK-specific failures.                                                                                              |
-| `ExecutionSummary` | The result of running a plan's compiled statements. It records successful statements and the first failed statement, if execution failed.                    |
-| `TableRunReport`   | The complete per-table outcome, including read state, plan, planned SQL statements, failures, and execution.                                                 |
-| `SyncReport`       | The aggregate result for the whole sync. It is returned on success and attached to `SyncFailedError` on real-run failure.                                    |
+| Concept            | Role                                                                                                                                                    |
+| ------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `DeltaTable`       | Public user declaration. It is the object users write in notebooks, scripts, and Python modules.                                                        |
+| `DesiredTable`     | Immutable domain snapshot of the target table state. `DeltaTable.to_desired_table()` lowers the public declaration into this shape.                     |
+| `ObservedTable`    | Immutable domain snapshot of the current catalog state. Reader adapters produce this after normalizing backend details.                                 |
+| `CatalogState`     | The result of reading one table: `TablePresent`, `TableAbsent`, or `ReadFailed`.                                                                        |
+| `TableDiff`        | Typed desired/observed drift. It is either `TableMissing` or `TableDrift`; both state their remedies as `actions`, and a drift also carries `findings`. |
+| `Finding`          | A `TableDrift` difference no action can close: `ColumnRenameConflict`, `PropertyUndeclared`, or `PartitioningChanged`.                                  |
+| `TableAspect`      | One managed aspect of a table: existence, columns, comments, properties, tags, partitioning, clustering, primary key, or foreign keys. Internal enum.   |
+| `ValidationResult` | Lower-level validation verdict used to test policy rules in isolation.                                                                                  |
+| `PlanningResult`   | The total application boundary: either `PlanningSucceeded(ActionPlan)` or `PlanningFailed(validation failures)`.                                        |
+| `ActionPlan`       | The ordered, table-local actions that should be executed if the table is allowed to run.                                                                |
+| `ResolveResult`    | The foreign-key dependency order plus any FK-specific failures.                                                                                         |
+| `ExecutionSummary` | The result of running a plan's compiled statements. It records successful statements and the first failed statement, if execution failed.               |
+| `TableRunReport`   | The complete per-table outcome, including read state, plan, planned SQL statements, failures, and execution.                                            |
+| `SyncReport`       | The aggregate result for the whole sync. It is returned on success and attached to `SyncFailedError` on real-run failure.                               |
 
 The table snapshots deliberately use domain vocabulary, not Spark vocabulary.
 For example, the domain has `Column`, `QualifiedName`, `PrimaryKeyConstraint`,
@@ -282,28 +282,28 @@ Execution is gated by accumulated failures. A table that failed read,
 validation, or foreign-key resolution keeps its failure in the report and is
 skipped during execution. The engine still processes other tables.
 
-| Shape              | Produced by           | Consumed by                      | Purpose                                        |
-| ------------------ | --------------------- | -------------------------------- | ---------------------------------------------- |
-| `DeltaTable`       | User code             | Application preparation          | Public declaration object                      |
-| `DesiredTable`     | API lowering          | Domain planner, resolver, report | Target schema snapshot                         |
-| `ObservedTable`    | Reader adapter        | Domain planner, report           | Catalog schema snapshot                        |
-| `TableDiff`        | `diff_table`          | `plan_diff`                      | Direct actions and non-action differences      |
-| `ActionPlan`       | successful `plan_diff` | Executor (`compile`), report    | Ordered, validated table-local actions         |
-| `CatalogState`     | Reader port           | Engine                           | Present, absent, or read-failed state          |
-| SQL statements     | Executor (`compile`)  | Executor (`execute`), report     | The DDL a plan lowers to                       |
-| `ExecutionSummary` | Executor port         | Engine, report                   | Attempted statement outcomes                   |
-| `SyncReport`       | Engine                | User code                        | Immutable run result                           |
+| Shape              | Produced by            | Consumed by                      | Purpose                                |
+| ------------------ | ---------------------- | -------------------------------- | -------------------------------------- |
+| `DeltaTable`       | User code              | Application preparation          | Public declaration object              |
+| `DesiredTable`     | API lowering           | Domain planner, resolver, report | Target schema snapshot                 |
+| `ObservedTable`    | Reader adapter         | Domain planner, report           | Catalog schema snapshot                |
+| `TableDiff`        | `diff_table`           | `plan_diff`                      | Direct actions and findings            |
+| `ActionPlan`       | successful `plan_diff` | Executor (`compile`), report     | Ordered, validated table-local actions |
+| `CatalogState`     | Reader port            | Engine                           | Present, absent, or read-failed state  |
+| SQL statements     | Executor (`compile`)   | Executor (`execute`), report     | The DDL a plan lowers to               |
+| `ExecutionSummary` | Executor port          | Engine, report                   | Attempted statement outcomes           |
+| `SyncReport`       | Engine                 | User code                        | Immutable run result                   |
 
 ## Package map
 
-| Package                    | Responsibility                                                                      | Examples                                                                                 |
-| -------------------------- | ----------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------- |
-| `delta_engine.cli`         | Read-only command composition and rendering                                          | `plan`, declaration loading, unified-auth SQL connection                                 |
-| `delta_engine.schema`      | User-facing declaration import surface                                              | `DeltaTable`, `ForeignKey`, `Property`                                                   |
-| `delta_engine.api`         | Declaration implementation package                                                  | `DeltaTable`, `ForeignKey`, `Property`                                                   |
+| Package                    | Responsibility                                                                                      | Examples                                                                             |
+| -------------------------- | --------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------ |
+| `delta_engine.cli`         | Read-only command composition and rendering                                                         | `plan`, declaration loading, unified-auth SQL connection                             |
+| `delta_engine.schema`      | User-facing declaration import surface                                                              | `DeltaTable`, `ForeignKey`, `Property`                                               |
+| `delta_engine.api`         | Declaration implementation package                                                                  | `DeltaTable`, `ForeignKey`, `Property`                                               |
 | `delta_engine.application` | Use-case orchestration, accepted/rejected planning, ports, failures, dependency resolution, reports | `Engine`, `plan_diff`, `CatalogStateReader`, `PlanExecutor`, `resolve`, `SyncReport` |
-| `delta_engine.domain`      | Backend-free snapshots, diffs, actions, and deterministic planning                  | `DesiredTable`, `ObservedTable`, `TableDiff`, `ActionPlan`                               |
-| `delta_engine.adapters`    | Backend integration and translation                                                 | `SparkReader`, `SparkExecutor`, `WarehouseReader`, `WarehouseExecutor`, SQL compiler     |
+| `delta_engine.domain`      | Backend-free snapshots, diffs, actions, and deterministic planning                                  | `DesiredTable`, `ObservedTable`, `TableDiff`, `ActionPlan`                           |
+| `delta_engine.adapters`    | Backend integration and translation                                                                 | `SparkReader`, `SparkExecutor`, `WarehouseReader`, `WarehouseExecutor`, SQL compiler |
 
 ```mermaid
 flowchart TB
@@ -375,13 +375,18 @@ can read catalogs without one, such as `hive_metastore`.
 
 Planning is two pure stages connected by a typed diff. `diff_table(desired,
 observed)` produces a `TableDiff` — `TableMissing` when the table does not
-exist, else a `TableDrift` holding direct executable actions and three
-non-action differences. Actions carry their `TableAspect` plus the complete
-desired/observed state needed by validation and reporting; `CreateTable` uses
-the table-existence aspect because it realizes a missing table's complete
-desired state rather than belonging to one schema dimension. Compiler-facing
-attributes remain read-only properties on the richer objects. There is no
-mirrored fact vocabulary and no lowering method.
+exist, else a `TableDrift` holding executable `actions` and non-action
+`findings` as two typed tuples. Actions carry their `TableAspect` plus the
+complete desired/observed state needed by validation and reporting;
+`CreateTable` uses the table-existence aspect because it realizes a missing
+table's complete desired state rather than belonging to one schema dimension.
+Compiler-facing attributes remain read-only properties on the richer objects.
+There is no mirrored fact vocabulary and no lowering method.
+
+Both arms state the complete intended transition the same way: a
+`TableMissing` exposes its creation actions — CREATE TABLE plus tag and
+foreign-key follow-ups — so accepted planning is uniformly "construct an
+`ActionPlan` from the diff's actions" for creation and drift alike.
 
 The domain also owns the operation semantics used to project a validated
 `TableDrift` into its final actions. In particular, the raw diff retains PK/FK
@@ -390,13 +395,13 @@ constraint state, while the domain's action projection omits drops performed
 atomically by `RENAME COLUMN`. The application layer neither compares schema
 state nor decides which constraint actions a rename supersedes.
 
-Only three diff members are non-executable: `ColumnRenameConflict`,
-`PropertyUndeclared`, and `PartitioningChanged`. Each states an ambiguity or
-unsupported transition without deciding its policy outcome. `Change` names
-these types directly alongside `Action`; the application default rules decide
-to reject each one.
+Only three findings exist: `ColumnRenameConflict`, `PropertyUndeclared`, and
+`PartitioningChanged`. Each states an ambiguity or unsupported transition
+without deciding its policy outcome. The `Finding` union names them, they
+live structurally apart from the actions, and the application default rules
+decide to reject each one.
 
-Whether a change is permitted is application policy. `plan_diff` always runs
+Whether a difference is permitted is application policy. `plan_diff` always runs
 the default policy and returns either `PlanningSucceeded(plan)` or
 `PlanningFailed(failures)`. Only the success arm has an `ActionPlan`, and plan
 construction is private to that boundary, so callers cannot plan raw diffs
@@ -424,11 +429,11 @@ table itself (symmetric with `TableMissing`), so the diff is self-contained
 and `validate_diff` takes only the diff. Scope awareness lives in
 validation, as an unconditional invariant rather than an optional rule:
 `validate_diff` fails the sync once per unmanaged aspect that has drifted
-(`UnmanagedAspectDrift`), and rules read `drift.managed_changes` — so
-unmanaged drift produces exactly one scope failure rather than also tripping
-safety rules for changes the user never requested. If planning succeeds,
-every change belongs to a managed aspect and every retained member is an
-executable action.
+(`UnmanagedAspectDrift`), and rules read `drift.managed_actions` and
+`drift.managed_findings` — so unmanaged drift produces exactly one scope
+failure rather than also tripping safety rules for differences the user never
+requested. If planning succeeds, every difference belongs to a managed aspect
+and the plan holds executable actions only.
 
 The public API exposes named scopes only: `DeltaTable`'s `scope` parameter
 maps `"metadata"` to the metadata aspects (comments, tags, key constraints)
@@ -442,11 +447,11 @@ never reconciles them, the same as `COLUMN_STRUCTURE` and `PARTITIONING`.
 `diff_table(desired, observed)` produces a `TableDiff`:
 
 - `TableMissing` means the catalog has no table at that name.
-- `TableDrift` means the table exists and carries a tuple of changes.
+- `TableDrift` means the table exists and carries its actions and findings.
 
 The diff produces backend-neutral commands but does not decide whether they are
-safe, and it does not talk to the backend. For an existing table, changes span these
-aspects:
+safe, and it does not talk to the backend. For an existing table, differences span
+these aspects:
 
 - columns
 - table comment
@@ -461,7 +466,7 @@ Each dimension produces canonical actions directly. For example, column
 additions produce `AddColumn` plus any `SetColumnTag` actions, table tag
 removals produce `UnsetTableTag`, and foreign-key additions produce
 `SetForeignKey`. Unsupported or ambiguous states use one of the three
-non-action difference types, which the current default policy rejects.
+finding types, which the current default policy rejects.
 
 `validate_diff` is where policy lives. A missing table passes when the
 declaration manages table existence because creating it from the full
@@ -547,7 +552,7 @@ connected components to produce a dependency-first order. It reports:
   a read failure, validation failure, unresolvable FK, invalid FK target, or FK
   cycle.
 
-Each rule implements the `Rule` protocol: a `name` `ClassVar[str]` and an `evaluate(drift: TableDrift) -> tuple[ValidationFailure, ...]` method. Rules usually scan `drift.managed_changes` directly — typically matching a specific action or non-action difference with `isinstance` — and return all violations at once, avoiding a fix-and-rerun cycle per failure.
+Each rule implements the `Rule` protocol: a `name` `ClassVar[str]` and an `evaluate(drift: TableDrift) -> tuple[ValidationFailure, ...]` method. Rules usually scan `drift.managed_actions` or `drift.managed_findings` directly — typically matching a specific type with `isinstance` — and return all violations at once, avoiding a fix-and-rerun cycle per failure.
 
 `validate_diff` dispatches on the diff variant first: a `TableMissing` passes automatically when table existence is managed — creating a table from its full declaration is always safe — and fails with `MissingTableUnmanaged` when it is not, so no rule ever sees a missing table. For a `TableDrift`, `validate_diff` calls every rule in `DEFAULT_RULES` with the drift and aggregates their failures into a `ValidationResult`. `plan_diff` fixes that default policy in place and turns the verdict into the accepted/rejected planning sum.
 
@@ -706,18 +711,18 @@ dependency cost.
 
 ## Where to make changes
 
-| Change                         | Main location                                                              | Notes                                                                                                                                                                                                                                                                               |
-| ------------------------------ | -------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Add a new backend              | `delta_engine.adapters`                                                    | Implement `CatalogStateReader` and `PlanExecutor`; keep backend exceptions inside the adapter.                                                                                                                                                                                      |
-| Add a new executable difference | `delta_engine.domain.plan.actions`, differ, and adapter compiler           | Define the rich action, its aspect and phase in `actions.py`; emit it directly from the relevant `_diff_*` helper; add policy rules if needed; compile it in the backend adapter.                                                                                                    |
-| Add a new non-action difference | `delta_engine.domain.plan.diff` and application validation                  | Add the frozen domain difference directly to `Change`, emit it from the differ, then make the rejection or acceptance decision in application policy. Successful planning must still contain actions only.                                                                        |
-| Add a safety rule              | `delta_engine.application.validation`                                      | Rules inspect the `TableDrift` changes and return `ValidationFailure` values.                                                                                                                                                                                                       |
-| Add a data type                | `delta_engine.domain.model.data_type` and adapter type mapping             | The domain type is backend-free; SQL names and Spark parsing live in the Databricks adapter.                                                                                                                                                                                        |
-| Change public declarations     | `delta_engine.api`, surfaced only through `delta_engine.schema`            | Keep public ergonomics in `delta_engine.schema` and lower choices into domain snapshots before the engine phases begin.                                                                                                                                                             |
-| Change FK ordering or blocking | `delta_engine.application.dependency_resolution`                           | Cross-table dependency policy lives in the application layer, not in the domain plan or SQL compiler.                                                                                                                                                                               |
-| Change report output           | `delta_engine.application.report` and `delta_engine.application.rendering` | Keep display formatting out of domain objects.                                                                                                                                                                                                                                      |
-| Change Databricks SQL          | `delta_engine.adapters.databricks.sql`                                     | Compile domain actions to backend statements at the adapter boundary.                                                                                                                                                                                                               |
-| Change CLI commands or output  | `delta_engine.cli`                                                         | Thin orchestration over `declarations.py`, `connection.py`, and the application ports; keep policy in the layers below.                                                                                                                                                             |
+| Change                          | Main location                                                              | Notes                                                                                                                                                                                                       |
+| ------------------------------- | -------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Add a new backend               | `delta_engine.adapters`                                                    | Implement `CatalogStateReader` and `PlanExecutor`; keep backend exceptions inside the adapter.                                                                                                              |
+| Add a new executable difference | `delta_engine.domain.plan.actions`, differ, and adapter compiler           | Define the rich action, its aspect and phase in `actions.py`; emit it directly from the relevant `_diff_*` helper; add policy rules if needed; compile it in the backend adapter.                           |
+| Add a new finding               | `delta_engine.domain.plan.diff` and application validation                 | Add the frozen domain difference to `Finding`, emit it into the diff's findings, then make the rejection or acceptance decision in application policy. Successful planning must still contain actions only. |
+| Add a safety rule               | `delta_engine.application.validation`                                      | Rules inspect the drift's managed actions and findings and return `ValidationFailure` values.                                                                                                               |
+| Add a data type                 | `delta_engine.domain.model.data_type` and adapter type mapping             | The domain type is backend-free; SQL names and Spark parsing live in the Databricks adapter.                                                                                                                |
+| Change public declarations      | `delta_engine.api`, surfaced only through `delta_engine.schema`            | Keep public ergonomics in `delta_engine.schema` and lower choices into domain snapshots before the engine phases begin.                                                                                     |
+| Change FK ordering or blocking  | `delta_engine.application.dependency_resolution`                           | Cross-table dependency policy lives in the application layer, not in the domain plan or SQL compiler.                                                                                                       |
+| Change report output            | `delta_engine.application.report` and `delta_engine.application.rendering` | Keep display formatting out of domain objects.                                                                                                                                                              |
+| Change Databricks SQL           | `delta_engine.adapters.databricks.sql`                                     | Compile domain actions to backend statements at the adapter boundary.                                                                                                                                       |
+| Change CLI commands or output   | `delta_engine.cli`                                                         | Thin orchestration over `declarations.py`, `connection.py`, and the application ports; keep policy in the layers below.                                                                                     |
 
 ## Architectural rules
 

--- a/docs/how-to-add-action-type.md
+++ b/docs/how-to-add-action-type.md
@@ -85,12 +85,12 @@ if desired.comment != observed.comment:
     )
 ```
 
-`Change` already includes every `Action`, so no union edit is needed. If the
-comparison cannot be represented as an action, add a frozen domain difference
-in `diff.py` and name it directly in `Change`. Decide whether it is accepted or
-rejected in application validation; the current three non-action differences
-are rejected by the default policy. Successful `plan_diff` results must
-contain actions only.
+Actions join the diff's `actions` tuple, so no union edit is needed. If the
+comparison cannot be represented as an action, add a frozen finding in
+`diff.py`, name it in `Finding`, and emit it into the diff's `findings`.
+Decide whether it is accepted or rejected in application validation; the
+current three findings are rejected by the default policy. Successful
+`plan_diff` results must contain actions only.
 
 ## 4. Register a SQL compiler
 
@@ -128,8 +128,8 @@ An action may emit several entries across categories (`CreateTable` lists its co
 
 If the new action can be unsafe, add a rule in
 `src/delta_engine/application/validation.py`. Rules receive the self-contained
-drift and match concrete actions or non-action differences from
-`drift.managed_changes`:
+drift and match concrete types from `drift.managed_actions` (or
+`drift.managed_findings` when judging findings):
 
 ```python
 from typing import ClassVar
@@ -147,7 +147,7 @@ class NoUnsafeCommentChange:
                 rule_name=self.name,
                 message=f"Operation not allowed: ...",
             )
-            for change in drift.managed_changes
+            for change in drift.managed_actions
             if isinstance(change, UpdateComment) and <condition>
         )
 ```

--- a/src/delta_engine/application/planning.py
+++ b/src/delta_engine/application/planning.py
@@ -7,10 +7,6 @@ from delta_engine.application.failures import ValidationFailure
 from delta_engine.application.validation import validate_diff
 from delta_engine.domain.plan import (
     ActionPlan,
-    CreateTable,
-    SetColumnTag,
-    SetForeignKey,
-    SetTableTag,
     TableDiff,
     TableDrift,
     TableMissing,
@@ -50,44 +46,10 @@ def plan_diff(diff: TableDiff) -> PlanningResult:
     validation = validate_diff(diff)
     if validation.failures:
         return PlanningFailed(failures=validation.failures)
-    return PlanningSucceeded(plan=_build_plan(diff))
-
-
-def _build_plan(diff: TableDiff) -> ActionPlan:
-    """Construct a plan privately after the default validation policy accepts a diff."""
     match diff:
         case TableMissing() as missing:
-            return _build_missing_table_plan(missing)
+            return PlanningSucceeded(plan=ActionPlan(missing.actions))
         case TableDrift() as drift:
-            return _build_drift_plan(drift)
+            return PlanningSucceeded(plan=ActionPlan(drift.executable_actions))
         case _ as unreachable:
             assert_never(unreachable)
-
-
-def _build_missing_table_plan(missing: TableMissing) -> ActionPlan:
-    """Build creation and follow-up actions for an accepted missing-table diff."""
-    desired = missing.desired
-    table_tag_actions = tuple(
-        SetTableTag(name=name, value=value) for name, value in desired.tags.items()
-    )
-    column_tag_actions = tuple(
-        SetColumnTag(column_name=column.name, name=name, value=value)
-        for column in desired.columns
-        for name, value in column.tags.items()
-    )
-    foreign_key_actions = tuple(
-        SetForeignKey(constraint=constraint) for constraint in desired.foreign_keys
-    )
-    return ActionPlan(
-        (
-            CreateTable(desired),
-            *table_tag_actions,
-            *column_tag_actions,
-            *foreign_key_actions,
-        )
-    )
-
-
-def _build_drift_plan(drift: TableDrift) -> ActionPlan:
-    """Order the domain-projected actions for an accepted drift diff."""
-    return ActionPlan(drift.executable_actions)

--- a/src/delta_engine/application/validation.py
+++ b/src/delta_engine/application/validation.py
@@ -58,13 +58,13 @@ class Rule(Protocol):
     """
     Interface for drift validation rules.
 
-    A rule judges whether a managed change is safe, given the declaration it
-    belongs to. It receives the whole ``TableDrift`` — the self-contained
-    diff — and reads what it needs: ``drift.managed_changes`` for the changes
-    to judge (unmanaged drift is a scope violation the validator reports
-    separately, never rule input), and ``drift.desired`` for declaration
-    context such as declared properties. Never called for a ``TableMissing``
-    diff.
+    A rule judges whether a managed difference is safe, given the declaration
+    it belongs to. It receives the whole ``TableDrift`` — the self-contained
+    diff — and reads what it needs: ``drift.managed_actions`` or
+    ``drift.managed_findings`` for the differences to judge (unmanaged drift
+    is a scope violation the validator reports separately, never rule input),
+    and ``drift.desired`` for declaration context such as declared
+    properties. Never called for a ``TableMissing`` diff.
     """
 
     name: ClassVar[str]
@@ -88,7 +88,7 @@ class NonNullableColumnAdd:
                     f"Operation not allowed: cannot add non-nullable column '{change.column.name}'"
                 ),
             )
-            for change in drift.managed_changes
+            for change in drift.managed_actions
             if isinstance(change, AddColumn) and not change.column.nullable
         )
 
@@ -111,7 +111,7 @@ class NullabilityTighteningOnExistingColumn:
                     " nullable=False — the next sync sees no drift."
                 ),
             )
-            for change in drift.managed_changes
+            for change in drift.managed_actions
             if isinstance(change, SetColumnNullability) and not change.desired_nullable
         )
 
@@ -187,7 +187,7 @@ class NonWideningColumnTypeChange:
                     " TimestampNtz); recreate the table to make any other type change."
                 ),
             )
-            for change in drift.managed_changes
+            for change in drift.managed_actions
             if isinstance(change, AlterColumnType)
             and not _is_safe_widening(change.observed_type, change.desired_type)
         )
@@ -219,7 +219,7 @@ class TypeWideningRequiredForTypeChange:
                     f" properties={{'{Property.TYPE_WIDENING}': 'true'}} on this table."
                 ),
             )
-            for change in drift.managed_changes
+            for change in drift.managed_actions
             if isinstance(change, AlterColumnType)
             and _is_safe_widening(change.observed_type, change.desired_type)
         )
@@ -237,13 +237,13 @@ class PartitioningChangeNotSupported:
                 rule_name=self.name,
                 message=(
                     "Operation not allowed: partitioning cannot be changed in place."
-                    f" Current: {change.observed_partitioning}."
-                    f" Requested: {change.desired_partitioning}."
+                    f" Current: {finding.observed_partitioning}."
+                    f" Requested: {finding.desired_partitioning}."
                     " Recreate the table with the desired partitioning."
                 ),
             )
-            for change in drift.managed_changes
-            if isinstance(change, PartitioningChanged)
+            for finding in drift.managed_findings
+            if isinstance(finding, PartitioningChanged)
         )
 
 
@@ -265,7 +265,7 @@ class PropertyTransitionNotSupported:
     def evaluate(self, drift: TableDrift) -> tuple[ValidationFailure, ...]:
         """Flag every restricted-key transition that is not permitted."""
         failures: list[ValidationFailure] = []
-        for change in drift.managed_changes:
+        for change in drift.managed_actions:
             match change:
                 case SetProperty(
                     name=name, desired_value=desired_value, observed_value=str() as observed_value
@@ -315,22 +315,22 @@ class PropertyMustBeDeclared:
     def evaluate(self, drift: TableDrift) -> tuple[ValidationFailure, ...]:
         """Flag every registered key set on the table but absent from the declaration."""
         return tuple(
-            ValidationFailure(rule_name=self.name, message=self._message(change))
-            for change in drift.managed_changes
-            if isinstance(change, PropertyUndeclared)
+            ValidationFailure(rule_name=self.name, message=self._message(finding))
+            for finding in drift.managed_findings
+            if isinstance(finding, PropertyUndeclared)
         )
 
-    def _message(self, change: PropertyUndeclared) -> str:
-        if not self._removal_permitted(change.name, change.observed_value):
+    def _message(self, finding: PropertyUndeclared) -> str:
+        if not self._removal_permitted(finding.name, finding.observed_value):
             return (
-                f"Operation not allowed: {change.name} is set on the table"
-                f" (value '{change.observed_value}') but not declared; it cannot"
+                f"Operation not allowed: {finding.name} is set on the table"
+                f" (value '{finding.observed_value}') but not declared; it cannot"
                 " be unset — declare it to continue managing this table's"
                 " properties."
             )
         return (
-            f"Operation not allowed: {change.name} is set on the table"
-            f" (value '{change.observed_value}') but not declared. Declare it"
+            f"Operation not allowed: {finding.name} is set on the table"
+            f" (value '{finding.observed_value}') but not declared. Declare it"
             " to manage it, or declare it as None to remove it."
         )
 
@@ -357,7 +357,7 @@ class ColumnMappingRequiredForDrop:
 
     def evaluate(self, drift: TableDrift) -> tuple[ValidationFailure, ...]:
         """Flag a column drop when the declaration lacks column mapping."""
-        drops_a_column = any(isinstance(change, DropColumn) for change in drift.managed_changes)
+        drops_a_column = any(isinstance(change, DropColumn) for change in drift.managed_actions)
         if not drops_a_column:
             return ()
         if drift.desired.properties.get(Property.COLUMN_MAPPING_MODE) == "name":
@@ -385,14 +385,14 @@ class AmbiguousColumnRename:
             ValidationFailure(
                 rule_name=self.name,
                 message=(
-                    f"Operation not allowed: cannot rename '{change.old_name}' to"
-                    f" '{change.new_name}' — both columns exist"
+                    f"Operation not allowed: cannot rename '{finding.old_name}' to"
+                    f" '{finding.new_name}' — both columns exist"
                     " on the table. If the old column should be dropped, remove the"
                     " renamed_from hint and drop it in its own sync."
                 ),
             )
-            for change in drift.managed_changes
-            if isinstance(change, ColumnRenameConflict)
+            for finding in drift.managed_findings
+            if isinstance(finding, ColumnRenameConflict)
         )
 
 
@@ -419,11 +419,11 @@ class PrimaryKeyReferencedByForeignKeys:
         """Flag every PK drop/change still referenced by a surviving foreign key."""
         dropped_here = {
             change.constraint.constraint_name
-            for change in drift.managed_changes
+            for change in drift.managed_actions
             if isinstance(change, DropForeignKey)
         }
         failures: list[ValidationFailure] = []
-        for change in drift.managed_changes:
+        for change in drift.managed_actions:
             if not isinstance(change, DropPrimaryKey):
                 continue
             blockers = tuple(
@@ -477,10 +477,10 @@ class UnmanagedAspectDrift:
     into executable work, so ``rules=()`` still cannot admit actions from an
     aspect the declaration does not manage.
 
-    Unlike the safety rules it reads ``drift.changes`` (unfiltered): its
-    subject is exactly the changes ``managed_changes`` excludes.
+    Unlike the safety rules it reads the unfiltered actions and findings:
+    its subject is exactly the differences the managed views exclude.
     dict.fromkeys deduplicates the aspects while preserving first-seen
-    order, so failure order follows change order deterministically.
+    order, so failure order follows diff order deterministically.
     """
 
     name: ClassVar[str] = "UnmanagedAspectDrift"
@@ -489,7 +489,9 @@ class UnmanagedAspectDrift:
         """Flag every drifted aspect the declaration does not manage."""
         managed_aspects = drift.desired.managed_aspects
         unmanaged_aspects = dict.fromkeys(
-            change.aspect for change in drift.changes if change.aspect not in managed_aspects
+            difference.aspect
+            for difference in (*drift.actions, *drift.findings)
+            if difference.aspect not in managed_aspects
         )
         return tuple(
             ValidationFailure(
@@ -555,9 +557,9 @@ def validate_diff(diff: TableDiff, rules: tuple[Rule, ...] = DEFAULT_RULES) -> V
       supplied.
 
     Rules are safety policy over the drift the declaration *does* manage:
-    each reads ``drift.managed_changes``, so unmanaged drift produces exactly
-    one scope failure rather than also tripping safety rules for changes the
-    user never requested.
+    each reads ``drift.managed_actions`` or ``drift.managed_findings``, so
+    unmanaged drift produces exactly one scope failure rather than also
+    tripping safety rules for differences the user never requested.
     """
     match diff:
         case TableMissing() as missing:

--- a/src/delta_engine/domain/plan/__init__.py
+++ b/src/delta_engine/domain/plan/__init__.py
@@ -23,8 +23,8 @@ from delta_engine.domain.plan.actions import (
     UnsetTableTag,
 )
 from delta_engine.domain.plan.diff import (
-    Change,
     ColumnRenameConflict,
+    Finding,
     PartitioningChanged,
     PropertyUndeclared,
     TableDiff,
@@ -40,12 +40,12 @@ __all__ = [
     "AddColumn",
     "AlterClustering",
     "AlterColumnType",
-    "Change",
     "ColumnRenameConflict",
     "CreateTable",
     "DropColumn",
     "DropForeignKey",
     "DropPrimaryKey",
+    "Finding",
     "PartitioningChanged",
     "PropertyUndeclared",
     "RenameColumn",

--- a/src/delta_engine/domain/plan/actions.py
+++ b/src/delta_engine/domain/plan/actions.py
@@ -472,19 +472,19 @@ def _execution_order(action: Action) -> tuple[int, str]:
 
 @dataclass(frozen=True, slots=True)
 class ActionPlan:
-    """Validated executable actions held in deterministic execution order."""
+    """
+    Validated executable actions held in deterministic execution order.
+
+    A plan keeps its actions sorted by execution phase and then by subject
+    name, regardless of the order they are supplied in: ordering is an
+    invariant of the plan, not a step a caller has to remember.
+    """
 
     actions: tuple[Action, ...] = ()
 
     def __post_init__(self) -> None:
-        """Reject non-actions and establish deterministic execution order."""
-        actions = tuple(self.actions)
-        for action in actions:
-            if not isinstance(action, Action):
-                raise TypeError(
-                    f"ActionPlan accepts only Action instances; received {type(action).__name__}"
-                )
-        object.__setattr__(self, "actions", tuple(sorted(actions, key=_execution_order)))
+        """Sort the actions into execution order, preserving input order on ties."""
+        object.__setattr__(self, "actions", tuple(sorted(self.actions, key=_execution_order)))
 
     def __len__(self) -> int:
         return len(self.actions)

--- a/src/delta_engine/domain/plan/diff.py
+++ b/src/delta_engine/domain/plan/diff.py
@@ -1,4 +1,17 @@
-"""Produce executable actions and non-action differences from table state."""
+"""
+Diff desired and observed table state into actions and findings.
+
+``diff_table`` states every difference separating the observed table from
+its declaration, deciding nothing about safety or scope. Differences come
+in two structural kinds:
+
+- Actions — remedied differences. Each carries the one executable
+  operation that closes its gap, plus the desired/observed state
+  validation and reporting need.
+- Findings — differences no action can close (an ambiguous rename, an
+  undeclared managed property, a partitioning change). They exist to be
+  judged; the default validation policy rejects each one.
+"""
 
 from collections.abc import Mapping
 from dataclasses import dataclass, replace
@@ -18,6 +31,7 @@ from delta_engine.domain.plan.actions import (
     AddColumn,
     AlterClustering,
     AlterColumnType,
+    CreateTable,
     DropColumn,
     DropForeignKey,
     DropPrimaryKey,
@@ -78,7 +92,7 @@ class PartitioningChanged:
             )
 
 
-type Change = Action | ColumnRenameConflict | PropertyUndeclared | PartitioningChanged
+type Finding = ColumnRenameConflict | PropertyUndeclared | PartitioningChanged
 
 
 @dataclass(frozen=True, slots=True)
@@ -87,19 +101,59 @@ class TableMissing:
 
     desired: DesiredTable
 
+    @property
+    def actions(self) -> tuple[Action, ...]:
+        """
+        Creation actions realizing the complete desired state.
+
+        CREATE TABLE covers columns, comment, properties, layout, and the
+        primary key; Unity Catalog tags and foreign keys are applied by
+        follow-up actions.
+        """
+        table_tag_actions = tuple(
+            SetTableTag(name=name, value=value) for name, value in self.desired.tags.items()
+        )
+        column_tag_actions = tuple(
+            SetColumnTag(column_name=column.name, name=name, value=value)
+            for column in self.desired.columns
+            for name, value in column.tags.items()
+        )
+        foreign_key_actions = tuple(
+            SetForeignKey(constraint=constraint) for constraint in self.desired.foreign_keys
+        )
+        return (
+            CreateTable(self.desired),
+            *table_tag_actions,
+            *column_tag_actions,
+            *foreign_key_actions,
+        )
+
 
 @dataclass(frozen=True, slots=True)
 class TableDrift:
-    """Actions and other differences separating observed state from its declaration."""
+    """
+    Differences separating observed state from its declaration.
+
+    ``actions`` are remedied differences, each carrying the executable
+    operation that closes its gap. ``findings`` are differences no action
+    can close; they exist to be judged by validation.
+    """
 
     desired: DesiredTable
-    changes: tuple[Change, ...]
+    actions: tuple[Action, ...] = ()
+    findings: tuple[Finding, ...] = ()
 
     @property
-    def managed_changes(self) -> tuple[Change, ...]:
-        """Return changes whose aspect the declaration manages."""
+    def managed_actions(self) -> tuple[Action, ...]:
+        """Return actions whose aspect the declaration manages."""
         managed = self.desired.managed_aspects
-        return tuple(change for change in self.changes if change.aspect in managed)
+        return tuple(action for action in self.actions if action.aspect in managed)
+
+    @property
+    def managed_findings(self) -> tuple[Finding, ...]:
+        """Return findings whose aspect the declaration manages."""
+        managed = self.desired.managed_aspects
+        return tuple(finding for finding in self.findings if finding.aspect in managed)
 
     @property
     def executable_actions(self) -> tuple[Action, ...]:
@@ -113,23 +167,21 @@ class TableDrift:
         that the actions are safe; only ``plan_diff`` may construct a plan.
         """
         renamed_sources = {
-            action.old_name for action in self.changes if isinstance(action, RenameColumn)
+            action.old_name for action in self.actions if isinstance(action, RenameColumn)
         }
         actions: list[Action] = []
-        for change in self.changes:
-            if not isinstance(change, Action):
-                continue
-            if isinstance(change, DropPrimaryKey) and not renamed_sources.isdisjoint(
-                change.primary_key.columns
+        for action in self.actions:
+            if isinstance(action, DropPrimaryKey) and not renamed_sources.isdisjoint(
+                action.primary_key.columns
             ):
                 continue
-            if isinstance(change, DropForeignKey) and _foreign_key_uses_renamed_column(
-                change.constraint,
+            if isinstance(action, DropForeignKey) and _foreign_key_uses_renamed_column(
+                action.constraint,
                 renamed_sources=renamed_sources,
                 table_name=self.desired.qualified_name,
             ):
                 continue
-            actions.append(change)
+            actions.append(action)
         return tuple(actions)
 
 
@@ -153,7 +205,7 @@ def _foreign_key_uses_renamed_column(
 
 def diff_table(desired: DesiredTable, observed: ObservedTable | None) -> TableDiff:
     """
-    Compute actions and non-action differences separating observed from desired state.
+    Compute the actions and findings separating observed from desired state.
 
     A rename pre-pass projects observed columns and layout names through
     ``renamed_from`` hints so residual drift is expressed under the declared
@@ -165,20 +217,24 @@ def diff_table(desired: DesiredTable, observed: ObservedTable | None) -> TableDi
         return TableMissing(desired=desired)
 
     rename_projection = _apply_renames(desired, observed)
-    changes: tuple[Change, ...] = (
-        *rename_projection.changes,
+    actions: tuple[Action, ...] = (
+        *rename_projection.renames,
         *_diff_column_structure(desired.columns, rename_projection.columns),
         *_diff_column_comments(desired.columns, rename_projection.columns),
         *_diff_column_tags(desired.columns, rename_projection.columns),
         *_diff_table_comment(desired, observed),
         *_diff_properties(desired, observed),
         *_diff_table_tags(desired, observed),
-        *_diff_partitioning(desired.partitioned_by, rename_projection.partitioned_by),
         *_diff_clustering(desired.clustered_by, rename_projection.clustered_by),
         *_diff_primary_key(desired, observed),
         *_diff_foreign_keys(desired, observed),
     )
-    return TableDrift(desired=desired, changes=changes)
+    findings: tuple[Finding, ...] = (
+        *rename_projection.conflicts,
+        *_diff_undeclared_properties(desired, observed),
+        *_diff_partitioning(desired.partitioned_by, rename_projection.partitioned_by),
+    )
+    return TableDrift(desired=desired, actions=actions, findings=findings)
 
 
 @dataclass(frozen=True, slots=True)
@@ -188,7 +244,8 @@ class _RenameProjection:
     columns: tuple[ObservedColumn, ...]
     partitioned_by: tuple[str, ...]
     clustered_by: tuple[str, ...]
-    changes: tuple[RenameColumn | ColumnRenameConflict, ...]
+    renames: tuple[RenameColumn, ...]
+    conflicts: tuple[ColumnRenameConflict, ...]
 
 
 def _apply_renames(desired: DesiredTable, observed: ObservedTable) -> _RenameProjection:
@@ -202,27 +259,29 @@ def _apply_renames(desired: DesiredTable, observed: ObservedTable) -> _RenamePro
     relabeled = observed.columns
     applied_renames: dict[str, str] = {}
     conflicted_sources: set[str] = set()
-    changes: list[RenameColumn | ColumnRenameConflict] = []
+    rename_actions: list[RenameColumn] = []
+    conflicts: list[ColumnRenameConflict] = []
     for old_name, new_name in renames.items():
         if old_name not in observed_names:
             continue
         if new_name in observed_names:
             conflicted_sources.add(old_name)
-            changes.append(ColumnRenameConflict(old_name=old_name, new_name=new_name))
+            conflicts.append(ColumnRenameConflict(old_name=old_name, new_name=new_name))
             continue
         relabeled = tuple(
             replace(column, name=new_name) if column.name == old_name else column
             for column in relabeled
         )
         applied_renames[old_name] = new_name
-        changes.append(RenameColumn(old_name=old_name, new_name=new_name))
+        rename_actions.append(RenameColumn(old_name=old_name, new_name=new_name))
 
     relabeled = tuple(column for column in relabeled if column.name not in conflicted_sources)
     return _RenameProjection(
         columns=relabeled,
         partitioned_by=_relabel_names(observed.partitioned_by, applied_renames),
         clustered_by=_relabel_names(observed.clustered_by, applied_renames),
-        changes=tuple(changes),
+        renames=tuple(rename_actions),
+        conflicts=tuple(conflicts),
     )
 
 
@@ -325,30 +384,40 @@ def _diff_table_comment(desired: DesiredTable, observed: ObservedTable) -> list[
 
 def _diff_properties(
     desired: DesiredTable, observed: ObservedTable
-) -> list[SetProperty | UnsetProperty | PropertyUndeclared]:
-    """Return exact-declaration property actions and undeclared-property differences."""
+) -> list[SetProperty | UnsetProperty]:
+    """Return exact-declaration property actions for declared keys."""
     if TableAspect.PROPERTIES not in desired.managed_aspects:
         return []
 
-    changes: list[SetProperty | UnsetProperty | PropertyUndeclared] = []
+    actions: list[SetProperty | UnsetProperty] = []
     for name, declared_value in desired.properties.items():
         observed_value = observed.properties.get(name)
         if declared_value is None:
             if observed_value is not None:
-                changes.append(UnsetProperty(name=name, observed_value=observed_value))
+                actions.append(UnsetProperty(name=name, observed_value=observed_value))
         elif observed_value != declared_value:
-            changes.append(
+            actions.append(
                 SetProperty(
                     name=name,
                     desired_value=declared_value,
                     observed_value=observed_value,
                 )
             )
+    return actions
 
-    for name, observed_value in observed.properties.items():
-        if name not in desired.properties:
-            changes.append(PropertyUndeclared(name=name, observed_value=observed_value))
-    return changes
+
+def _diff_undeclared_properties(
+    desired: DesiredTable, observed: ObservedTable
+) -> list[PropertyUndeclared]:
+    """Return findings for managed catalog keys the declaration omits."""
+    if TableAspect.PROPERTIES not in desired.managed_aspects:
+        return []
+
+    return [
+        PropertyUndeclared(name=name, observed_value=observed_value)
+        for name, observed_value in observed.properties.items()
+        if name not in desired.properties
+    ]
 
 
 def _diff_table_tags(

--- a/tests/api/test_foreign_key.py
+++ b/tests/api/test_foreign_key.py
@@ -477,4 +477,5 @@ def test_reordering_the_parent_primary_key_produces_no_foreign_key_drift():
     )
     diff = diff_table(after, observed)
     assert isinstance(diff, TableDrift)
-    assert diff.changes == ()
+    assert diff.actions == ()
+    assert diff.findings == ()

--- a/tests/application/test_validation.py
+++ b/tests/application/test_validation.py
@@ -30,12 +30,13 @@ from delta_engine.domain.model import (
     TimestampNtz,
 )
 from delta_engine.domain.plan import (
+    Action,
     AddColumn,
     AlterColumnType,
-    Change,
     DropColumn,
     DropForeignKey,
     DropPrimaryKey,
+    Finding,
     SetColumnComment,
     SetColumnTag,
     SetTableComment,
@@ -87,13 +88,15 @@ def _observed_table(
 
 
 def _drift(
-    *changes: Change,
+    *differences: Action | Finding,
     managed_aspects: frozenset[TableAspect] = ALL_ASPECTS,
     desired: DesiredTable | None = None,
 ) -> TableDrift:
     if desired is None:
         desired = _desired_table(managed_aspects=managed_aspects)
-    return TableDrift(desired=desired, changes=tuple(changes))
+    actions = tuple(item for item in differences if isinstance(item, Action))
+    findings = tuple(item for item in differences if not isinstance(item, Action))
+    return TableDrift(desired=desired, actions=actions, findings=findings)
 
 
 def _validate(
@@ -958,7 +961,7 @@ def test_ambiguous_rename_fails_when_source_and_target_both_exist():
     )
     drift = TableDrift(
         desired=desired,
-        changes=(ColumnRenameConflict(old_name="customer_nm", new_name="customer_name"),),
+        findings=(ColumnRenameConflict(old_name="customer_nm", new_name="customer_name"),),
     )
 
     result = validate_diff(drift)
@@ -974,7 +977,7 @@ def test_removed_column_that_is_not_a_rename_source_is_not_ambiguous():
         properties={"delta.columnMapping.mode": "name"},
     )
     drift = TableDrift(
-        desired=desired, changes=(DropColumn(column=ObservedColumn("old", String())),)
+        desired=desired, actions=(DropColumn(column=ObservedColumn("old", String())),)
     )
 
     result = validate_diff(drift)

--- a/tests/domain/plan/test_actions.py
+++ b/tests/domain/plan/test_actions.py
@@ -87,13 +87,6 @@ def test_actionplan_truthiness_and_length():
     assert len(non_empty) == 1
 
 
-def test_actionplan_rejects_non_actions():
-    non_action = ColumnRenameConflict(old_name="old", new_name="new")
-
-    with pytest.raises(TypeError, match="accepts only Action instances"):
-        ActionPlan((non_action,))  # type: ignore[arg-type]
-
-
 def test_plan_orders_within_a_phase_by_subject_name():
     plan = ActionPlan((AddColumn(_column("b_col")), AddColumn(_column("a_col"))))
 
@@ -322,11 +315,11 @@ def test_drop_foreign_key_phases_before_drop_primary_key():
     assert ActionPhase.DROP_FOREIGN_KEY < ActionPhase.DROP_PRIMARY_KEY
 
 
-def test_column_rename_conflict_is_a_non_action_difference():
-    difference = ColumnRenameConflict(old_name="customer_nm", new_name="customer_name")
+def test_column_rename_conflict_is_a_finding_not_an_action():
+    finding = ColumnRenameConflict(old_name="customer_nm", new_name="customer_name")
 
-    assert not isinstance(difference, Action)
-    assert difference.aspect is TableAspect.COLUMN_STRUCTURE
+    assert not isinstance(finding, Action)
+    assert finding.aspect is TableAspect.COLUMN_STRUCTURE
 
 
 def test_column_rename_conflict_rejects_no_difference():

--- a/tests/domain/plan/test_diff.py
+++ b/tests/domain/plan/test_diff.py
@@ -96,7 +96,8 @@ def test_equal_tables_diff_to_empty_drift():
 
     # Then no changes are produced — the natural zero
     assert isinstance(diff, TableDrift)
-    assert diff.changes == ()
+    assert diff.actions == ()
+    assert diff.findings == ()
 
 
 def test_drift_carries_the_desired_table():
@@ -125,7 +126,7 @@ def test_desired_only_column_produces_column_added_change():
 
     # Then a AddColumn change is produced
     assert isinstance(diff, TableDrift)
-    assert AddColumn(Column("age", Integer())) in diff.changes
+    assert AddColumn(Column("age", Integer())) in diff.actions
 
 
 def test_observed_only_column_produces_column_removed_change():
@@ -137,7 +138,7 @@ def test_observed_only_column_produces_column_removed_change():
 
     # Then a DropColumn change is produced
     assert isinstance(diff, TableDrift)
-    assert diff.changes == (DropColumn(ObservedColumn("stale", String())),)
+    assert diff.actions == (DropColumn(ObservedColumn("stale", String())),)
 
 
 def test_type_drift_produces_column_data_type_changed():
@@ -149,7 +150,7 @@ def test_type_drift_produces_column_data_type_changed():
 
     # Then a AlterColumnType change carries both sides
     assert isinstance(diff, TableDrift)
-    assert diff.changes == (
+    assert diff.actions == (
         AlterColumnType(column_name="id", desired_type=Integer(), observed_type=Long()),
     )
 
@@ -165,9 +166,9 @@ def test_type_drift_suppresses_nullability_change_but_not_comment_change():
     # Then the type change is present and nullability is suppressed (the column
     # must be recreated first); comment drift is independent and not suppressed
     assert isinstance(diff, TableDrift)
-    assert any(isinstance(change, AlterColumnType) for change in diff.changes)
-    assert not any(isinstance(change, SetColumnNullability) for change in diff.changes)
-    assert any(isinstance(change, SetColumnComment) for change in diff.changes)
+    assert any(isinstance(change, AlterColumnType) for change in diff.actions)
+    assert not any(isinstance(change, SetColumnNullability) for change in diff.actions)
+    assert any(isinstance(change, SetColumnComment) for change in diff.actions)
 
 
 def test_nullability_drift_produces_column_nullability_changed():
@@ -179,7 +180,7 @@ def test_nullability_drift_produces_column_nullability_changed():
 
     # Then a SetColumnNullability change carries the direction
     assert isinstance(diff, TableDrift)
-    assert diff.changes == (
+    assert diff.actions == (
         SetColumnNullability(column_name="id", desired_nullable=False, observed_nullable=True),
     )
 
@@ -199,7 +200,7 @@ def test_comment_drift_on_matched_column_produces_change():
     # Then only the matched column produces a comment change; the ghost column's
     # comment travels inside its AddColumn change
     assert isinstance(diff, TableDrift)
-    comment_changes = [change for change in diff.changes if isinstance(change, SetColumnComment)]
+    comment_changes = [change for change in diff.actions if isinstance(change, SetColumnComment)]
     assert comment_changes == [
         SetColumnComment(column_name="id", desired_comment="pk", observed_comment="")
     ]
@@ -218,7 +219,7 @@ def test_column_tag_drift_produces_set_and_unset_changes():
     # Then set changes cover added and updated tags; an unset change covers the removed tag
     assert isinstance(diff, TableDrift)
     tag_changes = {
-        change for change in diff.changes if isinstance(change, (SetColumnTag, UnsetColumnTag))
+        change for change in diff.actions if isinstance(change, (SetColumnTag, UnsetColumnTag))
     }
     assert tag_changes == {
         SetColumnTag(column_name="id", name="new", value="x"),
@@ -236,7 +237,7 @@ def test_added_columns_tags_produce_set_facts():
 
     # Then the added column's tags are changes too — ADD_COLUMN precedes SET_COLUMN_TAG
     assert isinstance(diff, TableDrift)
-    assert SetColumnTag(column_name="new", name="pii", value="true") in diff.changes
+    assert SetColumnTag(column_name="new", name="pii", value="true") in diff.actions
 
 
 def test_identical_column_tags_produce_no_changes():
@@ -246,7 +247,8 @@ def test_identical_column_tags_produce_no_changes():
 
     # Then no tag changes are produced
     assert isinstance(diff, TableDrift)
-    assert diff.changes == ()
+    assert diff.actions == ()
+    assert diff.findings == ()
 
 
 # ---------- table comment change
@@ -256,7 +258,7 @@ def test_table_comment_drift_produces_change_with_both_sides():
     diff = diff_table(_desired(comment="new"), _observed(comment="old"))
 
     assert isinstance(diff, TableDrift)
-    assert diff.changes == (SetTableComment(desired_comment="new", observed_comment="old"),)
+    assert diff.actions == (SetTableComment(desired_comment="new", observed_comment="old"),)
 
 
 # ---------- property changes (exact declaration)
@@ -270,7 +272,7 @@ def test_declared_property_absent_from_catalog_produces_first_write_set():
     )
 
     assert isinstance(diff, TableDrift)
-    assert diff.changes == (
+    assert diff.actions == (
         SetProperty(name="delta.enableChangeDataFeed", desired_value="true", observed_value=None),
     )
 
@@ -282,7 +284,7 @@ def test_declared_property_with_stale_value_produces_set_carrying_both_sides():
     )
 
     assert isinstance(diff, TableDrift)
-    assert diff.changes == (
+    assert diff.actions == (
         SetProperty(
             name="delta.enableChangeDataFeed", desired_value="true", observed_value="false"
         ),
@@ -297,7 +299,8 @@ def test_declared_property_matching_catalog_produces_no_change():
 
     # Then no change is produced — the property sync is idempotent
     assert isinstance(diff, TableDrift)
-    assert diff.changes == ()
+    assert diff.actions == ()
+    assert diff.findings == ()
 
 
 def test_none_declaration_on_present_key_produces_unset():
@@ -308,7 +311,7 @@ def test_none_declaration_on_present_key_produces_unset():
     )
 
     assert isinstance(diff, TableDrift)
-    assert diff.changes == (
+    assert diff.actions == (
         UnsetProperty(name="delta.logRetentionDuration", observed_value="interval 30 days"),
     )
 
@@ -321,24 +324,25 @@ def test_none_declaration_on_absent_key_produces_no_change():
     )
 
     assert isinstance(diff, TableDrift)
-    assert diff.changes == ()
+    assert diff.actions == ()
+    assert diff.findings == ()
 
 
-def test_undeclared_registered_key_produces_blocking_change():
+def test_undeclared_registered_key_produces_an_undeclared_property_finding():
     # Given a registered key on the table that the declaration omits
     diff = diff_table(
         _desired(properties={}),
         _observed(properties={"delta.columnMapping.mode": "name"}),
     )
 
-    # Then the diff records the missing declaration intent as a non-action difference
+    # Then the diff records the missing declaration intent as a finding
     assert isinstance(diff, TableDrift)
-    assert diff.changes == (
+    assert diff.findings == (
         PropertyUndeclared(name="delta.columnMapping.mode", observed_value="name"),
     )
 
 
-def test_every_observed_key_without_declaration_is_a_blocking_change():
+def test_every_observed_key_without_declaration_produces_a_finding():
     # Given an observed managed key the declaration omits — the reader filters
     # the catalog map to managed keys, so every surviving key demands a decision
     diff = diff_table(
@@ -347,7 +351,7 @@ def test_every_observed_key_without_declaration_is_a_blocking_change():
     )
 
     assert isinstance(diff, TableDrift)
-    assert diff.changes == (
+    assert diff.findings == (
         PropertyUndeclared(name="delta.enableChangeDataFeed", observed_value="true"),
     )
 
@@ -363,7 +367,8 @@ def test_properties_diff_is_skipped_when_properties_unmanaged():
 
     # Then no property change of any kind — no assertion was made
     assert isinstance(diff, TableDrift)
-    assert diff.changes == ()
+    assert diff.actions == ()
+    assert diff.findings == ()
 
 
 def test_declared_properties_are_not_compared_when_properties_unmanaged():
@@ -377,7 +382,8 @@ def test_declared_properties_are_not_compared_when_properties_unmanaged():
 
     # Then the carried property makes no assertion and produces no change
     assert isinstance(diff, TableDrift)
-    assert diff.changes == ()
+    assert diff.actions == ()
+    assert diff.findings == ()
 
 
 def test_property_set_rejects_equal_values():
@@ -406,7 +412,7 @@ def test_table_tag_drift_produces_set_and_unset_changes():
 
     # Then the declared tag is set and the undeclared tag is unset — full-state
     assert isinstance(diff, TableDrift)
-    assert set(diff.changes) == {
+    assert set(diff.actions) == {
         SetTableTag(name="env", value="prod"),
         UnsetTableTag(name="stale"),
     }
@@ -424,7 +430,7 @@ def test_partitioning_drift_produces_change_with_both_sides():
     )
 
     assert isinstance(diff, TableDrift)
-    assert diff.changes == (
+    assert diff.findings == (
         PartitioningChanged(desired_partitioning=("id",), observed_partitioning=()),
     )
 
@@ -439,7 +445,7 @@ def test_clustering_drift_produces_change_with_both_sides():
         _desired(columns=columns, clustered_by=("region",)),
         _observed(columns=columns, clustered_by=()),
     )
-    assert diff.changes == (
+    assert diff.actions == (
         AlterClustering(desired_clustering=("region",), observed_clustering=()),
     )
 
@@ -452,7 +458,8 @@ def test_reordered_clustering_keys_are_not_a_change():
         _observed(columns=columns, clustered_by=("id", "region")),
     )
     # Then no clustering change is produced — key order is immaterial
-    assert diff.changes == ()
+    assert diff.actions == ()
+    assert diff.findings == ()
 
 
 def test_clustering_removal_produces_cluster_by_none_action():
@@ -462,7 +469,7 @@ def test_clustering_removal_produces_cluster_by_none_action():
         _desired(columns=columns, clustered_by=()),
         _observed(columns=columns, clustered_by=("region",)),
     )
-    assert diff.changes == (
+    assert diff.actions == (
         AlterClustering(desired_clustering=(), observed_clustering=("region",)),
     )
 
@@ -488,7 +495,7 @@ def test_desired_only_primary_key_produces_added_change():
     )
 
     assert isinstance(diff, TableDrift)
-    assert diff.changes == (SetPrimaryKey(primary_key=pk),)
+    assert diff.actions == (SetPrimaryKey(primary_key=pk),)
 
 
 def test_equal_primary_keys_by_column_set_produce_no_change():
@@ -504,7 +511,8 @@ def test_equal_primary_keys_by_column_set_produce_no_change():
 
     # Then identity is column-set equality — no change
     assert isinstance(diff, TableDrift)
-    assert diff.changes == ()
+    assert diff.actions == ()
+    assert diff.findings == ()
 
 
 # ---------- foreign key changes
@@ -515,7 +523,7 @@ def test_desired_only_foreign_key_produces_added_change():
     diff = diff_table(_desired(foreign_keys=(fk,)), _observed())
 
     assert isinstance(diff, TableDrift)
-    assert diff.changes == (SetForeignKey(constraint=fk),)
+    assert diff.actions == (SetForeignKey(constraint=fk),)
 
 
 def test_equal_foreign_keys_by_signature_produce_no_change():
@@ -527,7 +535,8 @@ def test_equal_foreign_keys_by_signature_produce_no_change():
 
     # Then identity is the content signature — no change, sync stays idempotent
     assert isinstance(diff, TableDrift)
-    assert diff.changes == ()
+    assert diff.actions == ()
+    assert diff.findings == ()
 
 
 # ---------- no-difference changes are unrepresentable
@@ -558,19 +567,25 @@ def test_partitioning_changed_rejects_equal_specs():
         PartitioningChanged(desired_partitioning=("ds",), observed_partitioning=("ds",))
 
 
-def test_managed_changes_filters_out_unmanaged_aspects():
-    # Given a drift containing one managed change and one unmanaged change
+def test_managed_views_filter_out_unmanaged_aspects():
+    # Given a drift with one managed action, one unmanaged action, and an
+    # unmanaged finding
     desired = _desired(managed_aspects=frozenset({TableAspect.TABLE_COMMENT}))
-    table_comment_change = SetTableComment(desired_comment="new", observed_comment="old")
-    column_change = AddColumn(Column("new_col", Integer()))
+    table_comment_action = SetTableComment(desired_comment="new", observed_comment="old")
+    column_action = AddColumn(Column("new_col", Integer()))
+    partitioning_finding = PartitioningChanged(
+        desired_partitioning=("id",), observed_partitioning=()
+    )
 
     drift = TableDrift(
         desired=desired,
-        changes=(column_change, table_comment_change),
+        actions=(column_action, table_comment_action),
+        findings=(partitioning_finding,),
     )
 
-    # Then only the managed change is exposed to validation rules
-    assert drift.managed_changes == (table_comment_change,)
+    # Then only managed differences are exposed to validation rules
+    assert drift.managed_actions == (table_comment_action,)
+    assert drift.managed_findings == ()
 
 
 def test_observed_only_primary_key_produces_removed_change():
@@ -585,7 +600,7 @@ def test_observed_only_primary_key_produces_removed_change():
 
     # Then the primary key is marked for removal
     assert isinstance(diff, TableDrift)
-    assert diff.changes == (DropPrimaryKey(primary_key=primary_key, referencing_foreign_keys=()),)
+    assert diff.actions == (DropPrimaryKey(primary_key=primary_key, referencing_foreign_keys=()),)
 
 
 def test_primary_key_removal_carries_observed_referencing_foreign_keys():
@@ -604,7 +619,7 @@ def test_primary_key_removal_carries_observed_referencing_foreign_keys():
 
     # Then the removal change carries the inbound reference for validation to judge
     assert isinstance(diff, TableDrift)
-    (change,) = diff.changes
+    (change,) = diff.actions
     assert isinstance(change, DropPrimaryKey)
     assert change.referencing_foreign_keys == (reference,)
 
@@ -626,7 +641,7 @@ def test_changed_primary_key_produces_drop_and_set_actions():
 
     # Then the observed key is dropped and the desired key is set
     assert isinstance(diff, TableDrift)
-    assert diff.changes == (
+    assert diff.actions == (
         DropPrimaryKey(
             primary_key=observed_primary_key,
             referencing_foreign_keys=(),
@@ -661,7 +676,7 @@ def test_primary_key_change_carries_observed_referencing_foreign_keys():
 
     # Then the drop half carries the inbound reference for validation to judge
     assert isinstance(diff, TableDrift)
-    drop = next(change for change in diff.changes if isinstance(change, DropPrimaryKey))
+    drop = next(change for change in diff.actions if isinstance(change, DropPrimaryKey))
     assert drop.referencing_foreign_keys == (reference,)
 
 
@@ -677,7 +692,7 @@ def test_observed_only_foreign_key_produces_removed_change():
 
     # Then the foreign key is marked for removal
     assert isinstance(diff, TableDrift)
-    assert diff.changes == (DropForeignKey(constraint=foreign_key),)
+    assert diff.actions == (DropForeignKey(constraint=foreign_key),)
 
 
 def test_changed_foreign_key_signature_produces_remove_and_add_changes():
@@ -698,7 +713,7 @@ def test_changed_foreign_key_signature_produces_remove_and_add_changes():
 
     # Then the observed relationship is removed and the desired relationship is added
     assert isinstance(diff, TableDrift)
-    assert set(diff.changes) == {
+    assert set(diff.actions) == {
         SetForeignKey(constraint=desired_foreign_key),
         DropForeignKey(constraint=observed_foreign_key),
     }
@@ -717,7 +732,7 @@ def test_observed_only_column_tags_are_ignored_because_column_is_removed():
     # Then the column removal is enough; no tag-unset noise is produced for a
     # column that will be dropped
     assert isinstance(diff, TableDrift)
-    assert diff.changes == (DropColumn(observed_only_column),)
+    assert diff.actions == (DropColumn(observed_only_column),)
 
 
 # ---------- column renames
@@ -734,7 +749,7 @@ def test_diff_emits_rename_when_source_observed_and_target_absent():
 
     drift = diff_table(desired, observed)
 
-    assert drift.changes == (RenameColumn(old_name="customer_nm", new_name="customer_name"),)
+    assert drift.actions == (RenameColumn(old_name="customer_nm", new_name="customer_name"),)
 
 
 def test_diff_pairs_residual_drift_under_the_new_name():
@@ -744,18 +759,20 @@ def test_diff_pairs_residual_drift_under_the_new_name():
 
     drift = diff_table(desired, observed)
 
-    assert RenameColumn(old_name="amt", new_name="amount") in drift.changes
+    assert RenameColumn(old_name="amt", new_name="amount") in drift.actions
     assert (
         AlterColumnType(column_name="amount", desired_type=Long(), observed_type=Integer())
-        in drift.changes
+        in drift.actions
     )
-    assert not any(isinstance(c, AddColumn | DropColumn) for c in drift.changes)
+    assert not any(isinstance(c, AddColumn | DropColumn) for c in drift.actions)
 
 
 def test_diff_hint_is_inert_when_applied_rename_is_steady_state():
     desired = _desired(columns=(Column("customer_name", String(), renamed_from="customer_nm"),))
     applied = _observed(columns=(Column("customer_name", String()),))
-    assert diff_table(desired, applied).changes == ()
+    drift = diff_table(desired, applied)
+    assert drift.actions == ()
+    assert drift.findings == ()
 
 
 def test_diff_hint_is_a_plain_add_when_neither_name_is_observed():
@@ -767,9 +784,9 @@ def test_diff_hint_is_a_plain_add_when_neither_name_is_observed():
     )
     observed = _observed(columns=(Column("id", Integer()),))
 
-    changes = diff_table(desired, observed).changes
+    actions = diff_table(desired, observed).actions
 
-    assert changes == (
+    assert actions == (
         AddColumn(column=Column("customer_name", String(), renamed_from="customer_nm")),
     )
 
@@ -780,10 +797,13 @@ def test_diff_emits_explicit_conflict_when_source_and_target_both_observed():
         columns=(Column("customer_name", String()), Column("customer_nm", String()))
     )
 
-    changes = diff_table(desired, observed).changes
+    drift = diff_table(desired, observed)
 
-    assert changes == (ColumnRenameConflict(old_name="customer_nm", new_name="customer_name"),)
-    assert not any(isinstance(change, DropColumn | RenameColumn) for change in changes)
+    # The conflict is a finding, and the source column is neither dropped nor renamed
+    assert drift.findings == (
+        ColumnRenameConflict(old_name="customer_nm", new_name="customer_name"),
+    )
+    assert drift.actions == ()
 
 
 def test_diff_missing_table_ignores_rename_hints():
@@ -809,9 +829,9 @@ def test_diff_projects_clustering_identity_across_a_rename():
         clustered_by=("customer_nm",),
     )
 
-    changes = diff_table(desired, observed).changes
+    actions = diff_table(desired, observed).actions
 
-    assert changes == (RenameColumn(old_name="customer_nm", new_name="customer_name"),)
+    assert actions == (RenameColumn(old_name="customer_nm", new_name="customer_name"),)
 
 
 def test_diff_projects_partition_identity_across_a_rename():
@@ -827,9 +847,9 @@ def test_diff_projects_partition_identity_across_a_rename():
         partitioned_by=("day",),
     )
 
-    changes = diff_table(desired, observed).changes
+    actions = diff_table(desired, observed).actions
 
-    assert changes == (RenameColumn(old_name="day", new_name="event_day"),)
+    assert actions == (RenameColumn(old_name="day", new_name="event_day"),)
 
 
 def test_diff_rename_and_primary_key_replacement_are_direct_actions():
@@ -846,7 +866,7 @@ def test_diff_rename_and_primary_key_replacement_are_direct_actions():
 
     drift = diff_table(desired, observed)
 
-    assert set(drift.changes) == {
+    assert set(drift.actions) == {
         RenameColumn(old_name="customer_nm", new_name="customer_name"),
         DropPrimaryKey(
             primary_key=observed_key,
@@ -885,7 +905,7 @@ def test_diff_rename_and_foreign_key_replacement_are_direct_actions():
 
     drift = diff_table(desired, observed)
 
-    assert set(drift.changes) == {
+    assert set(drift.actions) == {
         RenameColumn(old_name="parent", new_name="parent_id"),
         SetForeignKey(constraint=desired_key),
         DropForeignKey(constraint=observed_key),
@@ -923,7 +943,7 @@ def test_diff_rename_and_self_referenced_foreign_key_replacement_are_direct_acti
 
     drift = diff_table(desired, observed)
 
-    assert set(drift.changes) == {
+    assert set(drift.actions) == {
         RenameColumn(old_name="id", new_name="employee_id"),
         SetForeignKey(constraint=desired_key),
         DropForeignKey(constraint=observed_key),
@@ -954,8 +974,8 @@ def test_diff_keeps_an_unrelated_foreign_key_drop_alongside_a_rename():
 
     drift = diff_table(desired, observed)
 
-    assert drift.changes == (
+    assert drift.actions == (
         RenameColumn(old_name="customer_nm", new_name="customer_name"),
         DropForeignKey(constraint=unrelated_key),
     )
-    assert drift.executable_actions == drift.changes
+    assert drift.executable_actions == drift.actions


### PR DESCRIPTION
## Summary

- split `TableDrift` into typed `actions` and `findings` tuples, retiring the mixed `Change` union
- give validation typed managed views (`managed_actions` / `managed_findings`); the scope invariant reads both
- move the missing-table creation expansion into the domain: `TableMissing.actions` states CREATE TABLE plus tag and FK follow-ups, symmetric with the drift arm
- collapse `plan_diff` to one uniform shape: validate, then construct an `ActionPlan` from the diff's stated transition
- drop the runtime isinstance guard on `ActionPlan` — non-actions in a plan are no longer representable by construction

## Why

Differences come in two structural kinds: remedied (each carries the one action that closes its gap) and remedy-less (an ambiguous rename, an undeclared managed property, a partitioning change — statable, only judgeable). The old `Change = Action | 3 facts` union pretended they were one kind, which forced a runtime type guard on `ActionPlan` and left creation planning asymmetrically in the application layer. With the split, "an accepted plan contains only actions" is structural end to end, and the application layer neither compares schema state nor assembles domain transitions — matching the architecture docs' claims exactly.

## Impact

- internal planning model only; public APIs, sync behavior, report output, and SQL are unchanged
- `domain.plan` exports `Finding` instead of `Change`
- the rename/constraint projection (`executable_actions`) is untouched; it remains gated on the live rename-constraint verification before any change

## Validation

- `uv run pytest` — 906 passed, 41 deselected, 98.21% coverage
- `uv run ruff check .` / `uv run ruff format --check .`
- `uv run mypy .`
- `uv run lint-imports`
- `uv run --group docs sphinx-build -W -b html docs <tmp>`