### PR TITLE
test: live coverage for declarative column renames

### DIFF
--- a/.github/workflows/live.yaml
+++ b/.github/workflows/live.yaml
@@ -1,0 +1,86 @@
+# Credentialed live suite against a real Databricks SQL warehouse.
+#
+# Deliberately not part of regular CI: manual dispatch only, and the run
+# targets whichever ref is selected (`gh workflow run live.yaml --ref <branch>`
+# once this file exists on main).
+#
+# Required repository variables:
+#   DATABRICKS_HOST            workspace URL
+#   DATABRICKS_HTTP_PATH       SQL warehouse endpoint path
+#   DELTA_ENGINE_E2E_CATALOG   catalog the suite may create tables in
+#   DELTA_ENGINE_E2E_SCHEMA    schema the suite may create tables in
+# Required repository secret (either one):
+#   DATABRICKS_TOKEN           personal access token, or
+#   DATABRICKS_CLIENT_ID       service principal for OIDC workload identity
+#                              federation (needs a Databricks federation
+#                              policy for this repository)
+name: Live
+
+on:
+  workflow_dispatch:
+
+# One live run at a time: the suite shares a schema and a warehouse.
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  live:
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    env:
+      DATABRICKS_HOST: ${{ vars.DATABRICKS_HOST }}
+      DATABRICKS_HTTP_PATH: ${{ vars.DATABRICKS_HTTP_PATH }}
+      DELTA_ENGINE_E2E_CATALOG: ${{ vars.DELTA_ENGINE_E2E_CATALOG }}
+      DELTA_ENGINE_E2E_SCHEMA: ${{ vars.DELTA_ENGINE_E2E_SCHEMA }}
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Require live configuration
+        # Missing configuration must fail loudly here: without these the
+        # suite's fixtures skip every test and the run would pass green.
+        run: |
+          missing=0
+          for name in DATABRICKS_HOST DATABRICKS_HTTP_PATH DELTA_ENGINE_E2E_CATALOG DELTA_ENGINE_E2E_SCHEMA; do
+            if [ -z "${!name}" ]; then
+              echo "::error::repository variable ${name} is not set"
+              missing=1
+            fi
+          done
+          exit "${missing}"
+
+      - name: Select Databricks authentication
+        env:
+          TOKEN: ${{ secrets.DATABRICKS_TOKEN }}
+          CLIENT_ID: ${{ secrets.DATABRICKS_CLIENT_ID }}
+        run: |
+          if [ -n "${TOKEN}" ]; then
+            echo "DATABRICKS_TOKEN=${TOKEN}" >> "$GITHUB_ENV"
+            echo "authenticating with a personal access token"
+          elif [ -n "${CLIENT_ID}" ]; then
+            echo "DATABRICKS_CLIENT_ID=${CLIENT_ID}" >> "$GITHUB_ENV"
+            echo "DATABRICKS_AUTH_TYPE=github-oidc" >> "$GITHUB_ENV"
+            echo "authenticating with OIDC workload identity federation"
+          else
+            echo "::error::set the DATABRICKS_TOKEN or DATABRICKS_CLIENT_ID repository secret"
+            exit 1
+          fi
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v8.2.0
+        with:
+          enable-cache: true
+          cache-dependency-glob: uv.lock
+
+      - name: Set up Python
+        run: uv python install 3.12
+
+      - name: Install dependencies
+        run: uv sync --locked
+
+      - name: Run live suite
+        run: uv run pytest tests/live -m databricks_e2e --no-cov -rA

--- a/tests/live/test_sql_warehouse_live_platform_assumptions.py
+++ b/tests/live/test_sql_warehouse_live_platform_assumptions.py
@@ -67,6 +67,92 @@ def test_special_characters_in_nested_struct_field_names_require_column_mapping(
     assert "bad name" in state["columns"][0]["full_data_type"]
 
 
+def test_platform_rename_silently_drops_keys_including_other_tables_foreign_keys(
+    live_connection, live_tables
+):
+    # RENAME COLUMN drops any PK/FK using the column, cascading into other
+    # tables' foreign keys with no error (first observed live 2026-07-14).
+    # This is the hazard behind PrimaryKeyReferencedByForeignKeys and the
+    # reason plans state key drops explicitly instead of relying on the
+    # rename: if this ever stops cascading, those become merely redundant.
+    parent_name = live_tables("cascade_parent")
+    child_name = live_tables("cascade_child")
+    execute_sql(
+        live_connection,
+        f"CREATE TABLE {qualified_table(parent_name)} (id INT NOT NULL, "
+        f"CONSTRAINT {parent_name}_pk PRIMARY KEY (id)) USING DELTA "
+        "TBLPROPERTIES ('delta.columnMapping.mode'='name')",
+    )
+    execute_sql(
+        live_connection,
+        f"CREATE TABLE {qualified_table(child_name)} (parent_id INT, "
+        f"CONSTRAINT {child_name}_fk FOREIGN KEY (parent_id) "
+        f"REFERENCES {qualified_table(parent_name)} (id)) USING DELTA",
+    )
+
+    execute_sql(
+        live_connection,
+        f"ALTER TABLE {qualified_table(parent_name)} RENAME COLUMN id TO account_id",
+    )
+
+    assert read_live_table(live_connection, parent_name)["primary_key"] == ()
+    assert read_live_table(live_connection, child_name)["foreign_keys"] == ()
+
+
+def test_platform_restricts_a_primary_key_drop_while_a_foreign_key_references_it(
+    live_connection, live_tables
+):
+    # DROP PRIMARY KEY defaults to RESTRICT, and IF EXISTS does not bypass
+    # it. This is the engine's fail-closed net: an inbound FK the reader
+    # could not observe (e.g. cross-catalog) fails the compiled drop, and
+    # execution stops before the rename can cascade.
+    parent_name = live_tables("restrict_parent")
+    child_name = live_tables("restrict_child")
+    execute_sql(
+        live_connection,
+        f"CREATE TABLE {qualified_table(parent_name)} (id INT NOT NULL, "
+        f"CONSTRAINT {parent_name}_pk PRIMARY KEY (id)) USING DELTA",
+    )
+    execute_sql(
+        live_connection,
+        f"CREATE TABLE {qualified_table(child_name)} (parent_id INT, "
+        f"CONSTRAINT {child_name}_fk FOREIGN KEY (parent_id) "
+        f"REFERENCES {qualified_table(parent_name)} (id)) USING DELTA",
+    )
+
+    with pytest.raises(ServerOperationError, match="child constraints"):
+        execute_sql(
+            live_connection,
+            f"ALTER TABLE {qualified_table(parent_name)} DROP PRIMARY KEY IF EXISTS",
+        )
+
+    assert read_live_table(live_connection, parent_name)["primary_key"] == ("id",)
+
+
+def test_platform_blocks_renaming_a_column_referenced_by_a_check_constraint(
+    live_connection, live_tables
+):
+    # The engine does not model CHECK constraints; renames of referenced
+    # columns are documented to fail at execution rather than validation.
+    table_name = live_tables("check_dependent")
+    execute_sql(
+        live_connection,
+        f"CREATE TABLE {qualified_table(table_name)} (amount INT) USING DELTA "
+        "TBLPROPERTIES ('delta.columnMapping.mode'='name')",
+    )
+    execute_sql(
+        live_connection,
+        f"ALTER TABLE {qualified_table(table_name)} "
+        f"ADD CONSTRAINT {table_name}_positive CHECK (amount > 0)",
+    )
+
+    with pytest.raises(ServerOperationError, match="DELTA_CONSTRAINT_DEPENDENT_COLUMN_CHANGE"):
+        execute_sql(
+            live_connection,
+            f"ALTER TABLE {qualified_table(table_name)} RENAME COLUMN amount TO amt",
+        )
+
+
 def test_platform_refuses_clustering_a_partitioned_table(live_connection, live_tables):
     # PartitioningChangeNotSupported blocks partitioned->clustered
     # conversions; the platform refuses the direct conversion too, so the

--- a/tests/live/test_sql_warehouse_live_renames.py
+++ b/tests/live/test_sql_warehouse_live_renames.py
@@ -1,0 +1,325 @@
+"""
+Live Unity Catalog coverage for declarative column renames.
+
+These tests prove the rename contract end to end through ``Engine.sync``:
+aspects the rename preserves (data, tags, comments, partition layout)
+converge in a single sync with no healing pass, keys the rename would
+destroy are replaced explicitly in the same plan, and the two undecidable
+states (ambiguous rename, referenced primary key) are rejected without
+touching the catalog.
+"""
+
+import pytest
+
+pytest.importorskip("databricks.sql")
+
+from delta_engine import SyncFailedError, TableRunStatus, ValidationFailure
+from delta_engine.databricks import build_sql_engine
+from delta_engine.schema import (
+    Column,
+    DeltaTable,
+    ForeignKey,
+    Integer,
+    Property,
+    String,
+)
+from tests.live.sql_warehouse_live_helpers import (
+    execute_sql,
+    fetch_rows,
+    live_catalog,
+    live_schema,
+    qualified_table,
+    read_live_table,
+)
+
+_COLUMN_MAPPING = {Property.COLUMN_MAPPING_MODE: "name"}
+
+
+def test_sync_renames_a_column_preserving_data_tags_and_comment(live_connection, live_tables):
+    table_name = live_tables("rename_travel")
+    engine = build_sql_engine(live_connection)
+    engine.sync(
+        DeltaTable(
+            live_catalog(),
+            live_schema(),
+            table_name,
+            columns=(
+                Column("id", Integer(), nullable=False),
+                Column("customer_nm", String(), comment="the name", tags={"pii": "true"}),
+            ),
+            properties=_COLUMN_MAPPING,
+        )
+    )
+    execute_sql(
+        live_connection,
+        f"INSERT INTO {qualified_table(table_name)} VALUES (1, 'ada'), (2, 'grace')",
+    )
+
+    renamed = DeltaTable(
+        live_catalog(),
+        live_schema(),
+        table_name,
+        columns=(
+            Column("id", Integer(), nullable=False),
+            Column(
+                "customer_name",
+                String(),
+                comment="the name",
+                tags={"pii": "true"},
+                renamed_from="customer_nm",
+            ),
+        ),
+        properties=_COLUMN_MAPPING,
+    )
+    engine.sync(renamed)
+
+    state = read_live_table(live_connection, table_name)
+    assert [column["column_name"] for column in state["columns"]] == ["id", "customer_name"]
+    [name_column] = [c for c in state["columns"] if c["column_name"] == "customer_name"]
+    assert name_column["comment"] == "the name"
+    assert state["column_tags"] == {("customer_name", "pii"): "true"}
+    rows = fetch_rows(
+        live_connection,
+        f"SELECT id, customer_name FROM {qualified_table(table_name)} ORDER BY id",
+    )
+    assert [(row["id"], row["customer_name"]) for row in rows] == [(1, "ada"), (2, "grace")]
+
+    # Everything travelled with the rename, so one sync converged: the same
+    # declaration finds no drift and the applied hint is inert.
+    assert engine.sync(renamed).has_changes is False
+
+
+def test_sync_replaces_a_primary_key_across_a_rename_in_one_plan(live_connection, live_tables):
+    table_name = live_tables("rename_pk")
+    engine = build_sql_engine(live_connection)
+    engine.sync(
+        DeltaTable(
+            live_catalog(),
+            live_schema(),
+            table_name,
+            columns=(
+                Column("customer_nm", String(), nullable=False),
+                Column("amount", Integer()),
+            ),
+            primary_key=("customer_nm",),
+            properties=_COLUMN_MAPPING,
+        )
+    )
+    assert read_live_table(live_connection, table_name)["primary_key"] == ("customer_nm",)
+
+    renamed = DeltaTable(
+        live_catalog(),
+        live_schema(),
+        table_name,
+        columns=(
+            Column("customer_name", String(), nullable=False, renamed_from="customer_nm"),
+            Column("amount", Integer()),
+        ),
+        primary_key=("customer_name",),
+        properties=_COLUMN_MAPPING,
+    )
+    report = engine.sync(renamed)
+
+    # The plan is a complete transcript: the key is dropped and re-added
+    # explicitly around the rename rather than relying on the implicit drop
+    # Databricks performs during RENAME COLUMN.
+    [table_report] = report.table_reports
+    statements = table_report.planned_sql_statements
+    assert len(statements) == 3
+    assert "DROP PRIMARY KEY" in statements[0]
+    assert "RENAME COLUMN" in statements[1]
+    assert "ADD CONSTRAINT" in statements[2]
+    state = read_live_table(live_connection, table_name)
+    assert state["primary_key"] == ("customer_name",)
+    assert state["primary_key_name"] == f"{table_name}_pk"
+    assert engine.sync(renamed).has_changes is False
+
+
+def test_sync_replaces_a_foreign_key_across_a_local_column_rename(live_connection, live_tables):
+    parent_name = live_tables("rename_fk_parent")
+    child_name = live_tables("rename_fk_child")
+    parent = DeltaTable(
+        live_catalog(),
+        live_schema(),
+        parent_name,
+        columns=(Column("id", Integer(), nullable=False),),
+        primary_key=("id",),
+    )
+    engine = build_sql_engine(live_connection)
+    engine.sync(
+        DeltaTable(
+            live_catalog(),
+            live_schema(),
+            child_name,
+            columns=(Column("parent", Integer()),),
+            foreign_keys=(ForeignKey(columns={"parent": "id"}, references=parent),),
+            properties=_COLUMN_MAPPING,
+        ),
+        parent,
+    )
+
+    renamed_child = DeltaTable(
+        live_catalog(),
+        live_schema(),
+        child_name,
+        columns=(Column("parent_id", Integer(), renamed_from="parent"),),
+        foreign_keys=(ForeignKey(columns={"parent_id": "id"}, references=parent),),
+        properties=_COLUMN_MAPPING,
+    )
+    engine.sync(renamed_child)
+
+    assert read_live_table(live_connection, child_name)["foreign_keys"] == (
+        (f"{child_name}_parent_id_fk", "parent_id", parent_name, "id"),
+    )
+    assert engine.sync(renamed_child).has_changes is False
+
+
+def test_sync_rejects_a_primary_key_rename_referenced_by_a_foreign_key(
+    live_connection, live_tables
+):
+    parent_name = live_tables("rename_blocked_parent")
+    child_name = live_tables("rename_blocked_child")
+    parent = DeltaTable(
+        live_catalog(),
+        live_schema(),
+        parent_name,
+        columns=(Column("id", Integer(), nullable=False),),
+        primary_key=("id",),
+        properties=_COLUMN_MAPPING,
+    )
+    child = DeltaTable(
+        live_catalog(),
+        live_schema(),
+        child_name,
+        columns=(Column("parent_id", Integer()),),
+        foreign_keys=(ForeignKey(columns={"parent_id": "id"}, references=parent),),
+    )
+    engine = build_sql_engine(live_connection)
+    engine.sync(child, parent)
+    parent_before = read_live_table(live_connection, parent_name)
+    child_before = read_live_table(live_connection, child_name)
+
+    with pytest.raises(SyncFailedError) as error:
+        engine.sync(
+            DeltaTable(
+                live_catalog(),
+                live_schema(),
+                parent_name,
+                columns=(Column("account_id", Integer(), nullable=False, renamed_from="id"),),
+                primary_key=("account_id",),
+                properties=_COLUMN_MAPPING,
+            )
+        )
+
+    # Renaming the key column would let RENAME COLUMN silently drop the
+    # child's foreign key, so the engine refuses client-side: nothing was
+    # planned and neither table changed.
+    [parent_report] = error.value.report.table_reports
+    assert parent_report.status is TableRunStatus.VALIDATION_FAILED
+    [failure] = parent_report.failures
+    assert isinstance(failure, ValidationFailure)
+    assert failure.rule_name == "PrimaryKeyReferencedByForeignKeys"
+    assert parent_report.planned_sql_statements == ()
+    assert read_live_table(live_connection, parent_name) == parent_before
+    assert read_live_table(live_connection, child_name) == child_before
+
+
+def test_sync_rejects_an_ambiguous_rename_without_catalog_change(live_connection, live_tables):
+    table_name = live_tables("rename_ambiguous")
+    engine = build_sql_engine(live_connection)
+    engine.sync(
+        DeltaTable(
+            live_catalog(),
+            live_schema(),
+            table_name,
+            columns=(Column("customer_nm", String()), Column("customer_name", String())),
+            properties=_COLUMN_MAPPING,
+        )
+    )
+    before = read_live_table(live_connection, table_name)
+
+    with pytest.raises(SyncFailedError) as error:
+        engine.sync(
+            DeltaTable(
+                live_catalog(),
+                live_schema(),
+                table_name,
+                columns=(Column("customer_name", String(), renamed_from="customer_nm"),),
+                properties=_COLUMN_MAPPING,
+            )
+        )
+
+    [table_report] = error.value.report.table_reports
+    assert table_report.status is TableRunStatus.VALIDATION_FAILED
+    assert "AmbiguousColumnRename" in {
+        failure.rule_name
+        for failure in table_report.failures
+        if isinstance(failure, ValidationFailure)
+    }
+    assert read_live_table(live_connection, table_name) == before
+
+
+def test_sync_renames_a_partition_column_without_layout_drift(live_connection, live_tables):
+    table_name = live_tables("rename_partition")
+    engine = build_sql_engine(live_connection)
+    engine.sync(
+        DeltaTable(
+            live_catalog(),
+            live_schema(),
+            table_name,
+            columns=(Column("id", Integer()), Column("day", String())),
+            partitioned_by=("day",),
+            properties=_COLUMN_MAPPING,
+        )
+    )
+    execute_sql(
+        live_connection,
+        f"INSERT INTO {qualified_table(table_name)} VALUES (1, 'mon'), (2, 'tue')",
+    )
+
+    renamed = DeltaTable(
+        live_catalog(),
+        live_schema(),
+        table_name,
+        columns=(Column("id", Integer()), Column("event_day", String(), renamed_from="day")),
+        partitioned_by=("event_day",),
+        properties=_COLUMN_MAPPING,
+    )
+    report = engine.sync(renamed)
+
+    # Partition metadata follows the mapped column's identity, so the whole
+    # plan is the rename itself — no layout action, no partitioning drift.
+    [table_report] = report.table_reports
+    [statement] = table_report.planned_sql_statements
+    assert "RENAME COLUMN" in statement
+    state = read_live_table(live_connection, table_name)
+    assert state["partitioning"] == ("event_day",)
+    rows = fetch_rows(
+        live_connection,
+        f"SELECT event_day FROM {qualified_table(table_name)} ORDER BY id",
+    )
+    assert [row["event_day"] for row in rows] == ["mon", "tue"]
+    assert engine.sync(renamed).has_changes is False
+
+
+def test_declaration_with_a_rename_hint_creates_a_fresh_table_under_the_new_name(
+    live_connection, live_tables
+):
+    table_name = live_tables("rename_fresh")
+    declaration = DeltaTable(
+        live_catalog(),
+        live_schema(),
+        table_name,
+        columns=(
+            Column("id", Integer(), nullable=False),
+            Column("customer_name", String(), renamed_from="customer_nm"),
+        ),
+        properties=_COLUMN_MAPPING,
+    )
+
+    build_sql_engine(live_connection).sync(declaration)
+
+    # Neither name is observed on a fresh catalog, so the hint is inert and
+    # the table is simply created under the declared name.
+    state = read_live_table(live_connection, table_name)
+    assert [column["column_name"] for column in state["columns"]] == ["id", "customer_name"]


### PR DESCRIPTION
## What

Adds rename coverage to the credentialed live suite (`tests/live`, opt-in via `databricks_e2e`, deselected from every default run — 51 collect under the marker, 0 without it).

**New module `test_sql_warehouse_live_renames.py`** — the rename contract through `Engine.sync`:

- rename preserves **data, tags, and comments** and converges in a single sync (the resync asserts `has_changes is False` — no healing pass)
- **PK replaced explicitly across a rename**: asserts the three-statement transcript (drop key → rename → re-add) via `planned_sql_statements` plus the final catalog state
- **FK replaced across a local-column rename**, new generated name adopted
- **referenced PK rename rejected** client-side (`PrimaryKeyReferencedByForeignKeys`, nothing planned, both tables unchanged)
- **ambiguous rename rejected** (`AmbiguousColumnRename`, catalog unchanged)
- **partition-column rename plans exactly one statement** — no layout action, partitioning follows the mapped identity, data intact
- **fresh-catalog declaration with a hint** creates the table under the new name (hint inert)

**Three pins in `test_sql_warehouse_live_platform_assumptions.py`** — the platform behaviour the design leans on, first observed manually on 2026-07-14, now repeatable:

- `RENAME COLUMN` silently drops keys **including other tables' FKs** (the hazard behind the validation rule and explicit drops)
- `DROP PRIMARY KEY IF EXISTS` still **RESTRICTs** under an inbound FK (the fail-closed net for unobserved references)
- a dependent CHECK constraint blocks a rename with `DELTA_CONSTRAINT_DEPENDENT_COLUMN_CHANGE`

## Notes

- I could not execute these here (no workspace credentials in this environment); they collect cleanly and follow the suite's fixtures/helpers. Run with:
  ```
  uv run pytest tests/live -m databricks_e2e --no-cov
  ```
- Companion to #224 (docs); no source changes.

## Checks

`ruff check .` + `ruff format --check .` clean, `mypy .` clean, 51 tests collect under the marker, default collection deselects all of them.

## CI

Adds `.github/workflows/live.yaml`: a **manually dispatched** workflow (never part of regular CI) that runs this suite against the real warehouse, so failures are debuggable from run logs. It fails loudly when configuration is missing rather than skip-passing. One-time setup — repository variables `DATABRICKS_HOST`, `DATABRICKS_HTTP_PATH`, `DELTA_ENGINE_E2E_CATALOG`, `DELTA_ENGINE_E2E_SCHEMA`, plus a `DATABRICKS_TOKEN` secret (or `DATABRICKS_CLIENT_ID` with an OIDC federation policy). GitHub only lists dispatchable workflows that exist on the default branch, so the first run needs this PR merged; after that any branch is runnable via `gh workflow run Live --ref <branch>`.
