### PR TITLE
refactor: make scope a short-circuiting validation gate

### DIFF
--- a/docs/explanation-architecture.md
+++ b/docs/explanation-architecture.md
@@ -439,13 +439,15 @@ properties diff runs only when the declaration manages `PROPERTIES` (see
 Diff-first planning). The `TableDrift` it produces carries the `desired`
 table itself (symmetric with `TableMissing`), so the diff is self-contained
 and `validate_diff` takes only the diff. Scope awareness lives in
-validation, as an unconditional invariant rather than an optional rule:
-`validate_diff` fails the sync once per unmanaged aspect that has drifted
-(`UnmanagedAspectDrift`), and rules read `drift.managed_actions` and
-`drift.managed_findings` — so unmanaged drift produces exactly one scope
-failure rather than also tripping safety rules for differences the user never
-requested. If planning succeeds, every difference belongs to a managed aspect
-and the plan holds executable actions only.
+validation, as a gate rather than an optional rule. Before any safety rule
+runs, `validate_diff` fails the sync once per unmanaged aspect that has
+drifted (`UnmanagedAspectDrift`) and short-circuits — so an unmanaged
+difference produces exactly the scope failure rather than also tripping
+safety rules for differences the user never requested. Because the gate runs
+first, the safety rules only ever see a fully in-scope diff and read
+`drift.actions` and `drift.findings` directly. If planning succeeds, every
+difference belongs to a managed aspect and the plan holds executable actions
+only.
 
 The public API exposes named scopes only: `DeltaTable`'s `scope` parameter
 maps `"metadata"` to the metadata aspects (comments, tags, key constraints)
@@ -560,9 +562,9 @@ connected components to produce a dependency-first order. It reports:
   a read failure, validation failure, unresolvable FK, invalid FK target, or FK
   cycle.
 
-Each rule implements the `Rule` protocol: a `name` `ClassVar[str]` and an `evaluate(drift: TableDrift) -> tuple[ValidationFailure, ...]` method. Rules usually scan `drift.managed_actions` or `drift.managed_findings` directly — typically matching a specific type with `isinstance` — and return all violations at once, avoiding a fix-and-rerun cycle per failure.
+Each rule implements the `Rule` protocol: a `name` `ClassVar[str]` and an `evaluate(drift: TableDrift) -> tuple[ValidationFailure, ...]` method. Rules usually scan `drift.actions` or `drift.findings` directly — typically matching a specific type with `isinstance` — and return all violations at once, avoiding a fix-and-rerun cycle per failure. The scope gate runs before any rule and short-circuits on out-of-scope drift, so a rule only ever sees differences the declaration manages and does no scope filtering of its own.
 
-`validate_diff` dispatches on the diff variant first: a `TableMissing` passes automatically when table existence is managed — creating a table from its full declaration is always safe — and fails with `MissingTableUnmanaged` when it is not, so no rule ever sees a missing table. For a `TableDrift`, `validate_diff` calls every rule in `DEFAULT_RULES` with the drift and aggregates their failures into a `ValidationResult`. `plan_diff` fixes that default policy in place and turns the verdict into the accepted/rejected planning sum.
+`validate_diff` checks the scope gate first: a `TableMissing` clears it when table existence is managed — creating a table from its full declaration is always safe — and fails with `MissingTableUnmanaged` when it is not, so no rule ever sees a missing table; a `TableDrift` clears it when no unmanaged aspect has drifted. Only past the gate does `validate_diff` call every rule in `DEFAULT_RULES` with the drift and aggregate their failures into a `ValidationResult`. `plan_diff` fixes that default policy in place and turns the verdict into the accepted/rejected planning sum.
 
 Execution walks the dependency-first order produced by the resolver and keeps a
 set of every table that has failed so far. Before each table executes, the engine

--- a/docs/how-to-add-action-type.md
+++ b/docs/how-to-add-action-type.md
@@ -135,8 +135,11 @@ An action may emit several entries across categories (`CreateTable` lists its co
 
 If the new action can be unsafe, add a rule in
 `src/delta_engine/application/validation.py`. Rules receive the self-contained
-drift and match concrete types from `drift.managed_actions` (or
-`drift.managed_findings` when judging findings):
+drift and match concrete types from `drift.actions` (or `drift.findings` when
+judging findings). The scope gate runs before any rule and short-circuits on
+out-of-scope drift, so a rule only ever sees differences the declaration
+manages — declare the correct `TableAspect` on the action (step 1) and no
+scope filtering is needed here:
 
 ```python
 from typing import ClassVar
@@ -154,7 +157,7 @@ class NoUnsafeCommentChange:
                 rule_name=self.name,
                 message=f"Operation not allowed: ...",
             )
-            for change in drift.managed_actions
+            for change in drift.actions
             if isinstance(change, UpdateComment) and <condition>
         )
 ```

--- a/src/delta_engine/application/validation.py
+++ b/src/delta_engine/application/validation.py
@@ -538,10 +538,6 @@ class MissingTableUnmanaged:
         )
 
 
-_UNMANAGED_ASPECT_DRIFT: Final = UnmanagedAspectDrift()
-_MISSING_TABLE_UNMANAGED: Final = MissingTableUnmanaged()
-
-
 def validate_diff(diff: TableDiff, rules: tuple[Rule, ...] = DEFAULT_RULES) -> ValidationResult:
     """
     Evaluate a table diff and return the verdict.
@@ -574,10 +570,13 @@ def validate_diff(diff: TableDiff, rules: tuple[Rule, ...] = DEFAULT_RULES) -> V
 
 def _scope_failures(diff: TableDiff) -> tuple[ValidationFailure, ...]:
     """Return the scope-gate failures for either diff arm; empty when in scope."""
+    # TODO: these are stateless single-method classes, constructed per call and
+    # invoked directly here (not pluggable rules in DEFAULT_RULES). Reconsider
+    # whether they should be plain module-level functions rather than classes.
     match diff:
         case TableMissing() as missing:
-            return _MISSING_TABLE_UNMANAGED.evaluate(missing)
+            return MissingTableUnmanaged().evaluate(missing)
         case TableDrift() as drift:
-            return _UNMANAGED_ASPECT_DRIFT.evaluate(drift)
+            return UnmanagedAspectDrift().evaluate(drift)
         case _ as unreachable:
             assert_never(unreachable)

--- a/src/delta_engine/application/validation.py
+++ b/src/delta_engine/application/validation.py
@@ -58,13 +58,14 @@ class Rule(Protocol):
     """
     Interface for drift validation rules.
 
-    A rule judges whether a managed difference is safe, given the declaration
-    it belongs to. It receives the whole ``TableDrift`` — the self-contained
-    diff — and reads what it needs: ``drift.managed_actions`` or
-    ``drift.managed_findings`` for the differences to judge (unmanaged drift
-    is a scope violation the validator reports separately, never rule input),
-    and ``drift.desired`` for declaration context such as declared
-    properties. Never called for a ``TableMissing`` diff.
+    A rule judges whether a change is safe, given the declaration it belongs
+    to. It receives the whole ``TableDrift`` and reads ``drift.actions`` or
+    ``drift.findings`` for the differences to judge, and ``drift.desired``
+    for declaration context such as declared properties. Because the scope
+    gate runs first and short-circuits, a rule is only ever evaluated on a
+    fully in-scope diff, so its actions and findings are exactly the ones the
+    declaration manages — it does no scope filtering of its own. Never called
+    for a ``TableMissing`` diff.
     """
 
     name: ClassVar[str]
@@ -88,7 +89,7 @@ class NonNullableColumnAdd:
                     f"Operation not allowed: cannot add non-nullable column '{change.column.name}'"
                 ),
             )
-            for change in drift.managed_actions
+            for change in drift.actions
             if isinstance(change, AddColumn) and not change.column.nullable
         )
 
@@ -111,7 +112,7 @@ class NullabilityTighteningOnExistingColumn:
                     " nullable=False — the next sync sees no drift."
                 ),
             )
-            for change in drift.managed_actions
+            for change in drift.actions
             if isinstance(change, SetColumnNullability) and not change.desired_nullable
         )
 
@@ -187,7 +188,7 @@ class NonWideningColumnTypeChange:
                     " TimestampNtz); recreate the table to make any other type change."
                 ),
             )
-            for change in drift.managed_actions
+            for change in drift.actions
             if isinstance(change, AlterColumnType)
             and not _is_safe_widening(change.observed_type, change.desired_type)
         )
@@ -219,7 +220,7 @@ class TypeWideningRequiredForTypeChange:
                     f" properties={{'{Property.TYPE_WIDENING}': 'true'}} on this table."
                 ),
             )
-            for change in drift.managed_actions
+            for change in drift.actions
             if isinstance(change, AlterColumnType)
             and _is_safe_widening(change.observed_type, change.desired_type)
         )
@@ -242,7 +243,7 @@ class PartitioningChangeNotSupported:
                     " Recreate the table with the desired partitioning."
                 ),
             )
-            for finding in drift.managed_findings
+            for finding in drift.findings
             if isinstance(finding, PartitioningChanged)
         )
 
@@ -265,7 +266,7 @@ class PropertyTransitionNotSupported:
     def evaluate(self, drift: TableDrift) -> tuple[ValidationFailure, ...]:
         """Flag every restricted-key transition that is not permitted."""
         failures: list[ValidationFailure] = []
-        for change in drift.managed_actions:
+        for change in drift.actions:
             match change:
                 case SetProperty(
                     name=name, desired_value=desired_value, observed_value=str() as observed_value
@@ -316,7 +317,7 @@ class PropertyMustBeDeclared:
         """Flag every registered key set on the table but absent from the declaration."""
         return tuple(
             ValidationFailure(rule_name=self.name, message=self._message(finding))
-            for finding in drift.managed_findings
+            for finding in drift.findings
             if isinstance(finding, PropertyUndeclared)
         )
 
@@ -357,7 +358,7 @@ class ColumnMappingRequiredForDrop:
 
     def evaluate(self, drift: TableDrift) -> tuple[ValidationFailure, ...]:
         """Flag a column drop when the declaration lacks column mapping."""
-        drops_a_column = any(isinstance(change, DropColumn) for change in drift.managed_actions)
+        drops_a_column = any(isinstance(change, DropColumn) for change in drift.actions)
         if not drops_a_column:
             return ()
         if drift.desired.properties.get(Property.COLUMN_MAPPING_MODE) == "name":
@@ -391,7 +392,7 @@ class AmbiguousColumnRename:
                     " renamed_from hint and drop it in its own sync."
                 ),
             )
-            for finding in drift.managed_findings
+            for finding in drift.findings
             if isinstance(finding, ColumnRenameConflict)
         )
 
@@ -419,11 +420,11 @@ class PrimaryKeyReferencedByForeignKeys:
         """Flag every PK drop/change still referenced by a surviving foreign key."""
         dropped_here = {
             change.constraint.constraint_name
-            for change in drift.managed_actions
+            for change in drift.actions
             if isinstance(change, DropForeignKey)
         }
         failures: list[ValidationFailure] = []
-        for change in drift.managed_actions:
+        for change in drift.actions:
             if not isinstance(change, DropPrimaryKey):
                 continue
             blockers = tuple(
@@ -470,17 +471,17 @@ class UnmanagedAspectDrift:
     """
     Fail once per unmanaged aspect that has drifted.
 
-    A scope invariant with the ``Rule`` interface, but not a member of
-    ``DEFAULT_RULES``: it defines what a declaration is allowed to govern
-    and runs unconditionally in ``validate_diff``. It must not be
-    suppressible: the accepted planning boundary turns every validated action
+    The drift arm of the scope gate: it defines what a declaration is allowed
+    to govern and runs before any safety rule, short-circuiting
+    ``validate_diff``. It is not a member of ``DEFAULT_RULES`` and cannot be
+    suppressed — the accepted planning boundary turns every validated action
     into executable work, so ``rules=()`` still cannot admit actions from an
     aspect the declaration does not manage.
 
-    Unlike the safety rules it reads the unfiltered actions and findings:
-    its subject is exactly the differences the managed views exclude.
-    dict.fromkeys deduplicates the aspects while preserving first-seen
-    order, so failure order follows diff order deterministically.
+    It reads the diff's raw actions and findings — its subject is exactly the
+    out-of-scope differences the gate exists to reject. dict.fromkeys
+    deduplicates the aspects while preserving first-seen order, so failure
+    order follows diff order deterministically.
     """
 
     name: ClassVar[str] = "UnmanagedAspectDrift"
@@ -537,7 +538,7 @@ class MissingTableUnmanaged:
         )
 
 
-_SCOPE_INVARIANTS: Final[tuple[Rule, ...]] = (UnmanagedAspectDrift(),)
+_UNMANAGED_ASPECT_DRIFT: Final = UnmanagedAspectDrift()
 _MISSING_TABLE_UNMANAGED: Final = MissingTableUnmanaged()
 
 
@@ -545,32 +546,38 @@ def validate_diff(diff: TableDiff, rules: tuple[Rule, ...] = DEFAULT_RULES) -> V
     """
     Evaluate a table diff and return the verdict.
 
-    Two scope invariants are checked unconditionally — they define what a
-    declaration is allowed to govern, and cannot be suppressed via ``rules``:
+    Scope is a gate, checked before any safety rule. An out-of-scope
+    difference — a drifted aspect the declaration does not manage, or a
+    missing table it may not create — fails here and short-circuits, so the
+    safety rules never run on a diff the engine has already rejected on
+    scope grounds. This is what makes an unmanaged difference produce
+    exactly the scope failure rather than also tripping rules for work the
+    user never requested. The gate cannot be suppressed via ``rules``.
 
-    - ``MissingTableUnmanaged`` judges the missing arm: a table that does
-      not exist cannot be created by a declaration that does not manage
-      table existence.
-    - ``UnmanagedAspectDrift`` judges the drift arm: one failure per
-      drifted unmanaged aspect. It shares the ``Rule`` interface but runs
-      from its own always-on tier, prepended to whatever ``rules`` are
-      supplied.
-
-    Rules are safety policy over the drift the declaration *does* manage:
-    each reads ``drift.managed_actions`` or ``drift.managed_findings``, so
-    unmanaged drift produces exactly one scope failure rather than also
-    tripping safety rules for differences the user never requested.
+    Past the gate every difference is in scope, so the safety rules judge
+    the managed drift. A missing table that clears the gate is a
+    fully-managed create and needs no safety judgement.
     """
+    scope_failures = _scope_failures(diff)
+    if scope_failures:
+        return ValidationResult(failures=scope_failures)
     match diff:
-        case TableMissing() as missing:
-            return ValidationResult(failures=_MISSING_TABLE_UNMANAGED.evaluate(missing))
+        case TableMissing():
+            return ValidationResult()
         case TableDrift() as drift:
             return ValidationResult(
-                failures=tuple(
-                    failure
-                    for rule in (*_SCOPE_INVARIANTS, *rules)
-                    for failure in rule.evaluate(drift)
-                )
+                failures=tuple(failure for rule in rules for failure in rule.evaluate(drift))
             )
+        case _ as unreachable:
+            assert_never(unreachable)
+
+
+def _scope_failures(diff: TableDiff) -> tuple[ValidationFailure, ...]:
+    """Return the scope-gate failures for either diff arm; empty when in scope."""
+    match diff:
+        case TableMissing() as missing:
+            return _MISSING_TABLE_UNMANAGED.evaluate(missing)
+        case TableDrift() as drift:
+            return _UNMANAGED_ASPECT_DRIFT.evaluate(drift)
         case _ as unreachable:
             assert_never(unreachable)

--- a/src/delta_engine/domain/plan/diff.py
+++ b/src/delta_engine/domain/plan/diff.py
@@ -134,24 +134,14 @@ class TableDrift:
 
     ``actions`` are remedied differences, each carrying the executable
     operation that closes its gap. ``findings`` are differences no action
-    can close; they exist to be judged by validation.
+    can close; they exist to be judged by validation. Both state every
+    difference regardless of scope; deciding which the declaration is
+    allowed to make is validation's scope gate, not the diff's concern.
     """
 
     desired: DesiredTable
     actions: tuple[Action, ...] = ()
     findings: tuple[Finding, ...] = ()
-
-    @property
-    def managed_actions(self) -> tuple[Action, ...]:
-        """Return actions whose aspect the declaration manages."""
-        managed = self.desired.managed_aspects
-        return tuple(action for action in self.actions if action.aspect in managed)
-
-    @property
-    def managed_findings(self) -> tuple[Finding, ...]:
-        """Return findings whose aspect the declaration manages."""
-        managed = self.desired.managed_aspects
-        return tuple(finding for finding in self.findings if finding.aspect in managed)
 
 
 type TableDiff = TableMissing | TableDrift
@@ -347,6 +337,12 @@ def _diff_properties(
     desired: DesiredTable, observed: ObservedTable
 ) -> list[SetProperty | UnsetProperty]:
     """Return exact-declaration property actions for declared keys."""
+    # Properties are the sole aspect the differ scopes, and this is fact
+    # production, not enforcement (enforcement is validation's scope gate):
+    # exact-declaration semantics mean an unmanaged PROPERTIES aspect asserts
+    # nothing and so yields no facts. Without this, every managed catalog
+    # property the declaration omits would read as unmanaged drift and fail
+    # the gate on every restricted sync.
     if TableAspect.PROPERTIES not in desired.managed_aspects:
         return []
 
@@ -371,6 +367,8 @@ def _diff_undeclared_properties(
     desired: DesiredTable, observed: ObservedTable
 ) -> list[PropertyUndeclared]:
     """Return findings for managed catalog keys the declaration omits."""
+    # See _diff_properties: exact-declaration semantics, so an unmanaged
+    # PROPERTIES aspect produces no findings for the scope gate to reject.
     if TableAspect.PROPERTIES not in desired.managed_aspects:
         return []
 

--- a/tests/application/test_validation.py
+++ b/tests/application/test_validation.py
@@ -642,6 +642,22 @@ def test_managed_drift_still_trips_safety_rules():
     assert result.failures[0].rule_name == "TypeWideningRequiredForTypeChange"
 
 
+def test_out_of_scope_drift_short_circuits_safety_rules():
+    # Given a declaration that manages column structure but not table comment,
+    # with both a managed-and-unsafe column add and out-of-scope comment drift
+    diff = _drift(
+        AddColumn(DesiredColumn("x", Integer(), nullable=False)),
+        SetTableComment(desired_comment="new", observed_comment="old"),
+        managed_aspects=frozenset({TableAspect.COLUMN_STRUCTURE}),
+    )
+
+    # When validating
+    result = validate_diff(diff)
+
+    # Then the scope violation is reported alone; the safety rule never runs
+    assert [failure.rule_name for failure in result.failures] == ["UnmanagedAspectDrift"]
+
+
 def test_drift_passes_when_no_unmanaged_aspect_has_drifted():
     # Given a metadata-only drift where only a managed aspect drifted
     diff = _drift(

--- a/tests/domain/plan/test_diff.py
+++ b/tests/domain/plan/test_diff.py
@@ -573,27 +573,6 @@ def test_partitioning_changed_rejects_equal_specs():
         PartitioningChanged(desired_partitioning=("ds",), observed_partitioning=("ds",))
 
 
-def test_managed_views_filter_out_unmanaged_aspects():
-    # Given a drift with one managed action, one unmanaged action, and an
-    # unmanaged finding
-    desired = _desired(managed_aspects=frozenset({TableAspect.TABLE_COMMENT}))
-    table_comment_action = SetTableComment(desired_comment="new", observed_comment="old")
-    column_action = AddColumn(DesiredColumn("new_col", Integer()))
-    partitioning_finding = PartitioningChanged(
-        desired_partitioning=("id",), observed_partitioning=()
-    )
-
-    drift = TableDrift(
-        desired=desired,
-        actions=(column_action, table_comment_action),
-        findings=(partitioning_finding,),
-    )
-
-    # Then only managed differences are exposed to validation rules
-    assert drift.managed_actions == (table_comment_action,)
-    assert drift.managed_findings == ()
-
-
 def test_observed_only_primary_key_produces_removed_change():
     # Given a catalog primary key that is absent from the declaration
     primary_key = PrimaryKeyConstraint(columns=("id",), constraint_name="legacy_pk")


### PR DESCRIPTION
## What

Consolidates managed-aspect ("scope") handling into a single gate in `validate_diff`, so scope is enforced in exactly one place instead of being smeared across the diff and the validator.

Before, three sites each carried partial knowledge of scope:
- `TableDrift.managed_actions` / `managed_findings` projected the managed subset,
- every safety rule filtered its input through those views,
- `UnmanagedAspectDrift` re-derived the unmanaged complement itself.

## How

`validate_diff` now checks scope **first** and short-circuits:

```python
scope_failures = _scope_failures(diff)
if scope_failures:
    return ValidationResult(failures=scope_failures)   # short-circuit
# ... past the gate, run the safety rules
```

Because the safety rules only ever run on a fully in-scope diff, they read `drift.actions` / `drift.findings` directly, and the `managed_actions` / `managed_findings` views are **removed**. `TableDrift` is now just `desired, actions, findings`; no rule mentions "managed."

The property guards in the differ stay, relabelled as scope-aware **fact production** (not enforcement): properties are exact-declaration, so an unmanaged `PROPERTIES` aspect must yield no facts — otherwise every managed catalog property the declaration omits would read as unmanaged drift and fail the gate on every restricted sync.

## Behavior change

When a diff has **both** out-of-scope drift **and** an in-scope unsafe change, only the scope failure is now reported (safety rules are short-circuited) instead of both together. All-or-nothing scope enforcement is otherwise unchanged. Pinned by the new `test_out_of_scope_drift_short_circuits_safety_rules`.

## Deliberately left open

- `UnmanagedAspectDrift` (drift arm) and `MissingTableUnmanaged` (missing arm) are kept as two arm-specific checks behind one `_scope_failures` gate, rather than fused into one rule — their messages differ legitimately and the reachable behavior of a fused check is identical.
- Consequently the missing-arm tag/FK asymmetry (a create applies follow-up tags/FKs without a per-aspect scope check) is untouched. It's unreachable via the public API today (only `full` scope manages table existence).
- Dependency resolution's own `FOREIGN_KEYS not in managed_aspects` check is left as-is — it's FK ordering, a separate concern, and runs post-gate.

## Verification

- `uv run pytest` — 930 passed, 97.92% coverage (incl. local Spark e2e)
- `ruff check`, `mypy src`, `lint-imports` (7/7 contracts) — clean
- `sphinx-build -W` — clean; docs updated in `explanation-architecture.md` and `how-to-add-action-type.md`