### PR TITLE
test: harden and surface the live Databricks suite

### DIFF
--- a/.github/workflows/live.yaml
+++ b/.github/workflows/live.yaml
@@ -16,7 +16,7 @@
 #   DATABRICKS_CLIENT_ID       service principal for OIDC workload identity
 #                              federation (needs a Databricks federation
 #                              policy for this repository)
-name: Live
+name: Live Databricks Tests
 
 on:
   workflow_dispatch:

--- a/.github/workflows/live.yaml
+++ b/.github/workflows/live.yaml
@@ -1,8 +1,10 @@
 # Credentialed live suite against a real Databricks SQL warehouse.
 #
-# Deliberately not part of regular CI: manual dispatch only, and the run
-# targets whichever ref is selected (`gh workflow run live.yaml --ref <branch>`
-# once this file exists on main).
+# Deliberately not part of PR CI: it runs on a weekly schedule (drift
+# detection against the live warehouse) and on manual dispatch, which targets
+# whichever ref is selected (`gh workflow run live.yaml --ref <branch>` once
+# this file exists on main). Scheduled runs only ever fire from the default
+# branch, so this trigger is inert until merged.
 #
 # Required repository variables:
 #   DATABRICKS_HOST            workspace URL
@@ -18,6 +20,11 @@ name: Live
 
 on:
   workflow_dispatch:
+  schedule:
+    # Weekly drift check (Mondays 07:00 UTC): catches Databricks-side
+    # behaviour changes the hermetic suite cannot see. Non-blocking — it
+    # never gates a PR.
+    - cron: "0 7 * * 1"
 
 # One live run at a time: the suite shares a schema and a warehouse.
 concurrency:

--- a/.github/workflows/live.yaml
+++ b/.github/workflows/live.yaml
@@ -90,4 +90,9 @@ jobs:
         run: uv sync --locked
 
       - name: Run live suite
-        run: uv run pytest tests/live -m databricks_e2e --no-cov -rA
+        # -n 8: the suite is I/O-bound on warehouse round-trips, not runner
+        # CPU, so running more workers than cores still speeds it up. Tests are
+        # isolated (uuid-named tables, per-test cleanup), so they parallelise
+        # safely; excess concurrency degrades to warehouse queueing, not
+        # failure. Tune to the warehouse's concurrency headroom.
+        run: uv run pytest tests/live -m databricks_e2e --no-cov -rA -n 8

--- a/.github/workflows/live.yaml
+++ b/.github/workflows/live.yaml
@@ -1,11 +1,5 @@
 # Credentialed live suite against a real Databricks SQL warehouse.
 #
-# Deliberately not part of PR CI: it runs on a weekly schedule (drift
-# detection against the live warehouse) and on manual dispatch, which targets
-# whichever ref is selected (`gh workflow run live.yaml --ref <branch>` once
-# this file exists on main). Scheduled runs only ever fire from the default
-# branch, so this trigger is inert until merged.
-#
 # Required repository variables:
 #   DATABRICKS_HOST            workspace URL
 #   DATABRICKS_HTTP_PATH       SQL warehouse endpoint path

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # delta-engine
 
+[![Live Databricks Tests](https://github.com/Tomoscorbin/delta-engine/actions/workflows/live.yaml/badge.svg?branch=main)](https://github.com/Tomoscorbin/delta-engine/actions/workflows/live.yaml)
+
 Declarative, safety-first schema and metadata management for Delta Lake tables on Databricks.
 
 Define the state your tables should have in Python. Delta Engine reads their current Unity Catalog state, calculates the difference, validates whether each change is safe, and executes only the DDL needed to reconcile them.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,6 +62,7 @@ dev = [
   # tests/test_packaging.py imports it directly; do not rely on pytest's
   # transitive dependency.
   "packaging>=24.0",
+  "pytest-xdist>=3.8.0",
 ]
 docs = [
   "sphinx>=8.0",

--- a/src/delta_engine/api/delta_table.py
+++ b/src/delta_engine/api/delta_table.py
@@ -68,7 +68,7 @@ _CDF_RESERVED_COLUMN_NAMES: Final[frozenset[str]] = frozenset(
 )
 
 # Complex types Delta accepts neither as partition columns
-# (DELTA_INVALID_PARTITION_COLUMN_TYPE) nor as liquid-clustering keys.
+# (INVALID_PARTITION_COLUMN_DATA_TYPE) nor as liquid-clustering keys.
 # Two distinct backend rules that happen to name the same types today.
 _TYPES_UNUSABLE_AS_LAYOUT_KEYS: Final[tuple[type[DataType], ...]] = (Array, Map, Struct, Variant)
 

--- a/tests/live/conftest.py
+++ b/tests/live/conftest.py
@@ -11,10 +11,11 @@ only runs when requested explicitly (a manual run or the live CI job):
                                                        # DATABRICKS_CONFIG_PROFILE
     export DATABRICKS_HTTP_PATH=...
     export DELTA_ENGINE_E2E_CATALOG=... DELTA_ENGINE_E2E_SCHEMA=...
-    uv run pytest tests/live -m databricks_e2e --no-cov
+    uv run pytest tests/live -m databricks_e2e --no-cov -n auto
 
 Every test allocates uniquely named tables through the ``live_tables`` factory
-and drops them afterwards, so runs are safe to repeat against a shared schema.
+and drops them afterwards, so runs are safe to repeat against a shared schema
+and safe to run in parallel: ``-n auto`` fans the suite across xdist workers.
 """
 
 from collections.abc import Callable
@@ -37,7 +38,9 @@ def pytest_collection_modifyitems(items: list[pytest.Item]) -> None:
             item.add_marker(pytest.mark.databricks_e2e)
 
 
-@pytest.fixture(scope="module")
+# Session-scoped so each parallel xdist worker opens one connection and reuses
+# it for every test it runs, rather than reconnecting per module.
+@pytest.fixture(scope="session")
 def live_connection():
     missing = [name for name in _LIVE_REQUIRED_ENV if not os.environ.get(name)]
     if missing:

--- a/tests/live/conftest.py
+++ b/tests/live/conftest.py
@@ -152,7 +152,7 @@ def pytest_terminal_summary(terminalreporter: pytest.TerminalReporter) -> None:
         "",
         "Verified against a real Databricks SQL warehouse (Unity Catalog).",
         "",
-        "| Area | What it verifies | Result |",
+        "| Area | Checks | Result |",
         "| --- | --- | --- |",
     ]
     for filename, (label, description) in _LIVE_AREAS.items():

--- a/tests/live/conftest.py
+++ b/tests/live/conftest.py
@@ -152,7 +152,7 @@ def pytest_terminal_summary(terminalreporter: pytest.TerminalReporter) -> None:
         "",
         "Verified against a real Databricks SQL warehouse (Unity Catalog).",
         "",
-        "| Area | What it proves | Result |",
+        "| Area | What it verifies | Result |",
         "| --- | --- | --- |",
     ]
     for filename, (label, description) in _LIVE_AREAS.items():

--- a/tests/live/conftest.py
+++ b/tests/live/conftest.py
@@ -67,3 +67,101 @@ def live_tables(live_connection) -> LiveTableFactory:
 
     for name in reversed(names):
         execute_sql(live_connection, f"DROP TABLE IF EXISTS {qualified_table(name)}")
+
+
+# Visitor-facing behaviour areas for the GitHub job summary, in report order.
+# Each live test file maps to a label and a one-line statement of what it
+# proves; a new live file needs an entry here to appear in the summary.
+_LIVE_AREAS: dict[str, tuple[str, str]] = {
+    "test_sql_warehouse_live.py": (
+        "Table lifecycle",
+        "create, evolve every mutable aspect, dry-run previews, idempotent resync",
+    ),
+    "test_sql_warehouse_live_constraints.py": (
+        "Primary & foreign keys",
+        "add, change, and drop keys; composite, self-referential, dependency order",
+    ),
+    "test_sql_warehouse_live_safety.py": (
+        "Validation blocks",
+        "unsafe DDL is rejected and the catalog is left unchanged",
+    ),
+    "test_sql_warehouse_live_scopes.py": (
+        "Scoped ownership",
+        "metadata-only and tags-only declarations change nothing outside their scope",
+    ),
+    "test_sql_warehouse_live_types_and_layout.py": (
+        "Types & layout",
+        "every column type round-trips; widening, partitioning, and clustering",
+    ),
+    "test_sql_warehouse_live_renames.py": (
+        "Column renames",
+        "data, tags, and comments travel; keys are replaced; ambiguity is rejected",
+    ),
+    "test_sql_warehouse_live_platform_assumptions.py": (
+        "Platform assumptions",
+        "Databricks behaviours the engine's safety gates rely on",
+    ),
+}
+
+
+def pytest_terminal_summary(terminalreporter: pytest.TerminalReporter) -> None:
+    """
+    Append a behaviour-area summary of the live suite to the GitHub job summary.
+
+    Only acts in CI (``GITHUB_STEP_SUMMARY`` set) and only counts this
+    directory's tests, so a full-repo run that deselects the live suite writes
+    nothing and non-live files never leak in. Runs once on the xdist
+    controller, with results already aggregated across workers.
+    """
+    summary_path = os.environ.get("GITHUB_STEP_SUMMARY")
+    if not summary_path:
+        return
+
+    # Collapse each test's phase reports (setup/call/teardown) to one pass/fail.
+    passed_by_test: dict[str, bool] = {}
+    for status in ("passed", "failed", "error"):
+        for report in terminalreporter.stats.get(status, []):
+            filename = report.nodeid.split("::", 1)[0].rsplit("/", 1)[-1]
+            if filename not in _LIVE_AREAS:
+                continue
+            passed_by_test[report.nodeid] = (
+                passed_by_test.get(report.nodeid, True) and status == "passed"
+            )
+
+    if not passed_by_test:
+        return
+
+    counts_by_file: dict[str, list[int]] = {}
+    for nodeid, passed in passed_by_test.items():
+        filename = nodeid.split("::", 1)[0].rsplit("/", 1)[-1]
+        counts = counts_by_file.setdefault(filename, [0, 0])
+        counts[0] += int(passed)
+        counts[1] += 1
+
+    total = len(passed_by_test)
+    total_passed = sum(passed_by_test.values())
+
+    lines: list[str] = []
+    if total_passed == total:
+        lines.append(f"## ✅ Live Databricks tests — all {total} passed")
+    else:
+        lines.append(
+            f"## ❌ Live Databricks tests — {total - total_passed} failed, {total_passed} passed"
+        )
+    lines += [
+        "",
+        "Verified against a real Databricks SQL warehouse (Unity Catalog).",
+        "",
+        "| Area | What it proves | Result |",
+        "| --- | --- | --- |",
+    ]
+    for filename, (label, description) in _LIVE_AREAS.items():
+        counts = counts_by_file.get(filename)
+        if counts is None:
+            continue
+        area_passed, area_total = counts
+        mark = "✅" if area_passed == area_total else "❌"
+        lines.append(f"| {label} | {description} | {mark} {area_passed}/{area_total} |")
+
+    with open(summary_path, "a", encoding="utf-8") as summary:
+        summary.write("\n".join(lines) + "\n")

--- a/tests/live/test_sql_warehouse_live_platform_assumptions.py
+++ b/tests/live/test_sql_warehouse_live_platform_assumptions.py
@@ -204,25 +204,20 @@ def test_platform_rejects_an_over_long_column_tag_key_or_value(live_connection, 
         )
 
 
-def test_platform_rejects_complex_types_as_partition_columns(live_connection, live_tables):
-    # Delta refuses complex/nested types as partition columns. This backs the
-    # layout gate in api/delta_table.py (_TYPES_UNUSABLE_AS_LAYOUT_KEYS), which
-    # rejects Array/Map/Struct/Variant as partition and clustering keys at
-    # declaration time; if the platform ever accepted one, that gate would be
-    # over-blocking. The parallel clustering rejection is a distinct backend
-    # rule whose error code is not pinned here.
+def test_platform_rejects_a_complex_type_as_a_partition_column(live_connection, live_tables):
+    # Delta refuses complex/nested types as partition columns, raising
+    # INVALID_PARTITION_COLUMN_DATA_TYPE (error class confirmed live
+    # 2026-07-14; the older DELTA_INVALID_PARTITION_COLUMN_TYPE spelling no
+    # longer matches). This backs the layout gate in api/delta_table.py
+    # (_TYPES_UNUSABLE_AS_LAYOUT_KEYS), which rejects Array/Map/Struct/Variant
+    # as partition and clustering keys at declaration time; if the platform
+    # ever accepted one, that gate would be over-blocking. An array stands in
+    # for the complex-type category; the parallel clustering rejection is a
+    # distinct backend rule not pinned here.
     array_name = live_tables("partition_array")
-    with pytest.raises(ServerOperationError, match="DELTA_INVALID_PARTITION_COLUMN_TYPE"):
+    with pytest.raises(ServerOperationError, match="INVALID_PARTITION_COLUMN_DATA_TYPE"):
         execute_sql(
             live_connection,
             f"CREATE TABLE {qualified_table(array_name)} "
             "(id INT, labels ARRAY<INT>) USING DELTA PARTITIONED BY (labels)",
-        )
-
-    struct_name = live_tables("partition_struct")
-    with pytest.raises(ServerOperationError, match="DELTA_INVALID_PARTITION_COLUMN_TYPE"):
-        execute_sql(
-            live_connection,
-            f"CREATE TABLE {qualified_table(struct_name)} "
-            "(id INT, payload STRUCT<x: INT>) USING DELTA PARTITIONED BY (payload)",
         )

--- a/tests/live/test_sql_warehouse_live_platform_assumptions.py
+++ b/tests/live/test_sql_warehouse_live_platform_assumptions.py
@@ -202,3 +202,27 @@ def test_platform_rejects_an_over_long_column_tag_key_or_value(live_connection, 
             f"ALTER TABLE {qualified_table(table_name)} ALTER COLUMN id "
             f"SET TAGS ('{over_long}'='prod')",
         )
+
+
+def test_platform_rejects_complex_types_as_partition_columns(live_connection, live_tables):
+    # Delta refuses complex/nested types as partition columns. This backs the
+    # layout gate in api/delta_table.py (_TYPES_UNUSABLE_AS_LAYOUT_KEYS), which
+    # rejects Array/Map/Struct/Variant as partition and clustering keys at
+    # declaration time; if the platform ever accepted one, that gate would be
+    # over-blocking. The parallel clustering rejection is a distinct backend
+    # rule whose error code is not pinned here.
+    array_name = live_tables("partition_array")
+    with pytest.raises(ServerOperationError, match="DELTA_INVALID_PARTITION_COLUMN_TYPE"):
+        execute_sql(
+            live_connection,
+            f"CREATE TABLE {qualified_table(array_name)} "
+            "(id INT, labels ARRAY<INT>) USING DELTA PARTITIONED BY (labels)",
+        )
+
+    struct_name = live_tables("partition_struct")
+    with pytest.raises(ServerOperationError, match="DELTA_INVALID_PARTITION_COLUMN_TYPE"):
+        execute_sql(
+            live_connection,
+            f"CREATE TABLE {qualified_table(struct_name)} "
+            "(id INT, payload STRUCT<x: INT>) USING DELTA PARTITIONED BY (payload)",
+        )

--- a/tests/live/test_sql_warehouse_live_types_and_layout.py
+++ b/tests/live/test_sql_warehouse_live_types_and_layout.py
@@ -44,7 +44,7 @@ def _types(state) -> dict[str, str]:
     }
 
 
-def test_sync_creates_every_supported_column_type(live_connection, live_tables):
+def test_sync_creates_and_round_trips_every_supported_column_type(live_connection, live_tables):
     table_name = live_tables("types")
     table = DeltaTable(
         live_catalog(),
@@ -87,7 +87,8 @@ def test_sync_creates_every_supported_column_type(live_connection, live_tables):
         ),
     )
 
-    build_sql_engine(live_connection).sync(table)
+    engine = build_sql_engine(live_connection)
+    engine.sync(table)
 
     assert _types(read_live_table(live_connection, table_name)) == {
         "tiny": "tinyint",
@@ -108,6 +109,12 @@ def test_sync_creates_every_supported_column_type(live_connection, live_tables):
         "map_value": "map<string,bigint>",
         "struct_value": "struct<name:string,location:struct<latitude:double,longitude:double>>",
     }
+    # Creation is only half the round trip: the reader must parse every nested
+    # and parameterised type — array<int>, map<string,bigint>, the nested
+    # struct, decimal(18,4), variant — back into a domain type equal to the
+    # declaration, or the table would re-diff forever. A converged resync
+    # proves the whole type surface round-trips through the engine's reader.
+    assert engine.sync(table).has_changes is False
 
 
 def test_sync_creates_every_managed_table_property(live_connection, live_tables):
@@ -305,6 +312,7 @@ def test_sync_widens_supported_column_types_in_live_catalog(live_connection, liv
                 Column("tiny", Byte()),
                 Column("small", Short()),
                 Column("count", Integer()),
+                Column("measure", Integer()),
                 Column("ratio", Float()),
                 Column("event_date", Date()),
                 Column("amount", Decimal(10, 2)),
@@ -327,6 +335,7 @@ def test_sync_widens_supported_column_types_in_live_catalog(live_connection, liv
                 Column("tiny", Short()),
                 Column("small", Integer()),
                 Column("count", Long()),
+                Column("measure", Double()),
                 Column("ratio", Double()),
                 Column("event_date", TimestampNtz()),
                 Column("amount", Decimal(12, 3)),
@@ -340,6 +349,7 @@ def test_sync_widens_supported_column_types_in_live_catalog(live_connection, liv
         "tiny": "smallint",
         "small": "int",
         "count": "bigint",
+        "measure": "double",
         "ratio": "double",
         "event_date": "timestamp_ntz",
         "amount": "decimal(12,3)",

--- a/uv.lock
+++ b/uv.lock
@@ -557,6 +557,7 @@ dev = [
     { name = "pyspark" },
     { name = "pytest" },
     { name = "pytest-cov" },
+    { name = "pytest-xdist" },
     { name = "ruff" },
     { name = "typer" },
 ]
@@ -595,6 +596,7 @@ dev = [
     { name = "pyspark", specifier = ">=4.0.0" },
     { name = "pytest", specifier = ">=8.4.1" },
     { name = "pytest-cov", specifier = ">=5.0" },
+    { name = "pytest-xdist", specifier = ">=3.8.0" },
     { name = "ruff", specifier = ">=0.12.9" },
     { name = "typer", specifier = ">=0.12" },
 ]
@@ -658,6 +660,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/d3/38/af70d7ab1ae9d4da450eeec1fa3918940a5fafb9055e934af8d6eb0c2313/et_xmlfile-2.0.0.tar.gz", hash = "sha256:dab3f4764309081ce75662649be815c4c9081e88f0837825f90fd28317d4da54", size = 17234, upload-time = "2024-10-25T17:25:40.039Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c1/8b/5fe2cc11fee489817272089c4203e679c63b570a5aaeb18d852ae3cbba6a/et_xmlfile-2.0.0-py3-none-any.whl", hash = "sha256:7a91720bc756843502c3b7504c77b8fe44217c85c537d85037f0f536151b2caa", size = 18059, upload-time = "2024-10-25T17:25:39.051Z" },
+]
+
+[[package]]
+name = "execnet"
+version = "2.1.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/bf/89/780e11f9588d9e7128a3f87788354c7946a9cbb1401ad38a48c4db9a4f07/execnet-2.1.2.tar.gz", hash = "sha256:63d83bfdd9a23e35b9c6a3261412324f964c2ec8dcd8d3c6916ee9373e0befcd", size = 166622, upload-time = "2025-11-12T09:56:37.75Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ab/84/02fc1827e8cdded4aa65baef11296a9bbe595c474f0d6d758af082d849fd/execnet-2.1.2-py3-none-any.whl", hash = "sha256:67fba928dd5a544b783f6056f449e5e3931a5c378b128bc18501f7ea79e296ec", size = 40708, upload-time = "2025-11-12T09:56:36.333Z" },
 ]
 
 [[package]]
@@ -1430,6 +1441,19 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/b1/51/a849f96e117386044471c8ec2bd6cfebacda285da9525c9106aeb28da671/pytest_cov-7.1.0.tar.gz", hash = "sha256:30674f2b5f6351aa09702a9c8c364f6a01c27aae0c1366ae8016160d1efc56b2", size = 55592, upload-time = "2026-03-21T20:11:16.284Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/9d/7a/d968e294073affff457b041c2be9868a40c1c71f4a35fcc1e45e5493067b/pytest_cov-7.1.0-py3-none-any.whl", hash = "sha256:a0461110b7865f9a271aa1b51e516c9a95de9d696734a2f71e3e78f46e1d4678", size = 22876, upload-time = "2026-03-21T20:11:14.438Z" },
+]
+
+[[package]]
+name = "pytest-xdist"
+version = "3.8.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "execnet" },
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/78/b4/439b179d1ff526791eb921115fca8e44e596a13efeda518b9d845a619450/pytest_xdist-3.8.0.tar.gz", hash = "sha256:7e578125ec9bc6050861aa93f2d59f1d8d085595d6551c2c90b6f4fad8d3a9f1", size = 88069, upload-time = "2025-07-01T13:30:59.346Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ca/31/d4e37e9e550c2b92a9cbc2e4d0b7420a27224968580b5a447f420847c975/pytest_xdist-3.8.0-py3-none-any.whl", hash = "sha256:202ca578cfeb7370784a8c33d6d05bc6e13b4f25b5053c30a152269fd10f0b88", size = 46396, upload-time = "2025-07-01T13:30:56.632Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## What & why

Makes the live Databricks suite both more thorough and more visible to visitors — it is the proof that the engine works against real Unity Catalog.

**Coverage**

- All 17 column types now round-trip: the all-types table is re-synced and asserted to find no drift, proving the reader parses nested `array`/`map`/`struct`, `decimal`, and `variant` back into domain types that compare equal to the declaration.
- Pin that Delta rejects a complex type as a partition column. The first live run showed the real error class is `INVALID_PARTITION_COLUMN_DATA_TYPE`, not the `DELTA_INVALID_PARTITION_COLUMN_TYPE` the code comment cited — the pin caught a stale comment on its first run, now corrected in `api/delta_table.py`.
- `Integer -> Double` added to the widening test, completing the type-widening matrix pins.

**Runs faster**

- Parallelised with `pytest-xdist` (`-n 8`) plus a session-scoped warehouse connection. The suite is isolated by design (uuid-named tables, per-test cleanup), so it parallelises safely. Wall-clock dropped from ~13m to ~6m (~2.3x — the suite is warehouse-concurrency-bound, not CPU-bound, so this is the sweet spot).

**More visible**

- Weekly `schedule` trigger for drift detection (non-blocking; never gates a PR; fires only from `main`).
- Renamed the workflow to **Live Databricks Tests** and added a README badge pinned to `main`.
- A `pytest_terminal_summary` hook renders a behaviour-area job summary on each run — grouping results into lifecycle, validation blocks, types & layout, keys, renames, and platform assumptions, with a one-line statement of what each proves. Guarded to CI and this directory's tests.

**Verified live:** run [29354603847](https://github.com/Tomoscorbin/delta-engine/actions/runs/29354603847) — 53 passed in 5m51s. The job summary renders from the next run onward (this run predated the hook).

## Checklist

- [x] PR title is a Conventional Commit (`test:` — no release; nothing shipped changes)
- [x] Tests added or updated for behaviour changes
- [x] Docs updated if public behaviour/architecture/validation changed (no public behaviour change; README badge added)
- [x] `uv run pytest` (916 passed, 98% cov), `uv run ruff check .`, `uv run mypy .`, `uv run lint-imports` pass
