### PR TITLE
docs: describe the fail-closed read for unmappable columns

### DIFF
--- a/docs/explanation-safety-model.md
+++ b/docs/explanation-safety-model.md
@@ -51,11 +51,11 @@ catalog state it can represent, the engine reconciles drift in managed aspects
 and refuses to proceed when an unmanaged aspect has drifted. It never silently
 reconciles something a declaration did not claim responsibility for.
 
-There is one current fail-open limitation at the catalog boundary: an observed
-non-partition column whose type the reader cannot parse is skipped with a logged
-warning, so drift in that column is invisible to validation. A table with no
-mappable columns, or an unsupported partition-column type, fails its read
-instead. See [unsupported types](reference-data-types.md#unsupported-types).
+The read boundary upholds this by failing closed: a column whose type the
+engine cannot model fails that table's read (`READ_FAILED`) rather than being
+silently omitted from the observed state, so drift can never hide in a column
+the reader could not represent. See
+[unsupported types](reference-data-types.md#unsupported-types).
 
 There are three public scopes, selected by `DeltaTable`'s `scope` parameter:
 

--- a/docs/reference-data-types.md
+++ b/docs/reference-data-types.md
@@ -25,8 +25,8 @@ under [Unsupported types](#unsupported-types).
 | `Byte()`                                 | `TINYINT`              |                                                                      |
 | `Short()`                                | `SMALLINT`             |                                                                      |
 | `Binary()`                               | `BINARY`               |                                                                      |
-| `TimestampNtz()`                         | `TIMESTAMP_NTZ`        | Creation enables the feature; existing tables need it enabled first |
-| `Variant()`                              | `VARIANT`              | Creation enables the feature; existing tables need it enabled first |
+| `TimestampNtz()`                         | `TIMESTAMP_NTZ`        | Creation enables the feature; existing tables need it enabled first  |
+| `Variant()`                              | `VARIANT`              | Creation enables the feature; existing tables need it enabled first  |
 | `Struct([StructField(name, type), ...])` | `STRUCT<name: T, ...>` | Field nullability/comments not modeled; fields are created nullable  |
 
 `Map` declarations should use a non-`Map` key type. The current declaration
@@ -41,18 +41,20 @@ a struct.
 
 ## Unsupported types
 
-A non-partition column whose Spark type is outside this table (`VOID`,
-`INTERVAL`, geospatial types, etc.) is skipped with a logged warning. The engine
-leaves it unmanaged — it neither creates, alters, nor drops it — and cannot
-detect drift in that column. This is a current fail-open limitation at the read
-boundary; do not rely on delta-engine as a complete drift gate for a table that
-contains an unsupported type. All mappable columns are still managed normally.
+A column whose catalog type is outside the table above (`VOID`, `INTERVAL`,
+geospatial types, a future Spark type, etc.) fails that table's read: the sync
+reports `READ_FAILED` for the table instead of planning against a partial view
+of it, and no column is ever silently skipped. The engine manages a table's
+full column set — an observed column absent from the declaration is planned as
+a `DROP COLUMN` — so an omitted column would make its drift invisible and
+could report a table as in sync when it is not. A failed read affects only
+that table; the other tables in the run still sync normally.
+
+Hitting this usually means the catalog's type vocabulary is ahead of this
+engine version: new Spark types (recent precedents: `TIMESTAMP_NTZ`,
+`VARIANT`) reach tables before tools that pin a type model.
 
 Observed `CHAR(n)`/`VARCHAR(n)` columns are treated as `String`: the length bound is not modeled, produces no drift, and is never altered. The reasoning — facts that cannot round-trip declaration → catalog → observation are normalized out on both sides — is explained in [explanation-architecture.md](explanation-architecture.md).
-
-A table where every column is unsupported surfaces as a `READ_FAILED` for that table alone.
-
-A table whose partition column has an unsupported type also surfaces as `READ_FAILED`, rather than being skipped: silently dropping a partition column would leave the observed partitioning incomplete, and the engine would report a false partitioning change instead of an honest "could not determine state". Hitting this usually means the catalog's type vocabulary is ahead of this engine version — new Spark types (recent precedents: `TIMESTAMP_NTZ`, `VARIANT`) reach tables before tools that pin a type model — or the name resolves to a non-Delta relation (a federated or legacy Hive table) with a broader partitioning vocabulary.
 
 For an existing Delta table, Databricks does not enable `TIMESTAMP_NTZ` or
 `VARIANT` support merely because an `ADD COLUMN` statement names the type.

--- a/docs/reference-limitations.md
+++ b/docs/reference-limitations.md
@@ -73,12 +73,12 @@ changes, or drops them, and they produce no drift.
 The full matrix is in [data types](reference-data-types.md). The limitations
 in brief:
 
-| Limitation               | Behaviour                                                                                                                                                     |
-| ------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Unsupported Spark types  | Non-partition columns are left unmanaged with a warning, so their drift is invisible; an unsupported partition type or wholly unmappable table fails its read |
-| `CHAR(n)` / `VARCHAR(n)` | Treated as `String`; the length bound is not modeled and never altered                                                                                        |
-| Struct fields            | Structs change as a whole: any field change is a blocked column type change                                                                                   |
-| `Decimal` precision      | Maximum 38, enforced at declaration                                                                                                                           |
+| Limitation               | Behaviour                                                                                                                     |
+| ------------------------ | ----------------------------------------------------------------------------------------------------------------------------- |
+| Unsupported Spark types  | Any column whose type the engine cannot model fails that table's read; columns are never skipped, so drift is never invisible |
+| `CHAR(n)` / `VARCHAR(n)` | Treated as `String`; the length bound is not modeled and never altered                                                        |
+| Struct fields            | Structs change as a whole: any field change is a blocked column type change                                                   |
+| `Decimal` precision      | Maximum 38, enforced at declaration                                                                                           |
 
 ## Clustering limits
 

--- a/docs/todo/business-logic-delta-databricks-correctness-review.md
+++ b/docs/todo/business-logic-delta-databricks-correctness-review.md
@@ -34,7 +34,7 @@ path currently produces an incorrect result.
 | 2 ✅ | High     | Unparseable columns are silently omitted                      | Existing drift can be reported as synchronized                     |
 | 3    | High     | Required Delta table features are not planned                 | Valid-looking plans fail during execution                          |
 | 4    | High     | Foreign-key types are checked against the wrong parent object | Invalid constraints pass declaration and resolution                |
-| 5    | Medium   | Clearing a column comment generates invalid SQL               | Warehouse execution fails on `UNSET COMMENT`                       |
+| 5 ✅ | Medium   | Clearing a column comment generates invalid SQL               | Warehouse execution fails on `UNSET COMMENT`                       |
 | 6    | Medium   | Identifier normalization disagrees with Unity Catalog         | Valid names can change identity; invalid object names pass locally |
 | 7    | Medium   | Layout and map-type validation is too permissive              | Unsupported declarations reach execution                           |
 | 8 ✅ | Medium   | `CREATE TABLE IF NOT EXISTS` can report false success         | A concurrent incompatible create is treated as success             |
@@ -242,6 +242,15 @@ The supported form is `ALTER COLUMN ... COMMENT '...'`; see the
 
 Always compile the comment action with a string literal, including
 `COMMENT ''`. Restore the empty-comment transition to the live lifecycle test.
+
+### Resolved (2026-07-14)
+
+Shipped in commit 05952ce, reapplying the fix reverted out of PR #213: the
+compiler always emits a string literal, so an empty desired comment compiles
+to `COMMENT ''` rather than `UNSET COMMENT`, which SQL warehouses reject
+(verified live 2026-07-12). `''` round-trips as the empty comment the reader
+observes, keeping resyncs idempotent on both backends. The live lifecycle
+test's empty-comment transition on `account_code` was restored with the fix.
 
 ## 6. Align identifier normalization with Unity Catalog
 


### PR DESCRIPTION
## What & why

Three doc pages still described the pre-#241 reader: unsupported non-partition column types "skipped with a logged warning" and left unmanaged, with unsupported partition types as a special case that failed the read. That skip path no longer exists. Since the AS JSON rewrite, `_columns_from_json` raises `MetadataParseError` for every column whose type the domain cannot model — unknown or future type name, unrepresentable nested type, or a domain-constructor rejection — and the total read boundary in `read.py` turns that into `ReadFailed`. The rationale is in the code comment: the differ plans `DROP COLUMN` for any observed column absent from the declaration, so a silently skipped column would read as a false "in sync".

- **`docs/reference-data-types.md`** — rewrote "Unsupported types": any column whose type is outside the supported set fails that table's read (`READ_FAILED`) instead of being skipped, so drift is never silently invisible; one table's failure doesn't stop the rest of the run. Kept the still-correct context: the type vocabulary usually being ahead of the engine version (`TIMESTAMP_NTZ`/`VARIANT` precedents), the `CHAR`/`VARCHAR`-as-`String` paragraph, and the table-feature-enablement paragraph. Dropped the now-redundant every-column-unsupported and partition-special-case paragraphs.
- **`docs/reference-limitations.md`** — replaced the "Unsupported Spark types" row's warn-and-skip wording with the fail-closed statement.
- **`docs/explanation-safety-model.md`** — the same fail-open caveat lived here too (beyond the two pages originally flagged); replaced it with the fail-closed statement. The dated design note in `docs/todo/2026-07-15-databricks-reader-efficiency-design.md` also mentions the old skip policy but is a historical snapshot, left as-is.
- **`docs/todo/business-logic-delta-databricks-correctness-review.md`** — marked finding #5 resolved: since commit 05952ce the compiler emits `COMMENT ''` for an empty column comment instead of the `UNSET COMMENT` syntax warehouses reject. Summary row gets ✅ like findings 1/2/8, plus a short Resolved note naming the commit and shipped shape.

Wording verified against `sql/describe.py`, `read.py`, `sql/types.py`, and `sql/compile.py`.

## Checklist

- [x] PR title is a Conventional Commit (see comment above)
- [x] Tests added or updated for behaviour changes — docs-only, no behaviour change
- [x] Docs updated if public behaviour/architecture/validation changed
- [x] `uv run pytest`, `uv run ruff check .`, `uv run mypy .`, `uv run lint-imports` pass

Also ran the strict docs build: `uv run --group docs sphinx-build -W -b html docs docs/_build/html` — build succeeded.