### PR TITLE
fix: harden general correctness edge cases

### DIFF
--- a/src/delta_engine/adapters/databricks/errors.py
+++ b/src/delta_engine/adapters/databricks/errors.py
@@ -1,7 +1,7 @@
 """
-Name exceptions for failure records: prefer the underlying Java class.
+Render exceptions safely for failure records.
 
-One total naming policy covers both backends. Most PySpark failures arrive
+One total rendering policy covers both backends. Most PySpark failures arrive
 already converted to PySpark's own exception hierarchy
 (``AnalysisException`` and friends), and every databricks-sql-connector
 failure is a plain Python exception — for all of those the Python class
@@ -16,6 +16,8 @@ of the warehouse backend (which must run without PySpark installed — see
 the import-linter contracts), and the duck-typing matches how this layer
 already treats catalog rows and connections.
 """
+
+_MESSAGE_UNAVAILABLE = "<exception message unavailable>"
 
 
 def exception_type_name(exception: Exception) -> str:
@@ -34,3 +36,20 @@ def exception_type_name(exception: Exception) -> str:
         except Exception:
             pass
     return type(exception).__name__
+
+
+def exception_message(exception: Exception) -> str:
+    """
+    Return ``exception``'s message without allowing rendering to raise.
+
+    ``Py4JJavaError.__str__`` makes another gateway call to render the wrapped
+    Java exception. If the gateway itself failed, that secondary call can
+    raise and break the readers' and executor's total boundary while they are
+    trying to record the original failure. A stable fallback keeps failure
+    construction non-throwing even when the backend can no longer describe
+    its exception.
+    """
+    try:
+        return str(exception)
+    except Exception:
+        return _MESSAGE_UNAVAILABLE

--- a/src/delta_engine/adapters/databricks/execution.py
+++ b/src/delta_engine/adapters/databricks/execution.py
@@ -11,7 +11,7 @@ py4j-aware resolver in :mod:`delta_engine.adapters.databricks.errors`.
 from collections.abc import Callable, Iterable
 import logging
 
-from delta_engine.adapters.databricks.errors import exception_type_name
+from delta_engine.adapters.databricks.errors import exception_message, exception_type_name
 from delta_engine.application.failures import ExecutionFailure
 from delta_engine.application.ports import (
     ExecutionFailed,
@@ -67,12 +67,13 @@ def _execute_statement(
     try:
         execute(statement)
     except Exception as exception:
-        logger.warning("Statement failed: %s\nSQL: %s", exception, statement)
+        message = exception_message(exception)
+        logger.warning("Statement failed: %s\nSQL: %s", message, statement)
         return ExecutionFailed(
             failure=ExecutionFailure(
                 statement_index=statement_index,
                 exception_type=exception_type_name(exception),
-                message=str(exception),
+                message=message,
                 statement=statement,
             ),
         )

--- a/src/delta_engine/adapters/databricks/log_config.py
+++ b/src/delta_engine/adapters/databricks/log_config.py
@@ -36,15 +36,15 @@ class SafeStreamHandler(logging.StreamHandler):
     """
     StreamHandler that tolerates interpreter/pytest teardown.
 
-    Swallows ValueError raised when the stream is already closed.
+    Skips emission when the stream is already closed.
     """
 
     def emit(self, record: logging.LogRecord) -> None:
-        """Emit a log record, swallowing ValueError if the stream is closed."""
-        try:
-            super().emit(record)
-        except ValueError:
-            pass
+        """Emit a log record unless teardown has already closed the stream."""
+        stream = self.stream
+        if stream is None or getattr(stream, "closed", False):
+            return
+        super().emit(record)
 
 
 def configure_logging(level: int = logging.INFO, stream: TextIO | None = None) -> None:

--- a/src/delta_engine/adapters/databricks/spark/reader.py
+++ b/src/delta_engine/adapters/databricks/spark/reader.py
@@ -8,7 +8,7 @@ from pyspark.errors.exceptions.base import AnalysisException
 from pyspark.sql import Row, SparkSession
 from pyspark.sql.catalog import Column as SparkColumn
 
-from delta_engine.adapters.databricks.errors import exception_type_name
+from delta_engine.adapters.databricks.errors import exception_message, exception_type_name
 from delta_engine.adapters.databricks.sql import (
     clustering_columns_from_detail_row,
     column_from_catalog,
@@ -112,7 +112,9 @@ class SparkReader:
         try:
             return self._read(qualified_name)
         except Exception as exception:
-            return ReadFailed(failure=ReadFailure(exception_type_name(exception), str(exception)))
+            return ReadFailed(
+                failure=ReadFailure(exception_type_name(exception), exception_message(exception))
+            )
 
     def _read(self, qualified_name: QualifiedName) -> CatalogState:
         """Read current state, letting any failure propagate to ``fetch_state``."""

--- a/src/delta_engine/adapters/databricks/warehouse/reader.py
+++ b/src/delta_engine/adapters/databricks/warehouse/reader.py
@@ -22,7 +22,7 @@ from dataclasses import replace
 from types import MappingProxyType
 from typing import TYPE_CHECKING, Any
 
-from delta_engine.adapters.databricks.errors import exception_type_name
+from delta_engine.adapters.databricks.errors import exception_message, exception_type_name
 from delta_engine.adapters.databricks.sql import (
     clustering_columns_from_detail_row,
     column_from_catalog,
@@ -78,7 +78,9 @@ class WarehouseReader:
         try:
             return self._read(qualified_name)
         except Exception as exception:
-            return ReadFailed(failure=ReadFailure(exception_type_name(exception), str(exception)))
+            return ReadFailed(
+                failure=ReadFailure(exception_type_name(exception), exception_message(exception))
+            )
 
     def _read(self, qualified_name: QualifiedName) -> CatalogState:
         """Read current state, letting any failure propagate to ``fetch_state``."""

--- a/src/delta_engine/application/dependency_resolution.py
+++ b/src/delta_engine/application/dependency_resolution.py
@@ -38,8 +38,10 @@ from dataclasses import dataclass
 from delta_engine.application.failures import ForeignKeyFailure, ForeignKeyFailureReason
 from delta_engine.domain.model import DesiredTable, ForeignKeyConstraint, QualifiedName, TableAspect
 
-# A table dependency graph is small (tens of tables, shallow chains), so the
-# recursion depth of the SCC traversal below stays far under Python's limit.
+# TODO: Replace the recursive SCC traversal with an iterative implementation.
+# Its call depth follows dependency depth, so a chain near Python's recursion
+# limit raises RecursionError even though the public API declares no table-count
+# or dependency-depth limit. Preserve deterministic dependency-first ordering.
 
 
 @dataclass(frozen=True, slots=True)

--- a/src/delta_engine/cli/connection.py
+++ b/src/delta_engine/cli/connection.py
@@ -9,6 +9,7 @@ import sys
 from types import ModuleType
 from typing import TYPE_CHECKING
 
+from delta_engine.adapters.databricks.errors import exception_message
 from delta_engine.cli.errors import ConfigError
 
 if TYPE_CHECKING:
@@ -184,7 +185,7 @@ def _connect(
 
 def _safe_error_detail(error: Exception) -> str:
     """Return one-line detail with secret-looking environment values redacted."""
-    message = " ".join(str(error).split())
+    message = " ".join(exception_message(error).split())
     sensitive_values = {
         value
         for name, value in os.environ.items()

--- a/tests/adapters/databricks/spark/test_build_engine.py
+++ b/tests/adapters/databricks/spark/test_build_engine.py
@@ -1,7 +1,11 @@
 import io
 import logging
 
-from delta_engine.adapters.databricks.log_config import LevelColorFormatter, configure_logging
+from delta_engine.adapters.databricks.log_config import (
+    LevelColorFormatter,
+    SafeStreamHandler,
+    configure_logging,
+)
 from delta_engine.adapters.databricks.spark.factory import build_engine
 from delta_engine.application.engine import Engine
 
@@ -70,3 +74,22 @@ def test_configure_logging_routes_records_to_the_given_stream():
     finally:
         root.handlers[:] = saved_handlers
         root.setLevel(saved_level)
+
+
+def test_safe_stream_handler_ignores_a_stream_closed_during_teardown(capsys):
+    stream = io.StringIO()
+    handler = SafeStreamHandler(stream)
+    stream.close()
+    record = logging.LogRecord(
+        name="delta_engine.test",
+        level=logging.INFO,
+        pathname=__file__,
+        lineno=0,
+        msg="late log record",
+        args=(),
+        exc_info=None,
+    )
+
+    handler.emit(record)
+
+    assert "Logging error" not in capsys.readouterr().err

--- a/tests/adapters/databricks/spark/test_reader.py
+++ b/tests/adapters/databricks/spark/test_reader.py
@@ -392,6 +392,20 @@ def test_fetch_state_returns_failed_when_existence_probe_raises(qn):
     assert result.failure.exception_type == "RuntimeError"
 
 
+def test_fetch_state_contains_an_exception_whose_message_cannot_be_rendered(qn):
+    class UnrenderableError(Exception):
+        def __str__(self) -> str:
+            raise RuntimeError("rendering failed")
+
+    spark = routed_spark(qn, catalog=FakeCatalog(exists_exc=UnrenderableError()))
+
+    result = SparkReader(spark).fetch_state(qn)
+
+    assert isinstance(result, ReadFailed)
+    assert result.failure.exception_type == "UnrenderableError"
+    assert result.failure.message == "<exception message unavailable>"
+
+
 def test_fetch_state_returns_failed_when_describe_detail_raises(qn):
     spark = routed_spark(qn, catalog=single_column_catalog(qn), describe=AnalysisException("boom"))
     result = SparkReader(spark).fetch_state(qn)

--- a/tests/adapters/databricks/test_errors.py
+++ b/tests/adapters/databricks/test_errors.py
@@ -1,5 +1,5 @@
 """
-Shared exception type naming (Java class preferred, Python fallback).
+Shared exception rendering (Java class preferred, non-throwing message fallback).
 
 The py4j wrapper is detected by duck-typing on ``java_exception``, so these
 tests pin that contract against a real ``Py4JJavaError`` rather than a
@@ -10,11 +10,15 @@ from types import SimpleNamespace
 
 from py4j.protocol import Py4JJavaError
 
-from delta_engine.adapters.databricks.errors import exception_type_name
+from delta_engine.adapters.databricks.errors import exception_message, exception_type_name
 
 
 def test_names_plain_exceptions_by_python_class():
     assert exception_type_name(ValueError("nope")) == "ValueError"
+
+
+def test_renders_plain_exception_messages():
+    assert exception_message(ValueError("nope")) == "nope"
 
 
 def test_names_py4j_errors_by_underlying_java_class():
@@ -37,11 +41,16 @@ def test_names_py4j_errors_by_underlying_java_class():
 
 def test_falls_back_to_wrapper_class_when_the_gateway_is_unreachable():
     # Given a wrapped JVM exception whose remote calls fail (dead gateway)
-    def raise_gateway_error() -> None:
+    def raise_gateway_error(*_args: object) -> None:
         raise RuntimeError("gateway is down")
 
-    java_exception = SimpleNamespace(_target_id="o1", getClass=raise_gateway_error)
+    java_exception = SimpleNamespace(
+        _target_id="o1",
+        _gateway_client=SimpleNamespace(send_command=raise_gateway_error),
+        getClass=raise_gateway_error,
+    )
     error = Py4JJavaError("boom", java_exception)
 
-    # Then naming still succeeds, using the wrapper's own class
+    # Then both parts of the failure record remain constructible without the gateway
     assert exception_type_name(error) == "Py4JJavaError"
+    assert exception_message(error) == "<exception message unavailable>"

--- a/tests/adapters/databricks/test_execution.py
+++ b/tests/adapters/databricks/test_execution.py
@@ -44,6 +44,22 @@ def test_execute_failure_records_exception_details_and_the_statement():
     assert result.failure.statement == "SELECT * FROM __nope__"
 
 
+def test_execute_contains_an_exception_whose_message_cannot_be_rendered():
+    class UnrenderableError(Exception):
+        def __str__(self) -> str:
+            raise RuntimeError("rendering failed")
+
+    def fail(_statement: str) -> None:
+        raise UnrenderableError()
+
+    summary = execute_statements(fail, ("SELECT 1",))
+
+    [result] = summary.results
+    assert isinstance(result, ExecutionFailed)
+    assert result.failure.exception_type == "UnrenderableError"
+    assert result.failure.message == "<exception message unavailable>"
+
+
 def test_execute_failure_names_wrapped_jvm_exceptions_by_java_class():
     # Given a backend failure that wraps a JVM exception, py4j-style
     class WrappingRunner:

--- a/tests/adapters/databricks/warehouse/test_reader.py
+++ b/tests/adapters/databricks/warehouse/test_reader.py
@@ -248,3 +248,17 @@ def test_any_backend_exception_becomes_read_failed():
     assert isinstance(state, ReadFailed)
     assert state.failure.exception_type == "RuntimeError"
     assert "warehouse gone" in state.failure.message
+
+
+def test_exception_with_an_unrenderable_message_becomes_read_failed():
+    class UnrenderableError(Exception):
+        def __str__(self) -> str:
+            raise RuntimeError("rendering failed")
+
+    connection = RoutedConnection({table_row_query(QN): UnrenderableError()})
+
+    state = WarehouseReader(connection).fetch_state(QN)
+
+    assert isinstance(state, ReadFailed)
+    assert state.failure.exception_type == "UnrenderableError"
+    assert state.failure.message == "<exception message unavailable>"

--- a/tests/cli/test_connection.py
+++ b/tests/cli/test_connection.py
@@ -135,6 +135,24 @@ def test_sdk_configuration_error_is_sanitized_and_translated(monkeypatch, wareho
     assert "<redacted>" in message
 
 
+def test_sdk_configuration_error_survives_an_unrenderable_message(monkeypatch, warehouse_env):
+    from databricks.sdk import core as sdk_core
+
+    class UnrenderableError(ValueError):
+        def __str__(self) -> str:
+            raise RuntimeError("rendering failed")
+
+    class BrokenConfig:
+        def __init__(self, **kwargs) -> None:
+            raise UnrenderableError()
+
+    monkeypatch.setattr(sdk_core, "Config", BrokenConfig)
+
+    with pytest.raises(ConfigError, match="exception message unavailable"):
+        with open_connection():
+            pass
+
+
 def test_sdk_configuration_must_resolve_a_workspace_host(monkeypatch, warehouse_env):
     from databricks.sdk import core as sdk_core
 


### PR DESCRIPTION
## Summary

- preserve `ReadFailed`, `ExecutionFailed`, and CLI configuration errors when an exception message cannot be rendered
- skip logging to streams that have already closed during teardown
- document the recursive dependency-resolution depth limit as an explicit TODO
- add focused regression coverage for Spark, SQL warehouse, execution, CLI, and logging paths

## Root cause

`Py4JJavaError.__str__()` can make another JVM gateway call. If that transport has already failed, formatting the caught exception raises a secondary exception before the typed failure can be constructed. Separately, `logging.StreamHandler.emit()` handles closed-stream `ValueError` internally, so catching it around `super().emit()` did not prevent Python's internal logging traceback.

## Impact

Backend failures remain reportable through the engine's total adapter boundaries, CLI connection errors retain their one-line typed form, and late teardown logging stays quiet. Dependency graphs near Python's recursion limit remain deferred work and are now documented honestly in the implementation.

## Validation

- `910 passed, 51 deselected` with 98.27% total coverage
- `ruff check src tests`
- `ruff format --check src tests`
- `mypy .`
- `lint-imports` (7 contracts kept)
- `git diff --check`