### PR TITLE
fix: validate foreign-key types against the registered parent declaration

### DIFF
--- a/.github/workflows/live.yaml
+++ b/.github/workflows/live.yaml
@@ -14,6 +14,11 @@ name: Live Databricks Tests
 
 on:
   workflow_dispatch:
+    inputs:
+      pytest_filter:
+        description: "Optional pytest -k expression to run a subset of the suite"
+        required: false
+        default: ""
   schedule:
     # Weekly drift check (Mondays 07:00 UTC): catches Databricks-side
     # behaviour changes the hermetic suite cannot see. Non-blocking — it
@@ -92,4 +97,8 @@ jobs:
         # --dist loadgroup: tests marked xdist_group("streaming_table") run
         # serially on one worker — the workspace tier allows one active DBSQL
         # pipeline at a time — while unmarked tests distribute as in load mode.
-        run: uv run pytest tests/live -m databricks_e2e --no-cov -rA -n 8 --dist loadgroup
+        env:
+          PYTEST_FILTER: ${{ inputs.pytest_filter }}
+        run: >
+          uv run pytest tests/live -m databricks_e2e --no-cov -rA -n 8
+          --dist loadgroup ${PYTEST_FILTER:+-k "${PYTEST_FILTER}"}

--- a/docs/explanation-architecture.md
+++ b/docs/explanation-architecture.md
@@ -572,6 +572,8 @@ connected components to produce a dependency-first order. It reports:
   of the sync.
 - `REFERENCED_COLUMNS_NOT_A_KEY` when the referenced columns are not exactly the
   referenced table's primary key.
+- `REFERENCED_COLUMN_TYPE_MISMATCH` when a foreign-key column's type does not
+  match the referenced column's type on the table registered for the sync.
 - `CYCLE` for true multi-table FK cycles.
 - `BLOCKED_BY_FAILED_DEPENDENCY` when a table depends on another table that
   is already known to have failed before execution begins, such as a table with

--- a/docs/explanation-safety-model.md
+++ b/docs/explanation-safety-model.md
@@ -85,17 +85,18 @@ protects it from the rest of the run: a table only executes when every table
 its foreign keys reference can be trusted to reach its desired state this
 sync.
 
-A table blocked by this layer reports `FOREIGN_KEY_FAILED`, with one of four
+A table blocked by this layer reports `FOREIGN_KEY_FAILED`, with one of five
 reasons in its failure message:
 
-| Failure reason                 | Fires when                                                                          |
-| ------------------------------ | ----------------------------------------------------------------------------------- |
-| `UNRESOLVABLE_REFERENCE`       | A foreign key references a table that is not part of the sync                       |
-| `CYCLE`                        | The table is part of a foreign-key dependency cycle                                 |
-| `REFERENCED_COLUMNS_NOT_A_KEY` | The referenced columns are not the referenced table's primary key                   |
-| `BLOCKED_BY_FAILED_DEPENDENCY` | A referenced table failed this run — at any of the layers above, or while executing |
+| Failure reason                    | Fires when                                                                                                   |
+| --------------------------------- | ------------------------------------------------------------------------------------------------------------ |
+| `UNRESOLVABLE_REFERENCE`          | A foreign key references a table that is not part of the sync                                                |
+| `CYCLE`                           | The table is part of a foreign-key dependency cycle                                                          |
+| `REFERENCED_COLUMNS_NOT_A_KEY`    | The referenced columns are not the referenced table's primary key                                            |
+| `REFERENCED_COLUMN_TYPE_MISMATCH` | A foreign-key column's type does not match the referenced column's type on the table registered for the sync |
+| `BLOCKED_BY_FAILED_DEPENDENCY`    | A referenced table failed this run — at any of the layers above, or while executing                          |
 
-The first three are structural problems with the declarations themselves —
+The first four are structural problems with the declarations themselves —
 validation in spirit, run separately only because they need to see every table
 in the sync at once. The last is failure propagation: the declaration is fine,
 but the state its foreign keys depend on won't exist, so the table is blocked

--- a/docs/how-to-handle-sync-failures.md
+++ b/docs/how-to-handle-sync-failures.md
@@ -90,7 +90,7 @@ See [reference-safe-change-rules.md](reference-safe-change-rules.md) for the ful
 
 ## Act on foreign key failures
 
-A `FOREIGN_KEY_FAILED` table ran no SQL. The cause is one of: a reference to an unregistered table, a dependency cycle, a foreign key that does not target the referenced table's primary key, or a dependency that won't reach its desired state this sync — whether it failed before execution (read or planning) or while executing earlier in the same run. When a dependency fails, every table downstream of it is blocked too — so fix the upstream table first, then re-run.
+A `FOREIGN_KEY_FAILED` table ran no SQL. The cause is one of: a reference to an unregistered table, a dependency cycle, a foreign key that does not target the referenced table's primary key, a foreign-key column whose type does not match the referenced column on the registered table, or a dependency that won't reach its desired state this sync — whether it failed before execution (read or planning) or while executing earlier in the same run. When a dependency fails, every table downstream of it is blocked too — so fix the upstream table first, then re-run.
 
 ```python
 for table_report in report:

--- a/docs/todo/business-logic-delta-databricks-correctness-review.md
+++ b/docs/todo/business-logic-delta-databricks-correctness-review.md
@@ -33,7 +33,7 @@ path currently produces an incorrect result.
 | 1 ✅ | High     | Non-Delta objects are not rejected                            | Invalid or partial plans against views, Iceberg, or other formats  |
 | 2 ✅ | High     | Unparseable columns are silently omitted                      | Existing drift can be reported as synchronized                     |
 | 3    | High     | Required Delta table features are not planned                 | Valid-looking plans fail during execution                          |
-| 4    | High     | Foreign-key types are checked against the wrong parent object | Invalid constraints pass declaration and resolution                |
+| 4 ✅ | High     | Foreign-key types are checked against the wrong parent object | Invalid constraints pass declaration and resolution                |
 | 5 ✅ | Medium   | Clearing a column comment generates invalid SQL               | Warehouse execution fails on `UNSET COMMENT`                       |
 | 6    | Medium   | Identifier normalization disagrees with Unity Catalog         | Valid names can change identity; invalid object names pass locally |
 | 7    | Medium   | Layout and map-type validation is too permissive              | Unsupported declarations reach execution                           |
@@ -220,6 +220,21 @@ each foreign-key column type must match the referenced column type. See the
 
 Cover the mismatch through resolver tests, engine tests, and the public
 declaration surface.
+
+### Resolved (2026-07-17)
+
+Fixed in [PR #256](https://github.com/Tomoscorbin/delta-engine/pull/256).
+Dependency resolution now compares each local column's type with the
+referenced column's type on the registered parent declaration and fails the
+table with the new `REFERENCED_COLUMN_TYPE_MISMATCH` reason. The check runs
+after `REFERENCED_COLUMNS_NOT_A_KEY` — which guarantees every referenced
+column exists on the registered parent — and before cycle classification,
+mirroring the existing structural-check precedence; dependents of a
+mismatched table are blocked through the existing propagation pass.
+Resolver, engine, and failure-detail coverage all construct the mismatch
+through the public declaration surface (an FK declared against one parent
+object while a differently-typed declaration is registered under the same
+qualified name).
 
 ## 5. Compile an empty column comment as `COMMENT ''`
 

--- a/src/delta_engine/application/dependency_resolution.py
+++ b/src/delta_engine/application/dependency_resolution.py
@@ -30,11 +30,17 @@ strongly-connected-components algorithm, fixpoint propagation of blocked
 dependents) are hidden behind that interface.
 """
 
-from collections.abc import Set as AbstractSet
+from collections.abc import Mapping, Set as AbstractSet
 from dataclasses import dataclass
 
 from delta_engine.application.failures import ForeignKeyFailure, ForeignKeyFailureReason
-from delta_engine.domain.model import DesiredTable, ForeignKeyConstraint, QualifiedName, TableAspect
+from delta_engine.domain.model import (
+    DataType,
+    DesiredTable,
+    ForeignKeyConstraint,
+    QualifiedName,
+    TableAspect,
+)
 
 # TODO: Replace the recursive SCC traversal with an iterative implementation.
 # Its call depth follows dependency depth, so a chain near Python's recursion
@@ -158,6 +164,21 @@ def _foreign_key_failure(
         local_columns=foreign_key.local_columns,
         references=foreign_key.referenced_table,
         reason=reason,
+    )
+
+
+def _foreign_key_types_match(
+    foreign_key: ForeignKeyConstraint,
+    *,
+    local_types: Mapping[str, DataType],
+    referenced_types: Mapping[str, DataType],
+) -> bool:
+    """Return True if every local column's type equals its referenced column's type."""
+    return all(
+        local_types[local_column] == referenced_types[referenced_column]
+        for local_column, referenced_column in zip(
+            foreign_key.local_columns, foreign_key.referenced_columns, strict=True
+        )
     )
 
 
@@ -326,8 +347,11 @@ def _classify_failures(
     Two passes:
 
     1. Direct failures — a foreign key to an unregistered table
-       (UNRESOLVABLE_REFERENCE) or a foreign key into the owning table's own
-       dependency cycle (CYCLE).
+       (UNRESOLVABLE_REFERENCE), a foreign key whose target is not the
+       registered table's primary key (REFERENCED_COLUMNS_NOT_A_KEY), a
+       foreign key whose column types disagree with the registered table's
+       (REFERENCED_COLUMN_TYPE_MISMATCH), or a foreign key into the owning
+       table's own dependency cycle (CYCLE).
     2. Propagation — a table that references a table which will not be built
        cannot be built either (its foreign key would target a missing table).
        This repeats to a fixpoint so the block flows along chains of dependents.
@@ -360,6 +384,18 @@ def _classify_failures(
     # aligned to local_columns, not PK order.
     primary_key_by_name = {table.qualified_name: set(table.primary_key_columns) for table in tables}
 
+    # Column types of every registered table, keyed by qualified name. A
+    # foreign key's types were validated at declaration time against the
+    # particular parent *object* it was declared with, but the table the sync
+    # will actually build is the declaration *registered* under that qualified
+    # name — and Databricks requires each foreign-key column type to equal the
+    # referenced column's type. The two declarations can differ, so the types
+    # are re-checked here against the registered parent.
+    column_types_by_name = {
+        table.qualified_name: {column.name: column.data_type for column in table.columns}
+        for table in tables
+    }
+
     # Pass 1 — direct failures.
     for table in tables:
         table_name = table.qualified_name
@@ -367,10 +403,19 @@ def _classify_failures(
             referenced_table = foreign_key.referenced_table
             if referenced_table not in registered_names:
                 record(table, foreign_key, ForeignKeyFailureReason.UNRESOLVABLE_REFERENCE)
-            # Checked before the cycle test so that a structural FK-target problem is
-            # reported per-FK even when the table also participates in a cycle.
+            # Structural FK-target checks run before the cycle test so that a
+            # structural problem is reported per-FK even when the table also
+            # participates in a cycle. The type check relies on the target
+            # being the registered parent's primary key: only then is every
+            # referenced column known to exist on the registered parent.
             elif set(foreign_key.referenced_columns) != primary_key_by_name[referenced_table]:
                 record(table, foreign_key, ForeignKeyFailureReason.REFERENCED_COLUMNS_NOT_A_KEY)
+            elif not _foreign_key_types_match(
+                foreign_key,
+                local_types=column_types_by_name[table_name],
+                referenced_types=column_types_by_name[referenced_table],
+            ):
+                record(table, foreign_key, ForeignKeyFailureReason.REFERENCED_COLUMN_TYPE_MISMATCH)
             elif referenced_table in cycle_partners_by_table.get(table_name, frozenset()):
                 record(table, foreign_key, ForeignKeyFailureReason.CYCLE)
 

--- a/src/delta_engine/application/failures.py
+++ b/src/delta_engine/application/failures.py
@@ -31,6 +31,7 @@ class ForeignKeyFailureReason(StrEnum):
     UNRESOLVABLE_REFERENCE = "UNRESOLVABLE_REFERENCE"
     BLOCKED_BY_FAILED_DEPENDENCY = "BLOCKED_BY_FAILED_DEPENDENCY"
     REFERENCED_COLUMNS_NOT_A_KEY = "REFERENCED_COLUMNS_NOT_A_KEY"
+    REFERENCED_COLUMN_TYPE_MISMATCH = "REFERENCED_COLUMN_TYPE_MISMATCH"
 
     @property
     def detail(self) -> str:
@@ -44,6 +45,10 @@ class ForeignKeyFailureReason(StrEnum):
                 return "it references a table that failed to sync"
             case ForeignKeyFailureReason.REFERENCED_COLUMNS_NOT_A_KEY:
                 return "its referenced columns are not the primary key of the referenced table"
+            case ForeignKeyFailureReason.REFERENCED_COLUMN_TYPE_MISMATCH:
+                return (
+                    "its column types do not match the registered referenced table's column types"
+                )
             case _ as unreachable:
                 assert_never(unreachable)
 

--- a/tests/application/test_dependency_resolution.py
+++ b/tests/application/test_dependency_resolution.py
@@ -19,7 +19,7 @@ from delta_engine.application.failures import ForeignKeyFailureReason
 from delta_engine.domain.model import QualifiedName
 from delta_engine.domain.model.constraints import ForeignKeyConstraint, PrimaryKeyConstraint
 from delta_engine.domain.model.table import DesiredTable
-from delta_engine.schema import Column, DeltaTable, ForeignKey, Self, String
+from delta_engine.schema import Column, DeltaTable, ForeignKey, Long, Self, String
 
 
 def _qualified_name(fqn: str) -> QualifiedName:
@@ -882,6 +882,112 @@ def test_resolve_fails_fk_whose_referenced_columns_are_not_the_pk():
         reason=ForeignKeyFailureReason.REFERENCED_COLUMNS_NOT_A_KEY,
         references="cat.sch.customers",
         local_columns=("ref_email",),
+    )
+
+
+def _long_id_table(fqn: str) -> DesiredTable:
+    """Build a table whose primary key column ``id`` is a Long rather than a String."""
+    catalog, schema, table_name = _split_fqn(fqn)
+
+    return DeltaTable(
+        catalog,
+        schema,
+        table_name,
+        columns=(Column("id", Long(), nullable=False),),
+        primary_key=["id"],
+    ).to_desired_table()
+
+
+def test_resolve_fails_fk_whose_types_mismatch_the_registered_parent():
+    # Given orders' FK was declared against a customers object whose id is a
+    # String, but the customers declaration registered for this sync types id
+    # as a Long
+    orders = _table_with_fk("cat.sch.orders", "cat.sch.customers")
+    customers = _long_id_table("cat.sch.customers")
+
+    # When resolving dependencies
+    result = resolve((orders, customers))
+
+    # Then orders fails because ref_id's type does not match the registered
+    # customers' primary key type, and customers itself is unaffected
+    _assert_has_failure(
+        result,
+        "cat.sch.orders",
+        reason=ForeignKeyFailureReason.REFERENCED_COLUMN_TYPE_MISMATCH,
+        references="cat.sch.customers",
+        local_columns=("ref_id",),
+    )
+    assert _failures_for(result, "cat.sch.customers") == ()
+
+
+def test_resolve_blocks_dependents_of_a_type_mismatched_table():
+    # Given orders' FK types mismatch the registered customers,
+    # and shipments depends on orders
+    orders = _table_with_fk("cat.sch.orders", "cat.sch.customers")
+    shipments = _table_with_fk("cat.sch.shipments", "cat.sch.orders")
+    customers = _long_id_table("cat.sch.customers")
+
+    # When resolving dependencies
+    result = resolve((shipments, orders, customers))
+
+    # Then orders fails directly and shipments is blocked by orders
+    _assert_has_failure(
+        result,
+        "cat.sch.orders",
+        reason=ForeignKeyFailureReason.REFERENCED_COLUMN_TYPE_MISMATCH,
+        references="cat.sch.customers",
+    )
+    _assert_has_failure(
+        result,
+        "cat.sch.shipments",
+        reason=ForeignKeyFailureReason.BLOCKED_BY_FAILED_DEPENDENCY,
+        references="cat.sch.orders",
+    )
+
+
+def test_resolve_reports_type_mismatch_over_cycle_for_the_same_fk():
+    # Given a <-> b form a cycle, and a's FK into b was declared against a
+    # String-id b while the registered b types id as a Long. The type check
+    # runs before cycle classification, so the structural problem is reported
+    # per-FK even though a is also in a cycle.
+    a = _table_with_fk("cat.sch.a", "cat.sch.b")
+    b = DeltaTable(
+        "cat",
+        "sch",
+        "b",
+        columns=(
+            Column("id", Long(), nullable=False),
+            Column("ref_id", String()),
+        ),
+        primary_key=["id"],
+        foreign_keys=[
+            ForeignKey(
+                columns={"ref_id": "id"},
+                references=_referenced_table("cat.sch.a"),
+            )
+        ],
+    ).to_desired_table()
+
+    # When resolving dependencies
+    result = resolve((a, b))
+
+    # Then a's single failure is the type mismatch, not a cycle failure,
+    # while b's FK back into the cycle still fails as a cycle
+    _assert_has_failure(
+        result,
+        "cat.sch.a",
+        reason=ForeignKeyFailureReason.REFERENCED_COLUMN_TYPE_MISMATCH,
+        references="cat.sch.b",
+        local_columns=("ref_id",),
+    )
+    assert _failure_reasons_for(result, "cat.sch.a") == [
+        ForeignKeyFailureReason.REFERENCED_COLUMN_TYPE_MISMATCH
+    ]
+    _assert_has_failure(
+        result,
+        "cat.sch.b",
+        reason=ForeignKeyFailureReason.CYCLE,
+        references="cat.sch.a",
     )
 
 

--- a/tests/application/test_engine.py
+++ b/tests/application/test_engine.py
@@ -37,7 +37,7 @@ from delta_engine.domain.plan.actions import (
     UnsetColumnTag,
     UnsetTableTag,
 )
-from delta_engine.schema import Column, DeltaTable, ForeignKey, String
+from delta_engine.schema import Column, DeltaTable, ForeignKey, Long, String
 from tests.builders import as_observed_columns
 
 # ---------------------------------------------------------------------------
@@ -864,6 +864,49 @@ def test_sync_fails_fk_that_does_not_reference_a_primary_key():
     _assert_has_fk_failure(
         orders,
         reason=ForeignKeyFailureReason.REFERENCED_COLUMNS_NOT_A_KEY,
+        references="cat.sch.customers",
+    )
+
+    assert orders.execution is None
+    assert customers.execution is not None
+    assert executor.executed_names == ["cat.sch.customers"]
+
+
+def test_sync_fails_fk_whose_types_mismatch_the_registered_parent():
+    # Given orders' FK was declared against a customers object whose id is a
+    # String, but the customers declaration registered for this sync types id
+    # as a Long
+    reader = _RecordingReader()
+    executor = _RecordingExecutor([(_ok_exec(0),)])
+    engine = Engine(reader=reader, executor=executor)
+
+    registered_customers = DeltaTable(
+        "cat",
+        "sch",
+        "customers",
+        columns=(Column("id", Long(), nullable=False),),
+        primary_key=["id"],
+    )
+
+    # When syncing
+    with pytest.raises(SyncFailedError) as exc_info:
+        engine.sync(
+            _spec_with_fk("cat.sch.orders", "cat.sch.customers"),
+            registered_customers,
+        )
+
+    # Then orders is FK-failed, but customers can still be created
+    report = exc_info.value.report
+    orders = _assert_status(
+        report,
+        "cat.sch.orders",
+        TableRunStatus.FOREIGN_KEY_FAILED,
+    )
+    customers = _assert_status(report, "cat.sch.customers", TableRunStatus.SUCCESS)
+
+    _assert_has_fk_failure(
+        orders,
+        reason=ForeignKeyFailureReason.REFERENCED_COLUMN_TYPE_MISMATCH,
         references="cat.sch.customers",
     )
 

--- a/tests/live/test_sql_warehouse_live_safety.py
+++ b/tests/live/test_sql_warehouse_live_safety.py
@@ -11,6 +11,7 @@ from delta_engine import (
     SyncFailedError,
     TableRunStatus,
     ValidationFailure,
+    render_report,
 )
 from delta_engine.databricks import build_sql_engine
 from delta_engine.schema import (
@@ -487,6 +488,69 @@ def test_child_with_foreign_key_is_blocked_when_its_parent_is_rejected(
     assert failure.reason == "BLOCKED_BY_FAILED_DEPENDENCY"
     assert table_exists(live_connection, child_name) is False
     assert read_live_table(live_connection, parent_name) == parent_before
+
+
+def test_fk_type_mismatch_against_registered_parent_is_blocked_before_execution(
+    live_connection, live_tables
+):
+    """Blocks a FK whose column types mismatch the registered parent before any child SQL runs."""
+    parent_name = live_tables("mismatch_parent")
+    child_name = live_tables("mismatch_child")
+
+    # The foreign key is internally consistent: it is declared against a
+    # parent object whose id is an Integer, matching the child's parent_id.
+    # But the parent declaration *registered for this sync* under the same
+    # qualified name types id as a Long — and Unity Catalog requires each
+    # foreign-key column's type to equal the referenced column's type. The
+    # engine must block the child before executing anything against it,
+    # rather than let the warehouse reject the constraint mid-execution and
+    # leave a half-built child behind.
+    declared_parent = DeltaTable(
+        live_catalog(),
+        live_schema(),
+        parent_name,
+        columns=(Column("id", Integer(), nullable=False),),
+        primary_key=("id",),
+    )
+    registered_parent = DeltaTable(
+        live_catalog(),
+        live_schema(),
+        parent_name,
+        columns=(Column("id", Long(), nullable=False),),
+        primary_key=("id",),
+    )
+    child = DeltaTable(
+        live_catalog(),
+        live_schema(),
+        child_name,
+        columns=(
+            Column("id", Integer(), nullable=False),
+            Column("parent_id", Integer()),
+        ),
+        primary_key=("id",),
+        foreign_keys=(ForeignKey(columns={"parent_id": "id"}, references=declared_parent),),
+    )
+
+    with pytest.raises(SyncFailedError) as error:
+        build_sql_engine(live_connection).sync(child, registered_parent)
+
+    report = error.value.report
+    [child_report] = [
+        table_report
+        for table_report in report.table_reports
+        if table_report.qualified_name.name == child_name
+    ]
+    # On failure the rendered report is the diagnosis: it shows what the
+    # engine actually did against the warehouse instead of blocking.
+    assert child_report.status is TableRunStatus.FOREIGN_KEY_FAILED, render_report(report)
+    [failure] = child_report.failures
+    assert isinstance(failure, ForeignKeyFailure)
+    assert failure.reason == "REFERENCED_COLUMN_TYPE_MISMATCH"
+    # The child never reached the warehouse: no SQL ran, no table was created.
+    assert child_report.execution is None
+    assert table_exists(live_connection, child_name) is False
+    # The registered parent is healthy and still synced.
+    assert read_live_table(live_connection, parent_name)["primary_key"] == ("id",)
 
 
 def test_unreadable_catalog_surfaces_as_typed_read_failure(live_connection):


### PR DESCRIPTION
## Summary

Item 4 of the [business-logic/Databricks correctness review](docs/todo/business-logic-delta-databricks-correctness-review.md): foreign-key column types were validated only against the particular parent *object* held by `ForeignKey.references`. Dependency resolution then found the *registered* table by qualified name and verified its primary-key column names — but never their types. A child declared against one parent object could therefore pass preparation and resolution even though the declaration registered under that name had incompatible column types; Databricks rejects the constraint at execution, since each foreign-key column type must match the referenced column type.

## Changes

- `_classify_failures` in dependency resolution now compares each local column's type with the referenced column's type on the registered parent declaration, recording the new `REFERENCED_COLUMN_TYPE_MISMATCH` reason.
- The check runs after `REFERENCED_COLUMNS_NOT_A_KEY` (which guarantees every referenced column exists on the registered parent, making the type lookup total) and before `CYCLE`, mirroring the existing structural-check precedence.
- Dependents of a mismatched table are blocked through the existing propagation pass — no new mechanism.
- Docs: the three pages enumerating FK failure reasons gained the new reason.

## Tests

- Resolver: direct mismatch, propagation to dependents, and mismatch-over-cycle precedence — all constructed through the public `DeltaTable`/`ForeignKey` API using the declared-object-vs-registered-declaration divergence.
- Engine: `sync` marks the child `FOREIGN_KEY_FAILED` with the new reason while the parent still executes; before the fix this test showed the child's invalid constraint reaching execution.
- `test_failures.py` covers the new reason's detail automatically (iterates all members).

## Checks

- `uv run pytest -m "not local_e2e and not databricks_e2e"` — 887 passed, coverage 98.05%
- `uv run ruff check src tests`, `uv run ruff format --check`, `uv run mypy src`, `uv run lint-imports` — clean
- `sphinx-build -W` — clean