### PR TITLE
docs: fix two stale claims found in a full doc review

### DIFF
--- a/docs/how-to-handle-sync-failures.md
+++ b/docs/how-to-handle-sync-failures.md
@@ -54,14 +54,13 @@ for table_report in report:
 
 For a machine-readable view of the whole run — each table's status, planned changes, SQL, and failures as plain JSON — call `report.to_dict()`; the `failures` list in each table record carries the `phase`, `type`, and `message` of every failure. See [the run report schema](reference-run-report.md).
 
-On Unity Catalog, constraint and tag metadata is read from `information_schema`.
-The reader probes once per catalog whether `information_schema` exists: where it
-does not (plain Spark), constraints and tags simply read as absent; where it
-does, a failing metadata query (for example a permissions gap on
-`information_schema`) fails that table's read with a `Read error` rather than
-silently reporting the table as having no constraints or tags. If you see a
-read failure naming an `information_schema` view, check the running principal's
-grants on that catalog's `information_schema`.
+Both backends are Unity Catalog only: after the initial describe, tag and key
+metadata is always read from `information_schema`, unconditionally. A failing
+metadata query (for example a permissions gap on `information_schema`) fails
+that table's read rather than silently reporting the table as having no
+constraints or tags. If you see a read failure naming an `information_schema`
+view, check the running principal's grants on that catalog's
+`information_schema`.
 
 ## Check which tables failed
 

--- a/docs/how-to-implement-adapter.md
+++ b/docs/how-to-implement-adapter.md
@@ -103,7 +103,7 @@ engine.sync(customers, orders)  # your DeltaTable definitions
 `plan.actions` is a sorted tuple containing only `Action` objects. Each action
 has a `TableAspect`, a `subject`, and an `ActionPhase`; richer actions also keep
 the desired/observed semantic state while exposing stable compiler-facing
-properties such as `DropColumn.column_name`. You can inspect the action type
+properties such as `SetColumnComment.column_name`. You can inspect the action type
 with `isinstance` or `match`/`case`:
 
 ```python


### PR DESCRIPTION
## What & why

Full sweep of the 18 user-facing pages under `docs/` (excluding `docs/todo/`), checking every checkable claim against current source. Two stale/incorrect claims found; everything else checked out.

- **`docs/how-to-implement-adapter.md`** — cited `DropColumn.column_name` as an example of a stable compiler-facing property. `DropColumn` only carries `column: ObservedColumn`; there is no `column_name` attribute (its name is exposed via `subject`, not directly). Swapped in `SetColumnComment.column_name`, which is real.
- **`docs/how-to-handle-sync-failures.md`** — described a per-catalog `information_schema`-existence probe with a "read as absent" fallback for plain Spark. That design predates the AS JSON reader rewrite: both backends are Unity Catalog only and read `information_schema` unconditionally (`src/delta_engine/adapters/databricks/read.py:_observed_table`); there is no absent-fallback path, and the "plain Spark" scenario doesn't apply to either reader.

No behavior changed; this is a docs-only correction.

## Checklist

- [x] PR title is a Conventional Commit
- [x] Tests added or updated for behaviour changes — docs-only, no behaviour change
- [x] Docs updated if public behaviour/architecture/validation changed
- [x] `uv run pytest`, `uv run ruff check .`, `uv run mypy .`, `uv run lint-imports` pass

Also ran the strict docs build: `uv run --group docs sphinx-build -W -b html docs docs/_build/html` — build succeeded.