### PR TITLE
fix: normalize identifier case to lowercase instead of rejecting mixed case

### DIFF
--- a/docs/reference-limitations.md
+++ b/docs/reference-limitations.md
@@ -19,15 +19,22 @@ the page with the detail.
 
 ## Identifier handling
 
-Declared identifiers must currently satisfy `name == name.casefold()`; they are
-rejected rather than normalized, while reader adapters casefold observed names.
-That is stricter than ordinary lowercase for some Unicode text. The engine also
-does not fully prevalidate Unity Catalog's length and character rules for
-catalog, schema, and table names, so quoting an accepted declaration does not
-guarantee that Databricks will accept it. Prefer simple lowercase object names
-until the identifier policy is aligned; column names that require special
-characters still need column mapping as described in [column mapping and
-dropping columns](how-to-configure-table.md#column-mapping-and-dropping-columns).
+Identifiers are case-insensitive, matching the platform: Databricks resolves
+all identifiers case-insensitively (backticked or not), and Unity Catalog
+stores catalog, schema, and table names in lowercase. The engine therefore
+accepts declarations in any case and normalizes every identifier — object
+name parts, column names, nested struct field names, and constraint names —
+to lowercase. A name that is already lowercase is preserved verbatim,
+including Unicode names such as `straße`. Case never distinguishes two
+identifiers, a case-only difference is never drift, and engine-created
+columns display in lowercase in the catalog.
+
+Declared catalog, schema, and table names are validated against Unity
+Catalog's object-name rules at declaration time: at most 255 characters, and
+no periods, spaces, forward slashes, control characters, or DEL. Column names
+are exempt from those rules; column names that require special characters
+need column mapping as described in [column mapping and dropping
+columns](how-to-configure-table.md#column-mapping-and-dropping-columns).
 
 ## What a sync manages
 

--- a/docs/todo/business-logic-delta-databricks-correctness-review.md
+++ b/docs/todo/business-logic-delta-databricks-correctness-review.md
@@ -35,7 +35,7 @@ path currently produces an incorrect result.
 | 3    | High     | Required Delta table features are not planned                 | Valid-looking plans fail during execution                          |
 | 4 ✅ | High     | Foreign-key types are checked against the wrong parent object | Invalid constraints pass declaration and resolution                |
 | 5 ✅ | Medium   | Clearing a column comment generates invalid SQL               | Warehouse execution fails on `UNSET COMMENT`                       |
-| 6    | Medium   | Identifier normalization disagrees with Unity Catalog         | Valid names can change identity; invalid object names pass locally |
+| 6 ✅ | Medium   | Identifier normalization disagrees with Unity Catalog         | Valid names can change identity; invalid object names pass locally |
 | 7 ✅ | Medium   | Layout and map-type validation is too permissive              | Unsupported declarations reach execution                           |
 | 8 ✅ | Medium   | `CREATE TABLE IF NOT EXISTS` can report false success         | A concurrent incompatible create is treated as success             |
 
@@ -304,6 +304,43 @@ DEL. See the
 
 Add Unicode regression tests that prove normalization never changes a valid
 lowercase identifier into a different spelling.
+
+### Resolved (2026-07-17)
+
+Resolved with one agreed policy change beyond the proposed solution: the
+engine no longer _rejects_ mixed-case declarations at all. The principle —
+reject what Databricks rejects, normalize what Databricks normalizes, no
+house rules beyond that. Identifiers are case-insensitive on the platform
+(backticked or not; backticks only widen the character set), Unity Catalog
+stores object names lowercase, and column display case is preserved but
+meaningless, so case is never identity and the engine canonicalizes rather
+than polices it.
+
+Identifier-carrying domain constructors now normalize with `str.lower()` in
+`__post_init__` instead of raising — `QualifiedName` parts, desired and
+observed column names, `renamed_from`, struct field names, constraint columns
+and names, and the partition/clustering lists. This is the normalization seam
+because the public `Column`/`StructField` are the domain classes re-exported;
+non-canonical names are now unrepresentable by construction. Reader adapters
+switched `casefold()` to `lower()`, fixing the defect where an
+already-lowercase name like `straße` was rejected on declaration and rewritten
+to `strasse` on observation. Declared catalog/schema/table parts are validated
+against the Unity Catalog object-name rules (at most 255 characters; no
+period, space, forward slash, control characters, or DEL — verified against
+the UC requirements page, uniform across the three parts) in the API layer,
+keeping the domain backend-free; column names stay governed by the
+column-mapping rules only. A case-only `renamed_from` collapses into the
+existing "cannot be renamed_from itself" rejection.
+
+Coverage: rejection tests flipped to normalization assertions; `straße`
+round-trip pins at the domain and the describe reader; a property-based test
+that normalization is identity on already-canonical names; a UC-rule
+rejection matrix (six rule classes across all three parts) plus a
+column-exemption test. Two live pins added for the next workflow run: Unity
+Catalog lowercases object names the way Python `lower()` does (and not the
+casefold), and the platform preserves column display case.
+`docs/reference-limitations.md` § Identifier handling rewritten from
+"known gap" to the new policy.
 
 ## 7. Separate partition and clustering type rules, and validate map keys
 

--- a/src/delta_engine/adapters/databricks/sql/describe.py
+++ b/src/delta_engine/adapters/databricks/sql/describe.py
@@ -66,8 +66,8 @@ def _parse_document(json_text: str, qualified_name: QualifiedName) -> TableDescr
         qualified_name=qualified_name,
         columns=_columns_from_json(document, qualified_name),
         comment=_string_or_empty(document, "comment", qualified_name, "table comment"),
-        partitioned_by=_casefolded_list(document, "partition_columns", qualified_name),
-        clustered_by=_casefolded_list(document, "clustering_columns", qualified_name),
+        partitioned_by=_lowercased_list(document, "partition_columns", qualified_name),
+        clustered_by=_lowercased_list(document, "clustering_columns", qualified_name),
         table_properties=_table_properties(document.get("table_properties"), qualified_name),
         relation_type=_optional_string(document, "type"),
         provider=_optional_string(document, "provider"),
@@ -104,7 +104,7 @@ def _columns_from_json(document: dict, qualified_name: QualifiedName) -> tuple[O
     for entry in columns_json:
         if not isinstance(entry, dict) or not isinstance(entry.get("name"), str):
             raise MetadataParseError(f"{qualified_name}: malformed column entry {entry!r}")
-        name = entry["name"].casefold()
+        name = entry["name"].lower()
         type_obj = entry.get("type")
         if not isinstance(type_obj, dict) or not isinstance(type_obj.get("name"), str):
             raise MetadataParseError(
@@ -154,9 +154,9 @@ def _table_properties(table_properties: object, qualified_name: QualifiedName) -
     return MappingProxyType(dict(table_properties))
 
 
-def _casefolded_list(document: dict, key: str, qualified_name: QualifiedName) -> tuple[str, ...]:
+def _lowercased_list(document: dict, key: str, qualified_name: QualifiedName) -> tuple[str, ...]:
     """
-    Read a layout column list (partition or clustering columns), casefolded.
+    Read a layout column list (partition or clustering columns), lowercased.
 
     Absent or null means no such layout. A present value of any other shape is
     drift, not "no layout", so it fails the read rather than silently reading as
@@ -169,4 +169,4 @@ def _casefolded_list(document: dict, key: str, qualified_name: QualifiedName) ->
         raise MetadataParseError(f"{qualified_name}: {key} is not a list, got {value!r}")
     if any(not isinstance(item, str) for item in value):
         raise MetadataParseError(f"{qualified_name}: {key} entries must be strings, got {value!r}")
-    return tuple(item.casefold() for item in value)
+    return tuple(item.lower() for item in value)

--- a/src/delta_engine/adapters/databricks/sql/describe.py
+++ b/src/delta_engine/adapters/databricks/sql/describe.py
@@ -66,8 +66,8 @@ def _parse_document(json_text: str, qualified_name: QualifiedName) -> TableDescr
         qualified_name=qualified_name,
         columns=_columns_from_json(document, qualified_name),
         comment=_string_or_empty(document, "comment", qualified_name, "table comment"),
-        partitioned_by=_lowercased_list(document, "partition_columns", qualified_name),
-        clustered_by=_lowercased_list(document, "clustering_columns", qualified_name),
+        partitioned_by=_string_list(document, "partition_columns", qualified_name),
+        clustered_by=_string_list(document, "clustering_columns", qualified_name),
         table_properties=_table_properties(document.get("table_properties"), qualified_name),
         relation_type=_optional_string(document, "type"),
         provider=_optional_string(document, "provider"),
@@ -104,7 +104,7 @@ def _columns_from_json(document: dict, qualified_name: QualifiedName) -> tuple[O
     for entry in columns_json:
         if not isinstance(entry, dict) or not isinstance(entry.get("name"), str):
             raise MetadataParseError(f"{qualified_name}: malformed column entry {entry!r}")
-        name = entry["name"].lower()
+        name = entry["name"]
         type_obj = entry.get("type")
         if not isinstance(type_obj, dict) or not isinstance(type_obj.get("name"), str):
             raise MetadataParseError(
@@ -154,13 +154,14 @@ def _table_properties(table_properties: object, qualified_name: QualifiedName) -
     return MappingProxyType(dict(table_properties))
 
 
-def _lowercased_list(document: dict, key: str, qualified_name: QualifiedName) -> tuple[str, ...]:
+def _string_list(document: dict, key: str, qualified_name: QualifiedName) -> tuple[str, ...]:
     """
-    Read a layout column list (partition or clustering columns), lowercased.
+    Read a layout column list (partition or clustering columns), verbatim.
 
     Absent or null means no such layout. A present value of any other shape is
     drift, not "no layout", so it fails the read rather than silently reading as
-    an empty layout.
+    an empty layout. Values carry the catalog's spelling; the domain table
+    canonicalizes them on construction.
     """
     value = document.get(key)
     if value is None:
@@ -169,4 +170,4 @@ def _lowercased_list(document: dict, key: str, qualified_name: QualifiedName) ->
         raise MetadataParseError(f"{qualified_name}: {key} is not a list, got {value!r}")
     if any(not isinstance(item, str) for item in value):
         raise MetadataParseError(f"{qualified_name}: {key} entries must be strings, got {value!r}")
-    return tuple(item.lower() for item in value)
+    return tuple(value)

--- a/src/delta_engine/adapters/databricks/sql/rows.py
+++ b/src/delta_engine/adapters/databricks/sql/rows.py
@@ -8,10 +8,10 @@ duck-typed catalog rows — pyspark ``Row`` or databricks-sql ``Row`` —
 accessed only by attribute lookups, so this module stays PySpark-free like
 the rest of the package.
 
-Identifier fields (constraint, column, table names) are casefolded here: the
-domain model requires lowercase identifiers, and normalising at the adapter
-boundary keeps that impedance mismatch out of the domain. Tag keys and values
-are case-sensitive and preserved verbatim.
+Identifier fields (constraint, column, table names) are lowercased here: the
+domain model stores identifiers in canonical lowercase, and normalising at the
+adapter boundary keeps pre-domain lookup keys (e.g. tag grouping) consistent
+with it. Tag keys and values are case-sensitive and preserved verbatim.
 """
 
 from collections.abc import Callable, Sequence
@@ -63,8 +63,8 @@ def read_primary_key(
     if not ordered:
         return None
     return PrimaryKeyConstraint(
-        columns=tuple(row.column_name.casefold() for row in ordered),
-        constraint_name=ordered[0].constraint_name.casefold(),
+        columns=tuple(row.column_name.lower() for row in ordered),
+        constraint_name=ordered[0].constraint_name.lower(),
     )
 
 
@@ -81,16 +81,16 @@ def read_foreign_keys(
     """
     grouped: dict[str, list[Any]] = {}
     for row in run_query(foreign_keys_query(qualified_name)):
-        grouped.setdefault(row.constraint_name.casefold(), []).append(row)
+        grouped.setdefault(row.constraint_name.lower(), []).append(row)
     return tuple(
         ForeignKeyConstraint(
-            local_columns=tuple(row.local_column.casefold() for row in group),
+            local_columns=tuple(row.local_column.lower() for row in group),
             referenced_table=QualifiedName(
-                group[0].referenced_catalog.casefold(),
-                group[0].referenced_schema.casefold(),
-                group[0].referenced_table.casefold(),
+                group[0].referenced_catalog.lower(),
+                group[0].referenced_schema.lower(),
+                group[0].referenced_table.lower(),
             ),
-            referenced_columns=tuple(row.referenced_column.casefold() for row in group),
+            referenced_columns=tuple(row.referenced_column.lower() for row in group),
             constraint_name=constraint_name,
         )
         for constraint_name, group in grouped.items()
@@ -104,11 +104,11 @@ def read_referencing_foreign_keys(
     """Read the inbound foreign keys owned by other tables that reference this one."""
     return tuple(
         ForeignKeyReference(
-            constraint_name=row.constraint_name.casefold(),
+            constraint_name=row.constraint_name.lower(),
             referencing_table=QualifiedName(
-                row.referencing_catalog.casefold(),
-                row.referencing_schema.casefold(),
-                row.referencing_table.casefold(),
+                row.referencing_catalog.lower(),
+                row.referencing_schema.lower(),
+                row.referencing_table.lower(),
             ),
         )
         for row in run_query(referencing_foreign_keys_query(qualified_name))
@@ -132,10 +132,10 @@ def read_column_tags(
     """
     Read all column tags of this table as ``{column_name: {tag: value}}``.
 
-    Column names are casefolded to match the domain's lowercase columns; tag
+    Column names are lowercased to match the domain's lowercase columns; tag
     keys and values are case-sensitive and returned verbatim.
     """
     grouped: dict[str, dict[str, str]] = {}
     for row in run_query(column_tags_query(qualified_name)):
-        grouped.setdefault(row.column_name.casefold(), {})[row.tag_name] = row.tag_value
+        grouped.setdefault(row.column_name.lower(), {})[row.tag_name] = row.tag_value
     return MappingProxyType({column: MappingProxyType(tags) for column, tags in grouped.items()})

--- a/src/delta_engine/adapters/databricks/sql/rows.py
+++ b/src/delta_engine/adapters/databricks/sql/rows.py
@@ -8,10 +8,12 @@ duck-typed catalog rows — pyspark ``Row`` or databricks-sql ``Row`` —
 accessed only by attribute lookups, so this module stays PySpark-free like
 the rest of the package.
 
-Identifier fields (constraint, column, table names) are lowercased here: the
-domain model stores identifiers in canonical lowercase, and normalising at the
-adapter boundary keeps pre-domain lookup keys (e.g. tag grouping) consistent
-with it. Tag keys and values are case-sensitive and preserved verbatim.
+Identifier normalization happens in the domain constructors, which store
+every identifier in canonical lowercase — mapped rows carry catalog values
+verbatim and let construction canonicalize. The one exception is
+``read_column_tags``, which builds a plain lookup dict keyed by column name
+before any domain object exists, so it lowercases its keys itself. Tag keys
+and values are case-sensitive and preserved verbatim.
 """
 
 from collections.abc import Callable, Sequence
@@ -63,8 +65,8 @@ def read_primary_key(
     if not ordered:
         return None
     return PrimaryKeyConstraint(
-        columns=tuple(row.column_name.lower() for row in ordered),
-        constraint_name=ordered[0].constraint_name.lower(),
+        columns=tuple(row.column_name for row in ordered),
+        constraint_name=ordered[0].constraint_name,
     )
 
 
@@ -81,16 +83,16 @@ def read_foreign_keys(
     """
     grouped: dict[str, list[Any]] = {}
     for row in run_query(foreign_keys_query(qualified_name)):
-        grouped.setdefault(row.constraint_name.lower(), []).append(row)
+        grouped.setdefault(row.constraint_name, []).append(row)
     return tuple(
         ForeignKeyConstraint(
-            local_columns=tuple(row.local_column.lower() for row in group),
+            local_columns=tuple(row.local_column for row in group),
             referenced_table=QualifiedName(
-                group[0].referenced_catalog.lower(),
-                group[0].referenced_schema.lower(),
-                group[0].referenced_table.lower(),
+                group[0].referenced_catalog,
+                group[0].referenced_schema,
+                group[0].referenced_table,
             ),
-            referenced_columns=tuple(row.referenced_column.lower() for row in group),
+            referenced_columns=tuple(row.referenced_column for row in group),
             constraint_name=constraint_name,
         )
         for constraint_name, group in grouped.items()
@@ -104,11 +106,11 @@ def read_referencing_foreign_keys(
     """Read the inbound foreign keys owned by other tables that reference this one."""
     return tuple(
         ForeignKeyReference(
-            constraint_name=row.constraint_name.lower(),
+            constraint_name=row.constraint_name,
             referencing_table=QualifiedName(
-                row.referencing_catalog.lower(),
-                row.referencing_schema.lower(),
-                row.referencing_table.lower(),
+                row.referencing_catalog,
+                row.referencing_schema,
+                row.referencing_table,
             ),
         )
         for row in run_query(referencing_foreign_keys_query(qualified_name))
@@ -132,7 +134,9 @@ def read_column_tags(
     """
     Read all column tags of this table as ``{column_name: {tag: value}}``.
 
-    Column names are lowercased to match the domain's lowercase columns; tag
+    The one adapter-side identifier lowering: this dict is probed with
+    domain-canonical column names, but it is a plain dict built before any
+    domain object exists, so nothing else can canonicalize its keys. Tag
     keys and values are case-sensitive and returned verbatim.
     """
     grouped: dict[str, dict[str, str]] = {}

--- a/src/delta_engine/adapters/databricks/sql/types.py
+++ b/src/delta_engine/adapters/databricks/sql/types.py
@@ -118,7 +118,7 @@ def data_type_from_json(type_obj: object) -> DataType | None:
 
     ``None`` covers a type the domain does not model (interval, void, geo,
     future types), malformed input, and domain constructor rejections (decimal
-    over the Delta limit, struct fields colliding after casefold). The column
+    over the Delta limit, struct fields colliding after lowercasing). The column
     reader treats ``None`` as an unreadable column and fails the read; the
     recursive element/key/value/field lookups here propagate it as an
     unmodelable nested type.
@@ -135,7 +135,7 @@ def _data_type_from_json(type_obj: object) -> DataType | None:
     name = type_obj.get("name")
     if not isinstance(name, str):
         return None
-    name = name.casefold()
+    name = name.lower()
 
     if name in _SIMPLE_TYPES:
         return _SIMPLE_TYPES[name]
@@ -187,7 +187,7 @@ def _struct_from_json(type_obj: dict) -> DataType | None:
         field_type = data_type_from_json(field.get("type"))
         if not isinstance(field_name, str) or field_type is None:
             return None
-        fields.append(StructField(name=field_name.casefold(), data_type=field_type))
+        fields.append(StructField(name=field_name.lower(), data_type=field_type))
     try:
         return Struct(tuple(fields))
     except ValueError:

--- a/src/delta_engine/adapters/databricks/sql/types.py
+++ b/src/delta_engine/adapters/databricks/sql/types.py
@@ -187,7 +187,7 @@ def _struct_from_json(type_obj: dict) -> DataType | None:
         field_type = data_type_from_json(field.get("type"))
         if not isinstance(field_name, str) or field_type is None:
             return None
-        fields.append(StructField(name=field_name.lower(), data_type=field_type))
+        fields.append(StructField(name=field_name, data_type=field_type))
     try:
         return Struct(tuple(fields))
     except ValueError:

--- a/src/delta_engine/api/delta_table.py
+++ b/src/delta_engine/api/delta_table.py
@@ -64,6 +64,15 @@ _ASPECTS_BY_SCOPE: Final[Mapping[str, frozenset[TableAspect]]] = {
 # Delta permits these characters in column names only under column mapping.
 _CHARACTERS_REQUIRING_COLUMN_MAPPING: Final[frozenset[str]] = frozenset(" ,;{}()\n\t=")
 
+# Unity Catalog rules for securable object names (catalogs, schemas, tables,
+# uniformly): at most 255 characters; no period, space, forward slash, ASCII
+# control character (00-1F hex), or DEL (7F hex). Column names are exempt —
+# their special characters are governed by column mapping instead.
+_OBJECT_NAME_MAX_LENGTH: Final[int] = 255
+_OBJECT_NAME_FORBIDDEN_CHARACTERS: Final[frozenset[str]] = frozenset(
+    {".", " ", "/", chr(0x7F), *(chr(code) for code in range(0x20))}
+)
+
 # Column names change data feed reserves for its own output columns.
 _CDF_RESERVED_COLUMN_NAMES: Final[frozenset[str]] = frozenset(
     {"_change_type", "_commit_version", "_commit_timestamp"}
@@ -102,6 +111,23 @@ class _SelfReference:
 
 
 Self: Final = _SelfReference()
+
+
+def _validate_object_name_parts(qualified_name: QualifiedName) -> None:
+    """Reject catalog, schema, or table name parts Unity Catalog cannot store."""
+    for label, part in zip(("catalog", "schema", "name"), qualified_name.parts, strict=True):
+        if len(part) > _OBJECT_NAME_MAX_LENGTH:
+            raise ValueError(
+                f"Table {label} is {len(part)} characters long; Unity Catalog"
+                f" limits object names to {_OBJECT_NAME_MAX_LENGTH} characters"
+            )
+        forbidden = sorted(set(part) & _OBJECT_NAME_FORBIDDEN_CHARACTERS)
+        if forbidden:
+            raise ValueError(
+                f"Table {label} {part!r} contains characters Unity Catalog"
+                f" forbids in object names: {forbidden}. Periods, spaces,"
+                " forward slashes, control characters, and DEL are not allowed."
+            )
 
 
 def _validate_tags(subject: str, tags: Mapping[str, str]) -> None:
@@ -521,6 +547,7 @@ class DeltaTable:
         )
 
         qualified_name = QualifiedName(catalog, schema, name)
+        _validate_object_name_parts(qualified_name)
         lowered_foreign_keys = tuple(
             declaration._to_constraint(qualified_name, columns, primary_key_columns)
             for declaration in (foreign_keys or ())

--- a/src/delta_engine/domain/model/column.py
+++ b/src/delta_engine/domain/model/column.py
@@ -11,8 +11,6 @@ def _validate_column_fields(name: str, tags: Mapping[str, str]) -> None:
     """Invariants shared by declared and observed columns."""
     if not name.strip():
         raise ValueError(f"Column name must not be blank: {name!r}")
-    if name != name.casefold():
-        raise ValueError(f"Column name must be lowercase: {name!r}")
     for tag_key in tags:
         if not tag_key.strip():
             raise ValueError(f"Tag key must not be blank: {tag_key!r}")
@@ -21,20 +19,21 @@ def _validate_column_fields(name: str, tags: Mapping[str, str]) -> None:
 @dataclass(frozen=True, slots=True)
 class DesiredColumn:
     """
-    Immutable column declaration with a casefold-stable name.
+    Immutable column declaration with a canonical-lowercase name.
 
     Exposed to users as ``Column`` through ``delta_engine.schema``; the
     domain name states the desired/observed side explicitly, mirroring
     :class:`ObservedColumn`.
 
     Attributes:
-        name: Column name. It must currently satisfy
-            ``name == name.casefold()`` and is stored verbatim.
+        name: Column name, lowercased on construction. Identifiers are
+            case-insensitive on the platform, so two names differing only in
+            case are the same column.
         data_type: Logical data type of the column.
         nullable: Whether the column accepts ``NULL`` values.
         comment: Optional column comment.
         tags: Read-only mapping of Unity Catalog column tag keys to values. Tag
-            keys are case-sensitive and are stored verbatim (never casefolded,
+            keys are case-sensitive and are stored verbatim (never lowercased,
             unlike the column name).
         renamed_from: The column's previous name, declaring a rename. Inert
             unless the old name is observed and the new one is not, so it is
@@ -51,13 +50,13 @@ class DesiredColumn:
     renamed_from: str | None = None
 
     def __post_init__(self) -> None:
+        object.__setattr__(self, "name", self.name.lower())
         object.__setattr__(self, "tags", MappingProxyType(dict(self.tags)))
         _validate_column_fields(self.name, self.tags)
         if self.renamed_from is not None:
             if not self.renamed_from.strip():
                 raise ValueError(f"renamed_from must not be blank: {self.renamed_from!r}")
-            if self.renamed_from != self.renamed_from.casefold():
-                raise ValueError(f"renamed_from must be lowercase: {self.renamed_from!r}")
+            object.__setattr__(self, "renamed_from", self.renamed_from.lower())
             if self.renamed_from == self.name:
                 raise ValueError(f"Column {self.name!r} cannot be renamed_from itself")
 
@@ -79,5 +78,6 @@ class ObservedColumn:
     tags: Mapping[str, str] = field(default_factory=dict)
 
     def __post_init__(self) -> None:
+        object.__setattr__(self, "name", self.name.lower())
         object.__setattr__(self, "tags", MappingProxyType(dict(self.tags)))
         _validate_column_fields(self.name, self.tags)

--- a/src/delta_engine/domain/model/constraints.py
+++ b/src/delta_engine/domain/model/constraints.py
@@ -26,7 +26,7 @@ class PrimaryKeyConstraint:
     constraint_name: str
 
     def __post_init__(self) -> None:
-        object.__setattr__(self, "columns", tuple(self.columns))
+        object.__setattr__(self, "columns", tuple(column.lower() for column in self.columns))
 
         if not self.columns:
             raise ValueError("columns must not be empty")
@@ -39,6 +39,7 @@ class PrimaryKeyConstraint:
 
         if not self.constraint_name.strip():
             raise ValueError("constraint_name must not be blank")
+        object.__setattr__(self, "constraint_name", self.constraint_name.lower())
 
     @classmethod
     def generate(cls, *, table_name: str, columns: tuple[str, ...]) -> Self:
@@ -106,11 +107,18 @@ class ForeignKeyConstraint:
                 f" {len(self.referenced_columns)} referenced"
             )
 
-        # Canonicalize: pairs are stored sorted by local column. Column order
-        # is not part of a foreign key's meaning (mirroring the primary key's
-        # set identity), so one canonical order makes identity, generated
-        # names, and rendered DDL independent of declaration order.
-        pairs = sorted(zip(self.local_columns, self.referenced_columns, strict=True))
+        # Canonicalize: names are lowercased, then pairs are stored sorted by
+        # local column. Column order is not part of a foreign key's meaning
+        # (mirroring the primary key's set identity), so one canonical order
+        # makes identity, generated names, and rendered DDL independent of
+        # declaration order and case.
+        pairs = sorted(
+            zip(
+                (column.lower() for column in self.local_columns),
+                (column.lower() for column in self.referenced_columns),
+                strict=True,
+            )
+        )
         object.__setattr__(self, "local_columns", tuple(pair[0] for pair in pairs))
         object.__setattr__(self, "referenced_columns", tuple(pair[1] for pair in pairs))
 
@@ -128,6 +136,7 @@ class ForeignKeyConstraint:
 
         if not self.constraint_name.strip():
             raise ValueError("constraint_name must not be blank")
+        object.__setattr__(self, "constraint_name", self.constraint_name.lower())
 
     @property
     def signature(self) -> tuple[tuple[str, ...], QualifiedName, tuple[str, ...]]:
@@ -164,3 +173,4 @@ class ForeignKeyReference:
     def __post_init__(self) -> None:
         if not self.constraint_name.strip():
             raise ValueError("constraint_name must not be blank")
+        object.__setattr__(self, "constraint_name", self.constraint_name.lower())

--- a/src/delta_engine/domain/model/data_type.py
+++ b/src/delta_engine/domain/model/data_type.py
@@ -118,8 +118,7 @@ class StructField:
     def __post_init__(self) -> None:
         if not self.name.strip():
             raise ValueError(f"Struct field name must not be blank: {self.name!r}")
-        if self.name != self.name.casefold():
-            raise ValueError(f"Struct field name must be lowercase: {self.name!r}")
+        object.__setattr__(self, "name", self.name.lower())
 
 
 @dataclass(frozen=True, slots=True)

--- a/src/delta_engine/domain/model/qualified_name.py
+++ b/src/delta_engine/domain/model/qualified_name.py
@@ -9,10 +9,14 @@ class QualifiedName:
     """
     Case-insensitive, fully qualified identifier (catalog.schema.name).
 
+    Parts are stored in canonical lowercase: identifiers are case-insensitive
+    on the platform and Unity Catalog stores object names lowercase, so two
+    names differing only in case are the same identifier and construct equal.
+
     Attributes:
-        catalog: Catalog name.
-        schema: Schema name.
-        name: Table or view name.
+        catalog: Catalog name, lowercased.
+        schema: Schema name, lowercased.
+        name: Table or view name, lowercased.
 
     """
 
@@ -28,8 +32,7 @@ class QualifiedName:
         ):
             if not value.strip():
                 raise ValueError(f"QualifiedName {field_name} must not be blank: {value!r}")
-            if value != value.casefold():
-                raise ValueError(f"QualifiedName {field_name} must be lowercase: {value!r}")
+            object.__setattr__(self, field_name, value.lower())
 
     def __str__(self) -> str:
         """Return the canonical fully qualified string ``catalog.schema.name``."""

--- a/src/delta_engine/domain/model/table.py
+++ b/src/delta_engine/domain/model/table.py
@@ -16,11 +16,7 @@ from delta_engine.domain.model.qualified_name import QualifiedName
 
 
 def _validate_key_column_list(kind: str, names: tuple[str, ...], column_names: set[str]) -> None:
-    """Rules shared by partition and clustering key lists: lowercase, existing, unique."""
-    for name in names:
-        if name != name.casefold():
-            raise ValueError(f"{kind} column name must be lowercase: {name!r}")
-
+    """Rules shared by partition and clustering key lists: existing and unique."""
     missing = [name for name in names if name not in column_names]
     if missing:
         raise ValueError(f"{kind} column not found: {', '.join(missing)}")
@@ -28,7 +24,7 @@ def _validate_key_column_list(kind: str, names: tuple[str, ...], column_names: s
     seen: set[str] = set()
     for name in names:
         if name in seen:
-            raise ValueError(f"Duplicate {kind.casefold()} column: {name}")
+            raise ValueError(f"Duplicate {kind.lower()} column: {name}")
         seen.add(name)
 
 
@@ -44,7 +40,7 @@ def _validate_table_structure(
     Validate the structural invariants shared by desired and observed tables.
 
     Columns must be non-empty and unique; partition and clustering columns
-    must be lowercase, must each exist in ``columns``, and must be unique.
+    must each exist in ``columns`` and must be unique.
     Primary key and foreign key local columns must each exist in ``columns``.
     Tag keys must not be blank.
     """
@@ -183,8 +179,8 @@ class DesiredTable:
         """
         object.__setattr__(self, "columns", tuple(self.columns))
         object.__setattr__(self, "tags", MappingProxyType(dict(self.tags)))
-        object.__setattr__(self, "partitioned_by", tuple(self.partitioned_by))
-        object.__setattr__(self, "clustered_by", tuple(self.clustered_by))
+        object.__setattr__(self, "partitioned_by", tuple(n.lower() for n in self.partitioned_by))
+        object.__setattr__(self, "clustered_by", tuple(n.lower() for n in self.clustered_by))
         object.__setattr__(self, "foreign_keys", tuple(self.foreign_keys))
         object.__setattr__(self, "properties", MappingProxyType(dict(self.properties)))
         object.__setattr__(self, "managed_aspects", frozenset(self.managed_aspects))
@@ -312,8 +308,8 @@ class ObservedTable:
     def __post_init__(self) -> None:
         object.__setattr__(self, "columns", tuple(self.columns))
         object.__setattr__(self, "tags", MappingProxyType(dict(self.tags)))
-        object.__setattr__(self, "partitioned_by", tuple(self.partitioned_by))
-        object.__setattr__(self, "clustered_by", tuple(self.clustered_by))
+        object.__setattr__(self, "partitioned_by", tuple(n.lower() for n in self.partitioned_by))
+        object.__setattr__(self, "clustered_by", tuple(n.lower() for n in self.clustered_by))
         object.__setattr__(self, "foreign_keys", tuple(self.foreign_keys))
         object.__setattr__(self, "properties", MappingProxyType(dict(self.properties)))
         object.__setattr__(

--- a/tests/adapters/databricks/sql/test_describe.py
+++ b/tests/adapters/databricks/sql/test_describe.py
@@ -82,7 +82,7 @@ def _valid_describe_documents(draw: st.DrawFn) -> DescribeCase:
         columns.append(column_document)
         expected_columns.append(
             ObservedColumn(
-                name=raw_name.casefold(),
+                name=raw_name.lower(),
                 data_type=data_type,
                 nullable=nullable,
                 comment=comment,
@@ -117,8 +117,10 @@ def _valid_describe_documents(draw: st.DrawFn) -> DescribeCase:
         document=document,
         columns=tuple(expected_columns),
         comment=comment,
-        partitioned_by=tuple(name.casefold() for name in partitioned_by),
-        clustered_by=tuple(name.casefold() for name in clustered_by),
+        # Layout lists are carried verbatim by the description; the domain
+        # table canonicalizes them on construction.
+        partitioned_by=tuple(partitioned_by),
+        clustered_by=tuple(clustered_by),
         properties=properties,
     )
 
@@ -172,7 +174,9 @@ def test_lowercase_unicode_column_name_is_preserved_verbatim():
     assert description.columns[0].name == "straße"
 
 
-def test_partitioning_and_clustering_lowercased_in_order():
+def test_partitioning_and_clustering_carried_verbatim_in_order():
+    # The description carries the catalog's spelling; identifier normalization
+    # happens once, in the domain constructors, not in the adapter carrier.
     description = _parse(
         _doc(
             partition_columns=["Region", "Store"],
@@ -184,8 +188,8 @@ def test_partitioning_and_clustering_lowercased_in_order():
             ],
         )
     )
-    assert description.partitioned_by == ("region", "store")
-    assert description.clustered_by == ("id",)
+    assert description.partitioned_by == ("Region", "Store")
+    assert description.clustered_by == ("ID",)
 
 
 def test_non_list_partition_columns_raises():

--- a/tests/adapters/databricks/sql/test_describe.py
+++ b/tests/adapters/databricks/sql/test_describe.py
@@ -163,7 +163,16 @@ def test_empty_table_comment_is_empty_string():
     assert _parse(json.dumps(doc)).comment == ""
 
 
-def test_partitioning_and_clustering_casefolded_in_order():
+def test_lowercase_unicode_column_name_is_preserved_verbatim():
+    # 'straße' is already lowercase; casefold would rewrite it to 'strasse',
+    # a different identifier from the one the catalog stores
+    description = _parse(
+        _doc(columns=[{"name": "straße", "type": {"name": "int"}, "nullable": True}])
+    )
+    assert description.columns[0].name == "straße"
+
+
+def test_partitioning_and_clustering_lowercased_in_order():
     description = _parse(
         _doc(
             partition_columns=["Region", "Store"],

--- a/tests/api/test_delta_table.py
+++ b/tests/api/test_delta_table.py
@@ -44,6 +44,52 @@ def test_delta_table_exposes_declared_name_parts():
     assert table.name == "orders"
 
 
+def test_mixed_case_declaration_normalizes_to_lowercase():
+    # Identifiers are case-insensitive on Databricks and Unity Catalog stores
+    # object names lowercase, so the declaration canonicalizes rather than rejects
+    table = DeltaTable(
+        catalog="Main",
+        schema="Sales",
+        name="Orders",
+        columns=[Column("Id", Integer())],
+    )
+
+    assert (table.catalog, table.schema, table.name) == ("main", "sales", "orders")
+    assert [column.name for column in table.columns] == ["id"]
+
+
+@pytest.mark.parametrize(
+    "bad_part",
+    ["or.ders", "or ders", "or/ders", "or\x07ders", "or\x7fders", "x" * 256],
+    ids=["period", "space", "slash", "control-char", "del", "over-255-chars"],
+)
+@pytest.mark.parametrize("position", ["catalog", "schema", "name"])
+def test_rejects_name_parts_unity_catalog_forbids(position, bad_part):
+    # Unity Catalog object names: at most 255 characters; no period, space,
+    # forward slash, ASCII control characters, or DEL
+    parts = {"catalog": "main", "schema": "sales", "name": "orders", position: bad_part}
+    with pytest.raises(ValueError, match="Unity Catalog"):
+        DeltaTable(
+            catalog=parts["catalog"],
+            schema=parts["schema"],
+            name=parts["name"],
+            columns=[Column("id", Integer())],
+        )
+
+
+def test_column_names_are_exempt_from_object_name_rules():
+    # Column-name characters are governed by column mapping, not the Unity
+    # Catalog object-name rules: a forward slash needs no special handling
+    table = DeltaTable(
+        catalog="main",
+        schema="sales",
+        name="orders",
+        columns=[Column("id", Integer()), Column("net/gross", String())],
+    )
+
+    assert [column.name for column in table.columns] == ["id", "net/gross"]
+
+
 def test_delta_table_exposes_declared_columns():
     # Given a table declared with ordered columns
     table = DeltaTable(

--- a/tests/domain/model/test_column.py
+++ b/tests/domain/model/test_column.py
@@ -1,3 +1,4 @@
+from hypothesis import given, strategies as st
 import pytest
 
 from delta_engine.domain.model.column import DesiredColumn, ObservedColumn
@@ -12,12 +13,25 @@ def test_defaults_to_nullable_true() -> None:
     assert col.nullable is True
 
 
-def test_raises_when_name_is_not_lowercase() -> None:
-    # Given: a column name containing uppercase characters
-    # When: constructing a DesiredColumn
-    # Then: a ValueError is raised
-    with pytest.raises(ValueError, match="lowercase"):
-        DesiredColumn("UserId", Integer())
+def test_mixed_case_name_normalizes_to_lowercase() -> None:
+    # Given: a column name containing uppercase characters (case is never
+    # identity on Databricks, so the engine canonicalizes rather than rejects)
+    col = DesiredColumn("UserId", Integer())
+    # Then: the name is stored in canonical lowercase
+    assert col.name == "userid"
+
+
+def test_already_lowercase_unicode_name_is_preserved_verbatim() -> None:
+    # 'straße' is already lowercase; casefold would rewrite it to 'strasse',
+    # a different identifier from the one Unity Catalog stores
+    assert DesiredColumn("straße", Integer()).name == "straße"
+
+
+@given(st.text(min_size=1).map(str.lower).filter(str.strip))
+def test_normalization_is_identity_on_already_canonical_names(name: str) -> None:
+    # Given any name already in canonical lowercase form
+    # Then construction preserves it verbatim — normalizing twice changes nothing
+    assert DesiredColumn(name, Integer()).name == name
 
 
 @pytest.mark.parametrize("blank", ["", "   ", "\t"], ids=["empty", "spaces", "tab"])
@@ -68,21 +82,30 @@ def test_column_defaults_to_no_rename_hint() -> None:
     assert DesiredColumn("customer_name", String()).renamed_from is None
 
 
+def test_renamed_from_normalizes_to_lowercase() -> None:
+    column = DesiredColumn("customer_name", String(), renamed_from="Customer_NM")
+    assert column.renamed_from == "customer_nm"
+
+
 def test_column_rejects_malformed_renamed_from() -> None:
-    with pytest.raises(ValueError, match="lowercase"):
-        DesiredColumn("customer_name", String(), renamed_from="Customer_NM")
     with pytest.raises(ValueError, match="blank"):
         DesiredColumn("customer_name", String(), renamed_from="  ")
     with pytest.raises(ValueError, match="itself"):
         DesiredColumn("customer_name", String(), renamed_from="customer_name")
 
 
+def test_case_only_rename_collapses_to_renamed_from_itself() -> None:
+    # Case is not identity, so a case-only rename names the same column after
+    # normalization; there is nothing to rename
+    with pytest.raises(ValueError, match="itself"):
+        DesiredColumn("customer_name", String(), renamed_from="Customer_Name")
+
+
 def test_observed_column_enforces_the_same_field_invariants_as_column() -> None:
-    # Given/Then: blank and non-lowercase names are rejected, like DesiredColumn
+    # Given/Then: blank names are rejected and mixed case normalizes, like DesiredColumn
     with pytest.raises(ValueError, match="blank"):
         ObservedColumn("  ", Integer())
-    with pytest.raises(ValueError, match="lowercase"):
-        ObservedColumn("Amount", Integer())
+    assert ObservedColumn("Amount", Integer()).name == "amount"
 
     # And a well-formed observed column carries the observable fields
     column = ObservedColumn("amount", Integer(), nullable=False, comment="c", tags={"k": "v"})

--- a/tests/domain/model/test_data_type.py
+++ b/tests/domain/model/test_data_type.py
@@ -41,11 +41,11 @@ def test_decimal_accepts_maximum_precision_and_scale() -> None:
     assert Decimal(38, 38).precision == 38
 
 
-def test_struct_field_requires_lowercase_non_blank_name() -> None:
+def test_struct_field_requires_non_blank_name_and_normalizes_case() -> None:
     with pytest.raises(ValueError):
         StructField("", Integer())
-    with pytest.raises(ValueError):
-        StructField("Amount", Integer())
+    assert StructField("Amount", Integer()).name == "amount"
+    assert StructField("straße", Integer()).name == "straße"
 
 
 def test_struct_requires_at_least_one_field_and_unique_names() -> None:

--- a/tests/domain/model/test_foreign_key.py
+++ b/tests/domain/model/test_foreign_key.py
@@ -192,3 +192,15 @@ def test_generate_names_identically_for_permuted_pairs():
     # Then the generated name is order-independent and canonical
     assert one.constraint_name == "orders_a_b_fk"
     assert two.constraint_name == "orders_a_b_fk"
+
+
+def test_mixed_case_columns_and_name_normalize_to_lowercase():
+    fk = ForeignKeyConstraint(
+        local_columns=("CustomerId",),
+        referenced_table=QualifiedName("cat", "sales", "customers"),
+        referenced_columns=("Id",),
+        constraint_name="Orders_CustomerId_FK",
+    )
+    assert fk.local_columns == ("customerid",)
+    assert fk.referenced_columns == ("id",)
+    assert fk.constraint_name == "orders_customerid_fk"

--- a/tests/domain/model/test_primary_key.py
+++ b/tests/domain/model/test_primary_key.py
@@ -37,3 +37,9 @@ def test_generate_names_constraint_from_table():
     # Then the name follows {table}_pk and the columns are carried through
     assert constraint.constraint_name == "orders_pk"
     assert constraint.columns == ("id",)
+
+
+def test_mixed_case_columns_and_name_normalize_to_lowercase():
+    pk = PrimaryKeyConstraint(columns=("OrderId",), constraint_name="Orders_PK")
+    assert pk.columns == ("orderid",)
+    assert pk.constraint_name == "orders_pk"

--- a/tests/domain/model/test_qualified_name.py
+++ b/tests/domain/model/test_qualified_name.py
@@ -11,16 +11,23 @@ def test_string_representation_is_canonical_fully_qualified_name() -> None:
     assert str(qn) == "core.public.orders"
 
 
-def test_raises_when_any_part_is_not_lowercase() -> None:
-    # Given / When / Then: each part raises when it contains uppercase
-    with pytest.raises(ValueError, match="lowercase"):
-        QualifiedName("MyCatalog", "schema", "table")
+def test_mixed_case_parts_normalize_to_lowercase() -> None:
+    # Given mixed-case parts (identifiers are case-insensitive on Databricks,
+    # and Unity Catalog stores object names lowercase)
+    qn = QualifiedName("MyCatalog", "MySchema", "MyTable")
 
-    with pytest.raises(ValueError, match="lowercase"):
-        QualifiedName("catalog", "MySchema", "table")
+    # Then every part is stored in the canonical lowercase form
+    assert qn.parts == ("mycatalog", "myschema", "mytable")
+    assert qn == QualifiedName("mycatalog", "myschema", "mytable")
 
-    with pytest.raises(ValueError, match="lowercase"):
-        QualifiedName("catalog", "schema", "MyTable")
+
+def test_lowercase_unicode_parts_are_preserved_verbatim() -> None:
+    # Given a part that is already lowercase but casefold-divergent
+    # (casefold would rewrite 'straße' to 'strasse' — a different identifier)
+    qn = QualifiedName("catalog", "schema", "straße")
+
+    # Then normalization does not change an already-lowercase name
+    assert qn.name == "straße"
 
 
 @pytest.mark.parametrize(
@@ -61,8 +68,10 @@ def test_parse_rejects_names_without_exactly_three_parts(raw: str) -> None:
         QualifiedName.parse(raw)
 
 
-def test_parse_delegates_part_validation_to_the_constructor() -> None:
+def test_parse_normalizes_parts_like_the_constructor() -> None:
     # Given a three-part string with an uppercase part
-    # When / Then parse raises the same lowercase error the constructor enforces
-    with pytest.raises(ValueError, match="lowercase"):
-        QualifiedName.parse("Core.public.orders")
+    # When parsing it
+    parsed = QualifiedName.parse("Core.public.orders")
+
+    # Then the part is normalized to the same canonical form the constructor produces
+    assert parsed == QualifiedName("core", "public", "orders")

--- a/tests/domain/model/test_table.py
+++ b/tests/domain/model/test_table.py
@@ -62,15 +62,15 @@ def test_fails_when_partition_references_undefined_column(table_type, column_typ
 
 
 @_EACH_TABLE_AND_COLUMN_TYPE
-def test_fails_when_partition_column_name_is_not_lowercase(table_type, column_type):
+def test_mixed_case_partition_reference_normalizes_to_lowercase(table_type, column_type):
     # Given: a column 'visit_date' and a partition spec naming it in upper case
     cols = (column_type("visit_date", Date()), column_type("id", Integer()))
 
     # When: constructing the table with a mixed-case partition reference
-    # Then: validation fails — partition column names must be lowercase, consistent
-    # with DesiredColumn and QualifiedName which reject non-lowercase identifiers at construction
-    with pytest.raises(ValueError, match="lowercase"):
-        table_type(_QUALIFIED_NAME, cols, partitioned_by=("VISIT_DATE",))
+    table = table_type(_QUALIFIED_NAME, cols, partitioned_by=("VISIT_DATE",))
+
+    # Then: the reference normalizes and resolves to the declared column
+    assert table.partitioned_by == ("visit_date",)
 
 
 @_EACH_TABLE_AND_COLUMN_TYPE
@@ -577,10 +577,10 @@ def test_table_rejects_clustering_column_not_in_columns(table_type, column_type)
 
 
 @_EACH_TABLE_AND_COLUMN_TYPE
-def test_table_rejects_non_lowercase_clustering_column(table_type, column_type):
+def test_mixed_case_clustering_reference_normalizes_to_lowercase(table_type, column_type):
     columns = (column_type("id", Integer()), column_type("region", String()))
-    with pytest.raises(ValueError, match="lowercase"):
-        table_type(_QUALIFIED_NAME, columns, clustered_by=("REGION",))
+    table = table_type(_QUALIFIED_NAME, columns, clustered_by=("REGION",))
+    assert table.clustered_by == ("region",)
 
 
 @_EACH_TABLE_AND_COLUMN_TYPE

--- a/tests/live/test_sql_warehouse_live_platform_assumptions.py
+++ b/tests/live/test_sql_warehouse_live_platform_assumptions.py
@@ -14,8 +14,10 @@ from databricks.sql.exc import ServerOperationError
 
 from tests.live.sql_warehouse_live_helpers import (
     execute_sql,
+    fetch_rows,
     qualified_table,
     read_live_table,
+    table_exists,
 )
 
 
@@ -230,3 +232,37 @@ def test_platform_rejects_a_complex_type_as_a_partition_column(live_connection, 
             f"CREATE TABLE {qualified_table(array_name)} "
             "(id INT, labels ARRAY<INT>) USING DELTA PARTITIONED BY (labels)",
         )
+
+
+def test_unity_catalog_lowercases_object_names_like_python_lower(live_connection, live_tables):
+    """Unity Catalog stores object names as the Python str.lower of the declared name."""
+    # The engine canonicalizes declared identifiers with str.lower(). The pin
+    # covers both halves of that choice: an uppercase non-ASCII name is stored
+    # as its Python lowercase, and the stored form is NOT the casefold ('ß'
+    # lowers to itself but casefolds to 'ss' — a different identifier). If
+    # either assertion fails, the engine's canonical form has diverged from
+    # what the platform stores.
+    declared = live_tables("GRÖßE")
+    execute_sql(
+        live_connection,
+        f"CREATE TABLE {qualified_table(declared)} (id INT) USING DELTA",
+    )
+
+    assert table_exists(live_connection, declared.lower())
+    assert not table_exists(live_connection, declared.casefold())
+
+
+def test_platform_preserves_column_display_case(live_connection, live_tables):
+    """Databricks preserves the declared casing of column names."""
+    # Column case is display metadata: references resolve case-insensitively,
+    # but DESCRIBE echoes the creator's casing back. This is what makes the
+    # reader's lowercasing of observed column names real normalization work
+    # rather than a no-op, and why engine-created columns display lowercase.
+    table_name = live_tables("column_case")
+    execute_sql(
+        live_connection,
+        f"CREATE TABLE {qualified_table(table_name)} (`MyCol` INT) USING DELTA",
+    )
+
+    rows = fetch_rows(live_connection, f"DESCRIBE TABLE {qualified_table(table_name)}")
+    assert rows[0]["col_name"] == "MyCol"


### PR DESCRIPTION
## Summary

Item 6 of the [business-logic/Databricks correctness review](docs/todo/business-logic-delta-databricks-correctness-review.md), resolved with one agreed policy change beyond the review's original proposed solution.

The engine used `casefold()` to mean lowercase — a stronger Unicode fold that rejected valid already-lowercase names like `straße` on declaration and silently rewrote them to `strasse` on observation. Declared catalog/schema/table parts were also never checked against Unity Catalog's naming rules, so a name the platform would reject (too long, forbidden character) passed locally and only failed at execution.

**Policy change:** the engine no longer *rejects* mixed-case declarations. Principle agreed with @Tomoscorbin: reject what Databricks rejects, normalize what Databricks normalizes, no house rules beyond that. Verified against the docs: identifiers are case-insensitive on Databricks whether backticked or not (backticks only widen the allowed character set), Unity Catalog stores catalog/schema/table names lowercase, and column case is preserved but has no effect on resolution. Since case is never identity on the platform, the engine now canonicalizes rather than polices it — the one accepted cosmetic cost is that engine-created columns display lowercase in the catalog.

## Changes

- Identifier-carrying domain constructors normalize with `str.lower()` in `__post_init__` instead of raising: `QualifiedName` parts, `DesiredColumn`/`ObservedColumn` names and `renamed_from`, `StructField` names, `PrimaryKeyConstraint`/`ForeignKeyConstraint` columns and constraint names, and the `partitioned_by`/`clustered_by` lists. This is the normalization seam because the public `Column`/`StructField` are the domain classes themselves (re-exported through `delta_engine.schema`) — there is no separate API-boundary hook for column names.
- Reader adapters (`sql/rows.py`, `sql/describe.py`, `sql/types.py`) switch `casefold()` to `lower()`.
- `api/delta_table.py` validates declared catalog/schema/table parts against Unity Catalog's object-name rules (≤255 characters; no period, space, forward slash, control characters, or DEL — verified against the UC requirements page, uniform across the three parts) at construction. Column names are exempt; they stay governed by the existing column-mapping character rules only.
- `docs/reference-limitations.md` § "Identifier handling" rewritten from documenting the casefold gap to describing the new policy.
- Item 6 marked resolved in the correctness-review doc.

## Tests

- Domain: lowercase-rejection tests flipped to normalization assertions (`QualifiedName`, columns, `StructField`, PK/FK constraints); `straße` round-trips verbatim at construction; a Hypothesis property test asserts normalization is identity on already-canonical names; a case-only `renamed_from` collapses into the existing "cannot be renamed_from itself" rejection.
- Adapter: `straße` round-trips verbatim through the AS JSON describe reader (previously corrupted to `strasse`).
- API: a UC-rule rejection matrix (6 rule classes × 3 name-part positions) plus a test that column names are exempt from object-name character rules.
- Live (added for the next Live workflow run, not part of the default suite): Unity Catalog lowercases object names the way Python `str.lower()` does — and not the way `casefold()` does, pinned against a table named with an uppercase non-ASCII character; the platform preserves column display case, which is what makes the reader's lowercasing real normalization rather than a no-op.
- Implemented test-first (TDD), five RED/GREEN cycles.

## Checks

- `uv run pytest` — 956 passed, coverage 98.06%, zero fallout beyond the deliberately flipped tests
- `uv run mypy src`, `uv run ruff check src tests`, `uv run lint-imports` (7/7 contracts) — clean
- `uv run --group docs sphinx-build -b html docs docs/_build/html -W` — clean