### PR TITLE
refactor(domain): rename Finding to Unresolvable, extract into its own module

### DIFF
--- a/docs/explanation-architecture.md
+++ b/docs/explanation-architecture.md
@@ -57,22 +57,22 @@ flowchart TB
 The architecture is easiest to follow if you start with the data that moves
 through a sync.
 
-| Concept            | Role                                                                                                                                                    |
-| ------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `DeltaTable`       | Public user declaration. It is the object users write in notebooks, scripts, and Python modules.                                                        |
-| `DesiredTable`     | Immutable domain snapshot of the target table state. `DeltaTable.to_desired_table()` lowers the public declaration into this shape.                     |
-| `ObservedTable`    | Immutable domain snapshot of the current catalog state. Reader adapters produce this after normalizing backend details.                                 |
-| `CatalogState`     | The result of reading one table: `TablePresent`, `TableAbsent`, or `ReadFailed`.                                                                        |
-| `TableDiff`        | Typed desired/observed drift. It is either `TableMissing` or `TableDrift`; both state their remedies as `actions`, and a drift also carries `findings`. |
-| `Finding`          | A `TableDrift` difference no action can close: `ColumnRenameConflict`, `PropertyUndeclared`, or `PartitioningChanged`.                                  |
-| `TableAspect`      | One managed aspect of a table: existence, columns, comments, properties, tags, partitioning, clustering, primary key, or foreign keys. Internal enum.   |
-| `ValidationResult` | Lower-level validation verdict used to test policy rules in isolation.                                                                                  |
-| `PlanningResult`   | The total application boundary: either `PlanningSucceeded(ActionPlan)` or `PlanningFailed(validation failures)`.                                        |
-| `ActionPlan`       | The ordered, table-local actions that should be executed if the table is allowed to run.                                                                |
-| `ResolveResult`    | One explicit success or failure per table in dependency-first order; successful outcomes retain their resolved dependencies for execution.              |
-| `ExecutionSummary` | The result of running a plan's compiled statements. It records successful statements and the first failed statement, if execution failed.               |
-| `TableRunReport`   | The complete per-table outcome, including read state, plan, planned SQL statements, failures, and execution.                                            |
-| `SyncReport`       | The aggregate result for the whole sync. It is returned on success and attached to `SyncFailedError` on real-run failure.                               |
+| Concept            | Role                                                                                                                                                        |
+| ------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `DeltaTable`       | Public user declaration. It is the object users write in notebooks, scripts, and Python modules.                                                            |
+| `DesiredTable`     | Immutable domain snapshot of the target table state. `DeltaTable.to_desired_table()` lowers the public declaration into this shape.                         |
+| `ObservedTable`    | Immutable domain snapshot of the current catalog state. Reader adapters produce this after normalizing backend details.                                     |
+| `CatalogState`     | The result of reading one table: `TablePresent`, `TableAbsent`, or `ReadFailed`.                                                                            |
+| `TableDiff`        | Typed desired/observed drift. It is either `TableMissing` or `TableDrift`; both state their remedies as `actions`, and a drift also carries `unresolvable`. |
+| `Unresolvable`     | A `TableDrift` difference no action can close: `ColumnRenameConflict`, `PropertyUndeclared`, or `PartitioningChanged`.                                      |
+| `TableAspect`      | One managed aspect of a table: existence, columns, comments, properties, tags, partitioning, clustering, primary key, or foreign keys. Internal enum.       |
+| `ValidationResult` | Lower-level validation verdict used to test policy rules in isolation.                                                                                      |
+| `PlanningResult`   | The total application boundary: either `PlanningSucceeded(ActionPlan)` or `PlanningFailed(validation failures)`.                                            |
+| `ActionPlan`       | The ordered, table-local actions that should be executed if the table is allowed to run.                                                                    |
+| `ResolveResult`    | One explicit success or failure per table in dependency-first order; successful outcomes retain their resolved dependencies for execution.                  |
+| `ExecutionSummary` | The result of running a plan's compiled statements. It records successful statements and the first failed statement, if execution failed.                   |
+| `TableRunReport`   | The complete per-table outcome, including read state, plan, planned SQL statements, failures, and execution.                                                |
+| `SyncReport`       | The aggregate result for the whole sync. It is returned on success and attached to `SyncFailedError` on real-run failure.                                   |
 
 The table snapshots deliberately use domain vocabulary, not Spark vocabulary.
 For example, the domain has `DesiredColumn`, `QualifiedName`, `PrimaryKeyConstraint`,
@@ -284,17 +284,17 @@ Execution is gated by accumulated failures. A table that failed read,
 validation, or foreign-key resolution keeps its failure in the report and is
 skipped during execution. The engine still processes other tables.
 
-| Shape              | Produced by            | Consumed by                      | Purpose                                |
-| ------------------ | ---------------------- | -------------------------------- | -------------------------------------- |
-| `DeltaTable`       | User code              | Application preparation          | Public declaration object              |
-| `DesiredTable`     | API lowering           | Domain planner, resolver, report | Target schema snapshot                 |
-| `ObservedTable`    | Reader adapter         | Domain planner, report           | Catalog schema snapshot                |
-| `TableDiff`        | `diff_table`           | `plan_diff`                      | Direct actions and findings            |
-| `ActionPlan`       | successful `plan_diff` | Executor (`compile`), report     | Ordered, validated table-local actions |
-| `CatalogState`     | Reader port            | Engine                           | Present, absent, or read-failed state  |
-| SQL statements     | Executor (`compile`)   | Executor (`execute`), report     | The DDL a plan lowers to               |
-| `ExecutionSummary` | Executor port          | Engine, report                   | Attempted statement outcomes           |
-| `SyncReport`       | Engine                 | User code                        | Immutable run result                   |
+| Shape              | Produced by            | Consumed by                      | Purpose                                     |
+| ------------------ | ---------------------- | -------------------------------- | ------------------------------------------- |
+| `DeltaTable`       | User code              | Application preparation          | Public declaration object                   |
+| `DesiredTable`     | API lowering           | Domain planner, resolver, report | Target schema snapshot                      |
+| `ObservedTable`    | Reader adapter         | Domain planner, report           | Catalog schema snapshot                     |
+| `TableDiff`        | `diff_table`           | `plan_diff`                      | Direct actions and unresolvable differences |
+| `ActionPlan`       | successful `plan_diff` | Executor (`compile`), report     | Ordered, validated table-local actions      |
+| `CatalogState`     | Reader port            | Engine                           | Present, absent, or read-failed state       |
+| SQL statements     | Executor (`compile`)   | Executor (`execute`), report     | The DDL a plan lowers to                    |
+| `ExecutionSummary` | Executor port          | Engine, report                   | Attempted statement outcomes                |
+| `SyncReport`       | Engine                 | User code                        | Immutable run result                        |
 
 ## Package map
 
@@ -380,7 +380,7 @@ either.
 Planning is two pure stages connected by a typed diff. `diff_table(desired,
 observed)` produces a `TableDiff` — `TableMissing` when the table does not
 exist, else a `TableDrift` holding executable `actions` and non-action
-`findings` as two typed tuples. Actions carry their `TableAspect` plus the
+`unresolvable` differences as two typed tuples. Actions carry their `TableAspect` plus the
 complete desired/observed state needed by validation and reporting;
 `CreateTable` uses the table-existence aspect because it realizes a missing
 table's complete desired state rather than belonging to one schema dimension.
@@ -411,11 +411,11 @@ would drop those constraints implicitly as part of `RENAME COLUMN`; the
 engine states the drops instead of relying on that, so the plan is a
 complete transcript of what executes.
 
-Only three findings exist: `ColumnRenameConflict`, `PropertyUndeclared`, and
-`PartitioningChanged`. Each states an ambiguity or unsupported transition
-without deciding its policy outcome. The `Finding` union names them, they
-live structurally apart from the actions, and the application default rules
-decide to reject each one.
+Only three unresolvable differences exist: `ColumnRenameConflict`,
+`PropertyUndeclared`, and `PartitioningChanged`. Each states an ambiguity or
+unsupported transition without deciding its policy outcome. The
+`Unresolvable` union names them, they live structurally apart from the
+actions, and the application default rules decide to reject each one.
 
 Whether a difference is permitted is application policy. `plan_diff` always runs
 the default policy and returns either `PlanningSucceeded(plan)` or
@@ -449,7 +449,7 @@ drifted (`UnmanagedAspectDrift`) and short-circuits — so an unmanaged
 difference produces exactly the scope failure rather than also tripping
 safety rules for differences the user never requested. Because the gate runs
 first, the safety rules only ever see a fully in-scope diff and read
-`drift.actions` and `drift.findings` directly. If planning succeeds, every
+`drift.actions` and `drift.unresolvable` directly. If planning succeeds, every
 difference belongs to a managed aspect and the plan holds executable actions
 only.
 
@@ -465,7 +465,7 @@ never reconciles them, the same as `COLUMN_STRUCTURE` and `PARTITIONING`.
 `diff_table(desired, observed)` produces a `TableDiff`:
 
 - `TableMissing` means the catalog has no table at that name.
-- `TableDrift` means the table exists and carries its actions and findings.
+- `TableDrift` means the table exists and carries its actions and unresolvable differences.
 
 The diff produces backend-neutral commands but does not decide whether they are
 safe, and it does not talk to the backend. For an existing table, differences span
@@ -484,7 +484,7 @@ Each dimension produces canonical actions directly. For example, column
 additions produce `AddColumn` plus any `SetColumnTag` actions, table tag
 removals produce `UnsetTableTag`, and foreign-key additions produce
 `SetForeignKey`. Unsupported or ambiguous states use one of the three
-finding types, which the current default policy rejects.
+unresolvable difference types, which the current default policy rejects.
 
 `validate_diff` is where policy lives. A missing table passes when the
 declaration manages table existence because creating it from the full
@@ -566,7 +566,7 @@ connected components to produce a dependency-first order. It reports:
   a read failure, validation failure, unresolvable FK, invalid FK target, or FK
   cycle.
 
-Each rule implements the `Rule` protocol: a `name` `ClassVar[str]` and an `evaluate(drift: TableDrift) -> tuple[ValidationFailure, ...]` method. Rules usually scan `drift.actions` or `drift.findings` directly — typically matching a specific type with `isinstance` — and return all violations at once, avoiding a fix-and-rerun cycle per failure. The scope gate runs before any rule and short-circuits on out-of-scope drift, so a rule only ever sees differences the declaration manages and does no scope filtering of its own.
+Each rule implements the `Rule` protocol: a `name` `ClassVar[str]` and an `evaluate(drift: TableDrift) -> tuple[ValidationFailure, ...]` method. Rules usually scan `drift.actions` or `drift.unresolvable` directly — typically matching a specific type with `isinstance` — and return all violations at once, avoiding a fix-and-rerun cycle per failure. The scope gate runs before any rule and short-circuits on out-of-scope drift, so a rule only ever sees differences the declaration manages and does no scope filtering of its own.
 
 `validate_diff` checks the scope gate first: a `TableMissing` clears it when table existence is managed — creating a table from its full declaration is always safe — and fails with `MissingTableUnmanaged` when it is not, so no rule ever sees a missing table; a `TableDrift` clears it when no unmanaged aspect has drifted. Only past the gate does `validate_diff` call every rule in `DEFAULT_RULES` with the drift and aggregate their failures into a `ValidationResult`. `plan_diff` fixes that default policy in place and turns the verdict into the accepted/rejected planning sum.
 
@@ -728,18 +728,18 @@ dependency cost.
 
 ## Where to make changes
 
-| Change                          | Main location                                                              | Notes                                                                                                                                                                                                       |
-| ------------------------------- | -------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Add a new backend               | `delta_engine.adapters`                                                    | Implement `CatalogStateReader` and `PlanExecutor`; keep backend exceptions inside the adapter.                                                                                                              |
-| Add a new executable difference | `delta_engine.domain.plan.actions`, differ, and adapter compiler           | Define the rich action, its aspect and phase in `actions.py`; emit it directly from the relevant `_diff_*` helper; add policy rules if needed; compile it in the backend adapter.                           |
-| Add a new finding               | `delta_engine.domain.plan.diff` and application validation                 | Add the frozen domain difference to `Finding`, emit it into the diff's findings, then make the rejection or acceptance decision in application policy. Successful planning must still contain actions only. |
-| Add a safety rule               | `delta_engine.application.validation`                                      | Rules inspect the drift's managed actions and findings and return `ValidationFailure` values.                                                                                                               |
-| Add a data type                 | `delta_engine.domain.model.data_type` and adapter type mapping             | The domain type is backend-free; SQL names and Spark parsing live in the Databricks adapter.                                                                                                                |
-| Change public declarations      | `delta_engine.api`, surfaced only through `delta_engine.schema`            | Keep public ergonomics in `delta_engine.schema` and lower choices into domain snapshots before the engine phases begin.                                                                                     |
-| Change FK ordering or blocking  | `delta_engine.application.dependency_resolution`                           | Cross-table dependency policy lives in the application layer, not in the domain plan or SQL compiler.                                                                                                       |
-| Change report output            | `delta_engine.application.report` and `delta_engine.application.rendering` | Keep display formatting out of domain objects.                                                                                                                                                              |
-| Change Databricks SQL           | `delta_engine.adapters.databricks.sql`                                     | Compile domain actions to backend statements at the adapter boundary.                                                                                                                                       |
-| Change CLI commands or output   | `delta_engine.cli`                                                         | Thin orchestration over `declarations.py`, `connection.py`, and the application ports; keep policy in the layers below.                                                                                     |
+| Change                            | Main location                                                              | Notes                                                                                                                                                                                                                                       |
+| --------------------------------- | -------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Add a new backend                 | `delta_engine.adapters`                                                    | Implement `CatalogStateReader` and `PlanExecutor`; keep backend exceptions inside the adapter.                                                                                                                                              |
+| Add a new executable difference   | `delta_engine.domain.plan.actions`, differ, and adapter compiler           | Define the rich action, its aspect and phase in `actions.py`; emit it directly from the relevant `_diff_*` helper; add policy rules if needed; compile it in the backend adapter.                                                           |
+| Add a new unresolvable difference | `delta_engine.domain.plan.unresolvable` and application validation         | Add the frozen domain difference to `Unresolvable`, emit it into the diff's `unresolvable` tuple from `diff.py`, then make the rejection or acceptance decision in application policy. Successful planning must still contain actions only. |
+| Add a safety rule                 | `delta_engine.application.validation`                                      | Rules inspect the drift's managed actions and unresolvable differences and return `ValidationFailure` values.                                                                                                                               |
+| Add a data type                   | `delta_engine.domain.model.data_type` and adapter type mapping             | The domain type is backend-free; SQL names and Spark parsing live in the Databricks adapter.                                                                                                                                                |
+| Change public declarations        | `delta_engine.api`, surfaced only through `delta_engine.schema`            | Keep public ergonomics in `delta_engine.schema` and lower choices into domain snapshots before the engine phases begin.                                                                                                                     |
+| Change FK ordering or blocking    | `delta_engine.application.dependency_resolution`                           | Cross-table dependency policy lives in the application layer, not in the domain plan or SQL compiler.                                                                                                                                       |
+| Change report output              | `delta_engine.application.report` and `delta_engine.application.rendering` | Keep display formatting out of domain objects.                                                                                                                                                                                              |
+| Change Databricks SQL             | `delta_engine.adapters.databricks.sql`                                     | Compile domain actions to backend statements at the adapter boundary.                                                                                                                                                                       |
+| Change CLI commands or output     | `delta_engine.cli`                                                         | Thin orchestration over `declarations.py`, `connection.py`, and the application ports; keep policy in the layers below.                                                                                                                     |
 
 ## Architectural rules
 

--- a/docs/how-to-add-action-type.md
+++ b/docs/how-to-add-action-type.md
@@ -93,11 +93,12 @@ if desired.comment != observed.comment:
 ```
 
 Actions join the diff's `actions` tuple, so no union edit is needed. If the
-comparison cannot be represented as an action, add a frozen finding in
-`diff.py`, name it in `Finding`, and emit it into the diff's `findings`.
-Decide whether it is accepted or rejected in application validation; the
-current three findings are rejected by the default policy. Successful
-`plan_diff` results must contain actions only.
+comparison cannot be represented as an action, add a frozen difference type in
+`unresolvable.py`, name it in `Unresolvable`, and emit it into the diff's
+`unresolvable` tuple from `diff.py`. Decide whether it is accepted or
+rejected in application validation; the current three unresolvable
+differences are rejected by the default policy. Successful `plan_diff`
+results must contain actions only.
 
 ## 4. Register a SQL compiler
 
@@ -135,11 +136,11 @@ An action may emit several entries across categories (`CreateTable` lists its co
 
 If the new action can be unsafe, add a rule in
 `src/delta_engine/application/validation.py`. Rules receive the self-contained
-drift and match concrete types from `drift.actions` (or `drift.findings` when
-judging findings). The scope gate runs before any rule and short-circuits on
-out-of-scope drift, so a rule only ever sees differences the declaration
-manages — declare the correct `TableAspect` on the action (step 1) and no
-scope filtering is needed here:
+drift and match concrete types from `drift.actions` (or `drift.unresolvable`
+when judging unresolvable differences). The scope gate runs before any rule
+and short-circuits on out-of-scope drift, so a rule only ever sees
+differences the declaration manages — declare the correct `TableAspect` on
+the action (step 1) and no scope filtering is needed here:
 
 ```python
 from typing import ClassVar

--- a/src/delta_engine/application/validation.py
+++ b/src/delta_engine/application/validation.py
@@ -60,12 +60,12 @@ class Rule(Protocol):
 
     A rule judges whether a change is safe, given the declaration it belongs
     to. It receives the whole ``TableDrift`` and reads ``drift.actions`` or
-    ``drift.findings`` for the differences to judge, and ``drift.desired``
+    ``drift.unresolvable`` for the differences to judge, and ``drift.desired``
     for declaration context such as declared properties. Because the scope
     gate runs first and short-circuits, a rule is only ever evaluated on a
-    fully in-scope diff, so its actions and findings are exactly the ones the
-    declaration manages — it does no scope filtering of its own. Never called
-    for a ``TableMissing`` diff.
+    fully in-scope diff, so its actions and unresolvable differences are
+    exactly the ones the declaration manages — it does no scope filtering of
+    its own. Never called for a ``TableMissing`` diff.
     """
 
     name: ClassVar[str]
@@ -238,13 +238,13 @@ class PartitioningChangeNotSupported:
                 rule_name=self.name,
                 message=(
                     "Operation not allowed: partitioning cannot be changed in place."
-                    f" Current: {finding.observed_partitioning}."
-                    f" Requested: {finding.desired_partitioning}."
+                    f" Current: {unresolvable.observed_partitioning}."
+                    f" Requested: {unresolvable.desired_partitioning}."
                     " Recreate the table with the desired partitioning."
                 ),
             )
-            for finding in drift.findings
-            if isinstance(finding, PartitioningChanged)
+            for unresolvable in drift.unresolvable
+            if isinstance(unresolvable, PartitioningChanged)
         )
 
 
@@ -316,22 +316,22 @@ class PropertyMustBeDeclared:
     def evaluate(self, drift: TableDrift) -> tuple[ValidationFailure, ...]:
         """Flag every registered key set on the table but absent from the declaration."""
         return tuple(
-            ValidationFailure(rule_name=self.name, message=self._message(finding))
-            for finding in drift.findings
-            if isinstance(finding, PropertyUndeclared)
+            ValidationFailure(rule_name=self.name, message=self._message(unresolvable))
+            for unresolvable in drift.unresolvable
+            if isinstance(unresolvable, PropertyUndeclared)
         )
 
-    def _message(self, finding: PropertyUndeclared) -> str:
-        if not self._removal_permitted(finding.name, finding.observed_value):
+    def _message(self, unresolvable: PropertyUndeclared) -> str:
+        if not self._removal_permitted(unresolvable.name, unresolvable.observed_value):
             return (
-                f"Operation not allowed: {finding.name} is set on the table"
-                f" (value '{finding.observed_value}') but not declared; it cannot"
+                f"Operation not allowed: {unresolvable.name} is set on the table"
+                f" (value '{unresolvable.observed_value}') but not declared; it cannot"
                 " be unset — declare it to continue managing this table's"
                 " properties."
             )
         return (
-            f"Operation not allowed: {finding.name} is set on the table"
-            f" (value '{finding.observed_value}') but not declared. Declare it"
+            f"Operation not allowed: {unresolvable.name} is set on the table"
+            f" (value '{unresolvable.observed_value}') but not declared. Declare it"
             " to manage it, or declare it as None to remove it."
         )
 
@@ -386,14 +386,14 @@ class AmbiguousColumnRename:
             ValidationFailure(
                 rule_name=self.name,
                 message=(
-                    f"Operation not allowed: cannot rename '{finding.old_name}' to"
-                    f" '{finding.new_name}' — both columns exist"
+                    f"Operation not allowed: cannot rename '{unresolvable.old_name}' to"
+                    f" '{unresolvable.new_name}' — both columns exist"
                     " on the table. If the old column should be dropped, remove the"
                     " renamed_from hint and drop it in its own sync."
                 ),
             )
-            for finding in drift.findings
-            if isinstance(finding, ColumnRenameConflict)
+            for unresolvable in drift.unresolvable
+            if isinstance(unresolvable, ColumnRenameConflict)
         )
 
 
@@ -478,8 +478,8 @@ class UnmanagedAspectDrift:
     into executable work, so ``rules=()`` still cannot admit actions from an
     aspect the declaration does not manage.
 
-    It reads the diff's raw actions and findings — its subject is exactly the
-    out-of-scope differences the gate exists to reject. dict.fromkeys
+    It reads the diff's raw actions and unresolvable differences — its subject
+    is exactly the out-of-scope differences the gate exists to reject. dict.fromkeys
     deduplicates the aspects while preserving first-seen order, so failure
     order follows diff order deterministically.
     """
@@ -491,7 +491,7 @@ class UnmanagedAspectDrift:
         managed_aspects = drift.desired.managed_aspects
         unmanaged_aspects = dict.fromkeys(
             difference.aspect
-            for difference in (*drift.actions, *drift.findings)
+            for difference in (*drift.actions, *drift.unresolvable)
             if difference.aspect not in managed_aspects
         )
         return tuple(

--- a/src/delta_engine/domain/plan/__init__.py
+++ b/src/delta_engine/domain/plan/__init__.py
@@ -23,14 +23,16 @@ from delta_engine.domain.plan.actions import (
     UnsetTableTag,
 )
 from delta_engine.domain.plan.diff import (
-    ColumnRenameConflict,
-    Finding,
-    PartitioningChanged,
-    PropertyUndeclared,
     TableDiff,
     TableDrift,
     TableMissing,
     diff_table,
+)
+from delta_engine.domain.plan.unresolvable import (
+    ColumnRenameConflict,
+    PartitioningChanged,
+    PropertyUndeclared,
+    Unresolvable,
 )
 
 __all__ = [
@@ -45,7 +47,6 @@ __all__ = [
     "DropColumn",
     "DropForeignKey",
     "DropPrimaryKey",
-    "Finding",
     "PartitioningChanged",
     "PropertyUndeclared",
     "RenameColumn",
@@ -60,6 +61,7 @@ __all__ = [
     "TableDiff",
     "TableDrift",
     "TableMissing",
+    "Unresolvable",
     "UnsetColumnTag",
     "UnsetProperty",
     "UnsetTableTag",

--- a/src/delta_engine/domain/plan/diff.py
+++ b/src/delta_engine/domain/plan/diff.py
@@ -1,5 +1,5 @@
 """
-Diff desired and observed table state into actions and findings.
+Diff desired and observed table state into actions and unresolvable differences.
 
 ``diff_table`` states every difference separating the observed table from
 its declaration, deciding nothing about safety or scope. Differences come
@@ -8,14 +8,13 @@ in two structural kinds:
 - Actions — remedied differences. Each carries the one executable
   operation that closes its gap, plus the desired/observed state
   validation and reporting need.
-- Findings — differences no action can close (an ambiguous rename, an
+- Unresolvable — differences no action can close (an ambiguous rename, an
   undeclared managed property, a partitioning change). They exist to be
   judged; the default validation policy rejects each one.
 """
 
 from collections.abc import Mapping
 from dataclasses import dataclass, replace
-from typing import ClassVar
 
 from delta_engine.domain.model import (
     DesiredColumn,
@@ -46,51 +45,12 @@ from delta_engine.domain.plan.actions import (
     UnsetProperty,
     UnsetTableTag,
 )
-
-
-@dataclass(frozen=True, slots=True)
-class ColumnRenameConflict:
-    """A declared rename whose source and target are both present."""
-
-    old_name: str
-    new_name: str
-
-    aspect: ClassVar[TableAspect] = TableAspect.COLUMN_STRUCTURE
-
-    def __post_init__(self) -> None:
-        if self.old_name == self.new_name:
-            raise ValueError(f"ColumnRenameConflict carries no difference: {self.old_name!r}")
-
-
-@dataclass(frozen=True, slots=True)
-class PropertyUndeclared:
-    """A managed catalog property for which the declaration states no intent."""
-
-    name: str
-    observed_value: str
-
-    aspect: ClassVar[TableAspect] = TableAspect.PROPERTIES
-
-
-@dataclass(frozen=True, slots=True)
-class PartitioningChanged:
-    """Partitioning drift, which has no supported in-place action."""
-
-    desired_partitioning: tuple[str, ...]
-    observed_partitioning: tuple[str, ...]
-
-    aspect: ClassVar[TableAspect] = TableAspect.PARTITIONING
-
-    def __post_init__(self) -> None:
-        object.__setattr__(self, "desired_partitioning", tuple(self.desired_partitioning))
-        object.__setattr__(self, "observed_partitioning", tuple(self.observed_partitioning))
-        if self.desired_partitioning == self.observed_partitioning:
-            raise ValueError(
-                f"PartitioningChanged carries no difference: {self.desired_partitioning!r}"
-            )
-
-
-type Finding = ColumnRenameConflict | PropertyUndeclared | PartitioningChanged
+from delta_engine.domain.plan.unresolvable import (
+    ColumnRenameConflict,
+    PartitioningChanged,
+    PropertyUndeclared,
+    Unresolvable,
+)
 
 
 @dataclass(frozen=True, slots=True)
@@ -133,7 +93,7 @@ class TableDrift:
     Differences separating observed state from its declaration.
 
     ``actions`` are remedied differences, each carrying the executable
-    operation that closes its gap. ``findings`` are differences no action
+    operation that closes its gap. ``unresolvable`` are differences no action
     can close; they exist to be judged by validation. Both state every
     difference regardless of scope; deciding which the declaration is
     allowed to make is validation's scope gate, not the diff's concern.
@@ -141,7 +101,7 @@ class TableDrift:
 
     desired: DesiredTable
     actions: tuple[Action, ...] = ()
-    findings: tuple[Finding, ...] = ()
+    unresolvable: tuple[Unresolvable, ...] = ()
 
 
 type TableDiff = TableMissing | TableDrift
@@ -149,7 +109,7 @@ type TableDiff = TableMissing | TableDrift
 
 def diff_table(desired: DesiredTable, observed: ObservedTable | None) -> TableDiff:
     """
-    Compute the actions and findings separating observed from desired state.
+    Compute the actions and unresolvable differences separating observed from desired state.
 
     A rename pre-pass projects observed columns and layout names through
     ``renamed_from`` hints so residual drift is expressed under the declared
@@ -185,12 +145,12 @@ def diff_table(desired: DesiredTable, observed: ObservedTable | None) -> TableDi
         *_diff_properties(desired, observed),
         *_diff_table_tags(desired, observed),
     )
-    findings: tuple[Finding, ...] = (
+    unresolvable: tuple[Unresolvable, ...] = (
         *rename_projection.conflicts,
         *_diff_undeclared_properties(desired, observed),
         *_diff_partitioning(desired.partitioned_by, rename_projection.partitioned_by),
     )
-    return TableDrift(desired=desired, actions=actions, findings=findings)
+    return TableDrift(desired=desired, actions=actions, unresolvable=unresolvable)
 
 
 @dataclass(frozen=True, slots=True)
@@ -232,7 +192,7 @@ def _apply_renames(desired: DesiredTable, observed: ObservedTable) -> _RenamePro
         rename_actions.append(RenameColumn(old_name=old_name, new_name=new_name))
 
     # A conflicted source yields no column facts — whether it is surplus or
-    # the rename's origin is unknowable, so the conflict finding carries the
+    # the rename's origin is unknowable, so the conflict is carried as an unresolvable
     # difference instead of a DropColumn.
     relabeled = tuple(column for column in relabeled if column.name not in conflicted_sources)
     return _RenameProjection(
@@ -381,9 +341,9 @@ def _diff_properties(
 def _diff_undeclared_properties(
     desired: DesiredTable, observed: ObservedTable
 ) -> list[PropertyUndeclared]:
-    """Return findings for managed catalog keys the declaration omits."""
+    """Return unresolvable differences for managed catalog keys the declaration omits."""
     # See _diff_properties: exact-declaration semantics, so an unmanaged
-    # PROPERTIES aspect produces no findings for the scope gate to reject.
+    # PROPERTIES aspect produces nothing for the scope gate to reject.
     if TableAspect.PROPERTIES not in desired.managed_aspects:
         return []
 

--- a/src/delta_engine/domain/plan/unresolvable.py
+++ b/src/delta_engine/domain/plan/unresolvable.py
@@ -1,0 +1,51 @@
+"""Canonical domain vocabulary for differences no action can close."""
+
+from dataclasses import dataclass
+from typing import ClassVar
+
+from delta_engine.domain.model import TableAspect
+
+
+@dataclass(frozen=True, slots=True)
+class ColumnRenameConflict:
+    """A declared rename whose source and target are both present."""
+
+    old_name: str
+    new_name: str
+
+    aspect: ClassVar[TableAspect] = TableAspect.COLUMN_STRUCTURE
+
+    def __post_init__(self) -> None:
+        if self.old_name == self.new_name:
+            raise ValueError(f"ColumnRenameConflict carries no difference: {self.old_name!r}")
+
+
+@dataclass(frozen=True, slots=True)
+class PropertyUndeclared:
+    """A managed catalog property for which the declaration states no intent."""
+
+    name: str
+    observed_value: str
+
+    aspect: ClassVar[TableAspect] = TableAspect.PROPERTIES
+
+
+@dataclass(frozen=True, slots=True)
+class PartitioningChanged:
+    """Partitioning drift, which has no supported in-place action."""
+
+    desired_partitioning: tuple[str, ...]
+    observed_partitioning: tuple[str, ...]
+
+    aspect: ClassVar[TableAspect] = TableAspect.PARTITIONING
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "desired_partitioning", tuple(self.desired_partitioning))
+        object.__setattr__(self, "observed_partitioning", tuple(self.observed_partitioning))
+        if self.desired_partitioning == self.observed_partitioning:
+            raise ValueError(
+                f"PartitioningChanged carries no difference: {self.desired_partitioning!r}"
+            )
+
+
+type Unresolvable = ColumnRenameConflict | PropertyUndeclared | PartitioningChanged

--- a/tests/api/test_foreign_key.py
+++ b/tests/api/test_foreign_key.py
@@ -478,4 +478,4 @@ def test_reordering_the_parent_primary_key_produces_no_foreign_key_drift():
     diff = diff_table(after, observed)
     assert isinstance(diff, TableDrift)
     assert diff.actions == ()
-    assert diff.findings == ()
+    assert diff.unresolvable == ()

--- a/tests/application/test_validation.py
+++ b/tests/application/test_validation.py
@@ -36,17 +36,17 @@ from delta_engine.domain.plan import (
     DropColumn,
     DropForeignKey,
     DropPrimaryKey,
-    Finding,
     SetColumnComment,
     SetColumnTag,
     SetTableComment,
+    Unresolvable,
 )
 from delta_engine.domain.plan.diff import (
-    ColumnRenameConflict,
     TableDrift,
     TableMissing,
     diff_table,
 )
+from delta_engine.domain.plan.unresolvable import ColumnRenameConflict
 from tests.builders import as_observed_columns
 
 _QUALIFIED_NAME = QualifiedName("dev", "silver", "test")
@@ -88,15 +88,15 @@ def _observed_table(
 
 
 def _drift(
-    *differences: Action | Finding,
+    *differences: Action | Unresolvable,
     managed_aspects: frozenset[TableAspect] = ALL_ASPECTS,
     desired: DesiredTable | None = None,
 ) -> TableDrift:
     if desired is None:
         desired = _desired_table(managed_aspects=managed_aspects)
     actions = tuple(item for item in differences if isinstance(item, Action))
-    findings = tuple(item for item in differences if not isinstance(item, Action))
-    return TableDrift(desired=desired, actions=actions, findings=findings)
+    unresolvable = tuple(item for item in differences if not isinstance(item, Action))
+    return TableDrift(desired=desired, actions=actions, unresolvable=unresolvable)
 
 
 def _validate(
@@ -979,7 +979,7 @@ def test_ambiguous_rename_fails_when_source_and_target_both_exist():
     )
     drift = TableDrift(
         desired=desired,
-        findings=(ColumnRenameConflict(old_name="customer_nm", new_name="customer_name"),),
+        unresolvable=(ColumnRenameConflict(old_name="customer_nm", new_name="customer_name"),),
     )
 
     result = validate_diff(drift)

--- a/tests/domain/plan/test_actions.py
+++ b/tests/domain/plan/test_actions.py
@@ -36,7 +36,7 @@ from delta_engine.domain.plan.actions import (
     UnsetProperty,
     UnsetTableTag,
 )
-from delta_engine.domain.plan.diff import ColumnRenameConflict
+from delta_engine.domain.plan.unresolvable import ColumnRenameConflict
 
 _TARGET = QualifiedName("cat", "sch", "table")
 
@@ -297,11 +297,11 @@ def test_drop_foreign_key_phases_before_drop_primary_key():
     assert ActionPhase.DROP_FOREIGN_KEY < ActionPhase.DROP_PRIMARY_KEY
 
 
-def test_column_rename_conflict_is_a_finding_not_an_action():
-    finding = ColumnRenameConflict(old_name="customer_nm", new_name="customer_name")
+def test_column_rename_conflict_is_unresolvable_not_an_action():
+    unresolvable = ColumnRenameConflict(old_name="customer_nm", new_name="customer_name")
 
-    assert not isinstance(finding, Action)
-    assert finding.aspect is TableAspect.COLUMN_STRUCTURE
+    assert not isinstance(unresolvable, Action)
+    assert unresolvable.aspect is TableAspect.COLUMN_STRUCTURE
 
 
 def test_column_rename_conflict_rejects_no_difference():

--- a/tests/domain/plan/test_diff.py
+++ b/tests/domain/plan/test_diff.py
@@ -35,12 +35,14 @@ from delta_engine.domain.plan.actions import (
     UnsetTableTag,
 )
 from delta_engine.domain.plan.diff import (
-    ColumnRenameConflict,
-    PartitioningChanged,
-    PropertyUndeclared,
     TableDrift,
     TableMissing,
     diff_table,
+)
+from delta_engine.domain.plan.unresolvable import (
+    ColumnRenameConflict,
+    PartitioningChanged,
+    PropertyUndeclared,
 )
 from tests.builders import as_observed_columns
 
@@ -97,7 +99,7 @@ def test_equal_tables_diff_to_empty_drift():
     # Then no changes are produced — the natural zero
     assert isinstance(diff, TableDrift)
     assert diff.actions == ()
-    assert diff.findings == ()
+    assert diff.unresolvable == ()
 
 
 def test_drift_carries_the_desired_table():
@@ -255,7 +257,7 @@ def test_identical_column_tags_produce_no_changes():
     # Then no tag changes are produced
     assert isinstance(diff, TableDrift)
     assert diff.actions == ()
-    assert diff.findings == ()
+    assert diff.unresolvable == ()
 
 
 # ---------- table comment change
@@ -307,7 +309,7 @@ def test_declared_property_matching_catalog_produces_no_change():
     # Then no change is produced — the property sync is idempotent
     assert isinstance(diff, TableDrift)
     assert diff.actions == ()
-    assert diff.findings == ()
+    assert diff.unresolvable == ()
 
 
 def test_none_declaration_on_present_key_produces_unset():
@@ -332,7 +334,7 @@ def test_none_declaration_on_absent_key_produces_no_change():
 
     assert isinstance(diff, TableDrift)
     assert diff.actions == ()
-    assert diff.findings == ()
+    assert diff.unresolvable == ()
 
 
 def test_undeclared_registered_key_produces_an_undeclared_property_finding():
@@ -342,9 +344,9 @@ def test_undeclared_registered_key_produces_an_undeclared_property_finding():
         _observed(properties={"delta.columnMapping.mode": "name"}),
     )
 
-    # Then the diff records the missing declaration intent as a finding
+    # Then the diff records the missing declaration intent as unresolvable
     assert isinstance(diff, TableDrift)
-    assert diff.findings == (
+    assert diff.unresolvable == (
         PropertyUndeclared(name="delta.columnMapping.mode", observed_value="name"),
     )
 
@@ -358,7 +360,7 @@ def test_every_observed_key_without_declaration_produces_a_finding():
     )
 
     assert isinstance(diff, TableDrift)
-    assert diff.findings == (
+    assert diff.unresolvable == (
         PropertyUndeclared(name="delta.enableChangeDataFeed", observed_value="true"),
     )
 
@@ -375,7 +377,7 @@ def test_properties_diff_is_skipped_when_properties_unmanaged():
     # Then no property change of any kind — no assertion was made
     assert isinstance(diff, TableDrift)
     assert diff.actions == ()
-    assert diff.findings == ()
+    assert diff.unresolvable == ()
 
 
 def test_declared_properties_are_not_compared_when_properties_unmanaged():
@@ -390,7 +392,7 @@ def test_declared_properties_are_not_compared_when_properties_unmanaged():
     # Then the carried property makes no assertion and produces no change
     assert isinstance(diff, TableDrift)
     assert diff.actions == ()
-    assert diff.findings == ()
+    assert diff.unresolvable == ()
 
 
 def test_property_set_rejects_equal_values():
@@ -437,7 +439,7 @@ def test_partitioning_drift_produces_change_with_both_sides():
     )
 
     assert isinstance(diff, TableDrift)
-    assert diff.findings == (
+    assert diff.unresolvable == (
         PartitioningChanged(desired_partitioning=("id",), observed_partitioning=()),
     )
 
@@ -466,7 +468,7 @@ def test_reordered_clustering_keys_are_not_a_change():
     )
     # Then no clustering change is produced — key order is immaterial
     assert diff.actions == ()
-    assert diff.findings == ()
+    assert diff.unresolvable == ()
 
 
 def test_clustering_removal_produces_cluster_by_none_action():
@@ -517,7 +519,7 @@ def test_equal_primary_keys_by_column_set_produce_no_change():
     # Then identity is column-set equality — no change
     assert isinstance(diff, TableDrift)
     assert diff.actions == ()
-    assert diff.findings == ()
+    assert diff.unresolvable == ()
 
 
 # ---------- foreign key changes
@@ -541,7 +543,7 @@ def test_equal_foreign_keys_by_signature_produce_no_change():
     # Then identity is the content signature — no change, sync stays idempotent
     assert isinstance(diff, TableDrift)
     assert diff.actions == ()
-    assert diff.findings == ()
+    assert diff.unresolvable == ()
 
 
 # ---------- no-difference changes are unrepresentable
@@ -760,7 +762,7 @@ def test_diff_hint_is_inert_when_applied_rename_is_steady_state():
     applied = _observed(columns=(DesiredColumn("customer_name", String()),))
     drift = diff_table(desired, applied)
     assert drift.actions == ()
-    assert drift.findings == ()
+    assert drift.unresolvable == ()
 
 
 def test_diff_hint_is_a_plain_add_when_neither_name_is_observed():
@@ -789,8 +791,8 @@ def test_diff_emits_explicit_conflict_when_source_and_target_both_observed():
 
     drift = diff_table(desired, observed)
 
-    # The conflict is a finding, and the source column is neither dropped nor renamed
-    assert drift.findings == (
+    # The conflict is unresolvable, and the source column is neither dropped nor renamed
+    assert drift.unresolvable == (
         ColumnRenameConflict(old_name="customer_nm", new_name="customer_name"),
     )
     assert drift.actions == ()


### PR DESCRIPTION
## Summary
- Rename `Finding`/`findings` to `Unresolvable`/`unresolvable` throughout the domain, application, tests, and docs — the old name read as passive/observational, but these differences (`ColumnRenameConflict`, `PropertyUndeclared`, `PartitioningChanged`) actually block a sync by default via the scope gate.
- Extract the three `Unresolvable` variants and the type alias out of `diff.py` into a new `src/delta_engine/domain/plan/unresolvable.py`, mirroring how `actions.py` already separates action types from the differ. `diff.py` now holds only the diffing algorithm.

No behavior change — pure rename and file split.

## Test plan
- [x] `uv run pytest -m "not local_e2e and not databricks_e2e"` — 827 passed
- [x] `uv run ruff check src tests`
- [x] `uv run mypy src`
- [x] `uv run lint-imports`
- [x] `uv run --group docs sphinx-build -b html docs docs/_build/html -W`