### PR TITLE
test: pin layout and key columns to declared names across a rename

### DIFF
--- a/tests/domain/model/test_table.py
+++ b/tests/domain/model/test_table.py
@@ -695,3 +695,36 @@ def test_desired_table_rejects_clustering_by_a_rename_source() -> None:
             ),
             clustered_by=("day",),
         )
+
+
+def test_desired_table_rejects_a_primary_key_on_a_rename_source() -> None:
+    # Constraint columns name desired columns, exactly like layout keys: a
+    # renamed key column moves the primary_key declaration to the new name.
+    with pytest.raises(ValueError, match="Primary key column not found"):
+        DesiredTable(
+            qualified_name=_QN,
+            columns=(
+                DesiredColumn(
+                    "customer_name", String(), nullable=False, renamed_from="customer_nm"
+                ),
+            ),
+            primary_key=PrimaryKeyConstraint.generate(
+                table_name="orders", columns=("customer_nm",)
+            ),
+        )
+
+
+def test_desired_table_rejects_a_foreign_key_local_column_on_a_rename_source() -> None:
+    with pytest.raises(ValueError, match="Foreign key local column not found"):
+        DesiredTable(
+            qualified_name=_QN,
+            columns=(DesiredColumn("parent_id", Integer(), renamed_from="parent"),),
+            foreign_keys=(
+                ForeignKeyConstraint(
+                    local_columns=("parent",),
+                    referenced_table=QualifiedName("c", "s", "parent"),
+                    referenced_columns=("id",),
+                    constraint_name="orders_parent_fk",
+                ),
+            ),
+        )

--- a/tests/domain/model/test_table.py
+++ b/tests/domain/model/test_table.py
@@ -668,3 +668,30 @@ def test_desired_table_accepts_a_valid_rename() -> None:
         ),
     )
     assert table.columns[1].renamed_from == "customer_nm"
+
+
+def test_desired_table_rejects_partitioning_by_a_rename_source() -> None:
+    # Layout keys name desired columns and are never resolved through rename
+    # hints: renaming a partition column must move partitioned_by to the new
+    # name in the same declaration.
+    with pytest.raises(ValueError, match="Partition column not found: day"):
+        DesiredTable(
+            qualified_name=_QN,
+            columns=(
+                DesiredColumn("id", Integer()),
+                DesiredColumn("event_day", String(), renamed_from="day"),
+            ),
+            partitioned_by=("day",),
+        )
+
+
+def test_desired_table_rejects_clustering_by_a_rename_source() -> None:
+    with pytest.raises(ValueError, match="Clustering column not found: day"):
+        DesiredTable(
+            qualified_name=_QN,
+            columns=(
+                DesiredColumn("id", Integer()),
+                DesiredColumn("event_day", String(), renamed_from="day"),
+            ),
+            clustered_by=("day",),
+        )


### PR DESCRIPTION
## What

Four construction-guard tests for declarations that rename a column but leave another part of the declaration pointing at the old name:

- `partitioned_by` still naming the rename source → `Partition column not found`
- `clustered_by` still naming the rename source → `Clustering column not found`
- `primary_key` still naming the rename source → `Primary key column not found`
- a foreign key's local column still naming the rename source → `Foreign key local column not found`

## Why

Each guard was already tested, but only via plain typos with no rename involved. Nothing pinned the contract that **every column reference in a declaration (layout keys, constraint columns) names desired columns and is deliberately not resolved through rename hints** — a future "convenience" change resolving these through hints would have passed the entire suite while silently changing the declaration contract. Found by auditing guard coverage at scenario granularity rather than line granularity; the diff-level projections and the hint-coherence guards (self/chain/duplicate/scope/mapping, both accept and reject directions) were already pinned.

## Checks

Focused file 59 passed; `ruff check` + `ruff format --check` clean; `mypy .` clean.