### PR TITLE
fix: remove false-success race from table creation

### DIFF
--- a/docs/reference-limitations.md
+++ b/docs/reference-limitations.md
@@ -10,12 +10,12 @@ the page with the detail.
 
 ## Platform
 
-| Requirement           | Supported                                                                                                                                                                                                             |
-| --------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Requirement           | Supported                                                                                                                                                                                                                              |
+| --------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | Backend               | Delta Lake tables on Databricks with Unity Catalog — the supported target today; the reader does not yet reliably fail closed on every non-Delta relation, so register Delta tables only ([architecture](explanation-architecture.md)) |
-| Python                | 3.12 or later                                                                                                                                                                                                         |
-| PySpark               | Needed only for the Spark backend; the SQL warehouse backend needs none. Declaring and planning are pure Python either way ([installation](installation.md))                                                          |
-| SQL warehouse backend | Unity Catalog only — every read runs through `information_schema`; a `hive_metastore` table is readable only through the Spark backend and fails as a read failure through this one ([installation](installation.md)) |
+| Python                | 3.12 or later                                                                                                                                                                                                                          |
+| PySpark               | Needed only for the Spark backend; the SQL warehouse backend needs none. Declaring and planning are pure Python either way ([installation](installation.md))                                                                           |
+| SQL warehouse backend | Unity Catalog only — every read runs through `information_schema`; a `hive_metastore` table is readable only through the Spark backend and fails as a read failure through this one ([installation](installation.md))                  |
 
 ## Identifier handling
 
@@ -40,7 +40,7 @@ dropping columns](how-to-configure-table.md#column-mapping-and-dropping-columns)
 | Tighten nullability       |       ✗       | Blocked — backfill first, then tighten ([rules](reference-safe-change-rules.md))                                                                                                                                          |
 | Change column type        | Widening only | Safe widenings (e.g. `Integer` → `Long`) apply in place with `delta.enableTypeWidening='true'` declared; anything else is blocked ([type widening](how-to-configure-table.md#type-widening))                              |
 | Rename column             |       ✓       | Declare `renamed_from` on the new column; requires `delta.columnMapping.mode='name'`. Editing a name directly (without the hint) is a drop plus an add ([renaming a column](how-to-configure-table.md#renaming-a-column)) |
-| Rename partition column   |       ✓       | Column mapping preserves the partition column's physical identity, so its layout metadata follows the rename ([rules](reference-safe-change-rules.md))                                                                  |
+| Rename partition column   |       ✓       | Column mapping preserves the partition column's physical identity, so its layout metadata follows the rename ([rules](reference-safe-change-rules.md))                                                                    |
 | Table and column comments |       ✓       | Always managed; an empty declaration clears the comment ([comments](how-to-configure-table.md#comments))                                                                                                                  |
 | Table properties          |       ✓       | Six managed `delta.*` keys; other keys are rejected at declaration ([properties](how-to-configure-table.md#properties))                                                                                                   |
 | Table and column tags     |       ✓       | Full-state: undeclared tags are removed ([tags](how-to-configure-table.md#tags))                                                                                                                                          |
@@ -59,11 +59,11 @@ changes, or drops them, and they produce no drift.
 
 | Not modeled                                                       | Meaning                                                                                                                                                                             |
 | ----------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| CHECK constraints                                                 | Cannot be declared; a constraint that references a renamed column must be changed before the rename                                                                                  |
+| CHECK constraints                                                 | Cannot be declared; a constraint that references a renamed column must be changed before the rename                                                                                 |
 | Key constraint options (`RELY`, `MATCH`, `ON UPDATE`/`ON DELETE`) | Keys are created with Databricks defaults (`NOT ENFORCED NORELY`); option drift is invisible, and an out-of-band `RELY` is lost when a primary-key change drops and re-adds the key |
-| `UNIQUE` constraints                                             | Cannot be declared or used as a registered foreign-key target, even on Databricks versions that support them                                                                         |
+| `UNIQUE` constraints                                              | Cannot be declared or used as a registered foreign-key target, even on Databricks versions that support them                                                                        |
 | Identity and generated columns                                    | Generation expressions are invisible; one that references a renamed column must be changed before the rename                                                                        |
-| Views and materialized views                                      | Unsupported; the reader does not yet reliably reject every relation before planning, so do not register them                                                                         |
+| Views and materialized views                                      | Unsupported; the reader does not yet reliably reject every relation before planning, so do not register them                                                                        |
 | Grants, row filters, column masks                                 | Governance beyond comments and tags is out of scope                                                                                                                                 |
 | Data                                                              | The engine runs DDL only; it never reads, writes, or backfills rows                                                                                                                 |
 
@@ -72,12 +72,12 @@ changes, or drops them, and they produce no drift.
 The full matrix is in [data types](reference-data-types.md). The limitations
 in brief:
 
-| Limitation               | Behaviour                                                                                         |
-| ------------------------ | ------------------------------------------------------------------------------------------------- |
+| Limitation               | Behaviour                                                                                                                                                     |
+| ------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | Unsupported Spark types  | Non-partition columns are left unmanaged with a warning, so their drift is invisible; an unsupported partition type or wholly unmappable table fails its read |
-| `CHAR(n)` / `VARCHAR(n)` | Treated as `String`; the length bound is not modeled and never altered                            |
-| Struct fields            | Structs change as a whole: any field change is a blocked column type change                       |
-| `Decimal` precision      | Maximum 38, enforced at declaration                                                               |
+| `CHAR(n)` / `VARCHAR(n)` | Treated as `String`; the length bound is not modeled and never altered                                                                                        |
+| Struct fields            | Structs change as a whole: any field change is a blocked column type change                                                                                   |
+| `Decimal` precision      | Maximum 38, enforced at declaration                                                                                                                           |
 
 ## Clustering limits
 
@@ -97,12 +97,11 @@ partitioning:
 ## Concurrent catalog changes
 
 A sync is not transactional across its read, plan, and execute phases. Table
-creation currently compiles as `CREATE TABLE IF NOT EXISTS`: if another writer
-creates the same name after the reader observed it missing, that statement
-becomes a no-op and the current report can say the create succeeded without
-re-reading or reconciling the winner's schema. The next sync reads the table and
-reports any resulting drift. Avoid concurrent creators for the same qualified
-table name.
+creation compiles as a plain `CREATE TABLE`: if another writer creates the same
+name after the reader observed it missing, that statement errors and the table
+is reported as an execution failure rather than a false success. The next sync
+reads the table that actually exists and reports any resulting drift. Avoid
+concurrent creators for the same qualified table name.
 
 ## Runtime features
 

--- a/docs/todo/business-logic-delta-databricks-correctness-review.md
+++ b/docs/todo/business-logic-delta-databricks-correctness-review.md
@@ -28,16 +28,16 @@ path currently produces an incorrect result.
 
 ## Summary
 
-| # | Severity | Finding | Failure mode |
-|---|---|---|---|
-| 1 | High | Non-Delta objects are not rejected | Invalid or partial plans against views, Iceberg, or other formats |
-| 2 | High | Unparseable columns are silently omitted | Existing drift can be reported as synchronized |
-| 3 | High | Required Delta table features are not planned | Valid-looking plans fail during execution |
-| 4 | High | Foreign-key types are checked against the wrong parent object | Invalid constraints pass declaration and resolution |
-| 5 | Medium | Clearing a column comment generates invalid SQL | Warehouse execution fails on `UNSET COMMENT` |
-| 6 | Medium | Identifier normalization disagrees with Unity Catalog | Valid names can change identity; invalid object names pass locally |
-| 7 | Medium | Layout and map-type validation is too permissive | Unsupported declarations reach execution |
-| 8 | Medium | `CREATE TABLE IF NOT EXISTS` can report false success | A concurrent incompatible create is treated as success |
+| #    | Severity | Finding                                                       | Failure mode                                                       |
+| ---- | -------- | ------------------------------------------------------------- | ------------------------------------------------------------------ |
+| 1    | High     | Non-Delta objects are not rejected                            | Invalid or partial plans against views, Iceberg, or other formats  |
+| 2    | High     | Unparseable columns are silently omitted                      | Existing drift can be reported as synchronized                     |
+| 3    | High     | Required Delta table features are not planned                 | Valid-looking plans fail during execution                          |
+| 4    | High     | Foreign-key types are checked against the wrong parent object | Invalid constraints pass declaration and resolution                |
+| 5    | Medium   | Clearing a column comment generates invalid SQL               | Warehouse execution fails on `UNSET COMMENT`                       |
+| 6    | Medium   | Identifier normalization disagrees with Unity Catalog         | Valid names can change identity; invalid object names pass locally |
+| 7    | Medium   | Layout and map-type validation is too permissive              | Unsupported declarations reach execution                           |
+| 8 ✅ | Medium   | `CREATE TABLE IF NOT EXISTS` can report false success         | A concurrent incompatible create is treated as success             |
 
 ## 1. Reject views and non-Delta tables at the read boundary
 
@@ -279,6 +279,8 @@ These are deterministic declaration errors and need no runtime probing.
 
 ## 8. Remove the false-success race from table creation
 
+**Status:** Done — `IF NOT EXISTS` removed from `compile_create_table`.
+
 ### Cause
 
 Creation compiles to `CREATE TABLE IF NOT EXISTS`. If another writer creates an
@@ -328,7 +330,7 @@ Before the implementation PR is ready for merge, run:
 - [ ] The eight items above are accepted as correctness defects.
 - [ ] The proposed solution for each item is accepted.
 - [ ] Feature enablement will be represented as a visible planned action rather
-  than an out-of-band prerequisite.
+      than an out-of-band prerequisite.
 - [ ] Lossy schema parsing will fail closed now; structured JSON observation is
-  deferred.
+      deferred.
 - [ ] Once agreed, implementation will be isolated in its own PR.

--- a/src/delta_engine/adapters/databricks/sql/compile.py
+++ b/src/delta_engine/adapters/databricks/sql/compile.py
@@ -69,16 +69,16 @@ def _(action: CreateTable, backticked_table_name: str) -> str:
     partition_by = _partitioned_by_clause(table.partitioned_by)
     cluster_by = _clustered_by_clause(table.clustered_by)
 
-    # IF NOT EXISTS, even though CreateTable is only emitted after the reader
-    # reports the table absent. It guards the read-then-create race: if another
-    # process creates the table in that window, the statement no-ops rather than
-    # erroring. The trade-off is that such a table is reported created without
-    # reconciling its schema; the next sync re-reads and plans any drift. This
-    # favours a resilient run over failing loud on a rare race. The resulting
-    # false-success window is documented under concurrent catalog changes in
+    # A plain CREATE TABLE (no IF NOT EXISTS). CreateTable is only emitted after
+    # the reader reports the table absent, but the read and the create are not
+    # atomic: if another process creates the name in that window, this statement
+    # errors and the executor reports ExecutionFailed rather than a false
+    # success. Failing the race explicitly matches the engine's no-retry policy;
+    # the user reruns sync, at which point the reader observes and diffs the
+    # table that actually exists. See concurrent catalog changes in
     # docs/reference-limitations.md.
     parts = [
-        f"CREATE TABLE IF NOT EXISTS {backticked_table_name}",
+        f"CREATE TABLE {backticked_table_name}",
         f"({columns_clause})",
         "USING delta",
         table_comment,

--- a/src/delta_engine/adapters/databricks/sql/compile.py
+++ b/src/delta_engine/adapters/databricks/sql/compile.py
@@ -73,10 +73,7 @@ def _(action: CreateTable, backticked_table_name: str) -> str:
     # the reader reports the table absent, but the read and the create are not
     # atomic: if another process creates the name in that window, this statement
     # errors and the executor reports ExecutionFailed rather than a false
-    # success. Failing the race explicitly matches the engine's no-retry policy;
-    # the user reruns sync, at which point the reader observes and diffs the
-    # table that actually exists. See concurrent catalog changes in
-    # docs/reference-limitations.md.
+    # success.
     parts = [
         f"CREATE TABLE {backticked_table_name}",
         f"({columns_clause})",

--- a/tests/adapters/databricks/sql/test_compile.py
+++ b/tests/adapters/databricks/sql/test_compile.py
@@ -198,7 +198,7 @@ def test_create_table_renders_columns_nullability_comments_table_comment_and_pro
 
     # Then all CREATE TABLE clauses are rendered
     assert statement == (
-        "CREATE TABLE IF NOT EXISTS `cat`.`sch`.`tbl`"
+        "CREATE TABLE `cat`.`sch`.`tbl`"
         " (`id` INT NOT NULL, `name` STRING COMMENT 'customer')"
         " USING delta"
         " COMMENT 'core table'"
@@ -214,7 +214,7 @@ def test_create_table_omits_comment_clause_when_table_comment_is_empty():
     statement = _compile_single(action)
 
     # Then no empty table COMMENT clause is emitted
-    assert statement == "CREATE TABLE IF NOT EXISTS `cat`.`sch`.`tbl` (`id` INT) USING delta"
+    assert statement == "CREATE TABLE `cat`.`sch`.`tbl` (`id` INT) USING delta"
 
 
 def test_create_table_renders_partition_clause():
@@ -290,7 +290,7 @@ def test_create_table_inlines_primary_key_constraint():
 
     # Then the primary key constraint is inlined in the column list
     assert statement == (
-        "CREATE TABLE IF NOT EXISTS `cat`.`sch`.`tbl`"
+        "CREATE TABLE `cat`.`sch`.`tbl`"
         " (`id` INT NOT NULL, `name` STRING, CONSTRAINT `tbl_pk` PRIMARY KEY (`id`))"
         " USING delta"
     )
@@ -322,7 +322,7 @@ def test_create_table_backticks_struct_field_names_and_renders_variant():
 
     # Then the struct field name is backtick-quoted and VARIANT is rendered
     assert statement == (
-        "CREATE TABLE IF NOT EXISTS `cat`.`sch`.`tbl`"
+        "CREATE TABLE `cat`.`sch`.`tbl`"
         " (`payload` STRUCT<`order id`: INT>, `attributes` VARIANT)"
         " USING delta"
         " TBLPROPERTIES ('delta.columnMapping.mode'='name')"


### PR DESCRIPTION
## Summary

Implements **item 8** of the [business-logic/Delta/Databricks correctness review](docs/todo/business-logic-delta-databricks-correctness-review.md): *Remove the false-success race from table creation.*

`CreateTable` compiled to `CREATE TABLE IF NOT EXISTS`. Because the action is only planned after the reader observes the table absent, that guard only ever mattered in the read-then-create race window: if another writer created an incompatible table in the gap, Databricks no-op'd and the executor reported the planned create as **succeeded** — a false success against a schema that was never reconciled.

This PR emits a plain `CREATE TABLE`. A concurrent create now errors, which the adapter translates into an `ExecutionFailed` rather than a false success. The next sync reads and diffs the table that actually exists. Failing the race explicitly is consistent with the engine's no-retry policy.

## Changes

- `adapters/databricks/sql/compile.py` — drop `IF NOT EXISTS` from `compile_create_table`; rewrite the accompanying comment to describe the fail-loud behaviour.
- `tests/adapters/databricks/sql/test_compile.py` — update the four expected-SQL assertions.
- `docs/reference-limitations.md` — "Concurrent catalog changes" now describes an execution failure instead of a silent no-op.
- `docs/todo/business-logic-delta-databricks-correctness-review.md` — tick item 8 off.

## Checks

- `tests/adapters/databricks/sql/test_compile.py` — 41 passed
- Full non-live suite (`-m "not local_e2e and not databricks_e2e"`) — 890 passed, 98% coverage
- Local Spark e2e (`tests/e2e/test_engine_e2e.py`) — 19 passed; plain `CREATE TABLE` works end-to-end
- `ruff check`, `ruff format --check`, `mypy src` — clean

## Risks / notes

- Happy path is unchanged: creation is still gated on observed absence, so a plain `CREATE TABLE` only runs when the table is genuinely missing. The only difference is that the rare race now fails loudly.
- Live SQL warehouse verification is **not** run here (no credentials in this repo, per project policy); it happens in the separate live-test project per the review's implementation boundary.
- Scoped strictly to item 8; the other seven review items remain unimplemented.