### PR TITLE
fix: write the live test summary once, not once per xdist worker

### DIFF
--- a/tests/live/conftest.py
+++ b/tests/live/conftest.py
@@ -108,11 +108,18 @@ def pytest_terminal_summary(terminalreporter: pytest.TerminalReporter) -> None:
     """
     Append a behaviour-area summary of the live suite to the GitHub job summary.
 
-    Only acts in CI (``GITHUB_STEP_SUMMARY`` set) and only counts this
-    directory's tests, so a full-repo run that deselects the live suite writes
-    nothing and non-live files never leak in. Runs once on the xdist
-    controller, with results already aggregated across workers.
+    Only acts in CI (``GITHUB_STEP_SUMMARY`` set), only counts this directory's
+    tests, and writes once from the xdist controller rather than once per
+    worker.
     """
+    # Under ``-n`` parallelism xdist runs this hook on every worker as well as
+    # the controller, but only the controller's stats are aggregated across
+    # workers -- a worker sees just the subset it ran and would append its own
+    # partial, duplicate summary. xdist sets ``workerinput`` on worker configs
+    # only, so this skips workers and leaves the controller to write once.
+    if hasattr(terminalreporter.config, "workerinput"):
+        return
+
     summary_path = os.environ.get("GITHUB_STEP_SUMMARY")
     if not summary_path:
         return


### PR DESCRIPTION
## Problem

The **Live Databricks Tests** job summary repeated the same block over and over, each line with a different partial count:

```
✅ Live Databricks tests — all 7 passed
✅ Live Databricks tests — all 9 passed
✅ Live Databricks tests — all 5 passed
...
```

The summary hook already builds a single `| Area | Checks | Result |` table. The repetition came from parallelism: the job runs the suite with `-n 8`, and pytest calls `pytest_terminal_summary` on **every xdist worker** as well as the controller. Each worker only ran a slice of the suite, so each appended its own header and partial table to the shared `$GITHUB_STEP_SUMMARY` — 8 partial blocks plus 1 correct one. The docstring claimed the hook "runs once on the xdist controller," but nothing enforced it.

## Fix

Guard the hook to the controller, which is the only process holding stats aggregated across workers. xdist sets `workerinput` on worker configs only, so `hasattr(config, "workerinput")` cleanly skips workers and leaves the controller to write the single, correct summary.

## Verification

Reproduced the bug and verified the fix with a throwaway xdist project (couldn't run the real live suite — it needs Databricks credentials):

- Before: `-n 4` over 21 tests → **5 blocks** (4 partial workers + 1 controller).
- After: same run → **1 block**, correct total (`21 passed`). Serial runs also emit exactly 1 block.

Also ran against the edited file:

- `uv run ruff check tests/live/conftest.py` — clean
- `uv run mypy tests/live/conftest.py` — clean
- `uv run pytest tests/live --collect-only` — 56 tests collect

## Notes

No automated regression test added: a faithful one needs a `pytester` subprocess run *with* xdist, which would be the repo's first such test, for opt-in scaffolding that only runs in credentialed CI. Happy to add one if preferred.