### PR TITLE
refactor: share observed-table assembly across the Databricks readers

### DIFF
--- a/src/delta_engine/adapters/databricks/__init__.py
+++ b/src/delta_engine/adapters/databricks/__init__.py
@@ -5,7 +5,8 @@ Two backends live here: ``spark`` syncs through an active Spark session, and
 ``warehouse`` syncs through a Databricks SQL warehouse connection over
 ``databricks-sql-connector``. Both build on shared modules: ``sql`` is the
 PySpark-free SQL core (DDL compilation, identifier quoting, information_schema
-queries, type rendering); ``execution`` is the statement-execution loop both
+queries, type rendering); ``read`` is the observed-table assembly both readers
+build state through and ``execution`` the statement-execution loop both
 executors run compiled SQL through; ``errors`` names failed exceptions,
 preferring the Java class when py4j wraps a JVM exception; and
 ``log_config`` is the shared colored-logging setup.

--- a/src/delta_engine/adapters/databricks/read.py
+++ b/src/delta_engine/adapters/databricks/read.py
@@ -1,0 +1,79 @@
+"""
+Shared observed-table assembly for the Databricks backends.
+
+Both backends build the same ``ObservedTable`` from the same information_schema
+queries and DESCRIBE DETAIL, feeding each query's rows to the same shared row
+mapper. Only one fact differs per backend — how information_schema rows are
+physically fetched — so it is injected as a callable, the read-side twin of the
+runner ``execution.execute_statements`` injects on the write side.
+
+The backend reads the facts whose *source* genuinely differs (existence, the
+columns, the table comment, the DESCRIBE DETAIL row, and the partition order)
+and passes them in; this module owns the query-to-mapper-to-field wiring that
+would otherwise be duplicated across the two readers and drift apart. It stays
+PySpark-free: the injected runner does the I/O, so importing it never pulls a
+backend.
+"""
+
+from collections.abc import Callable, Sequence
+from dataclasses import replace
+from types import MappingProxyType
+from typing import Any
+
+from delta_engine.adapters.databricks.sql import (
+    clustering_columns_from_detail_row,
+    column_tags_from_rows,
+    column_tags_query,
+    foreign_keys_from_rows,
+    foreign_keys_query,
+    managed_properties_from_detail_row,
+    primary_key_from_rows,
+    primary_key_query,
+    referencing_foreign_keys_from_rows,
+    referencing_foreign_keys_query,
+    table_tags_from_rows,
+    table_tags_query,
+)
+from delta_engine.domain.model import ObservedColumn, ObservedTable, QualifiedName
+
+
+def observed_table_from_reads(
+    qualified_name: QualifiedName,
+    *,
+    columns: tuple[ObservedColumn, ...],
+    comment: str,
+    detail_row: Any,
+    partitioned_by: tuple[str, ...],
+    run_info_schema_query: Callable[[str], Sequence[Any]],
+) -> ObservedTable:
+    """
+    Assemble an ``ObservedTable`` from a backend's reads plus information_schema.
+
+    ``columns`` are the table's observed columns *without* tags; this function
+    attaches column tags read from information_schema. ``run_info_schema_query``
+    runs one information_schema query and returns its rows — the Spark reader
+    passes its availability-gated reader, the warehouse reader a cursor fetch —
+    so the two backends share this assembly while differing only in how a query
+    is executed.
+    """
+    column_tags = column_tags_from_rows(run_info_schema_query(column_tags_query(qualified_name)))
+    tagged_columns = tuple(
+        replace(column, tags=column_tags.get(column.name, MappingProxyType({})))
+        for column in columns
+    )
+    return ObservedTable(
+        qualified_name=qualified_name,
+        columns=tagged_columns,
+        comment=comment,
+        properties=managed_properties_from_detail_row(detail_row),
+        tags=table_tags_from_rows(run_info_schema_query(table_tags_query(qualified_name))),
+        partitioned_by=partitioned_by,
+        clustered_by=clustering_columns_from_detail_row(detail_row),
+        primary_key=primary_key_from_rows(run_info_schema_query(primary_key_query(qualified_name))),
+        foreign_keys=foreign_keys_from_rows(
+            run_info_schema_query(foreign_keys_query(qualified_name))
+        ),
+        referencing_foreign_keys=referencing_foreign_keys_from_rows(
+            run_info_schema_query(referencing_foreign_keys_query(qualified_name))
+        ),
+    )

--- a/src/delta_engine/adapters/databricks/spark/reader.py
+++ b/src/delta_engine/adapters/databricks/spark/reader.py
@@ -1,7 +1,6 @@
 """Reader adapter for Databricks Unity Catalog."""
 
-from dataclasses import dataclass, replace
-from types import MappingProxyType
+from dataclasses import dataclass
 from typing import Final
 
 from pyspark.errors.exceptions.base import AnalysisException
@@ -9,22 +8,11 @@ from pyspark.sql import Row, SparkSession
 from pyspark.sql.catalog import Column as SparkColumn
 
 from delta_engine.adapters.databricks.errors import exception_message, exception_type_name
+from delta_engine.adapters.databricks.read import observed_table_from_reads
 from delta_engine.adapters.databricks.sql import (
-    clustering_columns_from_detail_row,
     column_from_catalog,
-    column_tags_from_rows,
-    column_tags_query,
     describe_detail_query,
-    foreign_keys_from_rows,
-    foreign_keys_query,
     information_schema_probe_query,
-    managed_properties_from_detail_row,
-    primary_key_from_rows,
-    primary_key_query,
-    referencing_foreign_keys_from_rows,
-    referencing_foreign_keys_query,
-    table_tags_from_rows,
-    table_tags_query,
 )
 from delta_engine.application.failures import ReadFailure
 from delta_engine.application.ports import (
@@ -35,7 +23,6 @@ from delta_engine.application.ports import (
 )
 from delta_engine.domain.model import (
     ObservedColumn,
-    ObservedTable,
     QualifiedName,
 )
 
@@ -128,40 +115,15 @@ class SparkReader:
             for spark_column in self.spark.catalog.listColumns(str(qualified_name))
         )
         mappings = tuple(mapping for mapping in candidate_mappings if mapping is not None)
-        column_tags = column_tags_from_rows(
-            self._information_schema_rows(catalog, column_tags_query(qualified_name))
-        )
-        columns = tuple(
-            replace(
-                mapping.column,
-                tags=column_tags.get(mapping.column.name, MappingProxyType({})),
-            )
-            for mapping in mappings
-        )
-        detail_row = self._describe_detail_row(qualified_name)
-        observed = ObservedTable(
-            qualified_name=qualified_name,
-            columns=columns,
+        observed = observed_table_from_reads(
+            qualified_name,
+            columns=tuple(mapping.column for mapping in mappings),
             comment=self._fetch_table_comment(qualified_name),
-            properties=managed_properties_from_detail_row(detail_row),
-            tags=table_tags_from_rows(
-                self._information_schema_rows(catalog, table_tags_query(qualified_name))
-            ),
+            detail_row=self._describe_detail_row(qualified_name),
             partitioned_by=tuple(
                 mapping.column.name for mapping in mappings if mapping.is_partition
             ),
-            clustered_by=clustering_columns_from_detail_row(detail_row),
-            primary_key=primary_key_from_rows(
-                self._information_schema_rows(catalog, primary_key_query(qualified_name))
-            ),
-            foreign_keys=foreign_keys_from_rows(
-                self._information_schema_rows(catalog, foreign_keys_query(qualified_name))
-            ),
-            referencing_foreign_keys=referencing_foreign_keys_from_rows(
-                self._information_schema_rows(
-                    catalog, referencing_foreign_keys_query(qualified_name)
-                )
-            ),
+            run_info_schema_query=lambda query: self._information_schema_rows(catalog, query),
         )
         return TablePresent(table=observed)
 

--- a/src/delta_engine/adapters/databricks/sql/compile.py
+++ b/src/delta_engine/adapters/databricks/sql/compile.py
@@ -273,7 +273,7 @@ def _properties_clause(props: Mapping[str, str | None]) -> str:
     return f"TBLPROPERTIES ({pairs})"
 
 
-def _partitioned_by_clause(partitioned_by: tuple[str, ...] = ()) -> str:
+def _partitioned_by_clause(partitioned_by: tuple[str, ...]) -> str:
     """Return PARTITIONED BY (...) or '' if unpartitioned."""
     if not partitioned_by:
         return ""
@@ -281,7 +281,7 @@ def _partitioned_by_clause(partitioned_by: tuple[str, ...] = ()) -> str:
     return f"PARTITIONED BY ({quoted_columns})"
 
 
-def _clustered_by_clause(clustered_by: tuple[str, ...] = ()) -> str:
+def _clustered_by_clause(clustered_by: tuple[str, ...]) -> str:
     """Return CLUSTER BY (...) or '' when the table declares no clustering."""
     if not clustered_by:
         return ""

--- a/src/delta_engine/adapters/databricks/warehouse/reader.py
+++ b/src/delta_engine/adapters/databricks/warehouse/reader.py
@@ -18,28 +18,15 @@ either connection mode reads correctly.
 from __future__ import annotations
 
 from collections.abc import Sequence
-from dataclasses import replace
-from types import MappingProxyType
 from typing import TYPE_CHECKING, Any
 
 from delta_engine.adapters.databricks.errors import exception_message, exception_type_name
+from delta_engine.adapters.databricks.read import observed_table_from_reads
 from delta_engine.adapters.databricks.sql import (
-    clustering_columns_from_detail_row,
     column_from_catalog,
-    column_tags_from_rows,
-    column_tags_query,
     columns_query,
     describe_detail_query,
-    foreign_keys_from_rows,
-    foreign_keys_query,
-    managed_properties_from_detail_row,
-    primary_key_from_rows,
-    primary_key_query,
-    referencing_foreign_keys_from_rows,
-    referencing_foreign_keys_query,
     table_row_query,
-    table_tags_from_rows,
-    table_tags_query,
 )
 from delta_engine.application.failures import ReadFailure
 from delta_engine.application.ports import (
@@ -50,7 +37,6 @@ from delta_engine.application.ports import (
 )
 from delta_engine.domain.model import (
     ObservedColumn,
-    ObservedTable,
     QualifiedName,
 )
 
@@ -88,35 +74,15 @@ class WarehouseReader:
             table_rows = _fetch_all(cursor, table_row_query(qualified_name))
             if not table_rows:
                 return TableAbsent()
-            comment = table_rows[0].comment or ""
 
             column_rows = _fetch_all(cursor, columns_query(qualified_name))
-            column_tags = column_tags_from_rows(
-                _fetch_all(cursor, column_tags_query(qualified_name))
-            )
-            columns = tuple(
-                replace(column, tags=column_tags.get(column.name, MappingProxyType({})))
-                for column in _to_columns(column_rows, qualified_name)
-            )
-
-            detail = _describe_detail_row(cursor, qualified_name)
-            observed = ObservedTable(
-                qualified_name=qualified_name,
-                columns=columns,
-                comment=comment,
-                properties=managed_properties_from_detail_row(detail),
-                tags=table_tags_from_rows(_fetch_all(cursor, table_tags_query(qualified_name))),
+            observed = observed_table_from_reads(
+                qualified_name,
+                columns=_to_columns(column_rows, qualified_name),
+                comment=table_rows[0].comment or "",
+                detail_row=_describe_detail_row(cursor, qualified_name),
                 partitioned_by=_partitioned_by(column_rows),
-                clustered_by=clustering_columns_from_detail_row(detail),
-                primary_key=primary_key_from_rows(
-                    _fetch_all(cursor, primary_key_query(qualified_name))
-                ),
-                foreign_keys=foreign_keys_from_rows(
-                    _fetch_all(cursor, foreign_keys_query(qualified_name))
-                ),
-                referencing_foreign_keys=referencing_foreign_keys_from_rows(
-                    _fetch_all(cursor, referencing_foreign_keys_query(qualified_name))
-                ),
+                run_info_schema_query=lambda query: _fetch_all(cursor, query),
             )
         return TablePresent(table=observed)
 


### PR DESCRIPTION
## What

Extracts the `ObservedTable` assembly that was duplicated between the Spark and warehouse readers into a shared `read.observed_table_from_reads`, and drops two dead default arguments in the SQL compiler.

## Why

The two `_read` methods each built an `ObservedTable` from the same information_schema queries + `DESCRIBE DETAIL`, feeding each query's rows to the same shared mapper. Six of the eleven fields (and the column-tag merge) were **identical modulo one thing — how a query's rows are fetched**. That query→mapper→field wiring lived in two places that had to be edited in lockstep; a new observed aspect meant editing both readers or silently diverging.

The write side already solved exactly this shape: `execution.execute_statements(run, statements)` is a shared loop parameterized by a runner, with each executor supplying only its backend. This change gives the read side the missing counterpart — a shared assembler parameterized by a `run_info_schema_query` callable. Each reader now supplies only its genuinely backend-specific reads (existence, columns, comment, the `DESCRIBE DETAIL` row, partition order) plus the runner.

`read.py` stays PySpark-free (the runner does the I/O), so it's importable by the warehouse backend without pulling PySpark, and all import-linter contracts still pass.

## Changes

- **New** `adapters/databricks/read.py` — `observed_table_from_reads(...)`, the shared assembly.
- **`spark/reader.py`, `warehouse/reader.py`** — `_read` slimmed to backend-specific reads + one call; net −71 lines across the two.
- **`sql/compile.py`** — remove the dead `= ()` defaults on `_partitioned_by_clause` / `_clustered_by_clause` (both always called with an argument).
- **`adapters/databricks/__init__.py`** — module-map docstring now lists `read` alongside `execution`.

## Testing

Behaviour-preserving refactor — **no test changes**. The existing reader tests route by exact query text and assert query *sets*/counts (not ordered sequences), so they cover the new seam unchanged.

- `uv run pytest` → 916 passed (incl. local Spark/Delta e2e, which drive both real readers through the shared assembly), coverage 98.28%
- `uv run ruff check .` → clean
- `uv run ruff format --check src` → clean
- `uv run mypy src` → clean
- `uv run lint-imports` → 7 contracts kept, 0 broken