### PR TITLE
fix: reject clustering keys and Map-of-Map declarations Databricks cannot deploy

### DIFF
--- a/docs/todo/business-logic-delta-databricks-correctness-review.md
+++ b/docs/todo/business-logic-delta-databricks-correctness-review.md
@@ -36,7 +36,7 @@ path currently produces an incorrect result.
 | 4 ✅ | High     | Foreign-key types are checked against the wrong parent object | Invalid constraints pass declaration and resolution                |
 | 5 ✅ | Medium   | Clearing a column comment generates invalid SQL               | Warehouse execution fails on `UNSET COMMENT`                       |
 | 6    | Medium   | Identifier normalization disagrees with Unity Catalog         | Valid names can change identity; invalid object names pass locally |
-| 7    | Medium   | Layout and map-type validation is too permissive              | Unsupported declarations reach execution                           |
+| 7 ✅ | Medium   | Layout and map-type validation is too permissive              | Unsupported declarations reach execution                           |
 | 8 ✅ | Medium   | `CREATE TABLE IF NOT EXISTS` can report false success         | A concurrent incompatible create is treated as success             |
 
 ## 1. Reject views and non-Delta tables at the read boundary
@@ -336,6 +336,26 @@ Platform references:
 3. Add `Map.__post_init__` validation that rejects a `Map` key type.
 
 These are deterministic declaration errors and need no runtime probing.
+
+### Resolved (2026-07-17)
+
+The shared `_TYPES_UNUSABLE_AS_LAYOUT_KEYS` tuple was split into
+`_TYPES_UNUSABLE_AS_PARTITION_KEYS` (Array/Map/Struct/Variant, unchanged) and
+`_TYPES_UNUSABLE_AS_CLUSTERING_KEYS`, which adds Boolean and Binary. The
+clustering exclusion was verified against the liquid-clustering supported-type
+list, whose enumerated types omit Boolean and Binary even though both are valid
+partition columns. `Map` gained a `__post_init__` that rejects a `Map` key
+type, matching the platform rule that a MAP key may be any type except MAP; a
+MAP value may still be a MAP.
+
+Coverage: API-layer tests assert clustering rejects Boolean and Binary while
+partitioning still accepts them (the two rules are now distinct), and
+domain-layer tests assert the Map key rejection and that a Map value type is
+still allowed. The shared AS JSON type-document strategy was narrowed to stop
+generating map-keyed maps, which the domain now forbids. Both changes are
+declaration-time errors with no runtime probing, so no live coverage is
+required; the live partition-rejection assumption test was reworded to name the
+now-separate partition and clustering type lists.
 
 ## 8. Remove the false-success race from table creation
 

--- a/src/delta_engine/api/delta_table.py
+++ b/src/delta_engine/api/delta_table.py
@@ -20,6 +20,8 @@ from delta_engine.application.properties import DELTA_PROPERTY_REGISTRY, Propert
 from delta_engine.domain.model import (
     ALL_ASPECTS,
     Array,
+    Binary,
+    Boolean,
     DataType,
     DesiredColumn as Column,
     DesiredTable,
@@ -67,10 +69,18 @@ _CDF_RESERVED_COLUMN_NAMES: Final[frozenset[str]] = frozenset(
     {"_change_type", "_commit_version", "_commit_timestamp"}
 )
 
-# Complex types Delta accepts neither as partition columns
-# (INVALID_PARTITION_COLUMN_DATA_TYPE) nor as liquid-clustering keys.
-# Two distinct backend rules that happen to name the same types today.
-_TYPES_UNUSABLE_AS_LAYOUT_KEYS: Final[tuple[type[DataType], ...]] = (Array, Map, Struct, Variant)
+# Partitioning and clustering are distinct backend rules with distinct type
+# lists. Delta refuses complex types as partition columns
+# (INVALID_PARTITION_COLUMN_DATA_TYPE).
+_TYPES_UNUSABLE_AS_PARTITION_KEYS: Final[tuple[type[DataType], ...]] = (Array, Map, Struct, Variant)
+
+# Liquid clustering's supported-type list is narrower: on top of the complex
+# types, it also excludes Boolean and Binary, which partitioning accepts.
+_TYPES_UNUSABLE_AS_CLUSTERING_KEYS: Final[tuple[type[DataType], ...]] = (
+    *_TYPES_UNUSABLE_AS_PARTITION_KEYS,
+    Boolean,
+    Binary,
+)
 
 # Tag limits enforced per securable object (a table and each of its columns
 # are separate securables). Databricks caps both tag keys and values at 256
@@ -171,14 +181,14 @@ def _validate_layout(
     columns_by_name = {column.name: column for column in columns}
     for name in partitioned_by:
         column = columns_by_name.get(name)
-        if column is not None and isinstance(column.data_type, _TYPES_UNUSABLE_AS_LAYOUT_KEYS):
+        if column is not None and isinstance(column.data_type, _TYPES_UNUSABLE_AS_PARTITION_KEYS):
             raise ValueError(
                 f"Partition column {name!r} has type"
                 f" {type(column.data_type).__name__}, which Delta cannot partition by"
             )
     for name in clustered_by:
         column = columns_by_name.get(name)
-        if column is not None and isinstance(column.data_type, _TYPES_UNUSABLE_AS_LAYOUT_KEYS):
+        if column is not None and isinstance(column.data_type, _TYPES_UNUSABLE_AS_CLUSTERING_KEYS):
             raise ValueError(
                 f"Clustering column {name!r} has type"
                 f" {type(column.data_type).__name__}, which cannot be a clustering key"

--- a/src/delta_engine/domain/model/data_type.py
+++ b/src/delta_engine/domain/model/data_type.py
@@ -154,3 +154,8 @@ class Map(DataType):
 
     key: DataType
     value: DataType
+
+    def __post_init__(self) -> None:
+        # Databricks accepts any MAP key type except MAP itself.
+        if isinstance(self.key, Map):
+            raise ValueError("Map key type must not be a Map")

--- a/tests/adapters/databricks/sql/strategies.py
+++ b/tests/adapters/databricks/sql/strategies.py
@@ -204,9 +204,12 @@ def _struct_documents(
 def _nested_type_documents(
     children: st.SearchStrategy[TypeDocument],
 ) -> st.SearchStrategy[TypeDocument]:
+    # A MAP key may be any type except MAP itself, so keys exclude map documents
+    # (the value stays unrestricted).
+    map_keys = children.filter(lambda item: item[1]["name"] != "map")
     return st.one_of(
         children.map(_array_document),
-        st.tuples(children, children).map(_map_document),
+        st.tuples(map_keys, children).map(_map_document),
         _struct_documents(children),
     )
 

--- a/tests/api/test_delta_table.py
+++ b/tests/api/test_delta_table.py
@@ -12,6 +12,8 @@ from delta_engine.domain.model import (
 from delta_engine.domain.model.constraints import PrimaryKeyConstraint
 from delta_engine.schema import (
     Array,
+    Binary,
+    Boolean,
     Column,
     Date,
     DeltaTable,
@@ -190,6 +192,35 @@ def test_delta_table_rejects_complex_typed_clustering_column():
             columns=[Column("id", Integer()), Column("attrs", Map(String(), String()))],
             clustered_by=["attrs"],
         )
+
+
+@pytest.mark.parametrize("data_type", [Boolean(), Binary()])
+def test_delta_table_rejects_boolean_or_binary_clustering_column(data_type):
+    # Liquid clustering's supported-type list excludes Boolean and Binary, even
+    # though both are valid partition columns.
+    with pytest.raises(ValueError, match="clustering key"):
+        DeltaTable(
+            catalog="main",
+            schema="sales",
+            name="orders",
+            columns=[Column("id", Integer()), Column("flag", data_type)],
+            clustered_by=["flag"],
+        )
+
+
+@pytest.mark.parametrize("data_type", [Boolean(), Binary()])
+def test_delta_table_accepts_boolean_or_binary_partition_column(data_type):
+    # Partitioning and clustering have distinct type rules: Boolean and Binary
+    # are rejected as clustering keys but accepted as partition columns.
+    table = DeltaTable(
+        catalog="main",
+        schema="sales",
+        name="orders",
+        columns=[Column("id", Integer()), Column("flag", data_type)],
+        partitioned_by=["flag"],
+    )
+
+    assert table.partitioned_by == ("flag",)
 
 
 @pytest.mark.parametrize(

--- a/tests/domain/model/test_data_type.py
+++ b/tests/domain/model/test_data_type.py
@@ -5,6 +5,7 @@ from delta_engine.domain.model.data_type import (
     Array,
     Decimal,
     Integer,
+    Map,
     String,
     Struct,
     StructField,
@@ -66,3 +67,15 @@ def test_struct_accepts_fields_as_a_list_and_compares_equal_to_tuple_form() -> N
 
     assert from_list == from_tuple
     assert from_list.fields == (StructField("a", Integer()),)
+
+
+def test_map_rejects_a_map_key_type() -> None:
+    # Databricks allows any MAP key type except MAP itself.
+    with pytest.raises(ValueError, match="key"):
+        Map(Map(String(), Integer()), String())
+
+
+def test_map_allows_a_map_value_type() -> None:
+    # Only the key is restricted; a MAP value may itself be a MAP.
+    nested = Map(String(), Map(String(), Integer()))
+    assert nested.value == Map(String(), Integer())

--- a/tests/live/test_sql_warehouse_live_platform_assumptions.py
+++ b/tests/live/test_sql_warehouse_live_platform_assumptions.py
@@ -216,12 +216,13 @@ def test_platform_rejects_a_complex_type_as_a_partition_column(live_connection, 
     # Delta refuses complex/nested types as partition columns, raising
     # INVALID_PARTITION_COLUMN_DATA_TYPE (error class confirmed live
     # 2026-07-14; the older DELTA_INVALID_PARTITION_COLUMN_TYPE spelling no
-    # longer matches). This backs the layout gate in api/delta_table.py
-    # (_TYPES_UNUSABLE_AS_LAYOUT_KEYS), which rejects Array/Map/Struct/Variant
-    # as partition and clustering keys at declaration time; if the platform
-    # ever accepted one, that gate would be over-blocking. An array stands in
-    # for the complex-type category; the parallel clustering rejection is a
-    # distinct backend rule not pinned here.
+    # longer matches). This backs the partition gate in api/delta_table.py
+    # (_TYPES_UNUSABLE_AS_PARTITION_KEYS), which rejects Array/Map/Struct/Variant
+    # as partition columns at declaration time; if the platform ever accepted
+    # one, that gate would be over-blocking. An array stands in for the
+    # complex-type category. Clustering is a distinct backend rule with a
+    # narrower type list (_TYPES_UNUSABLE_AS_CLUSTERING_KEYS also excludes
+    # Boolean and Binary), not pinned here.
     array_name = live_tables("partition_array")
     with pytest.raises(ServerOperationError, match="INVALID_PARTITION_COLUMN_DATA_TYPE"):
         execute_sql(


### PR DESCRIPTION
## Summary

Item 7 of the [business-logic/Databricks correctness review](docs/todo/business-logic-delta-databricks-correctness-review.md): partitioning and clustering shared one unsupported-type tuple (`_TYPES_UNUSABLE_AS_LAYOUT_KEYS`). That's correct for the complex types (Array/Map/Struct/Variant), but Databricks' liquid clustering supported-type list also excludes Boolean and Binary — types it *does* allow as partition columns. Because the shared tuple didn't mention them, a `clustered_by` declaration on a Boolean or Binary column passed the engine's validation and only failed once the warehouse ran `CLUSTER BY` against it.

Separately, `Map` had no constraint on its `key` type, so `Map(key=Map(...), value=...)` constructed without complaint even though Databricks allows any MAP key type except MAP itself.

Both platform facts were verified against current Databricks docs before implementing (liquid clustering's supported-type list; MAP key-type restrictions).

## Changes

- `api/delta_table.py`: split `_TYPES_UNUSABLE_AS_LAYOUT_KEYS` into `_TYPES_UNUSABLE_AS_PARTITION_KEYS` (unchanged: Array/Map/Struct/Variant) and `_TYPES_UNUSABLE_AS_CLUSTERING_KEYS` (adds Boolean, Binary).
- `domain/model/data_type.py`: `Map.__post_init__` rejects a `Map` key type, matching the existing `Decimal`/`StructField` post-init validation pattern. A `Map` value may still be a `Map`.
- `tests/adapters/databricks/sql/strategies.py`: the shared AS JSON type-document strategy generated map-keyed maps for property tests; narrowed the map-key sub-strategy to exclude map documents (the value strategy is unrestricted).
- `tests/live/test_sql_warehouse_live_platform_assumptions.py`: updated the comment referencing the old constant name to reflect the split.
- Docs: item 7 marked resolved in the correctness-review doc.

Both fixes are deterministic declaration-time errors requiring no runtime probing, per the review's proposed solution.

## Tests

- API layer: parametrized tests asserting clustering rejects Boolean and Binary while partitioning still accepts them (proving the two rules are now distinct, not just additive).
- Domain layer: `Map` rejects a `Map` key, and still accepts a `Map` value.
- Implemented test-first (TDD): watched each new test fail for the right reason before adding the corresponding validation.

## Checks

- `uv run pytest` — 928 passed, coverage 98.06%
- `uv run mypy src`, `uv run ruff check src tests`, `uv run lint-imports` (7/7 contracts) — clean