### PR TITLE
refactor: name action state once

### DIFF
--- a/docs/explanation-architecture.md
+++ b/docs/explanation-architecture.md
@@ -380,8 +380,18 @@ exist, else a `TableDrift` holding executable `actions` and non-action
 complete desired/observed state needed by validation and reporting;
 `CreateTable` uses the table-existence aspect because it realizes a missing
 table's complete desired state rather than belonging to one schema dimension.
-Compiler-facing attributes remain read-only properties on the richer objects.
-There is no mirrored fact vocabulary and no lowering method.
+Every value is named once (`desired_*` / `observed_*` for transition state),
+and compilers and renderers read those names directly. There is no mirrored
+fact vocabulary and no lowering method.
+
+Naming differences by their remedies (`SetTableComment` rather than a
+separate "comment changed" fact) rests on one assumption: remedies are
+one-to-one. For every remedied difference this engine has exactly one
+operation that closes it, which is what lets a single vocabulary serve
+diffing, validation, reporting, and compilation. If an aspect ever admits
+alternative remedies — say, a type change resolvable by an in-place widen
+or by an add-and-backfill — the difference and its remedy stop being the
+same thing, and the vocabularies must separate again for that aspect.
 
 Both arms state the complete intended transition the same way: a
 `TableMissing` exposes its creation actions — CREATE TABLE plus tag and

--- a/docs/how-to-add-action-type.md
+++ b/docs/how-to-add-action-type.md
@@ -36,11 +36,9 @@ class UpdateComment(Action):
 Every action declares its `TableAspect`, carries enough desired and observed
 state for validation and reporting, and rejects a no-op payload when that is
 representable. Name each field once, semantically (`desired_*` / `observed_*`
-for transition state), and have compilers and renderers read those names
-directly — the read-only alias properties on some existing actions are a
-compatibility seam, not a pattern to copy. `Action.subject` determines
-alphabetical sort order within a phase; `ActionPhase` is an `IntEnum` — lower
-values run first.
+for transition state); compilers and renderers read those names directly.
+`Action.subject` determines alphabetical sort order within a phase;
+`ActionPhase` is an `IntEnum` — lower values run first.
 
 ## 2. Add a phase constant if needed
 
@@ -104,7 +102,7 @@ def _(action: UpdateComment, backticked_table_name: str) -> str:
     return f"ALTER TABLE {backticked_table_name} ALTER COLUMN {col} COMMENT {comment}"
 ```
 
-Each handler receives the `backticked_table_name` and renders SQL. A constraint action carries its own name (generated when the `DesiredTable` was built, or read from the catalog for an observed one), so the handler renders `action.constraint_name` directly rather than computing it.
+Each handler receives the `backticked_table_name` and renders SQL. A constraint action carries its complete constraint (named when the `DesiredTable` was built, or read from the catalog for an observed one), so the handler renders `action.constraint.constraint_name` directly rather than computing it.
 
 Use `backtick` for identifiers and `quote_literal` for string literals (both in `delta_engine/adapters/databricks/sql/dialect.py`).
 

--- a/src/delta_engine/adapters/databricks/sql/compile.py
+++ b/src/delta_engine/adapters/databricks/sql/compile.py
@@ -115,7 +115,7 @@ def _(action: AddColumn, backticked_table_name: str) -> str:
 @_compile_action.register
 def _(action: DropColumn, backticked_table_name: str) -> str:
     """Compile an ALTER TABLE ... DROP COLUMN statement for a column name."""
-    column_name = backtick(action.column_name)
+    column_name = backtick(action.column.name)
     return f"ALTER TABLE {backticked_table_name} DROP COLUMN {column_name}"
 
 
@@ -129,7 +129,7 @@ def _(action: RenameColumn, backticked_table_name: str) -> str:
 
 @_compile_action.register
 def _(action: SetProperty, backticked_table_name: str) -> str:
-    pair = f"{quote_literal(action.name)}={quote_literal(action.value)}"
+    pair = f"{quote_literal(action.name)}={quote_literal(action.desired_value)}"
     return f"ALTER TABLE {backticked_table_name} SET TBLPROPERTIES ({pair})"
 
 
@@ -169,31 +169,31 @@ def _(action: UnsetColumnTag, backticked_table_name: str) -> str:
 @_compile_action.register
 def _(action: SetColumnComment, backticked_table_name: str) -> str:
     column_name = backtick(action.column_name)
-    if not action.comment:
+    if not action.desired_comment:
         return f"ALTER TABLE {backticked_table_name} ALTER COLUMN {column_name} UNSET COMMENT"
-    comment = quote_literal(action.comment)
+    comment = quote_literal(action.desired_comment)
     return f"ALTER TABLE {backticked_table_name} ALTER COLUMN {column_name} COMMENT {comment}"
 
 
 @_compile_action.register
 def _(action: SetTableComment, backticked_table_name: str) -> str:
-    comment = quote_literal(action.comment)
+    comment = quote_literal(action.desired_comment)
     return f"COMMENT ON TABLE {backticked_table_name} IS {comment}"
 
 
 @_compile_action.register
 def _(action: SetColumnNullability, backticked_table_name: str) -> str:
     column_name = backtick(action.column_name)
-    sign = "DROP" if action.nullable else "SET"
+    sign = "DROP" if action.desired_nullable else "SET"
     return f"ALTER TABLE {backticked_table_name} ALTER COLUMN {column_name} {sign} NOT NULL"
 
 
 @_compile_action.register
 def _(action: AlterClustering, backticked_table_name: str) -> str:
     """Compile ALTER TABLE ... CLUSTER BY (...) or CLUSTER BY NONE."""
-    if not action.columns:
+    if not action.desired_clustering:
         return f"ALTER TABLE {backticked_table_name} CLUSTER BY NONE"
-    columns = ", ".join(backtick(column) for column in action.columns)
+    columns = ", ".join(backtick(column) for column in action.desired_clustering)
     return f"ALTER TABLE {backticked_table_name} CLUSTER BY ({columns})"
 
 
@@ -201,7 +201,7 @@ def _(action: AlterClustering, backticked_table_name: str) -> str:
 def _(action: AlterColumnType, backticked_table_name: str) -> str:
     """Compile ALTER TABLE ... ALTER COLUMN ... TYPE for a validated type widening."""
     column_name = backtick(action.column_name)
-    sql_type = render_data_type(action.data_type)
+    sql_type = render_data_type(action.desired_type)
     return f"ALTER TABLE {backticked_table_name} ALTER COLUMN {column_name} TYPE {sql_type}"
 
 
@@ -214,8 +214,8 @@ def _(action: DropPrimaryKey, backticked_table_name: str) -> str:
 @_compile_action.register
 def _(action: SetPrimaryKey, backticked_table_name: str) -> str:
     """Compile an ALTER TABLE ... ADD CONSTRAINT ... PRIMARY KEY statement."""
-    column_clause = ", ".join(backtick(name) for name in action.columns)
-    constraint = backtick(action.constraint_name)
+    column_clause = ", ".join(backtick(name) for name in action.primary_key.columns)
+    constraint = backtick(action.primary_key.constraint_name)
     return (
         f"ALTER TABLE {backticked_table_name}"
         f" ADD CONSTRAINT {constraint} PRIMARY KEY ({column_clause})"
@@ -225,17 +225,17 @@ def _(action: SetPrimaryKey, backticked_table_name: str) -> str:
 @_compile_action.register
 def _(action: DropForeignKey, backticked_table_name: str) -> str:
     """Compile ALTER TABLE ... DROP CONSTRAINT IF EXISTS for a foreign key."""
-    constraint = backtick(action.constraint_name)
+    constraint = backtick(action.constraint.constraint_name)
     return f"ALTER TABLE {backticked_table_name} DROP CONSTRAINT IF EXISTS {constraint}"
 
 
 @_compile_action.register
 def _(action: SetForeignKey, backticked_table_name: str) -> str:
     """Compile ALTER TABLE ... ADD CONSTRAINT ... FOREIGN KEY ... REFERENCES ..."""
-    constraint = backtick(action.constraint_name)
-    local_cols = ", ".join(backtick(col) for col in action.local_columns)
-    ref_cols = ", ".join(backtick(col) for col in action.referenced_columns)
-    backticked_ref = backtick_qualified_name(action.referenced_table)
+    constraint = backtick(action.constraint.constraint_name)
+    local_cols = ", ".join(backtick(col) for col in action.constraint.local_columns)
+    ref_cols = ", ".join(backtick(col) for col in action.constraint.referenced_columns)
+    backticked_ref = backtick_qualified_name(action.constraint.referenced_table)
     return (
         f"ALTER TABLE {backticked_table_name}"
         f" ADD CONSTRAINT {constraint}"

--- a/src/delta_engine/application/diff_entries.py
+++ b/src/delta_engine/application/diff_entries.py
@@ -140,7 +140,7 @@ def _(action: AddColumn) -> tuple[DiffEntry, ...]:
 
 @action_entries.register
 def _(action: DropColumn) -> tuple[DiffEntry, ...]:
-    return (DiffEntry(DiffCategory.COLUMNS, "-", (action.column_name,)),)
+    return (DiffEntry(DiffCategory.COLUMNS, "-", (action.column.name,)),)
 
 
 @action_entries.register
@@ -152,20 +152,23 @@ def _(action: RenameColumn) -> tuple[DiffEntry, ...]:
 
 @action_entries.register
 def _(action: SetColumnNullability) -> tuple[DiffEntry, ...]:
-    change = "drop NOT NULL (was NOT NULL)" if action.nullable else "set NOT NULL (was nullable)"
+    if action.desired_nullable:
+        change = "drop NOT NULL (was NOT NULL)"
+    else:
+        change = "set NOT NULL (was nullable)"
     return (DiffEntry(DiffCategory.COLUMNS, "~", (action.column_name, change)),)
 
 
 @action_entries.register
 def _(action: AlterColumnType) -> tuple[DiffEntry, ...]:
-    change = f"{_type_display(action.observed_type)} → {_type_display(action.data_type)}"
+    change = f"{_type_display(action.observed_type)} → {_type_display(action.desired_type)}"
     return (DiffEntry(DiffCategory.COLUMNS, "~", (action.column_name, change)),)
 
 
 @action_entries.register
 def _(action: SetColumnComment) -> tuple[DiffEntry, ...]:
-    if action.comment:
-        text = f"column {action.column_name}: '{action.comment}'"
+    if action.desired_comment:
+        text = f"column {action.column_name}: '{action.desired_comment}'"
     else:
         text = f"column {action.column_name} comment (unset)"
     return (DiffEntry(DiffCategory.COMMENTS, "~", (text,)),)
@@ -173,15 +176,19 @@ def _(action: SetColumnComment) -> tuple[DiffEntry, ...]:
 
 @action_entries.register
 def _(action: SetTableComment) -> tuple[DiffEntry, ...]:
-    text = f"table: '{action.comment}'" if action.comment else "table comment (unset)"
+    text = (
+        f"table: '{action.desired_comment}'" if action.desired_comment else "table comment (unset)"
+    )
     return (DiffEntry(DiffCategory.COMMENTS, "~", (text,)),)
 
 
 @action_entries.register
 def _(action: SetProperty) -> tuple[DiffEntry, ...]:
     if action.observed_value is None:
-        return (DiffEntry(DiffCategory.PROPERTIES, "+", (f"{action.name} = '{action.value}'",)),)
-    text = f"{action.name} = '{action.value}' (was '{action.observed_value}')"
+        return (
+            DiffEntry(DiffCategory.PROPERTIES, "+", (f"{action.name} = '{action.desired_value}'",)),
+        )
+    text = f"{action.name} = '{action.desired_value}' (was '{action.observed_value}')"
     return (DiffEntry(DiffCategory.PROPERTIES, "~", (text,)),)
 
 
@@ -213,7 +220,11 @@ def _(action: UnsetColumnTag) -> tuple[DiffEntry, ...]:
 
 @action_entries.register
 def _(action: SetPrimaryKey) -> tuple[DiffEntry, ...]:
-    return (DiffEntry(DiffCategory.KEYS, "+", (f"primary key ({', '.join(action.columns)})",)),)
+    return (
+        DiffEntry(
+            DiffCategory.KEYS, "+", (f"primary key ({', '.join(action.primary_key.columns)})",)
+        ),
+    )
 
 
 @action_entries.register
@@ -223,13 +234,16 @@ def _(action: DropPrimaryKey) -> tuple[DiffEntry, ...]:
 
 @action_entries.register
 def _(action: SetForeignKey) -> tuple[DiffEntry, ...]:
-    text = f"foreign key ({', '.join(action.local_columns)}) → {action.referenced_table}"
+    local_columns = ", ".join(action.constraint.local_columns)
+    text = f"foreign key ({local_columns}) → {action.constraint.referenced_table}"
     return (DiffEntry(DiffCategory.KEYS, "+", (text,)),)
 
 
 @action_entries.register
 def _(action: DropForeignKey) -> tuple[DiffEntry, ...]:
-    return (DiffEntry(DiffCategory.KEYS, "-", (f"foreign key {action.constraint_name}",)),)
+    return (
+        DiffEntry(DiffCategory.KEYS, "-", (f"foreign key {action.constraint.constraint_name}",)),
+    )
 
 
 _OPTIMIZE_FULL_HINT: Final[str] = "run OPTIMIZE FULL to recluster existing data"
@@ -240,8 +254,8 @@ def _(action: AlterClustering) -> tuple[DiffEntry, ...]:
     # No hint on removal: OPTIMIZE FULL errors on a table without clustering
     # columns (DELTA_OPTIMIZE_FULL_NOT_SUPPORTED); existing files simply keep
     # their old layout after CLUSTER BY NONE.
-    if not action.columns:
+    if not action.desired_clustering:
         return (DiffEntry(DiffCategory.CLUSTERING, "-", ("clustering",)),)
-    columns = ", ".join(action.columns)
+    columns = ", ".join(action.desired_clustering)
     text = f"clustering ({columns}) — {_OPTIMIZE_FULL_HINT}"
     return (DiffEntry(DiffCategory.CLUSTERING, "~", (text,)),)

--- a/src/delta_engine/domain/plan/actions.py
+++ b/src/delta_engine/domain/plan/actions.py
@@ -14,7 +14,6 @@ from delta_engine.domain.model import (
     ForeignKeyReference,
     ObservedColumn,
     PrimaryKeyConstraint,
-    QualifiedName,
     TableAspect,
 )
 
@@ -56,10 +55,10 @@ class Action(ABC):
     """
     Base class for executable table actions.
 
-    Every action carries the complete semantic state needed to validate and
-    report it as well as the compiler-facing state needed to execute it. Each
-    subclass declares its managed ``aspect``, execution ``phase``, and stable
-    within-phase ``subject``.
+    Every action carries the complete semantic state needed to validate,
+    report, and execute it, with each value named once (``desired_*`` /
+    ``observed_*`` for transition state). Each subclass declares its managed
+    ``aspect``, execution ``phase``, and stable within-phase ``subject``.
     """
 
     aspect: ClassVar[TableAspect]
@@ -110,11 +109,6 @@ class DropColumn(Action):
     phase: ClassVar[ActionPhase] = ActionPhase.DROP_COLUMN
 
     @property
-    def column_name(self) -> str:
-        """Observed column name consumed by action compilers."""
-        return self.column.name
-
-    @property
     def subject(self) -> str:
         return self.column.name
 
@@ -152,11 +146,6 @@ class SetProperty(Action):
     def __post_init__(self) -> None:
         if self.desired_value == self.observed_value:
             raise ValueError(f"SetProperty carries no difference: {self.desired_value!r}")
-
-    @property
-    def value(self) -> str:
-        """Desired value consumed by action compilers."""
-        return self.desired_value
 
     @property
     def subject(self) -> str:
@@ -223,11 +212,6 @@ class SetColumnComment(Action):
             raise ValueError(f"SetColumnComment carries no difference: {self.desired_comment!r}")
 
     @property
-    def comment(self) -> str:
-        """Desired comment consumed by action compilers."""
-        return self.desired_comment
-
-    @property
     def subject(self) -> str:
         return self.column_name
 
@@ -278,11 +262,6 @@ class SetTableComment(Action):
             raise ValueError(f"SetTableComment carries no difference: {self.desired_comment!r}")
 
     @property
-    def comment(self) -> str:
-        """Desired comment consumed by action compilers."""
-        return self.desired_comment
-
-    @property
     def subject(self) -> str:
         return ""
 
@@ -305,11 +284,6 @@ class SetColumnNullability(Action):
             )
 
     @property
-    def nullable(self) -> bool:
-        """Desired nullability consumed by action compilers."""
-        return self.desired_nullable
-
-    @property
     def subject(self) -> str:
         return self.column_name
 
@@ -328,11 +302,6 @@ class DropPrimaryKey(Action):
         object.__setattr__(self, "referencing_foreign_keys", tuple(self.referencing_foreign_keys))
 
     @property
-    def observed_primary_key(self) -> PrimaryKeyConstraint:
-        """The catalog constraint that will be dropped."""
-        return self.primary_key
-
-    @property
     def subject(self) -> str:
         return ""
 
@@ -345,16 +314,6 @@ class SetPrimaryKey(Action):
 
     aspect: ClassVar[TableAspect] = TableAspect.PRIMARY_KEY
     phase: ClassVar[ActionPhase] = ActionPhase.SET_PRIMARY_KEY
-
-    @property
-    def columns(self) -> tuple[str, ...]:
-        """Primary-key columns consumed by action compilers."""
-        return self.primary_key.columns
-
-    @property
-    def constraint_name(self) -> str:
-        """Primary-key name consumed by action compilers."""
-        return self.primary_key.constraint_name
 
     @property
     def subject(self) -> str:
@@ -371,11 +330,6 @@ class DropForeignKey(Action):
     phase: ClassVar[ActionPhase] = ActionPhase.DROP_FOREIGN_KEY
 
     @property
-    def constraint_name(self) -> str:
-        """Catalog constraint name consumed by action compilers."""
-        return self.constraint.constraint_name
-
-    @property
     def subject(self) -> str:
         return self.constraint.constraint_name
 
@@ -388,26 +342,6 @@ class SetForeignKey(Action):
 
     aspect: ClassVar[TableAspect] = TableAspect.FOREIGN_KEYS
     phase: ClassVar[ActionPhase] = ActionPhase.SET_FOREIGN_KEY
-
-    @property
-    def local_columns(self) -> tuple[str, ...]:
-        """Local columns consumed by action compilers."""
-        return self.constraint.local_columns
-
-    @property
-    def referenced_table(self) -> QualifiedName:
-        """Referenced table consumed by action compilers."""
-        return self.constraint.referenced_table
-
-    @property
-    def referenced_columns(self) -> tuple[str, ...]:
-        """Referenced columns consumed by action compilers."""
-        return self.constraint.referenced_columns
-
-    @property
-    def constraint_name(self) -> str:
-        """Constraint name consumed by action compilers."""
-        return self.constraint.constraint_name
 
     @property
     def subject(self) -> str:
@@ -431,11 +365,6 @@ class AlterClustering(Action):
             raise ValueError(f"AlterClustering carries no difference: {self.desired_clustering!r}")
 
     @property
-    def columns(self) -> tuple[str, ...]:
-        """Desired clustering columns consumed by action compilers."""
-        return self.desired_clustering
-
-    @property
     def subject(self) -> str:
         return ""
 
@@ -454,11 +383,6 @@ class AlterColumnType(Action):
     def __post_init__(self) -> None:
         if self.desired_type == self.observed_type:
             raise ValueError(f"AlterColumnType carries no difference: {self.desired_type!r}")
-
-    @property
-    def data_type(self) -> DataType:
-        """Desired type consumed by action compilers."""
-        return self.desired_type
 
     @property
     def subject(self) -> str:

--- a/tests/domain/plan/test_actions.py
+++ b/tests/domain/plan/test_actions.py
@@ -276,24 +276,6 @@ def test_plan_reclusters_after_add_and_before_drop():
     assert [type(action) for action in plan] == [AddColumn, AlterClustering, DropColumn]
 
 
-def test_enriched_actions_preserve_compiler_facing_properties():
-    observed_column = _observed_column("legacy")
-    primary_key = _primary_key()
-    foreign_key = _foreign_key()
-
-    assert DropColumn(observed_column).column_name == "legacy"
-    assert SetProperty("prop", "new", "old").value == "new"
-    assert SetColumnComment("id", "new", "old").comment == "new"
-    assert SetTableComment("new", "old").comment == "new"
-    assert SetColumnNullability("id", False, True).nullable is False
-    assert SetPrimaryKey(primary_key).columns == ("id",)
-    assert SetPrimaryKey(primary_key).constraint_name == "table_pk"
-    assert DropForeignKey(foreign_key).constraint_name == "table_customer_id_fk"
-    assert SetForeignKey(foreign_key).referenced_table == foreign_key.referenced_table
-    assert AlterClustering(("region",), ()).columns == ("region",)
-    assert AlterColumnType("id", Long(), Integer()).data_type == Long()
-
-
 @pytest.mark.parametrize(
     "factory",
     [

--- a/tests/domain/plan/test_diff.py
+++ b/tests/domain/plan/test_diff.py
@@ -474,11 +474,6 @@ def test_clustering_removal_produces_cluster_by_none_action():
     )
 
 
-def test_clustering_change_produces_alter_clustering_action():
-    change = AlterClustering(desired_clustering=("region",), observed_clustering=("id",))
-    assert change.columns == ("region",)
-
-
 def test_clustering_changed_rejects_equal_key_sets():
     with pytest.raises(ValueError, match="no difference"):
         AlterClustering(desired_clustering=("a", "b"), observed_clustering=("b", "a"))


### PR DESCRIPTION
## Summary

- migrate `compile.py` and `diff_entries.py` to the semantic action fields (`desired_*` / `observed_*`, `constraint.*`, `primary_key.*`, `column.name`)
- delete the 15 compiler-facing alias properties from `actions.py` — every value now has exactly one name
- document the boundary condition of the canonical-action vocabulary in `explanation-architecture.md`: naming differences by their remedies is valid exactly while remedies are 1:1; if an aspect ever admits alternative remedies, the vocabularies must separate again for that aspect

## Why

The aliases were a deliberate compatibility seam in #219 so the adapter layer could stay diff-free while the rich action vocabulary landed. Kept permanently they are two names for one value (`SetProperty.value` vs `desired_value`), inviting drift and confusion about which is canonical. With the consumers migrated, the seam has no remaining purpose.

## Impact

- internal only; compiled SQL, report output, and public APIs are byte-identical
- two tests that existed solely to pin the aliases are removed

## Validation

- `uv run pytest` — 904 passed, 41 deselected, 98.22% coverage
- `uv run ruff check .` / `uv run ruff format --check .`
- `uv run mypy .`
- `uv run lint-imports`
- `uv run --group docs sphinx-build -W -b html docs <tmp>`