### PR TITLE
refactor: plan explicit constraint drops around column renames

### DIFF
--- a/docs/explanation-architecture.md
+++ b/docs/explanation-architecture.md
@@ -398,12 +398,14 @@ Both arms state the complete intended transition the same way: a
 foreign-key follow-ups — so accepted planning is uniformly "construct an
 `ActionPlan` from the diff's actions" for creation and drift alike.
 
-The domain also owns the operation semantics used to project a validated
-`TableDrift` into its final actions. In particular, the raw diff retains PK/FK
-drops involving a renamed column because validation needs their observed
-constraint state, while the domain's action projection omits drops performed
-atomically by `RENAME COLUMN`. The application layer neither compares schema
-state nor decides which constraint actions a rename supersedes.
+An accepted plan is the diff's actions verbatim; nothing sits between
+validation and plan construction. Constraint replacement around a column
+rename is stated explicitly and sequenced by `ActionPlan` phase ordering:
+PK/FK drops run before the rename, while each constraint still exists under
+its observed name, and declared keys are re-added afterwards. Databricks
+would drop those constraints implicitly as part of `RENAME COLUMN`; the
+engine states the drops instead of relying on that, so the plan is a
+complete transcript of what executes.
 
 Only three findings exist: `ColumnRenameConflict`, `PropertyUndeclared`, and
 `PartitioningChanged`. Each states an ambiguity or unsupported transition

--- a/docs/how-to-configure-table.md
+++ b/docs/how-to-configure-table.md
@@ -180,9 +180,12 @@ into a fresh catalog. If both the old and new names exist on the table the
 rename cannot apply and the sync fails (`AmbiguousColumnRename`); if the old
 column should instead be dropped, remove the hint and drop it in its own sync.
 
-Databricks drops a primary or foreign key involving the column as part of a
-successful rename; the engine restores each declared key afterwards. It does
-not pre-drop those keys, so a failed rename does not leave them removed. If
+A primary or foreign key involving the column is replaced across the rename:
+the plan drops the key, renames the column, then re-adds the declared key, so
+every statement the engine runs is stated in the plan. (Databricks would drop
+those keys implicitly during `RENAME COLUMN`; the engine does not rely on
+that.) Keys on Databricks are informational, so if a later statement fails the
+only exposure is a missing key until the next successful sync restores it. If
 **another** table's foreign key references the renamed primary key, sync that
 table without the foreign key first — an inbound reference blocks the change.
 Partitioning and clustering metadata follow the mapped column's identity, so

--- a/docs/reference-safe-change-rules.md
+++ b/docs/reference-safe-change-rules.md
@@ -51,9 +51,10 @@ both names are observed the rename cannot apply and `AmbiguousColumnRename`
 blocks the sync.
 
 Partitioning and clustering metadata follow a mapped column's identity, so a
-layout key rename does not create layout drift. Databricks drops any primary
-or foreign key involving the column as part of a successful rename; the
-engine restores declared keys afterwards without pre-dropping them. An inbound
+layout key rename does not create layout drift. Primary and foreign keys
+involving the column are replaced explicitly: the plan drops each key before
+the rename and re-adds the declared key afterwards, rather than relying on
+the implicit drops Databricks performs during `RENAME COLUMN`. An inbound
 foreign key still blocks a primary-key rename via
 `PrimaryKeyReferencedByForeignKeys`.
 

--- a/src/delta_engine/application/planning.py
+++ b/src/delta_engine/application/planning.py
@@ -50,6 +50,6 @@ def plan_diff(diff: TableDiff) -> PlanningResult:
         case TableMissing() as missing:
             return PlanningSucceeded(plan=ActionPlan(missing.actions))
         case TableDrift() as drift:
-            return PlanningSucceeded(plan=ActionPlan(drift.executable_actions))
+            return PlanningSucceeded(plan=ActionPlan(drift.actions))
         case _ as unreachable:
             assert_never(unreachable)

--- a/src/delta_engine/domain/plan/diff.py
+++ b/src/delta_engine/domain/plan/diff.py
@@ -20,10 +20,8 @@ from typing import ClassVar
 from delta_engine.domain.model import (
     DesiredColumn,
     DesiredTable,
-    ForeignKeyConstraint,
     ObservedColumn,
     ObservedTable,
-    QualifiedName,
     TableAspect,
 )
 from delta_engine.domain.plan.actions import (
@@ -155,52 +153,8 @@ class TableDrift:
         managed = self.desired.managed_aspects
         return tuple(finding for finding in self.findings if finding.aspect in managed)
 
-    @property
-    def executable_actions(self) -> tuple[Action, ...]:
-        """
-        Project diff actions through operation semantics owned by the domain.
-
-        The raw diff retains constraint drops because validation needs their
-        observed state. A column rename performs drops for constraints using
-        that column atomically, so those redundant actions are omitted only
-        from this post-validation projection. This property does not imply
-        that the actions are safe; only ``plan_diff`` may construct a plan.
-        """
-        renamed_sources = {
-            action.old_name for action in self.actions if isinstance(action, RenameColumn)
-        }
-        actions: list[Action] = []
-        for action in self.actions:
-            if isinstance(action, DropPrimaryKey) and not renamed_sources.isdisjoint(
-                action.primary_key.columns
-            ):
-                continue
-            if isinstance(action, DropForeignKey) and _foreign_key_uses_renamed_column(
-                action.constraint,
-                renamed_sources=renamed_sources,
-                table_name=self.desired.qualified_name,
-            ):
-                continue
-            actions.append(action)
-        return tuple(actions)
-
 
 type TableDiff = TableMissing | TableDrift
-
-
-def _foreign_key_uses_renamed_column(
-    constraint: ForeignKeyConstraint,
-    *,
-    renamed_sources: set[str],
-    table_name: QualifiedName,
-) -> bool:
-    """Whether a local or self-referenced FK column is renamed by this table."""
-    local_column_renamed = not renamed_sources.isdisjoint(constraint.local_columns)
-    self_reference_renamed = (
-        constraint.referenced_table == table_name
-        and not renamed_sources.isdisjoint(constraint.referenced_columns)
-    )
-    return local_column_renamed or self_reference_renamed
 
 
 def diff_table(desired: DesiredTable, observed: ObservedTable | None) -> TableDiff:

--- a/tests/application/test_planning.py
+++ b/tests/application/test_planning.py
@@ -24,6 +24,7 @@ from delta_engine.domain.plan import (
     AlterColumnType,
     CreateTable,
     DropForeignKey,
+    DropPrimaryKey,
     RenameColumn,
     SetColumnTag,
     SetForeignKey,
@@ -203,7 +204,7 @@ def test_plan_diff_keeps_rename_and_residual_drift_under_the_new_name():
     )
 
 
-def test_plan_diff_uses_domain_projected_primary_key_actions_for_rename():
+def test_plan_diff_replaces_a_primary_key_explicitly_across_a_rename():
     desired_key = PrimaryKeyConstraint(("customer_name",), "test_pk")
     observed_key = PrimaryKeyConstraint(("customer_nm",), "legacy_pk")
     desired = _desired(
@@ -219,12 +220,13 @@ def test_plan_diff_uses_domain_projected_primary_key_actions_for_rename():
 
     assert isinstance(result, PlanningSucceeded)
     assert result.plan.actions == (
+        DropPrimaryKey(primary_key=observed_key, referencing_foreign_keys=()),
         RenameColumn("customer_nm", "customer_name"),
         SetPrimaryKey(primary_key=desired_key),
     )
 
 
-def test_plan_diff_validates_rename_constraint_drops_before_domain_projection():
+def test_plan_diff_rejects_rename_of_a_primary_key_referenced_by_foreign_keys():
     reference = ForeignKeyReference(
         constraint_name="orders_customer_id_fk",
         referencing_table=QualifiedName("dev", "silver", "orders"),
@@ -250,7 +252,7 @@ def test_plan_diff_validates_rename_constraint_drops_before_domain_projection():
     assert not hasattr(result, "plan")
 
 
-def test_plan_diff_uses_domain_projected_local_foreign_key_actions_for_rename():
+def test_plan_diff_replaces_a_foreign_key_explicitly_across_a_rename():
     parent = QualifiedName("dev", "silver", "parent")
     desired_key = _foreign_key(
         local_columns=("parent_id",),
@@ -276,12 +278,13 @@ def test_plan_diff_uses_domain_projected_local_foreign_key_actions_for_rename():
 
     assert isinstance(result, PlanningSucceeded)
     assert result.plan.actions == (
+        DropForeignKey(constraint=observed_key),
         RenameColumn("parent", "parent_id"),
         SetForeignKey(constraint=desired_key),
     )
 
 
-def test_plan_diff_uses_domain_projected_self_referencing_foreign_key_actions_for_rename():
+def test_plan_diff_replaces_a_self_referencing_foreign_key_explicitly_across_a_rename():
     desired_key = _foreign_key(
         local_columns=("manager_id",),
         referenced_table=_NAME,
@@ -310,12 +313,13 @@ def test_plan_diff_uses_domain_projected_self_referencing_foreign_key_actions_fo
 
     assert isinstance(result, PlanningSucceeded)
     assert result.plan.actions == (
+        DropForeignKey(constraint=observed_key),
         RenameColumn("id", "employee_id"),
         SetForeignKey(constraint=desired_key),
     )
 
 
-def test_plan_diff_retains_unrelated_foreign_key_drop_before_rename():
+def test_plan_diff_drops_an_observed_only_foreign_key_alongside_a_rename():
     unrelated_key = _foreign_key(
         local_columns=("id",),
         referenced_table=QualifiedName("dev", "silver", "parent"),

--- a/tests/domain/plan/test_diff.py
+++ b/tests/domain/plan/test_diff.py
@@ -890,10 +890,6 @@ def test_diff_rename_and_primary_key_replacement_are_direct_actions():
         ),
         SetPrimaryKey(primary_key=desired_key),
     }
-    assert drift.executable_actions == (
-        RenameColumn(old_name="customer_nm", new_name="customer_name"),
-        SetPrimaryKey(primary_key=desired_key),
-    )
 
 
 def test_diff_rename_and_foreign_key_replacement_are_direct_actions():
@@ -926,10 +922,6 @@ def test_diff_rename_and_foreign_key_replacement_are_direct_actions():
         SetForeignKey(constraint=desired_key),
         DropForeignKey(constraint=observed_key),
     }
-    assert drift.executable_actions == (
-        RenameColumn(old_name="parent", new_name="parent_id"),
-        SetForeignKey(constraint=desired_key),
-    )
 
 
 def test_diff_rename_and_self_referenced_foreign_key_replacement_are_direct_actions():
@@ -964,10 +956,6 @@ def test_diff_rename_and_self_referenced_foreign_key_replacement_are_direct_acti
         SetForeignKey(constraint=desired_key),
         DropForeignKey(constraint=observed_key),
     }
-    assert drift.executable_actions == (
-        RenameColumn(old_name="id", new_name="employee_id"),
-        SetForeignKey(constraint=desired_key),
-    )
 
 
 def test_diff_keeps_an_unrelated_foreign_key_drop_alongside_a_rename():
@@ -994,4 +982,3 @@ def test_diff_keeps_an_unrelated_foreign_key_drop_alongside_a_rename():
         RenameColumn(old_name="customer_nm", new_name="customer_name"),
         DropForeignKey(constraint=unrelated_key),
     )
-    assert drift.executable_actions == drift.actions


### PR DESCRIPTION
## What

Deletes the rename projection: `TableDrift.executable_actions` and `_foreign_key_uses_renamed_column` are gone, and `plan_diff` now constructs an accepted plan from `drift.actions` verbatim. A rename that touches a primary or foreign key plans the full explicit sequence:

```sql
ALTER TABLE `dev`.`silver`.`orders` DROP PRIMARY KEY IF EXISTS
ALTER TABLE `dev`.`silver`.`orders` RENAME COLUMN `customer_nm` TO `customer_name`
ALTER TABLE `dev`.`silver`.`orders` ADD CONSTRAINT `orders_pk` PRIMARY KEY (`customer_name`)
```

Previously the plan omitted the drop and relied on the backend performing it implicitly.

## Why

The [RENAME COLUMN reference](https://learn.microsoft.com/en-us/azure/databricks/sql/language-manual/sql-ref-syntax-ddl-alter-table-manage-column) documents that renaming drops any primary and foreign keys using the column. The projection existed to suppress drop statements the backend performs implicitly — correct, but it made the plan diverge from the diff and required domain code (`_foreign_key_uses_renamed_column`) to re-derive which constraints a rename supersedes. Explicit drops are equally correct under the documented semantics: `ActionPhase` already orders constraint drops before renames, so each drop targets the constraint while it still exists under its observed name. The plan becomes a complete transcript of what executes, and the last special case between diff and plan disappears.

Bonus safety: the explicit PK drop compiles without `CASCADE`, so Databricks' `RESTRICT` default fails closed if an unseen inbound FK exists — a second net under `PrimaryKeyReferencedByForeignKeys`, which continues to reject that scenario at validation.

## Trade-off

The projection meant a failed rename could not leave keys pre-dropped. That window now exists — matching plain key replacements, which already run as separate drop/add statements. Keys are informational on Unity Catalog, so the exposure is a missing optimizer hint until the next successful sync restores them; a rerun converges (the differ observes the key absent and plans the re-add). Docs updated to state this honestly.

## Notes

- Stacked on #222 (`refactor/desired-column`); retarget to `main` after it merges.
- Docs updated: `explanation-architecture.md` (diff-first planning), `reference-safe-change-rules.md`, `how-to-configure-table.md` (rename section).
- Follow-up outside this PR: one live smoke-check of a PK-bearing rename on a real workspace, since we now (deliberately) issue drops the backend would also perform implicitly.