### PR TITLE
fix: register the parent in the FK-rename live test

### DIFF
--- a/tests/live/test_sql_warehouse_live_renames.py
+++ b/tests/live/test_sql_warehouse_live_renames.py
@@ -166,12 +166,14 @@ def test_sync_replaces_a_foreign_key_across_a_local_column_rename(live_connectio
         foreign_keys=(ForeignKey(columns={"parent_id": "id"}, references=parent),),
         properties=_COLUMN_MAPPING,
     )
-    engine.sync(renamed_child)
+    # The parent rides along: dependency resolution blocks a foreign-key add
+    # whose referenced table is not registered in the same run.
+    engine.sync(renamed_child, parent)
 
     assert read_live_table(live_connection, child_name)["foreign_keys"] == (
         (f"{child_name}_parent_id_fk", "parent_id", parent_name, "id"),
     )
-    assert engine.sync(renamed_child).has_changes is False
+    assert engine.sync(renamed_child, parent).has_changes is False
 
 
 def test_sync_rejects_a_primary_key_rename_referenced_by_a_foreign_key(


### PR DESCRIPTION
## What

One-line fix to `test_sync_replaces_a_foreign_key_across_a_local_column_rename`: the rename sync (and its convergence resync) now register the parent table alongside the child.

## Why

The first Live workflow run surfaced this — **50/51 passed, this the only failure**, and it was the test's mistake, not the engine's. Re-adding a foreign key requires the referenced table in the same sync run so dependency resolution can order parent-before-child; the test synced the child alone and got the engine's own `FOREIGN_KEY_FAILED`: *"it references a table that is not registered."* The comment on the fix states the policy.

This is real user-facing behaviour: anyone syncing a child table solo after an FK-column rename hits the same message. Worth a docs sentence eventually (noted for a follow-up), but the fix here is just to make the test declare what the engine requires.

## Verification

Live workflow run [29339622068](https://github.com/Tomoscorbin/delta-engine/actions/runs/29339622068): **51 passed** against the real SQL warehouse.