### PR TITLE
refactor: make SQL compilation an explicit phase

### DIFF
--- a/docs/explanation-architecture.md
+++ b/docs/explanation-architecture.md
@@ -113,10 +113,10 @@ flowchart LR
 - `ReadFailed(failure=ReadFailure(...))`
 
 `PlanExecutor` is a two-stage boundary. `compile(qualified_name, plan)` lowers
-a plan to the backend statements that apply it — the engine calls it in the
-plan phase on every run, dry or real, and records the statements on the
-table's report. `execute(statements)` then runs that same tuple and returns an
-`ExecutionSummary` with one result per attempted statement, so the previewed
+a plan to the backend statements that apply it — the engine calls it for every
+accepted plan in the compile phase, dry or real, and records the statements on
+the table's report. `execute(statements)` then runs that same tuple and returns
+an `ExecutionSummary` with one result per attempted statement, so the previewed
 SQL is exactly what executes.
 
 `fetch_state` and `execute` are **total**. Adapter implementations catch
@@ -239,10 +239,10 @@ qualified names are rejected, and the desired tables are sorted by qualified
 name so reports and sync behavior do not depend on the order arguments were
 passed.
 
-After preparation, the engine runs five internal phases over private `_TableRun`
+After preparation, the engine runs six internal phases over private `_TableRun`
 objects. A `_TableRun` is a mutable scratch pad for one table. It accumulates
-read state, diff, plan, failures, and execution results before it is frozen into
-an immutable `TableRunReport`.
+read state, diff, plan, compiled SQL, failures, and execution results before it
+is frozen into an immutable `TableRunReport`.
 
 ```mermaid
 sequenceDiagram
@@ -271,7 +271,7 @@ sequenceDiagram
     Engine-->>User: SyncReport or SyncFailedError(report)
 ```
 
-The full run, with preparation first and reporting last bracketing the five
+The full run, with preparation first and reporting last bracketing the six
 phases:
 
 1. **Prepare** (before the chain): lower user-facing table declarations to
@@ -281,13 +281,14 @@ phases:
 4. **Plan**: call the total `plan_diff` boundary, which always applies the
    default validation policy. A rejected result contributes validation
    failures and has no plan; an accepted result carries the privately
-   constructed `ActionPlan`, which the engine compiles through the executor
-   port for dry-run preview and execution.
-5. **Resolve**: order tables by foreign-key dependency and block dependents of
+   constructed `ActionPlan` into the next phase.
+5. **Compile**: lower every accepted plan through the executor port and record
+   the exact statements used for both dry-run preview and real execution.
+6. **Resolve**: order tables by foreign-key dependency and block dependents of
    failed tables.
-6. **Execute**: run the compiled statements of every table that has a
+7. **Execute**: run the compiled statements of every table that has a
    non-empty plan and no failures.
-7. **Report** (after the chain): return `SyncReport`, or raise
+8. **Report** (after the chain): return `SyncReport`, or raise
    `SyncFailedError` with the report on real runs that failed.
 
 Execution is gated by accumulated failures. A table that failed read,

--- a/docs/explanation-sync-lifecycle.md
+++ b/docs/explanation-sync-lifecycle.md
@@ -17,16 +17,17 @@ one table's failure does not take down the rest of the run.
 Every sync runs the same chain of phases over every table in the call:
 
 ```text
-read → diff → plan → resolve → execute → report
+read → diff → plan → compile → resolve → execute → report
 ```
 
-| Phase        | Question it answers                          | Outcome                                                           |
-| ------------ | -------------------------------------------- | ----------------------------------------------------------------- |
-| **Read**     | What does the table look like right now?     | Present (with its observed state), absent, or a read failure      |
-| **Diff**     | How does observed state differ from desired? | Direct actions and non-action differences — or no drift           |
-| **Plan**     | Is the diff accepted, and in what order?     | A validated action plan, or named validation failures with no plan |
-| **Resolve**  | Which tables must be synced before which?    | Tables ordered so foreign-key targets go first                    |
-| **Execute**  | Apply the plan                               | An execution summary per table (skipped entirely on a dry run)    |
+| Phase       | Question it answers                          | Outcome                                                            |
+| ----------- | -------------------------------------------- | ------------------------------------------------------------------ |
+| **Read**    | What does the table look like right now?     | Present (with its observed state), absent, or a read failure       |
+| **Diff**    | How does observed state differ from desired? | Direct actions and non-action differences — or no drift            |
+| **Plan**    | Is the diff accepted, and in what order?     | A validated action plan, or named validation failures with no plan |
+| **Compile** | What exact backend statements apply it?     | The SQL exposed on the report and passed unchanged to execution    |
+| **Resolve** | Which tables must be synced before which?    | Tables ordered so foreign-key targets go first                     |
+| **Execute** | Apply the compiled statements                | An execution summary per table (skipped entirely on a dry run)     |
 
 The result is a `SyncReport` with one entry per table. On a real run, if any
 table failed, the engine raises `SyncFailedError` with that report attached; a
@@ -87,12 +88,12 @@ declaration side.
 
 ## Dry runs stop before execution
 
-`sync(..., dry_run=True)` runs read, diff, accepted/rejected planning, and
-resolve, then skips execution. You get every action and SQL statement planned
-from the catalog snapshot it read, plus any read, validation, or foreign-key
-failure found before execution. It cannot predict execution-time Databricks
-errors. The run makes zero catalog mutations and raises no exception. See [how
-to preview changes](how-to-preview-changes.md).
+`sync(..., dry_run=True)` runs read, diff, accepted/rejected planning,
+compilation, and resolve, then skips execution. You get every action and SQL
+statement planned from the catalog snapshot it read, plus any read, validation,
+or foreign-key failure found before execution. It cannot predict execution-time
+Databricks errors. The run makes zero catalog mutations and raises no exception.
+See [how to preview changes](how-to-preview-changes.md).
 
 ## Where to drill down
 

--- a/docs/how-to-preview-changes.md
+++ b/docs/how-to-preview-changes.md
@@ -5,11 +5,11 @@ tags:
 
 # How to preview changes with a dry run
 
-`sync(..., dry_run=True)` runs read, diff, accepted/rejected planning, and
-dependency resolution, then skips execution. Nothing in the catalog changes.
-The report shows the plan and every pre-execution failure discoverable from the
-catalog snapshot it read; it cannot predict a Databricks error that would occur
-only while executing SQL.
+`sync(..., dry_run=True)` runs read, diff, accepted/rejected planning, SQL
+compilation, and dependency resolution, then skips execution. Nothing in the
+catalog changes. The report shows the plan, its exact compiled SQL, and every
+pre-execution failure discoverable from the catalog snapshot it read; it cannot
+predict a Databricks error that would occur only while executing SQL.
 
 ## Run a dry run
 

--- a/src/delta_engine/application/engine.py
+++ b/src/delta_engine/application/engine.py
@@ -6,14 +6,21 @@ runs — one `TableRunReport` is born per table in the read phase and accretes
 its plan, SQL, failures, and execution as the chain proceeds. On a real run, if
 any table fails, `SyncFailedError` is raised with a formatted summary.
 
-The five phases, each taking the runs and returning them:
+The six phases, each taking the runs and returning them:
   1. Read     — fetch current catalog state; birth one run per table
   2. Diff     — compute direct actions and non-action differences
   3. Plan     — validate each diff, then accept a plan or append failures
-  4. Resolve  — order runs by FK dependency; append FK failures and
+  4. Compile  — lower every accepted plan to its exact backend statements
+  5. Resolve  — order runs by FK dependency; append FK failures and
                 propagate blocking to dependents
-  5. Execute  — run the plan of every run with no failures and a non-empty
+  6. Execute  — run the plan of every run with no failures and a non-empty
                 plan, blocking FK dependents of runs that fail mid-execution
+
+Compilation deliberately precedes resolution. An accepted plan is a
+table-local fact, so it receives the exact SQL exposed on the report before
+cross-table dependency checks decide whether it may execute. A later FK failure
+therefore does not erase a valid preview or force compilation to understand
+resolution failures.
 
 Running `resolve()` after validation means a table that fails validation
 blocks its FK dependents with BLOCKED_BY_FAILED_DEPENDENCY, not just tables
@@ -93,10 +100,11 @@ class _TableRun:
     """
     Mutable scratch pad threaded through the sync phases.
 
-    Born in the read phase, it accretes its diff, plan, resolution, failures,
-    and execution as the phase chain proceeds, then is frozen into a public
-    :class:`TableRunReport` once complete. Kept private to the engine so the
-    published report stays immutable while the phases mutate in place.
+    Born in the read phase, it accretes its diff, plan, compiled SQL,
+    resolution, failures, and execution as the phase chain proceeds, then is
+    frozen into a public :class:`TableRunReport` once complete. Kept private to
+    the engine so the published report stays immutable while the phases mutate
+    in place.
     """
 
     qualified_name: QualifiedName
@@ -150,9 +158,9 @@ class Engine:
         Synchronize all registered tables to their desired state.
 
         Runs the phases as a chain, each transforming the per-table runs:
-        read → diff → plan → resolve → execute. Each
+        read → diff → plan → compile → resolve → execute. Each
         ``TableRunReport`` is born in the read phase and accretes its diff,
-        plan, failures, and execution as later phases run.
+        plan, compiled SQL, failures, and execution as later phases run.
 
         A table that fails an early phase carries that failure forward and is
         skipped by execution; its partial run is still included in the report.
@@ -161,7 +169,7 @@ class Engine:
             *tables: The table specifications to synchronize. Duplicate
                 qualified names raise ``DuplicateTableDefinitionError`` before
                 any phase runs.
-            dry_run: When True, run read → diff → plan → resolve
+            dry_run: When True, run read → diff → plan → compile → resolve
                 but skip execution (zero catalog mutations). Every run's
                 ``execution`` stays ``None`` while its ``plan`` still records
                 the actions compiled from the observed snapshot, and the report
@@ -187,6 +195,7 @@ class Engine:
         runs = self._read(desired)
         runs = self._diff(runs)
         runs = self._plan(runs)
+        runs = self._compile(runs)
         runs = self._resolve(runs)
 
         if not dry_run:
@@ -254,12 +263,10 @@ class Engine:
 
     def _plan(self, runs: tuple[_TableRun, ...]) -> tuple[_TableRun, ...]:
         """
-        Accept or reject each diff, then compile every accepted plan.
+        Accept or reject each diff according to the default planning policy.
 
-        Compiling here, before the dry-run/execute split, means a dry run exposes
-        the exact DDL for its own snapshot. ``plan_diff`` always applies the
-        default policy; rejected runs retain an empty plan and carry validation
-        failures.
+        Rejected runs retain an empty plan and carry validation failures;
+        accepted runs carry the validated action plan into compilation.
         """
         for run in runs:
             if run.diff is None:
@@ -274,10 +281,29 @@ class Engine:
                     )
                 case PlanningSucceeded(plan=plan):
                     run.plan = plan
-                    run.planned_sql_statements = self.executor.compile(run.qualified_name, run.plan)
                     logger.info("Planned %d action(s) for %s", len(run.plan), run.qualified_name)
                 case _ as unreachable:
                     assert_never(unreachable)
+        return runs
+
+    def _compile(self, runs: tuple[_TableRun, ...]) -> tuple[_TableRun, ...]:
+        """
+        Lower every accepted plan to the exact statements exposed and executed.
+
+        Compilation is a distinct backend boundary after planning: a dry run
+        reports these statements, while a real run passes the same tuple to
+        execution. Runs rejected by an earlier phase carry no compiled SQL.
+        """
+        for run in runs:
+            if run.diff is None or run.has_failures:
+                continue
+
+            run.planned_sql_statements = self.executor.compile(run.qualified_name, run.plan)
+            logger.info(
+                "Compiled %d statement(s) for %s",
+                len(run.planned_sql_statements),
+                run.qualified_name,
+            )
         return runs
 
     def _resolve(self, runs: tuple[_TableRun, ...]) -> tuple[_TableRun, ...]:
@@ -290,7 +316,7 @@ class Engine:
         """
         failed_names = {run.qualified_name for run in runs if run.has_failures}
         ordered_resolutions = resolve(
-            tuple(run.desired for run in runs),
+            tables=tuple(run.desired for run in runs),
             failed_names=failed_names,
         )
         runs_by_name = {run.qualified_name: run for run in runs}

--- a/tests/application/test_engine.py
+++ b/tests/application/test_engine.py
@@ -1,6 +1,7 @@
 from hypothesis import given, strategies as st
 import pytest
 
+import delta_engine.application.engine as engine_module
 from delta_engine.application.engine import Engine
 from delta_engine.application.errors import DuplicateTableDefinitionError, SyncFailedError
 from delta_engine.application.failures import (
@@ -526,9 +527,22 @@ def test_real_run_records_dry_run_false():
 # ---------------------------------------------------------------------------
 
 
-def test_read_phase_attempts_all_tables_before_any_execution():
+def test_phase_chain_reads_compiles_resolves_then_executes_all_eligible_tables(
+    monkeypatch: pytest.MonkeyPatch,
+):
     # Given three tables where the middle read fails
     events: list[str] = []
+
+    # This intentionally observes private phase order. Compiling accepted plans
+    # before resolution keeps the compiler independent of resolution failures
+    # while preserving SQL previews for plans that dependency checks later block.
+    original_resolve = engine_module.resolve
+
+    def recording_resolve(*args, **kwargs):
+        events.append("resolve")
+        return original_resolve(*args, **kwargs)
+
+    monkeypatch.setattr(engine_module, "resolve", recording_resolve)
 
     class _EventRecordingReader:
         def fetch_state(self, qualified_name: QualifiedName) -> CatalogState:
@@ -539,9 +553,8 @@ def test_read_phase_attempts_all_tables_before_any_execution():
 
     class _EventRecordingExecutor:
         def compile(self, qualified_name: QualifiedName, plan: ActionPlan) -> tuple[str, ...]:
-            # Silent by design: the plan phase compiles every table, but this
-            # test asserts read/execute event ordering, not compilation. The
-            # name is embedded so execute can name the table in its event.
+            events.append(f"compile:{qualified_name}")
+            # The name is embedded so execute can recover the target table.
             return tuple(f"STATEMENT {index} FOR {qualified_name}" for index in range(len(plan)))
 
         def execute(self, statements: tuple[str, ...]) -> ExecutionSummary:
@@ -567,7 +580,12 @@ def test_read_phase_attempts_all_tables_before_any_execution():
         "read:c.s.b",
         "read:c.s.c",
     ]
-    assert events[3:] == [
+    assert events[3:5] == [
+        "compile:c.s.a",
+        "compile:c.s.c",
+    ]
+    assert events[5] == "resolve"
+    assert events[6:] == [
         "execute:c.s.a",
         "execute:c.s.c",
     ]
@@ -1173,8 +1191,8 @@ def test_failed_table_records_no_planned_sql():
 
 def test_fk_failed_table_still_reports_its_planned_sql_without_executing():
     # Given an absent table whose FK references a table not in the sync.
-    # FK resolution runs after planning, so the plan and its SQL are already
-    # legitimate facts about the table — only the ordering/dependency failed.
+    # FK resolution runs after planning and compilation, so the plan and its
+    # SQL are already legitimate facts — only the dependency check failed.
     reader = _RecordingReader()
     executor = _RecordingExecutor(per_call_results=[])
     engine = Engine(reader=reader, executor=executor)


### PR DESCRIPTION
## Summary

- extract SQL compilation from `Engine._plan()` into an explicit `_compile()` phase
- keep planning focused on accepting or rejecting domain diffs
- document the six-phase lifecycle and why compilation deliberately precedes dependency resolution
- protect the phase ordering with a focused architecture test while retaining the FK-blocked SQL-preview behavior test

## Why

Planning previously both accepted a domain plan and lowered it to backend SQL, hiding a distinct adapter boundary inside `_plan()`. Making compilation explicit keeps the lifecycle truthful and separates policy from backend lowering.

Compilation remains before resolution because an accepted plan is a table-local fact. Its exact SQL should remain available in reports even when later cross-table dependency checks block execution, without requiring the compiler to understand resolution failures.

## Impact

There is no public API or report-schema change. Dry runs and real runs continue to expose and execute the same compiled statement tuple; the lifecycle and documentation now make that behavior explicit.

## Validation

- `uv run pytest --ignore=tests/live -q` — 877 passed
- `uv run pytest tests/application -q --no-cov` — 262 passed
- `uv run pytest tests/application/test_engine.py -q --no-cov` — 37 passed
- `uv run ruff check .`
- `uv run ruff format . --check`
- `uv run mypy src tests`
- `uv run lint-imports`
- `uv run --group docs sphinx-build -W -b html docs /private/tmp/delta-engine-docs-explicit-compile-phase-final`
- `git diff --check`
