### PR TITLE
fix(reader): a missing schema or catalog fails the read instead of reading as absent

### DIFF
--- a/src/delta_engine/adapters/databricks/errors.py
+++ b/src/delta_engine/adapters/databricks/errors.py
@@ -22,9 +22,12 @@ from typing import Final
 
 _MESSAGE_UNAVAILABLE = "<exception message unavailable>"
 
-_MISSING_RELATION_CONDITIONS: Final[frozenset[str]] = frozenset(
-    {"TABLE_OR_VIEW_NOT_FOUND", "SCHEMA_NOT_FOUND", "CATALOG_NOT_FOUND"}
-)
+# Only the table itself missing reads as absence. A missing schema or catalog
+# is an unreadable environment, not a creatable absence: the engine creates
+# tables but never their containers, so treating it as absence would plan a
+# CREATE TABLE that cannot succeed — and a dry run would report that
+# impossible plan as success.
+_MISSING_TABLE_CONDITION: Final = "TABLE_OR_VIEW_NOT_FOUND"
 _CONDITION_PREFIX: Final = re.compile(r"\s*\[([A-Z0-9_.]+)\]")
 
 
@@ -78,5 +81,5 @@ def _error_condition(exception: BaseException) -> str | None:
 
 
 def is_missing_relation(exception: BaseException) -> bool:
-    """Whether ``exception`` reports that the described table/schema/catalog does not exist."""
-    return _error_condition(exception) in _MISSING_RELATION_CONDITIONS
+    """Whether ``exception`` reports that the described table itself does not exist."""
+    return _error_condition(exception) == _MISSING_TABLE_CONDITION

--- a/src/delta_engine/adapters/databricks/read.py
+++ b/src/delta_engine/adapters/databricks/read.py
@@ -33,6 +33,7 @@ from delta_engine.adapters.databricks.sql import (
     primary_key_query,
     referencing_foreign_keys_from_rows,
     referencing_foreign_keys_query,
+    schema_exists_query,
     table_tags_from_rows,
     table_tags_query,
 )
@@ -67,14 +68,32 @@ def _read(run_query: Callable[[str], Sequence[Any]], qualified_name: QualifiedNa
     try:
         rows = run_query(describe_json_query(qualified_name))
     except Exception as exception:
-        if is_missing_relation(exception):
-            return TableAbsent()
-        raise
+        if not is_missing_relation(exception):
+            raise
+        # The describe reports TABLE_OR_VIEW_NOT_FOUND even when the schema or
+        # the catalog is what is missing (verified live), so absence needs
+        # positive confirmation. The engine creates tables, never their
+        # containers: reading a missing container as "absent" would plan a
+        # CREATE TABLE that cannot succeed — and a dry run would report that
+        # impossible plan as success.
+        if not _schema_exists(run_query, qualified_name):
+            raise RuntimeError(
+                f"schema {qualified_name.catalog}.{qualified_name.schema} does not exist"
+            ) from exception
+        return TableAbsent()
     if not rows:
         raise RuntimeError(f"DESCRIBE AS JSON returned no row for {qualified_name}")
     description = parse_table_description(rows[0][0], qualified_name)
     observed = observed_table_from_description(description, run_info_schema_query=run_query)
     return TablePresent(table=observed)
+
+
+def _schema_exists(
+    run_query: Callable[[str], Sequence[Any]],
+    qualified_name: QualifiedName,
+) -> bool:
+    """Whether the table's parent schema exists; raises when the catalog cannot be read."""
+    return bool(run_query(schema_exists_query(qualified_name)))
 
 
 def observed_table_from_description(

--- a/src/delta_engine/adapters/databricks/sql/__init__.py
+++ b/src/delta_engine/adapters/databricks/sql/__init__.py
@@ -20,6 +20,7 @@ from delta_engine.adapters.databricks.sql.queries import (
     foreign_keys_query,
     primary_key_query,
     referencing_foreign_keys_query,
+    schema_exists_query,
     table_tags_query,
 )
 from delta_engine.adapters.databricks.sql.rows import (
@@ -46,6 +47,7 @@ __all__ = [
     "referencing_foreign_keys_from_rows",
     "referencing_foreign_keys_query",
     "render_data_type",
+    "schema_exists_query",
     "table_tags_from_rows",
     "table_tags_query",
 ]

--- a/src/delta_engine/adapters/databricks/sql/queries.py
+++ b/src/delta_engine/adapters/databricks/sql/queries.py
@@ -34,6 +34,22 @@ def describe_json_query(qualified_name: QualifiedName) -> str:
     return f"DESCRIBE TABLE EXTENDED {backtick_qualified_name(qualified_name)} AS JSON"
 
 
+def schema_exists_query(qualified_name: QualifiedName) -> str:
+    """
+    Render the information_schema probe for the table's parent schema.
+
+    Returns one row when the schema exists and no rows when it does not.
+    Resolving ``<catalog>.information_schema`` requires the catalog itself to
+    exist, so a missing catalog fails this query rather than returning no rows.
+    """
+    catalog = backtick(qualified_name.catalog)
+    return (
+        f"SELECT schema_name"
+        f" FROM {catalog}.information_schema.schemata"
+        f" WHERE schema_name = {quote_literal(qualified_name.schema)}"
+    )
+
+
 def primary_key_query(qualified_name: QualifiedName) -> str:
     """
     Render the information_schema query for a table's primary key.

--- a/tests/adapters/databricks/spark/test_reader.py
+++ b/tests/adapters/databricks/spark/test_reader.py
@@ -9,6 +9,7 @@ from delta_engine.adapters.databricks.sql import (
     foreign_keys_query,
     primary_key_query,
     referencing_foreign_keys_query,
+    schema_exists_query,
     table_tags_query,
 )
 from delta_engine.application.ports import ReadFailed, TableAbsent, TablePresent
@@ -90,10 +91,15 @@ def test_present_table_uses_six_queries():
     assert spark.queries[0] == describe_json_query(QN)
 
 
-def test_missing_table_is_absent():
-    spark = FakeSpark({describe_json_query(QN): FakeAnalysisError("TABLE_OR_VIEW_NOT_FOUND")})
+def test_missing_table_is_absent_after_confirming_the_schema_exists():
+    spark = FakeSpark(
+        {
+            describe_json_query(QN): FakeAnalysisError("TABLE_OR_VIEW_NOT_FOUND"),
+            schema_exists_query(QN): [("sch",)],
+        }
+    )
     assert isinstance(SparkReader(spark).fetch_state(QN), TableAbsent)
-    assert spark.queries == [describe_json_query(QN)]
+    assert spark.queries == [describe_json_query(QN), schema_exists_query(QN)]
 
 
 def test_other_error_is_read_failed():

--- a/tests/adapters/databricks/sql/test_queries.py
+++ b/tests/adapters/databricks/sql/test_queries.py
@@ -6,6 +6,7 @@ from delta_engine.adapters.databricks.sql import (
     foreign_keys_query,
     primary_key_query,
     referencing_foreign_keys_query,
+    schema_exists_query,
     table_tags_query,
 )
 from delta_engine.domain.model import QualifiedName
@@ -15,6 +16,12 @@ QN = QualifiedName("cat", "sch", "tbl")
 
 def test_describe_json_query_is_extended_and_backticked():
     assert describe_json_query(QN) == "DESCRIBE TABLE EXTENDED `cat`.`sch`.`tbl` AS JSON"
+
+
+def test_schema_exists_query_golden():
+    assert schema_exists_query(QN) == (
+        "SELECT schema_name FROM `cat`.information_schema.schemata WHERE schema_name = 'sch'"
+    )
 
 
 def test_primary_key_query_golden():

--- a/tests/adapters/databricks/test_errors.py
+++ b/tests/adapters/databricks/test_errors.py
@@ -79,3 +79,15 @@ def test_missing_relation_from_warehouse_message_prefix() -> None:
 
     assert is_missing_relation(RuntimeError("[TABLE_OR_VIEW_NOT_FOUND] Table … not found")) is True
     assert is_missing_relation(RuntimeError("connection reset")) is False
+
+
+def test_missing_schema_or_catalog_is_not_a_missing_relation() -> None:
+    # The engine creates tables, never schemas or catalogs, so a missing
+    # container must not read as a creatable absence.
+    from delta_engine.adapters.databricks.errors import is_missing_relation
+
+    assert is_missing_relation(_AnalysisError("SCHEMA_NOT_FOUND")) is False
+    assert is_missing_relation(_AnalysisError("CATALOG_NOT_FOUND")) is False
+    assert (
+        is_missing_relation(RuntimeError("[SCHEMA_NOT_FOUND] The schema cannot be found")) is False
+    )

--- a/tests/adapters/databricks/test_read.py
+++ b/tests/adapters/databricks/test_read.py
@@ -11,6 +11,7 @@ from delta_engine.adapters.databricks.sql import (
     foreign_keys_query,
     primary_key_query,
     referencing_foreign_keys_query,
+    schema_exists_query,
     table_tags_query,
 )
 from delta_engine.adapters.databricks.sql.describe import TableDescription
@@ -173,17 +174,44 @@ def test_read_catalog_state_describes_first_then_reads_info_schema():
     assert len(calls) == 6
 
 
-def test_missing_relation_on_describe_reads_as_absent():
-    responses = {describe_json_query(QN): RuntimeError("[TABLE_OR_VIEW_NOT_FOUND] nope")}
+def test_missing_table_in_an_existing_schema_reads_as_absent():
+    responses = {
+        describe_json_query(QN): RuntimeError("[TABLE_OR_VIEW_NOT_FOUND] nope"),
+        schema_exists_query(QN): [("sch",)],
+    }
 
     assert isinstance(read_catalog_state(_router(responses), QN), TableAbsent)
 
 
-def test_missing_schema_or_catalog_on_describe_reads_as_failed_not_absent():
+def test_missing_table_in_a_missing_schema_reads_as_failed_not_absent():
     # Absent means "create the table". The engine never creates schemas or
     # catalogs, so a missing container must fail the read — reading it as
     # absent would plan a CREATE TABLE that cannot succeed, and a dry run
-    # would report that impossible plan as success.
+    # would report that impossible plan as success. The router returns no
+    # rows for the schema probe: the schema does not exist.
+    responses = {describe_json_query(QN): RuntimeError("[TABLE_OR_VIEW_NOT_FOUND] nope")}
+
+    state = read_catalog_state(_router(responses), QN)
+
+    assert isinstance(state, ReadFailed)
+    assert "does not exist" in state.failure.message
+
+
+def test_missing_table_in_an_unreadable_catalog_reads_as_failed_not_absent():
+    # A nonexistent catalog also reports TABLE_OR_VIEW_NOT_FOUND on describe;
+    # the schema probe then fails because <catalog>.information_schema cannot
+    # resolve, and that failure is the read's outcome.
+    responses = {
+        describe_json_query(QN): RuntimeError("[TABLE_OR_VIEW_NOT_FOUND] nope"),
+        schema_exists_query(QN): RuntimeError("[SCHEMA_NOT_FOUND] cat.information_schema"),
+    }
+
+    assert isinstance(read_catalog_state(_router(responses), QN), ReadFailed)
+
+
+def test_missing_schema_or_catalog_on_describe_reads_as_failed_not_absent():
+    # Where the backend does name the missing container on the describe, that
+    # is not a creatable absence either.
     for condition in ("SCHEMA_NOT_FOUND", "CATALOG_NOT_FOUND"):
         responses = {describe_json_query(QN): RuntimeError(f"[{condition}] nope")}
 

--- a/tests/adapters/databricks/test_read.py
+++ b/tests/adapters/databricks/test_read.py
@@ -179,6 +179,17 @@ def test_missing_relation_on_describe_reads_as_absent():
     assert isinstance(read_catalog_state(_router(responses), QN), TableAbsent)
 
 
+def test_missing_schema_or_catalog_on_describe_reads_as_failed_not_absent():
+    # Absent means "create the table". The engine never creates schemas or
+    # catalogs, so a missing container must fail the read — reading it as
+    # absent would plan a CREATE TABLE that cannot succeed, and a dry run
+    # would report that impossible plan as success.
+    for condition in ("SCHEMA_NOT_FOUND", "CATALOG_NOT_FOUND"):
+        responses = {describe_json_query(QN): RuntimeError(f"[{condition}] nope")}
+
+        assert isinstance(read_catalog_state(_router(responses), QN), ReadFailed)
+
+
 def test_other_describe_error_reads_as_failed():
     responses = {describe_json_query(QN): RuntimeError("warehouse gone")}
 

--- a/tests/adapters/databricks/warehouse/test_reader.py
+++ b/tests/adapters/databricks/warehouse/test_reader.py
@@ -6,6 +6,7 @@ from delta_engine.adapters.databricks.sql import (
     foreign_keys_query,
     primary_key_query,
     referencing_foreign_keys_query,
+    schema_exists_query,
     table_tags_query,
 )
 from delta_engine.adapters.databricks.warehouse.reader import WarehouseReader
@@ -98,11 +99,14 @@ def test_present_table_uses_six_queries():
     assert connection.cursor_fake.queries[0] == describe_json_query(QN)
 
 
-def test_missing_table_is_absent_and_stops_after_describe():
-    responses = {describe_json_query(QN): RuntimeError("[TABLE_OR_VIEW_NOT_FOUND] nope")}
+def test_missing_table_is_absent_after_confirming_the_schema_exists():
+    responses = {
+        describe_json_query(QN): RuntimeError("[TABLE_OR_VIEW_NOT_FOUND] nope"),
+        schema_exists_query(QN): [("sch",)],
+    }
     connection = RoutedConnection(responses)
     assert isinstance(WarehouseReader(connection).fetch_state(QN), TableAbsent)
-    assert connection.cursor_fake.queries == [describe_json_query(QN)]
+    assert connection.cursor_fake.queries == [describe_json_query(QN), schema_exists_query(QN)]
 
 
 def test_other_backend_error_is_read_failed():


### PR DESCRIPTION
## What

Makes "table absent" require positive confirmation. Two commits:

1. **Narrow the missing-relation classifier** to `TABLE_OR_VIEW_NOT_FOUND` (a `SCHEMA_NOT_FOUND`/`CATALOG_NOT_FOUND` on the describe is never a creatable absence).
2. **Confirm the schema exists before reading a missing table as absent** — the live re-run on this branch proved commit 1 insufficient on its own: Databricks reports `TABLE_OR_VIEW_NOT_FOUND` on the describe **even when the schema or the whole catalog is what's missing**, so the error condition alone cannot distinguish a creatable absence from an unreadable environment.

After a not-found describe, one `information_schema.schemata` probe checks the parent schema:

| Environment | Probe outcome | Read result |
| --- | --- | --- |
| Catalog missing | probe itself fails (`<catalog>.information_schema` cannot resolve) | `ReadFailed` with the backend error |
| Catalog exists, schema missing | no rows | `ReadFailed`: `schema <catalog>.<schema> does not exist` |
| Schema exists, table missing | one row | `TableAbsent` — safe to plan the CREATE |

The probe runs only on the not-found path; present-table reads are unchanged at six queries. This is also why the pre-#241 readers passed this case: their existence probe queried the target catalog's own `information_schema`, so a missing catalog failed the probe.

## Why

Caught by the Live suite ([run 29495700326](https://github.com/Tomoscorbin/delta-engine/actions/runs/29495700326)): `test_unreadable_catalog_surfaces_as_typed_read_failure` was the only failure in 56. PR #241 classified a missing container as `TableAbsent`, but **absent means "create the table"** and the engine creates tables — never schemas or catalogs. So a missing container produced a plan that cannot succeed: a real run failed at execution blaming the wrong phase, and a **dry run reported the impossible plan as success** — a false-green CI dry run.

## Changes

- `errors.py` — classifier narrowed to `_MISSING_TABLE_CONDITION = "TABLE_OR_VIEW_NOT_FOUND"`.
- `queries.py` — `schema_exists_query` (golden-tested).
- `read.py` — the not-found path confirms the schema before returning `TableAbsent`.
- Tests — container conditions pinned as not-missing-relation; absent now asserted as describe + probe on both reader shells; hermetic reproductions of the live failure (catalog unreadable, schema missing).

## Testing

- `uv run pytest -m "not databricks_e2e"` → **863 passed**, coverage 97.96%
- ruff / mypy / lint-imports → clean
- Live workflow re-dispatched on this branch — first dispatch (classifier-only, [run 29500129341](https://github.com/Tomoscorbin/delta-engine/actions/runs/29500129341)) reproduced the failure and disproved the classifier-only fix; current dispatch validates the probe.

## Note

Textual conflict expected with #246 in `test_read.py`/`read.py`; merge this first — I'll reconcile #246 on top.
