### PR TITLE
refactor: judge managed properties in the shared read

### DIFF
--- a/docs/explanation-architecture.md
+++ b/docs/explanation-architecture.md
@@ -132,7 +132,7 @@ between the two backends through the `sql` core and the `read` assembly. Both
 backends read a table with one `DESCRIBE TABLE EXTENDED … AS JSON` call, and a
 shared parser turns that JSON document into a backend-neutral `TableDescription`:
 lowercasing catalog identifiers, mapping the structured column types, and reading
-the comment, partitioning, clustering, and registry-filtered properties.
+the comment, partitioning, clustering, and table properties.
 `information_schema` supplies the constraint and tag metadata as structured rows
 — Unity Catalog tags, the table's own primary and foreign keys, and inbound
 foreign keys (the JSON document's embedded `table_constraints` string is left
@@ -143,7 +143,10 @@ or external Delta tables, judged from the relation kind and provider the
 description carries — so a view, streaming table, foreign table, or non-Delta
 format fails the read instead of being modelled as a table and planned
 against. (Existing external tables are read and altered like managed ones;
-creating one is not yet supported.) The
+creating one is not yet supported.) The read also decides which observed
+property keys become engine state: only the keys the property registry
+manages are kept, so the protocol internals every Delta table carries do not
+read as drift. The
 per-column read policy is shared and fails closed the same way: a column whose type
 the domain cannot model fails the read rather than being dropped, because a
 silently omitted column would read as "in sync" against a declaration that still

--- a/src/delta_engine/adapters/databricks/read.py
+++ b/src/delta_engine/adapters/databricks/read.py
@@ -9,10 +9,12 @@ physically run differs per backend, so it is injected as a callable:
 ``read_catalog_state`` is the one entry point both readers call, the
 read-side twin of the write side's ``execution.execute_statements``. Each
 backend supplies only how a query runs (returning its rows) and owns its own
-connection resource; the describe, the relation acceptance policy, assembly,
+connection resource; the describe, the acceptance policies (which relation
+kinds are read, which observed property keys become engine state), assembly,
 and the total failure boundary all live here. This module stays PySpark-free.
 """
 
+from collections.abc import Mapping
 from dataclasses import replace
 from types import MappingProxyType
 from typing import Final
@@ -38,6 +40,7 @@ from delta_engine.adapters.databricks.sql.describe import (
 )
 from delta_engine.application.failures import ReadFailure
 from delta_engine.application.ports import CatalogState, ReadFailed, TableAbsent, TablePresent
+from delta_engine.application.properties import DELTA_PROPERTY_REGISTRY
 from delta_engine.domain.model import ObservedTable, QualifiedName
 
 
@@ -134,11 +137,23 @@ def _observed_table(run_query: RunQuery, description: TableDescription) -> Obser
         qualified_name=qualified_name,
         columns=tagged_columns,
         comment=description.comment,
-        properties=description.properties,
+        properties=_managed_properties(description.table_properties),
         tags=read_table_tags(run_query, qualified_name),
         partitioned_by=description.partitioned_by,
         clustered_by=description.clustered_by,
         primary_key=read_primary_key(run_query, qualified_name),
         foreign_keys=read_foreign_keys(run_query, qualified_name),
         referencing_foreign_keys=read_referencing_foreign_keys(run_query, qualified_name),
+    )
+
+
+def _managed_properties(table_properties: Mapping[str, str]) -> Mapping[str, str]:
+    """Keep the observed property keys the engine manages."""
+    # The registry names every property key the engine declares and reconciles.
+    # A Delta table carries many more — protocol internals like
+    # delta.minReaderVersion, feature flags, writer bookkeeping — that no
+    # declaration can own, so observing them is not drift: they stay out of
+    # engine state rather than being diffed against the declaration.
+    return MappingProxyType(
+        {name: value for name, value in table_properties.items() if name in DELTA_PROPERTY_REGISTRY}
     )

--- a/src/delta_engine/adapters/databricks/sql/compile.py
+++ b/src/delta_engine/adapters/databricks/sql/compile.py
@@ -207,6 +207,11 @@ def _(action: AlterColumnType, backticked_table_name: str) -> str:
 @_compile_action.register
 def _(action: DropPrimaryKey, backticked_table_name: str) -> str:
     """Compile an ALTER TABLE ... DROP PRIMARY KEY IF EXISTS statement."""
+    # IF EXISTS is the deliberate mirror of CreateTable's plain CREATE: a
+    # constraint already gone is the end state this action wants, so an
+    # out-of-band drop in the read-execute window converges instead of failing
+    # the sync — whereas a table that appeared in that window has contents the
+    # plan knows nothing about, so the create must surface it as a failure.
     return f"ALTER TABLE {backticked_table_name} DROP PRIMARY KEY IF EXISTS"
 
 
@@ -224,6 +229,7 @@ def _(action: SetPrimaryKey, backticked_table_name: str) -> str:
 @_compile_action.register
 def _(action: DropForeignKey, backticked_table_name: str) -> str:
     """Compile ALTER TABLE ... DROP CONSTRAINT IF EXISTS for a foreign key."""
+    # IF EXISTS converges like DropPrimaryKey: already absent is the end state.
     constraint = backtick(action.constraint.constraint_name)
     return f"ALTER TABLE {backticked_table_name} DROP CONSTRAINT IF EXISTS {constraint}"
 

--- a/src/delta_engine/adapters/databricks/sql/describe.py
+++ b/src/delta_engine/adapters/databricks/sql/describe.py
@@ -2,10 +2,11 @@
 Turn a ``DESCRIBE TABLE EXTENDED <table> AS JSON`` result into a table description.
 
 Columns carry type objects (mapped by ``types.data_type_from_json``); comment,
-partitioning, clustering, and properties are plain JSON. The relation kind and
-storage format are carried through as the ``relation_type`` and ``provider``
-facts — whether the engine reads that kind of relation is the reader's
-decision, not the parser's. Key constraints and tags are not read from this
+partitioning, clustering, and properties are plain JSON. The relation kind,
+storage format, and table properties are carried through verbatim as facts —
+whether the engine reads that kind of relation, and which property keys it
+manages, are the reader's decisions, not the parser's. Key constraints and
+tags are not read from this
 document — they come from information_schema as structured rows (see
 ``queries`` and ``rows``), so the one embedded formatted ``table_constraints``
 string this document also carries is left unread.
@@ -18,7 +19,6 @@ from types import MappingProxyType
 
 from delta_engine.adapters.databricks.sql.rows import Rows
 from delta_engine.adapters.databricks.sql.types import data_type_from_json
-from delta_engine.application.properties import DELTA_PROPERTY_REGISTRY
 from delta_engine.domain.model import ObservedColumn, QualifiedName
 
 
@@ -35,7 +35,7 @@ class TableDescription:
     comment: str
     partitioned_by: tuple[str, ...]
     clustered_by: tuple[str, ...]
-    properties: Mapping[str, str]
+    table_properties: Mapping[str, str]
     relation_type: str | None
     provider: str | None
 
@@ -68,7 +68,7 @@ def _parse_document(json_text: str, qualified_name: QualifiedName) -> TableDescr
         comment=document.get("comment") or "",
         partitioned_by=_casefolded_list(document, "partition_columns", qualified_name),
         clustered_by=_casefolded_list(document, "clustering_columns", qualified_name),
-        properties=_managed_properties(document.get("table_properties"), qualified_name),
+        table_properties=_table_properties(document.get("table_properties"), qualified_name),
         relation_type=_optional_string(document, "type"),
         provider=_optional_string(document, "provider"),
     )
@@ -123,16 +123,13 @@ def _columns_from_json(document: dict, qualified_name: QualifiedName) -> tuple[O
     return tuple(columns)
 
 
-def _managed_properties(
-    table_properties: object, qualified_name: QualifiedName
-) -> Mapping[str, str]:
+def _table_properties(table_properties: object, qualified_name: QualifiedName) -> Mapping[str, str]:
+    """Carry the document's table properties verbatim; absent means none."""
     if table_properties is None:
         return MappingProxyType({})
     if not isinstance(table_properties, dict):
         raise MetadataParseError(f"{qualified_name}: table_properties is not an object")
-    return MappingProxyType(
-        {name: value for name, value in table_properties.items() if name in DELTA_PROPERTY_REGISTRY}
-    )
+    return MappingProxyType(dict(table_properties))
 
 
 def _casefolded_list(document: dict, key: str, qualified_name: QualifiedName) -> tuple[str, ...]:

--- a/src/delta_engine/adapters/databricks/sql/types.py
+++ b/src/delta_engine/adapters/databricks/sql/types.py
@@ -111,9 +111,6 @@ _SIMPLE_TYPES: Final[dict[str, DataType]] = {
     "variant": Variant(),
 }
 
-_DEFAULT_DECIMAL_PRECISION: Final = 10
-_DEFAULT_DECIMAL_SCALE: Final = 0
-
 
 def data_type_from_json(type_obj: object) -> DataType | None:
     """
@@ -161,8 +158,14 @@ def _data_type_from_json(type_obj: object) -> DataType | None:
 
 
 def _decimal_from_json(type_obj: dict) -> DataType | None:
-    precision = type_obj.get("precision", _DEFAULT_DECIMAL_PRECISION)
-    scale = type_obj.get("scale", _DEFAULT_DECIMAL_SCALE)
+    # No default precision or scale: Unity Catalog records concrete values for
+    # every decimal column, so an absent field is a malformed document.
+    # Inventing DECIMAL(10,0) for a column that is really DECIMAL(12,4) would
+    # read as false type drift and be planned against; fail the read instead.
+    precision = type_obj.get("precision")
+    scale = type_obj.get("scale")
+    if precision is None or scale is None:
+        return None
     try:
         return Decimal(int(precision), int(scale))
     except (TypeError, ValueError):

--- a/src/delta_engine/domain/model/table.py
+++ b/src/delta_engine/domain/model/table.py
@@ -264,7 +264,8 @@ class ObservedTable:
         clustered_by: Ordered tuple of liquid clustering column names.
         primary_key: Primary key constraint, or ``None`` when no primary key is defined.
         foreign_keys: Foreign key constraints owned by this table.
-        properties: Table properties as reported by the catalog (values only —
+        properties: Observed values of the engine-managed property keys only;
+            the other keys a table carries are not engine state (values only —
             a catalog has no absence assertions, unlike a desired table's).
         referencing_foreign_keys: Inbound foreign keys owned by other tables.
 

--- a/tests/adapters/databricks/sql/test_describe.py
+++ b/tests/adapters/databricks/sql/test_describe.py
@@ -105,17 +105,25 @@ def test_non_list_clustering_columns_raises():
         _parse(_doc(clustering_columns="id"))
 
 
-def test_properties_filtered_to_registry():
-    description = _parse(
-        _doc(
-            table_properties={
-                "delta.columnMapping.mode": "name",
-                "delta.feature.clustering": "supported",
-                "delta.minReaderVersion": "3",
-            }
-        )
-    )
-    assert dict(description.properties) == {"delta.columnMapping.mode": "name"}
+def test_table_properties_are_carried_verbatim():
+    # Which property keys the engine manages is the reader's decision; the
+    # parse carries every observed key, protocol internals included.
+    properties = {
+        "delta.columnMapping.mode": "name",
+        "delta.feature.clustering": "supported",
+        "delta.minReaderVersion": "3",
+    }
+    description = _parse(_doc(table_properties=properties))
+    assert dict(description.table_properties) == properties
+
+
+def test_absent_table_properties_carry_as_empty():
+    assert dict(_parse(_doc()).table_properties) == {}
+
+
+def test_non_object_table_properties_raises():
+    with pytest.raises(MetadataParseError):
+        _parse(_doc(table_properties="delta.appendOnly=true"))
 
 
 def test_unsupported_column_type_fails_the_read():
@@ -212,4 +220,5 @@ def test_real_order_fact_fixture():
     assert len(description.columns) == 7
     assert description.columns[0].name == "order_id"
     assert description.columns[0].nullable is False
-    assert dict(description.properties) == {"delta.columnMapping.mode": "name"}
+    assert description.table_properties["delta.columnMapping.mode"] == "name"
+    assert description.table_properties["delta.minReaderVersion"] == "3"  # unregistered, carried

--- a/tests/adapters/databricks/sql/test_types.py
+++ b/tests/adapters/databricks/sql/test_types.py
@@ -74,6 +74,16 @@ def test_decimal_reads_precision_and_scale():
     assert data_type_from_json({"name": "decimal", "precision": 10, "scale": 2}) == Decimal(10, 2)
 
 
+def test_decimal_without_precision_or_scale_is_unmodelable():
+    # Unity Catalog records concrete precision and scale for every decimal
+    # column. Rather than invent DECIMAL(10,0) — false type drift against
+    # whatever the column really is — an absent field is unmodelable and
+    # fails the read like any other unreadable type.
+    assert data_type_from_json({"name": "decimal"}) is None
+    assert data_type_from_json({"name": "decimal", "precision": 12}) is None
+    assert data_type_from_json({"name": "decimal", "scale": 4}) is None
+
+
 def test_array_map_struct_nested():
     assert data_type_from_json(
         {"name": "array", "element_type": {"name": "string"}, "element_nullable": True}

--- a/tests/adapters/databricks/sql/test_types.py
+++ b/tests/adapters/databricks/sql/test_types.py
@@ -74,10 +74,10 @@ def test_decimal_reads_precision_and_scale():
     assert data_type_from_json({"name": "decimal", "precision": 10, "scale": 2}) == Decimal(10, 2)
 
 
-def test_decimal_without_precision_or_scale_is_unmodelable():
+def test_decimal_without_precision_or_scale_is_unmappable():
     # Unity Catalog records concrete precision and scale for every decimal
     # column. Rather than invent DECIMAL(10,0) — false type drift against
-    # whatever the column really is — an absent field is unmodelable and
+    # whatever the column really is — an absent field is unmappable and
     # fails the read like any other unreadable type.
     assert data_type_from_json({"name": "decimal"}) is None
     assert data_type_from_json({"name": "decimal", "precision": 12}) is None

--- a/tests/adapters/databricks/sql/test_types.py
+++ b/tests/adapters/databricks/sql/test_types.py
@@ -74,14 +74,16 @@ def test_decimal_reads_precision_and_scale():
     assert data_type_from_json({"name": "decimal", "precision": 10, "scale": 2}) == Decimal(10, 2)
 
 
-def test_decimal_without_precision_or_scale_is_unmappable():
+def test_decimal_without_concrete_precision_and_scale_is_unmappable():
     # Unity Catalog records concrete precision and scale for every decimal
     # column. Rather than invent DECIMAL(10,0) — false type drift against
-    # whatever the column really is — an absent field is unmappable and
-    # fails the read like any other unreadable type.
+    # whatever the column really is — an absent or non-numeric field is
+    # unmappable and fails the read like any other unreadable type.
     assert data_type_from_json({"name": "decimal"}) is None
     assert data_type_from_json({"name": "decimal", "precision": 12}) is None
     assert data_type_from_json({"name": "decimal", "scale": 4}) is None
+    assert data_type_from_json({"name": "decimal", "precision": "abc", "scale": 2}) is None
+    assert data_type_from_json({"name": "decimal", "precision": [10], "scale": 2}) is None
 
 
 def test_array_map_struct_nested():

--- a/tests/adapters/databricks/test_read.py
+++ b/tests/adapters/databricks/test_read.py
@@ -147,6 +147,25 @@ def test_all_description_fields_pass_through():
     assert dict(observed.columns[0].tags) == {}
 
 
+def test_unregistered_observed_properties_are_invisible():
+    # The description carries every observed property key; the read keeps only
+    # the keys the engine manages. Protocol internals no declaration can own
+    # (delta.minReaderVersion, feature flags) must not read as drift.
+    doc = _describe_doc(
+        table_properties={
+            "delta.columnMapping.mode": "name",
+            "delta.minReaderVersion": "3",
+            "delta.feature.columnMapping": "supported",
+        }
+    )
+    responses = _describe_responses(**{describe_json_query(QN): [(doc,)]})
+
+    state = read_catalog_state(_router(responses), QN)
+
+    assert isinstance(state, TablePresent)
+    assert dict(state.table.properties) == {"delta.columnMapping.mode": "name"}
+
+
 def test_read_catalog_state_returns_the_present_table():
     state = read_catalog_state(_router(_describe_responses()), QN)
 


### PR DESCRIPTION
## Summary

Follow-up to #249, implementing the three findings from the hidden-policy audit of the adapter layer. The theme is the same fact/policy split #249 established: parsers carry what they saw; the shared read makes the visible judgments.

### 1. The property registry filter moves out of the parser (`refactor`)

`describe.py` silently filtered `table_properties` to the registry's keys — a policy decision buried in a fact-carrier, the exact shape #249 moved out for relation acceptance. Now:

- `TableDescription.table_properties` carries every observed key verbatim (named for the AS JSON field, distinct from `ObservedTable.properties`, the engine-state term).
- `read.py` applies the registry filter in `_managed_properties` during assembly, beside `_require_supported_relation` — the acceptance policies live in one place, and the parser no longer imports the registry at all.
- **Observed behaviour is unchanged**: protocol internals (`delta.minReaderVersion`, feature flags) still never reach engine state or read as drift. The pre-existing warehouse reader test pins this end-to-end and passes unmodified.

### 2. Decimal metadata fails closed (`fix`)

A decimal type object missing `precision` or `scale` was read as an invented `DECIMAL(10,0)`. Unity Catalog records concrete values for every decimal column, so the default could only misrepresent the table — observing false type drift and planning against it (a blocked narrow, or worse). An absent field is now unmappable like any other unreadable type: `MetadataParseError` → `ReadFailed`.

### 3. The `IF EXISTS` asymmetry is now explained (`docs`, comment-only)

`CreateTable` compiles a plain `CREATE` with a comment explaining the read→execute race; the constraint drops compile `IF EXISTS` with no explanation. The rationale is now recorded where the statements are built: an already-absent constraint **is** the end state the drop wants, so tolerating an out-of-band removal converges — while a table that appeared unexpectedly has contents the plan knows nothing about and must surface as a failure.

Also fixes the `ObservedTable.properties` docstring ("as reported by the catalog" — precisely the wrong words once the verbatim fact and the managed subset have different names) and the one line of the architecture doc that attributed the filter to the parser.

## Verification

- 877 passed, 98.03% coverage; ruff + format, mypy, all 7 import contracts, strict Sphinx build.
- New pins: properties carried verbatim / absent-as-empty / non-object-raises (parse seam); unregistered keys invisible (read seam); decimal absent-precision/scale unmappable in all three shapes.
- Design + test review passed (no serious issues; their two nits are the last two commits).
- Live run on this branch: dispatched, result to follow in a comment.