### PR TITLE
test: surface each live test's behaviour in the CI job summary

### DIFF
--- a/tests/live/conftest.py
+++ b/tests/live/conftest.py
@@ -25,6 +25,8 @@ from uuid import uuid4
 
 import pytest
 
+from tests.live.job_summary import docstring_property, write_summary
+
 _LIVE_REQUIRED_ENV = ("DELTA_ENGINE_E2E_CATALOG", "DELTA_ENGINE_E2E_SCHEMA")
 _LIVE_DIRECTORY = Path(__file__).parent
 
@@ -69,106 +71,21 @@ def live_tables(live_connection) -> LiveTableFactory:
         execute_sql(live_connection, f"DROP TABLE IF EXISTS {qualified_table(name)}")
 
 
-# Visitor-facing behaviour areas for the GitHub job summary, in report order.
-# Each live test file maps to a label and a one-line statement of what it
-# proves; a new live file needs an entry here to appear in the summary.
-_LIVE_AREAS: dict[str, tuple[str, str]] = {
-    "test_sql_warehouse_live.py": (
-        "Table lifecycle",
-        "create, evolve every mutable aspect, dry-run previews, idempotent resync",
-    ),
-    "test_sql_warehouse_live_constraints.py": (
-        "Primary & foreign keys",
-        "add, change, and drop keys; composite, self-referential, dependency order",
-    ),
-    "test_sql_warehouse_live_safety.py": (
-        "Validation blocks",
-        "unsafe DDL is rejected and the catalog is left unchanged",
-    ),
-    "test_sql_warehouse_live_scopes.py": (
-        "Scoped ownership",
-        "metadata-only and tags-only declarations change nothing outside their scope",
-    ),
-    "test_sql_warehouse_live_types_and_layout.py": (
-        "Types & layout",
-        "every column type round-trips; widening, partitioning, and clustering",
-    ),
-    "test_sql_warehouse_live_renames.py": (
-        "Column renames",
-        "data, tags, comments, and layout travel; keys are replaced; ambiguity is rejected",
-    ),
-    "test_sql_warehouse_live_platform_assumptions.py": (
-        "Platform assumptions",
-        "Databricks behaviours the engine's safety gates rely on",
-    ),
-}
+@pytest.hookimpl(wrapper=True)
+def pytest_runtest_makereport(item, call):
+    """
+    Carry each live test's docstring to the controller on its report.
+
+    The summary hook runs on the xdist controller, which never imported the test
+    functions the workers collected. ``user_properties`` are serialized back with
+    the report, so the docstring reaches the controller that renders the summary.
+    """
+    report = yield
+    if report.when == "call":
+        report.user_properties.append(docstring_property(item.obj))
+    return report
 
 
 def pytest_terminal_summary(terminalreporter: pytest.TerminalReporter) -> None:
-    """
-    Append a behaviour-area summary of the live suite to the GitHub job summary.
-
-    Only acts in CI (``GITHUB_STEP_SUMMARY`` set), only counts this directory's
-    tests, and writes once from the xdist controller rather than once per
-    worker.
-    """
-    # Under ``-n`` parallelism xdist runs this hook on every worker as well as
-    # the controller, but only the controller's stats are aggregated across
-    # workers -- a worker sees just the subset it ran and would append its own
-    # partial, duplicate summary. xdist sets ``workerinput`` on worker configs
-    # only, so this skips workers and leaves the controller to write once.
-    if hasattr(terminalreporter.config, "workerinput"):
-        return
-
-    summary_path = os.environ.get("GITHUB_STEP_SUMMARY")
-    if not summary_path:
-        return
-
-    # Collapse each test's phase reports (setup/call/teardown) to one pass/fail.
-    passed_by_test: dict[str, bool] = {}
-    for status in ("passed", "failed", "error"):
-        for report in terminalreporter.stats.get(status, []):
-            filename = report.nodeid.split("::", 1)[0].rsplit("/", 1)[-1]
-            if filename not in _LIVE_AREAS:
-                continue
-            passed_by_test[report.nodeid] = (
-                passed_by_test.get(report.nodeid, True) and status == "passed"
-            )
-
-    if not passed_by_test:
-        return
-
-    counts_by_file: dict[str, list[int]] = {}
-    for nodeid, passed in passed_by_test.items():
-        filename = nodeid.split("::", 1)[0].rsplit("/", 1)[-1]
-        counts = counts_by_file.setdefault(filename, [0, 0])
-        counts[0] += int(passed)
-        counts[1] += 1
-
-    total = len(passed_by_test)
-    total_passed = sum(passed_by_test.values())
-
-    lines: list[str] = []
-    if total_passed == total:
-        lines.append(f"## ✅ Live Databricks tests — all {total} passed")
-    else:
-        lines.append(
-            f"## ❌ Live Databricks tests — {total - total_passed} failed, {total_passed} passed"
-        )
-    lines += [
-        "",
-        "Verified against a real Databricks SQL warehouse (Unity Catalog).",
-        "",
-        "| Area | Checks | Result |",
-        "| --- | --- | --- |",
-    ]
-    for filename, (label, description) in _LIVE_AREAS.items():
-        counts = counts_by_file.get(filename)
-        if counts is None:
-            continue
-        area_passed, area_total = counts
-        mark = "✅" if area_passed == area_total else "❌"
-        lines.append(f"| {label} | {description} | {mark} {area_passed}/{area_total} |")
-
-    with open(summary_path, "a", encoding="utf-8") as summary:
-        summary.write("\n".join(lines) + "\n")
+    """Append the live suite's behaviour-area summary to the GitHub job summary."""
+    write_summary(terminalreporter)

--- a/tests/live/job_summary.py
+++ b/tests/live/job_summary.py
@@ -1,0 +1,226 @@
+"""
+Collect and render the live suite's GitHub job summary.
+
+Backend-free and importable without a Databricks connection: the live
+``conftest`` attaches each test's docstring to its report and, at the end of the
+run, hands the terminal reporter to :func:`write_summary`. The hermetic tests in
+``tests/test_live_job_summary.py`` drive these functions directly.
+
+The summary keeps a high-level overview table (one row per behaviour area) and
+adds a collapsible ``<details>`` drill-down per area listing the individual
+checks that ran. Each check's text is the first line of its test's docstring,
+falling back to a humanized test name when a test has none.
+"""
+
+from dataclasses import dataclass
+import os
+
+# Visitor-facing behaviour areas for the GitHub job summary, in report order.
+# Each live test file maps to a label and a one-line statement of what it
+# proves; a new live file needs an entry here to appear in the summary.
+LIVE_AREAS: dict[str, tuple[str, str]] = {
+    "test_sql_warehouse_live.py": (
+        "Table lifecycle",
+        "create, evolve every mutable aspect, dry-run previews, idempotent resync",
+    ),
+    "test_sql_warehouse_live_constraints.py": (
+        "Primary & foreign keys",
+        "add, change, and drop keys; composite, self-referential, dependency order",
+    ),
+    "test_sql_warehouse_live_safety.py": (
+        "Validation blocks",
+        "unsafe DDL is rejected and the catalog is left unchanged",
+    ),
+    "test_sql_warehouse_live_scopes.py": (
+        "Scoped ownership",
+        "metadata-only and tags-only declarations change nothing outside their scope",
+    ),
+    "test_sql_warehouse_live_types_and_layout.py": (
+        "Types & layout",
+        "every column type round-trips; widening, partitioning, and clustering",
+    ),
+    "test_sql_warehouse_live_renames.py": (
+        "Column renames",
+        "data, tags, comments, and layout travel; keys are replaced; ambiguity is rejected",
+    ),
+    "test_sql_warehouse_live_platform_assumptions.py": (
+        "Platform assumptions",
+        "Databricks behaviours the engine's safety gates rely on",
+    ),
+}
+
+# The user_property key under which a test's docstring rides its report from the
+# xdist worker back to the controller that writes the summary.
+_AREA_DOC_KEY = "area_doc"
+
+# Acronyms to re-case when falling back to a humanized test name.
+_ACRONYMS = {
+    "cdf": "CDF",
+    "cdc": "CDC",
+    "ddl": "DDL",
+    "sql": "SQL",
+    "pk": "PK",
+    "fk": "FK",
+    "ntz": "NTZ",
+}
+
+
+@dataclass(frozen=True)
+class CheckOutcome:
+    """One live test's contribution to the summary."""
+
+    nodeid: str
+    filename: str
+    passed: bool
+    docstring: str  # first docstring line, or "" when the test has none
+    line: int  # definition line, used only to order checks deterministically
+
+
+def docstring_property(obj: object) -> tuple[str, str]:
+    """Return the report ``user_property`` carrying a test's one-line docstring."""
+    doc = (getattr(obj, "__doc__", None) or "").strip()
+    return (_AREA_DOC_KEY, doc.splitlines()[0] if doc else "")
+
+
+def collect_outcomes(stats: dict) -> list[CheckOutcome]:
+    """
+    Collapse a reporter's phase reports into one outcome per live test.
+
+    A test contributes several reports (setup, call, teardown); it counts as
+    passed only when every phase passed, and its docstring rides the ``call``
+    report's ``user_properties``.
+    """
+    passed: dict[str, bool] = {}
+    docstrings: dict[str, str] = {}
+    lines: dict[str, int] = {}
+    for status in ("passed", "failed", "error"):
+        for report in stats.get(status, []):
+            filename = _filename(report.nodeid)
+            if filename not in LIVE_AREAS:
+                continue
+            nodeid = report.nodeid
+            passed[nodeid] = passed.get(nodeid, True) and status == "passed"
+            doc = _area_doc(report)
+            if doc:
+                docstrings[nodeid] = doc
+            lines.setdefault(nodeid, _line_of(report))
+    return [
+        CheckOutcome(
+            nodeid=nodeid,
+            filename=_filename(nodeid),
+            passed=passed[nodeid],
+            docstring=docstrings.get(nodeid, ""),
+            line=lines[nodeid],
+        )
+        for nodeid in passed
+    ]
+
+
+def render_summary(
+    outcomes: list[CheckOutcome],
+    areas: dict[str, tuple[str, str]] = LIVE_AREAS,
+) -> str | None:
+    """Render the whole job-summary markdown, or ``None`` when no live tests ran."""
+    if not outcomes:
+        return None
+
+    checks_by_file: dict[str, list[CheckOutcome]] = {}
+    for outcome in outcomes:
+        checks_by_file.setdefault(outcome.filename, []).append(outcome)
+
+    total = len(outcomes)
+    total_passed = sum(1 for outcome in outcomes if outcome.passed)
+
+    lines: list[str] = []
+    if total_passed == total:
+        lines.append(f"## ✅ Live Databricks tests — all {total} passed")
+    else:
+        lines.append(
+            f"## ❌ Live Databricks tests — {total - total_passed} failed, {total_passed} passed"
+        )
+    lines += [
+        "",
+        "Verified against a real Databricks SQL warehouse (Unity Catalog).",
+        "",
+        "| Area | Checks | Result |",
+        "| --- | --- | --- |",
+    ]
+    for filename, (label, description) in areas.items():
+        checks = checks_by_file.get(filename)
+        if not checks:
+            continue
+        area_passed = sum(1 for check in checks if check.passed)
+        mark = "✅" if area_passed == len(checks) else "❌"
+        lines.append(f"| {label} | {description} | {mark} {area_passed}/{len(checks)} |")
+
+    lines.append("")
+    for filename, (label, _description) in areas.items():
+        checks = checks_by_file.get(filename)
+        if not checks:
+            continue
+        area_passed = sum(1 for check in checks if check.passed)
+        if area_passed == len(checks):
+            summary_line = f"✅ {label} — {len(checks)} checks"
+        else:
+            summary_line = f"❌ {label} — {area_passed}/{len(checks)}"
+        lines.append(f"<details><summary>{summary_line}</summary>")
+        lines.append("")
+        for check in sorted(checks, key=lambda outcome: outcome.line):
+            prefix = "" if check.passed else "❌ "
+            lines.append(f"- {prefix}{_describe(check)}")
+        lines.append("</details>")
+        lines.append("")
+
+    return "\n".join(lines) + "\n"
+
+
+def write_summary(terminalreporter) -> None:
+    """
+    Append the rendered summary to ``GITHUB_STEP_SUMMARY``, once, from the controller.
+
+    Under ``-n`` parallelism xdist runs the terminal-summary hook on every worker
+    as well as the controller, but only the controller aggregates stats across
+    workers; a worker would append its own partial, duplicate summary. xdist sets
+    ``workerinput`` on worker configs only, so this returns early on workers.
+    """
+    if hasattr(terminalreporter.config, "workerinput"):
+        return
+    summary_path = os.environ.get("GITHUB_STEP_SUMMARY")
+    if not summary_path:
+        return
+    summary = render_summary(collect_outcomes(terminalreporter.stats))
+    if summary is None:
+        return
+    with open(summary_path, "a", encoding="utf-8") as handle:
+        handle.write(summary)
+
+
+def _filename(nodeid: str) -> str:
+    return nodeid.split("::", 1)[0].rsplit("/", 1)[-1]
+
+
+def _area_doc(report) -> str:
+    for key, value in getattr(report, "user_properties", ()):
+        if key == _AREA_DOC_KEY:
+            return value
+    return ""
+
+
+def _line_of(report) -> int:
+    location = getattr(report, "location", None)
+    if location and location[1] is not None:
+        return location[1]
+    return 0
+
+
+def _describe(outcome: CheckOutcome) -> str:
+    return outcome.docstring or _humanize(outcome.nodeid)
+
+
+def _humanize(nodeid: str) -> str:
+    name = nodeid.rsplit("::", 1)[-1].split("[", 1)[0].removeprefix("test_")
+    words = [_ACRONYMS.get(word, word) for word in name.split("_")]
+    sentence = " ".join(words).strip()
+    if not sentence:
+        return nodeid
+    return sentence[0].upper() + sentence[1:]

--- a/tests/live/test_sql_warehouse_live.py
+++ b/tests/live/test_sql_warehouse_live.py
@@ -18,6 +18,7 @@ from tests.live.sql_warehouse_live_helpers import (
 
 
 def test_sync_builds_feature_rich_table_in_live_catalog(live_connection, live_tables):
+    """Creates a table with columns, comments, tags, clustering, keys, and properties."""
     table_name = live_tables("create")
     table = DeltaTable(
         catalog=live_catalog(),
@@ -58,6 +59,7 @@ def test_sync_builds_feature_rich_table_in_live_catalog(live_connection, live_ta
 
 
 def test_sync_changes_every_mutable_table_aspect_in_live_catalog(live_connection, live_tables):
+    """Evolves columns, comments, clustering, tags, and properties in a single sync."""
     table_name = live_tables("lifecycle")
     initial = DeltaTable(
         live_catalog(),
@@ -152,6 +154,7 @@ def test_sync_changes_every_mutable_table_aspect_in_live_catalog(live_connection
 
 
 def test_identical_sync_does_not_alter_live_catalog(live_connection, live_tables):
+    """Re-applying an identical declaration leaves the catalog byte-for-byte unchanged."""
     table_name = live_tables("idempotent")
     table = DeltaTable(
         live_catalog(),
@@ -172,6 +175,7 @@ def test_identical_sync_does_not_alter_live_catalog(live_connection, live_tables
 
 
 def test_dry_run_previews_creation_sql_without_creating_the_table(live_connection, live_tables):
+    """A dry run previews the CREATE TABLE SQL without creating the table."""
     table_name = live_tables("dry_run_create")
     table = DeltaTable(
         live_catalog(),
@@ -188,6 +192,7 @@ def test_dry_run_previews_creation_sql_without_creating_the_table(live_connectio
 
 
 def test_dry_run_previews_alterations_without_changing_the_live_table(live_connection, live_tables):
+    """A dry run previews ALTER SQL without changing the live table."""
     table_name = live_tables("dry_run_alter")
     engine = build_sql_engine(live_connection)
     engine.sync(
@@ -224,6 +229,7 @@ def test_dry_run_previews_alterations_without_changing_the_live_table(live_conne
 
 
 def test_sync_alters_preserve_existing_rows(live_connection, live_tables):
+    """Widening, adding a column, and re-clustering preserve every existing row."""
     table_name = live_tables("data_preserved")
     engine = build_sql_engine(live_connection)
     engine.sync(
@@ -274,6 +280,7 @@ def test_sync_alters_preserve_existing_rows(live_connection, live_tables):
 
 
 def test_sync_round_trips_quoted_identifiers_and_unicode_metadata(live_connection, live_tables):
+    """Quoted identifiers and Unicode comments, tags, and names round-trip intact."""
     table_name = live_tables("quoted")
     table = DeltaTable(
         live_catalog(),

--- a/tests/live/test_sql_warehouse_live_constraints.py
+++ b/tests/live/test_sql_warehouse_live_constraints.py
@@ -24,6 +24,7 @@ from tests.live.sql_warehouse_live_helpers import (
 
 
 def test_sync_adds_changes_and_drops_primary_key(live_connection, live_tables):
+    """Adds, widens to composite, and drops a primary key across successive syncs."""
     table_name = live_tables("pk_lifecycle")
     columns = (
         Column("tenant_id", Integer(), nullable=False),
@@ -62,6 +63,7 @@ def test_sync_adds_changes_and_drops_primary_key(live_connection, live_tables):
 def test_sync_creates_composite_foreign_key_in_dependency_order_and_removes_it(
     live_connection, live_tables
 ):
+    """Creates a composite foreign key parent-first from reversed input, then drops it."""
     parent_name = live_tables("accounts")
     child_name = live_tables("orders")
     parent_columns = (
@@ -126,6 +128,7 @@ def test_sync_creates_composite_foreign_key_in_dependency_order_and_removes_it(
 
 
 def test_sync_creates_self_referential_foreign_key(live_connection, live_tables):
+    """Creates a self-referential foreign key on a single table."""
     table_name = live_tables("employees")
     table = DeltaTable(
         live_catalog(),
@@ -149,6 +152,7 @@ def test_sync_creates_self_referential_foreign_key(live_connection, live_tables)
 def test_structurally_matching_constraints_adopt_foreign_names_without_drift(
     live_connection, live_tables
 ):
+    """Adopts a live key created under foreign constraint names, finding no drift."""
     # Constraint identity is structural: a live PK/FK created under names the
     # engine would never generate is still the declared constraint, so a sync
     # finds no drift and the foreign names survive.
@@ -187,6 +191,7 @@ def test_structurally_matching_constraints_adopt_foreign_names_without_drift(
 def test_primary_key_drop_is_not_blocked_by_unique_backed_foreign_keys(
     live_connection, live_tables
 ):
+    """Drops a primary key even while a UNIQUE constraint outside the model backs an FK."""
     # given a parent whose primary key has no referencing foreign keys, but
     # whose UNIQUE constraint backs one (UNIQUE constraints are DBR 18.2+
     # Public Preview and outside the engine's model)

--- a/tests/live/test_sql_warehouse_live_platform_assumptions.py
+++ b/tests/live/test_sql_warehouse_live_platform_assumptions.py
@@ -22,6 +22,7 @@ from tests.live.sql_warehouse_live_helpers import (
 def test_cdf_enablement_fails_on_a_table_carrying_reserved_cdf_columns(
     live_connection, live_tables
 ):
+    """Databricks blocks enabling change data feed on a table with reserved CDF columns."""
     # The API refuses declarations that combine change data feed with
     # _change_type/_commit_version/_commit_timestamp columns because the
     # platform enforces the same rule at enablement time.
@@ -42,6 +43,7 @@ def test_cdf_enablement_fails_on_a_table_carrying_reserved_cdf_columns(
 def test_special_characters_in_nested_struct_field_names_require_column_mapping(
     live_connection, live_tables
 ):
+    """Databricks needs column mapping for special characters in nested struct fields."""
     # The declaration gate recursively rejects special characters in nested
     # struct field names unless column mapping is on — both directions of
     # that assumption must match the platform. (The engine deliberately does
@@ -70,6 +72,7 @@ def test_special_characters_in_nested_struct_field_names_require_column_mapping(
 def test_platform_rename_silently_drops_keys_including_other_tables_foreign_keys(
     live_connection, live_tables
 ):
+    """RENAME COLUMN silently drops keys, cascading into other tables' foreign keys."""
     # RENAME COLUMN drops any PK/FK using the column, cascading into other
     # tables' foreign keys with no error (first observed live 2026-07-14).
     # This is the hazard behind PrimaryKeyReferencedByForeignKeys and the
@@ -102,6 +105,7 @@ def test_platform_rename_silently_drops_keys_including_other_tables_foreign_keys
 def test_platform_restricts_a_primary_key_drop_while_a_foreign_key_references_it(
     live_connection, live_tables
 ):
+    """DROP PRIMARY KEY is RESTRICTed while a foreign key references it, even IF EXISTS."""
     # DROP PRIMARY KEY defaults to RESTRICT, and IF EXISTS does not bypass
     # it. This is the engine's fail-closed net: an inbound FK the reader
     # could not observe (e.g. cross-catalog) fails the compiled drop, and
@@ -132,6 +136,7 @@ def test_platform_restricts_a_primary_key_drop_while_a_foreign_key_references_it
 def test_platform_blocks_renaming_a_column_referenced_by_a_check_constraint(
     live_connection, live_tables
 ):
+    """Databricks blocks renaming a column a CHECK constraint references."""
     # The engine does not model CHECK constraints; renames of referenced
     # columns are documented to fail at execution rather than validation.
     table_name = live_tables("check_dependent")
@@ -154,6 +159,7 @@ def test_platform_blocks_renaming_a_column_referenced_by_a_check_constraint(
 
 
 def test_platform_refuses_clustering_a_partitioned_table(live_connection, live_tables):
+    """Databricks refuses to cluster a partitioned table."""
     # PartitioningChangeNotSupported blocks partitioned->clustered
     # conversions; the platform refuses the direct conversion too, so the
     # engine is not withholding a supported operation.
@@ -175,6 +181,7 @@ def test_platform_refuses_clustering_a_partitioned_table(live_connection, live_t
 
 
 def test_platform_rejects_an_over_long_column_tag_key_or_value(live_connection, live_tables):
+    """Databricks rejects a column tag key or value longer than 256 characters."""
     # A column tag key or value longer than 256 characters is rejected (first
     # observed live 2026-07-14). This backs the length gates in
     # api/delta_table.py (_validate_tags), which reject both at declaration
@@ -205,6 +212,7 @@ def test_platform_rejects_an_over_long_column_tag_key_or_value(live_connection, 
 
 
 def test_platform_rejects_a_complex_type_as_a_partition_column(live_connection, live_tables):
+    """Databricks rejects a complex type as a partition column."""
     # Delta refuses complex/nested types as partition columns, raising
     # INVALID_PARTITION_COLUMN_DATA_TYPE (error class confirmed live
     # 2026-07-14; the older DELTA_INVALID_PARTITION_COLUMN_TYPE spelling no

--- a/tests/live/test_sql_warehouse_live_renames.py
+++ b/tests/live/test_sql_warehouse_live_renames.py
@@ -36,6 +36,7 @@ _COLUMN_MAPPING = {Property.COLUMN_MAPPING_MODE: "name"}
 
 
 def test_sync_renames_a_column_preserving_data_tags_and_comment(live_connection, live_tables):
+    """Renaming a column carries its data, tags, and comment, converging in one sync."""
     table_name = live_tables("rename_travel")
     engine = build_sql_engine(live_connection)
     engine.sync(
@@ -90,6 +91,7 @@ def test_sync_renames_a_column_preserving_data_tags_and_comment(live_connection,
 
 
 def test_sync_replaces_a_primary_key_across_a_rename_in_one_plan(live_connection, live_tables):
+    """Renaming a primary-key column replaces the key explicitly in one plan."""
     table_name = live_tables("rename_pk")
     engine = build_sql_engine(live_connection)
     engine.sync(
@@ -138,6 +140,7 @@ def test_sync_replaces_a_primary_key_across_a_rename_in_one_plan(live_connection
 def test_sync_replaces_a_composite_primary_key_when_one_member_is_renamed(
     live_connection, live_tables
 ):
+    """Renaming one member of a composite primary key replaces the whole key."""
     table_name = live_tables("rename_composite_pk")
     engine = build_sql_engine(live_connection)
     engine.sync(
@@ -188,6 +191,7 @@ def test_sync_replaces_a_composite_primary_key_when_one_member_is_renamed(
 
 
 def test_sync_replaces_a_foreign_key_across_a_local_column_rename(live_connection, live_tables):
+    """Renaming a local foreign-key column replaces the foreign key in one plan."""
     parent_name = live_tables("rename_fk_parent")
     child_name = live_tables("rename_fk_child")
     parent = DeltaTable(
@@ -231,6 +235,7 @@ def test_sync_replaces_a_foreign_key_across_a_local_column_rename(live_connectio
 def test_sync_replaces_a_composite_foreign_key_when_one_local_column_is_renamed(
     live_connection, live_tables
 ):
+    """Renaming one local column of a composite foreign key replaces the whole key."""
     parent_name = live_tables("rename_composite_fk_parent")
     child_name = live_tables("rename_composite_fk_child")
     parent = DeltaTable(
@@ -297,6 +302,7 @@ def test_sync_replaces_a_composite_foreign_key_when_one_local_column_is_renamed(
 def test_sync_rejects_a_primary_key_rename_referenced_by_a_foreign_key(
     live_connection, live_tables
 ):
+    """Renaming a primary key an FK references is rejected, touching neither table."""
     parent_name = live_tables("rename_blocked_parent")
     child_name = live_tables("rename_blocked_child")
     parent = DeltaTable(
@@ -345,6 +351,7 @@ def test_sync_rejects_a_primary_key_rename_referenced_by_a_foreign_key(
 
 
 def test_sync_rejects_an_ambiguous_rename_without_catalog_change(live_connection, live_tables):
+    """An ambiguous column rename is rejected, and the catalog is left unchanged."""
     table_name = live_tables("rename_ambiguous")
     engine = build_sql_engine(live_connection)
     engine.sync(
@@ -380,6 +387,7 @@ def test_sync_rejects_an_ambiguous_rename_without_catalog_change(live_connection
 
 
 def test_sync_renames_a_partition_column_without_layout_drift(live_connection, live_tables):
+    """Renaming a partition column carries the layout with no partitioning drift."""
     table_name = live_tables("rename_partition")
     engine = build_sql_engine(live_connection)
     engine.sync(
@@ -423,6 +431,7 @@ def test_sync_renames_a_partition_column_without_layout_drift(live_connection, l
 
 
 def test_sync_renames_a_clustering_key_without_layout_drift(live_connection, live_tables):
+    """Renaming a clustering key carries the layout with no clustering drift."""
     table_name = live_tables("rename_cluster")
     engine = build_sql_engine(live_connection)
     engine.sync(
@@ -468,6 +477,7 @@ def test_sync_renames_a_clustering_key_without_layout_drift(live_connection, liv
 def test_declaration_with_a_rename_hint_creates_a_fresh_table_under_the_new_name(
     live_connection, live_tables
 ):
+    """A rename hint on a fresh catalog is inert; the table is created under the new name."""
     table_name = live_tables("rename_fresh")
     declaration = DeltaTable(
         live_catalog(),

--- a/tests/live/test_sql_warehouse_live_safety.py
+++ b/tests/live/test_sql_warehouse_live_safety.py
@@ -42,6 +42,7 @@ def _assert_rejected_without_catalog_change(connection, table_name, declaration)
 
 
 def test_non_nullable_column_add_is_rejected_without_catalog_change(live_connection, live_tables):
+    """Adding a non-nullable column is rejected, and the catalog is left unchanged."""
     table_name = live_tables("reject_required_add")
     engine = build_sql_engine(live_connection)
     engine.sync(
@@ -66,6 +67,7 @@ def test_non_nullable_column_add_is_rejected_without_catalog_change(live_connect
 
 
 def test_nullability_tightening_is_rejected_without_catalog_change(live_connection, live_tables):
+    """Tightening a column to non-nullable is rejected, and the catalog is unchanged."""
     table_name = live_tables("reject_not_null")
     engine = build_sql_engine(live_connection)
     engine.sync(
@@ -90,6 +92,7 @@ def test_nullability_tightening_is_rejected_without_catalog_change(live_connecti
 
 
 def test_type_narrowing_is_rejected_without_catalog_change(live_connection, live_tables):
+    """Narrowing a column's type is rejected, and the catalog is left unchanged."""
     table_name = live_tables("reject_narrow")
     engine = build_sql_engine(live_connection)
     engine.sync(
@@ -116,6 +119,7 @@ def test_type_narrowing_is_rejected_without_catalog_change(live_connection, live
 def test_column_drop_without_column_mapping_is_rejected_without_catalog_change(
     live_connection, live_tables
 ):
+    """Dropping a column without column mapping is rejected; the catalog is unchanged."""
     table_name = live_tables("reject_drop")
     engine = build_sql_engine(live_connection)
     engine.sync(
@@ -140,6 +144,7 @@ def test_column_drop_without_column_mapping_is_rejected_without_catalog_change(
 
 
 def test_partitioning_change_is_rejected_without_catalog_change(live_connection, live_tables):
+    """Changing an existing table's partitioning is rejected; the catalog is unchanged."""
     table_name = live_tables("reject_partition")
     columns = (Column("id", Integer()), Column("region", String()))
     engine = build_sql_engine(live_connection)
@@ -161,6 +166,7 @@ def test_partitioning_change_is_rejected_without_catalog_change(live_connection,
 def test_partitioned_to_clustered_conversion_is_rejected_without_catalog_change(
     live_connection, live_tables
 ):
+    """Converting a partitioned table to clustering is rejected, and nothing changes."""
     table_name = live_tables("reject_convert")
     execute_sql(
         live_connection,
@@ -184,6 +190,7 @@ def test_partitioned_to_clustered_conversion_is_rejected_without_catalog_change(
 def test_permanent_column_mapping_transition_is_rejected_without_catalog_change(
     live_connection, live_tables
 ):
+    """Turning column mapping off is rejected, and the catalog is left unchanged."""
     table_name = live_tables("reject_mapping")
     columns = (Column("id", Integer()),)
     engine = build_sql_engine(live_connection)
@@ -213,6 +220,7 @@ def test_permanent_column_mapping_transition_is_rejected_without_catalog_change(
 def test_referenced_primary_key_change_is_rejected_without_catalog_change(
     live_connection, live_tables
 ):
+    """Changing a primary key referenced by another table's FK is rejected client-side."""
     parent_name = live_tables("referenced_parent")
     child_name = live_tables("referencing_child")
     parent_columns = (Column("id", Integer(), nullable=False),)
@@ -257,6 +265,7 @@ def test_referenced_primary_key_change_is_rejected_without_catalog_change(
 
 
 def test_restricted_scope_drift_is_rejected_without_catalog_change(live_connection, live_tables):
+    """Drift outside a restricted scope is rejected, and the catalog is left unchanged."""
     table_name = live_tables("reject_scope_drift")
     execute_sql(
         live_connection,
@@ -278,6 +287,7 @@ def test_restricted_scope_drift_is_rejected_without_catalog_change(live_connecti
 
 
 def test_restricted_scope_does_not_create_missing_table(live_connection, live_tables):
+    """A restricted-scope declaration refuses to create a missing table."""
     table_name = live_tables("missing_scope")
     declaration = DeltaTable(
         live_catalog(),
@@ -297,6 +307,7 @@ def test_restricted_scope_does_not_create_missing_table(live_connection, live_ta
 def test_independent_table_still_changes_when_another_table_is_rejected(
     live_connection, live_tables
 ):
+    """An independent table still syncs when another table in the run is rejected."""
     unsafe_name = live_tables("batch_unsafe")
     healthy_name = live_tables("batch_healthy")
     engine = build_sql_engine(live_connection)
@@ -335,6 +346,7 @@ def test_independent_table_still_changes_when_another_table_is_rejected(
 def test_server_rejected_statement_surfaces_as_typed_execution_failure(
     live_connection, live_tables
 ):
+    """A warehouse-rejected statement surfaces as a typed execution failure with its SQL."""
     table_name = live_tables("reject_execution")
     engine = build_sql_engine(live_connection)
     engine.sync(
@@ -375,6 +387,7 @@ def test_server_rejected_statement_surfaces_as_typed_execution_failure(
 def test_widening_without_the_type_widening_property_is_rejected_without_catalog_change(
     live_connection, live_tables
 ):
+    """Widening without the type-widening property is rejected, and nothing changes."""
     table_name = live_tables("reject_widen")
     engine = build_sql_engine(live_connection)
     engine.sync(
@@ -401,6 +414,7 @@ def test_widening_without_the_type_widening_property_is_rejected_without_catalog
 def test_undeclared_managed_property_is_rejected_without_catalog_change(
     live_connection, live_tables
 ):
+    """A managed property set outside the declaration is rejected, not reconciled."""
     # Exact-declaration semantics: a managed key set outside the declaration
     # is drift the sync must refuse to reconcile silently, not quietly unset.
     table_name = live_tables("reject_undeclared")
@@ -424,6 +438,7 @@ def test_undeclared_managed_property_is_rejected_without_catalog_change(
 def test_child_with_foreign_key_is_blocked_when_its_parent_is_rejected(
     live_connection, live_tables
 ):
+    """A child table is blocked when its foreign-key parent is rejected in the same run."""
     parent_name = live_tables("blocked_parent")
     child_name = live_tables("blocked_child")
     engine = build_sql_engine(live_connection)
@@ -475,6 +490,7 @@ def test_child_with_foreign_key_is_blocked_when_its_parent_is_rejected(
 
 
 def test_unreadable_catalog_surfaces_as_typed_read_failure(live_connection):
+    """An unreadable catalog surfaces as a typed read failure, not a raw connector error."""
     declaration = DeltaTable(
         "de_live_nonexistent_catalog",
         live_schema(),

--- a/tests/live/test_sql_warehouse_live_scopes.py
+++ b/tests/live/test_sql_warehouse_live_scopes.py
@@ -16,6 +16,7 @@ from tests.live.sql_warehouse_live_helpers import (
 
 
 def test_metadata_scope_changes_metadata_and_preserves_external_ddl(live_connection, live_tables):
+    """A metadata-scoped sync updates governed metadata but preserves external structure."""
     table_name = live_tables("metadata_scope")
     execute_sql(
         live_connection,
@@ -60,6 +61,7 @@ def test_metadata_scope_changes_metadata_and_preserves_external_ddl(live_connect
 
 
 def test_tag_scope_changes_only_table_and_column_tags(live_connection, live_tables):
+    """A tags-scoped sync changes only table and column tags, leaving all else intact."""
     table_name = live_tables("tag_scope")
     execute_sql(
         live_connection,

--- a/tests/live/test_sql_warehouse_live_types_and_layout.py
+++ b/tests/live/test_sql_warehouse_live_types_and_layout.py
@@ -45,6 +45,7 @@ def _types(state) -> dict[str, str]:
 
 
 def test_sync_creates_and_round_trips_every_supported_column_type(live_connection, live_tables):
+    """Every supported column type, including nested and parameterised ones, round-trips."""
     table_name = live_tables("types")
     table = DeltaTable(
         live_catalog(),
@@ -118,6 +119,7 @@ def test_sync_creates_and_round_trips_every_supported_column_type(live_connectio
 
 
 def test_sync_creates_every_managed_table_property(live_connection, live_tables):
+    """Every managed table property is written and read back on creation."""
     table_name = live_tables("properties")
     declared = {
         Property.COLUMN_MAPPING_MODE: "name",
@@ -143,6 +145,7 @@ def test_sync_creates_every_managed_table_property(live_connection, live_tables)
 
 
 def test_fresh_table_carries_no_managed_property_keys(live_connection, live_tables):
+    """A freshly created table carries none of the managed property keys."""
     # Registry admission policy: a key belongs in the managed registry only
     # if Databricks does not auto-write it, otherwise every undeclared table
     # would fail validation on resync.
@@ -161,6 +164,7 @@ def test_fresh_table_carries_no_managed_property_keys(live_connection, live_tabl
 
 
 def test_unregistered_properties_are_invisible_to_a_full_sync(live_connection, live_tables):
+    """Properties outside the managed registry are neither drift nor unset on a full sync."""
     # The reader filters unregistered keys out of observed state, so keys
     # owned by other tooling or the platform are neither drift nor unset.
     table_name = live_tables("custom_properties")
@@ -185,6 +189,7 @@ def test_unregistered_properties_are_invisible_to_a_full_sync(live_connection, l
 
 
 def test_sync_widens_partition_clustering_and_key_columns(live_connection, live_tables):
+    """Partition, clustering, and primary-key columns can all be widened."""
     # The engine does not model platform restrictions on which column roles
     # may widen; Unity Catalog imposes none for these roles, so the plain
     # widening path must succeed on partition, clustering, and key columns.
@@ -244,6 +249,7 @@ def test_sync_widens_partition_clustering_and_key_columns(live_connection, live_
 def test_sync_creates_partitioned_table_with_ordered_partition_columns(
     live_connection, live_tables
 ):
+    """A partitioned table is created with its partition columns in declared order."""
     table_name = live_tables("partitioned")
     build_sql_engine(live_connection).sync(
         DeltaTable(
@@ -269,6 +275,7 @@ def test_sync_creates_partitioned_table_with_ordered_partition_columns(
 
 
 def test_sync_changes_and_removes_liquid_clustering(live_connection, live_tables):
+    """Liquid clustering keys can be changed and then removed entirely."""
     table_name = live_tables("clustering")
     columns = (Column("id", Integer()), Column("region", String()))
     engine = build_sql_engine(live_connection)
@@ -301,6 +308,7 @@ def test_sync_changes_and_removes_liquid_clustering(live_connection, live_tables
 
 
 def test_sync_widens_supported_column_types_in_live_catalog(live_connection, live_tables):
+    """Supported numeric, decimal, and temporal column types widen in place."""
     table_name = live_tables("widen")
     engine = build_sql_engine(live_connection)
     engine.sync(

--- a/tests/test_live_job_summary.py
+++ b/tests/test_live_job_summary.py
@@ -1,0 +1,214 @@
+"""
+Hermetic tests for the live suite's GitHub job-summary rendering.
+
+These exercise ``tests/live/job_summary.py`` without a Databricks connection, so
+they run in default CI. The live suite itself (``tests/live/``) is credentialed
+and excluded from default runs; this file lives outside that directory so it is
+not auto-marked ``databricks_e2e``.
+"""
+
+from types import SimpleNamespace
+
+from tests.live.job_summary import (
+    LIVE_AREAS,
+    CheckOutcome,
+    collect_outcomes,
+    docstring_property,
+    render_summary,
+    write_summary,
+)
+
+_SAFETY = "test_sql_warehouse_live_safety.py"
+_LIFECYCLE = "test_sql_warehouse_live.py"
+
+
+def _outcome(filename, name, *, passed=True, docstring="", line=0):
+    return CheckOutcome(
+        nodeid=f"tests/live/{filename}::{name}",
+        filename=filename,
+        passed=passed,
+        docstring=docstring,
+        line=line,
+    )
+
+
+def _report(filename, name, *, when="call", doc=None, line=0):
+    return SimpleNamespace(
+        nodeid=f"tests/live/{filename}::{name}",
+        location=(f"tests/live/{filename}", line, name),
+        user_properties=[("area_doc", doc)] if doc is not None else [],
+        when=when,
+    )
+
+
+# --- render_summary -------------------------------------------------------
+
+
+def test_render_keeps_the_overview_row_and_adds_a_drilldown_for_the_area():
+    # Given two passing checks in one area
+    outcomes = [
+        _outcome(_SAFETY, "test_a", docstring="Narrowing a type is rejected.", line=10),
+        _outcome(_SAFETY, "test_b", docstring="Adding a required column is rejected.", line=20),
+    ]
+
+    # When the summary is rendered
+    summary = render_summary(outcomes)
+
+    # Then the status line and overview row are unchanged, and a drill-down lists each check
+    assert summary is not None
+    assert summary.startswith("## ✅ Live Databricks tests — all 2 passed")
+    label, description = LIVE_AREAS[_SAFETY]
+    assert f"| {label} | {description} | ✅ 2/2 |" in summary
+    assert "<details><summary>✅ Validation blocks — 2 checks</summary>" in summary
+    assert "- Narrowing a type is rejected." in summary
+    assert "- Adding a required column is rejected." in summary
+
+
+def test_render_orders_checks_by_definition_line_and_falls_back_to_the_name():
+    # Given checks defined out of report order, one without a docstring
+    outcomes = [
+        _outcome(_SAFETY, "test_second_defined", docstring="", line=50),
+        _outcome(_SAFETY, "test_first_defined", docstring="First runs.", line=10),
+    ]
+
+    summary = render_summary(outcomes)
+
+    # Then they render in definition order, and the docstring-less one is humanized
+    body = summary.split("<summary>✅ Validation blocks", 1)[1]
+    assert body.index("First runs.") < body.index("Second defined")
+
+
+def test_render_flags_a_failing_area_and_only_its_failed_check():
+    outcomes = [
+        _outcome(_SAFETY, "test_pass", passed=True, docstring="A passing check.", line=10),
+        _outcome(_SAFETY, "test_fail", passed=False, docstring="A failing check.", line=20),
+    ]
+
+    summary = render_summary(outcomes)
+
+    assert summary.startswith("## ❌ Live Databricks tests — 1 failed, 1 passed")
+    label, description = LIVE_AREAS[_SAFETY]
+    assert f"| {label} | {description} | ❌ 1/2 |" in summary
+    assert "<details><summary>❌ Validation blocks — 1/2</summary>" in summary
+    assert "- A passing check." in summary
+    assert "- ❌ A failing check." in summary
+
+
+def test_render_groups_checks_under_their_area_in_report_order():
+    outcomes = [
+        _outcome(_SAFETY, "test_s", docstring="A safety check.", line=10),
+        _outcome(_LIFECYCLE, "test_l", docstring="A lifecycle check.", line=10),
+    ]
+
+    summary = render_summary(outcomes)
+
+    # Table lifecycle precedes Validation blocks in LIVE_AREAS order
+    assert summary.index("Table lifecycle —") < summary.index("Validation blocks —")
+    assert "- A lifecycle check." in summary
+    assert "- A safety check." in summary
+
+
+def test_render_returns_none_when_no_live_tests_ran():
+    assert render_summary([]) is None
+
+
+# --- collect_outcomes -----------------------------------------------------
+
+
+def test_collect_collapses_phase_reports_and_reads_the_docstring_from_the_report():
+    stats = {
+        "passed": [
+            _report(_SAFETY, "test_a", when="setup", line=12),
+            _report(_SAFETY, "test_a", when="call", doc="Alpha is rejected.", line=12),
+            _report(_SAFETY, "test_a", when="teardown", line=12),
+        ],
+    }
+
+    [outcome] = collect_outcomes(stats)
+
+    assert outcome.nodeid.endswith("::test_a")
+    assert outcome.filename == _SAFETY
+    assert outcome.passed is True
+    assert outcome.docstring == "Alpha is rejected."
+    assert outcome.line == 12
+
+
+def test_collect_marks_a_test_failed_when_any_phase_did_not_pass():
+    stats = {
+        "passed": [_report(_SAFETY, "test_a", when="setup", line=5)],
+        "failed": [_report(_SAFETY, "test_a", when="call", doc="A.", line=5)],
+    }
+
+    [outcome] = collect_outcomes(stats)
+
+    assert outcome.passed is False
+    assert outcome.docstring == "A."
+
+
+def test_collect_ignores_tests_outside_the_live_areas():
+    stats = {"passed": [_report("test_unrelated.py", "test_x", doc="x", line=1)]}
+
+    assert collect_outcomes(stats) == []
+
+
+# --- docstring_property ---------------------------------------------------
+
+
+def test_docstring_property_takes_only_the_first_line():
+    def fn():
+        """
+        First line.
+
+        Second paragraph is ignored.
+        """
+
+    assert docstring_property(fn) == ("area_doc", "First line.")
+
+
+def test_docstring_property_is_empty_without_a_docstring():
+    def fn(): ...
+
+    assert docstring_property(fn) == ("area_doc", "")
+
+
+# --- write_summary --------------------------------------------------------
+
+
+def test_write_summary_appends_the_rendered_summary_once(tmp_path, monkeypatch):
+    summary_file = tmp_path / "summary.md"
+    monkeypatch.setenv("GITHUB_STEP_SUMMARY", str(summary_file))
+    reporter = SimpleNamespace(
+        config=SimpleNamespace(),  # controller: no workerinput
+        stats={
+            "passed": [
+                _report(_SAFETY, "test_a", when="setup", line=10),
+                _report(_SAFETY, "test_a", when="call", doc="Alpha is rejected.", line=10),
+            ],
+        },
+    )
+
+    write_summary(reporter)
+
+    text = summary_file.read_text(encoding="utf-8")
+    assert "Alpha is rejected." in text
+    assert text.count("## ") == 1  # written once, not once per phase report
+
+
+def test_write_summary_skips_on_an_xdist_worker(tmp_path, monkeypatch):
+    summary_file = tmp_path / "summary.md"
+    monkeypatch.setenv("GITHUB_STEP_SUMMARY", str(summary_file))
+    reporter = SimpleNamespace(
+        config=SimpleNamespace(workerinput={}),  # worker: has workerinput
+        stats={"passed": [_report(_SAFETY, "test_a", doc="A.", line=1)]},
+    )
+
+    write_summary(reporter)
+
+    assert not summary_file.exists()
+
+
+def test_write_summary_is_a_noop_without_the_step_summary_env(monkeypatch):
+    monkeypatch.delenv("GITHUB_STEP_SUMMARY", raising=False)
+    reporter = SimpleNamespace(config=SimpleNamespace(), stats={"passed": []})
+
+    write_summary(reporter)  # must not raise


### PR DESCRIPTION
## What & why

The Live Databricks job summary collapsed all 56 tests into 7 hand-written area
lines — a viewer saw the pass counts but not _what_ was actually verified. This
adds a collapsible drill-down under each area that lists every individual check,
sourced from a new one-line docstring on each live test. **The overview table is
unchanged.**

Collapsed, a viewer sees the same 7-row table plus one `▸ Area — N checks` bar
per area; expanding a bar reveals that area's behaviour claims. On a failing run
the bar shows `❌ Area — P/N` and only the failed check inside is prefixed `❌`,
so you expand the red area and see exactly which behaviour regressed.

## How

- **`tests/live/job_summary.py`** (new, backend-free): collects per-test outcomes
  and renders the markdown. Owns `LIVE_AREAS`, leaving the conftest as thin
  pytest wiring.
- **`tests/live/conftest.py`**: a `pytest_runtest_makereport` wrapper attaches
  each test's first docstring line to `report.user_properties`;
  `pytest_terminal_summary` delegates to `write_summary`.
- **56 docstrings**: one per live test — the drill-down text.
- **`tests/test_live_job_summary.py`** (new): 13 hermetic tests. Placed _outside_
  `tests/live/` because everything there is auto-marked `databricks_e2e` and
  excluded from default CI.

### Why the docstring rides the report

The summary is written by the xdist **controller**, which never imported the
test functions the workers collected. A collection-time `nodeid → docstring` map
is therefore empty on the controller (verified). `user_properties` serialize back
with each report, so the docstring reaches the controller that renders it.

## Verification

- 13 new hermetic tests pass; full non-e2e suite: **903 passed** (confirms the
  live conftest imports cleanly in default runs).
- Live suite collects all **56** with the docstrings + hook, no errors.
- `mypy .`, `ruff check .`, `ruff format`, `lint-imports` all clean.
- Rendered a realistic full summary from the real docstrings — overview table
  **byte-identical** to today's.

The credentialed Live workflow can't run in this environment; the
worker→controller serialization is a framework guarantee exercised by the unit
tests and verified in a throwaway experiment. The next Live run is the first
end-to-end proof.

## What it looks like

| Area              | Checks                                                   | Result   |
| ----------------- | -------------------------------------------------------- | -------- |
| Validation blocks | unsafe DDL is rejected and the catalog is left unchanged | ✅ 16/16 |

<details><summary>✅ Validation blocks — 16 checks</summary>

- Adding a non-nullable column is rejected, and the catalog is left unchanged.
- Tightening a column to non-nullable is rejected, and the catalog is unchanged.
- Narrowing a column's type is rejected, and the catalog is left unchanged.
- Dropping a column without column mapping is rejected; the catalog is unchanged.
- Changing an existing table's partitioning is rejected; the catalog is unchanged.
- Converting a partitioned table to clustering is rejected, and nothing changes.
- Turning column mapping off is rejected, and the catalog is left unchanged.
- Changing a primary key referenced by another table's FK is rejected client-side.
- Drift outside a restricted scope is rejected, and the catalog is left unchanged.
- A restricted-scope declaration refuses to create a missing table.
- An independent table still syncs when another table in the run is rejected.
- A warehouse-rejected statement surfaces as a typed execution failure with its SQL.
- Widening without the type-widening property is rejected, and nothing changes.
- A managed property set outside the declaration is rejected, not reconciled.
- A child table is blocked when its foreign-key parent is rejected in the same run.
- An unreadable catalog surfaces as a typed read failure, not a raw connector error.

</details>
