### PR TITLE
refactor: consolidate named scope policy

### DIFF
--- a/docs/todo/policy-visibility-review.md
+++ b/docs/todo/policy-visibility-review.md
@@ -73,23 +73,17 @@ needs no further judgement, while a `TableDrift` is evaluated by every
 configured `SafetyRule`. The adjacent tuples therefore show every validation
 mechanism and its deterministic evaluation order in one short block.
 
-### Named scopes
+### Named scopes — consolidated
 
-Scope semantics are spread across:
+`application/scopes.py` owns the public scope names, their aspect sets, and
+the name-to-aspects translation. `DeltaTable` resolves its `scope` at the API
+boundary, while `StreamingTableTagsOnly` reuses `TAG_ASPECTS`; the public
+`"tags"` definition and streaming-table allowance cannot diverge.
 
-- scope-to-aspect mapping in `api/delta_table.py`;
-- streaming-table allowed aspects in `application/validation.py`;
-- the property exception in `domain/plan/diff.py`; and
-- managed foreign-key filtering in `application/dependency_resolution.py`.
-
-The latter two need to act locally, but the definitions of `full`, `metadata`,
-and `tags` should have one owner. An `application/scopes.py` module could hold
-the named aspect sets and their mapping. The API would translate public scope
-names there, and streaming validation would reuse the same tag-aspect set
-instead of restating it.
-
-The domain should continue to receive only `managed_aspects`; it should not
-import application policy.
+The domain continues to receive only `managed_aspects`. Its property exception
+in `domain/plan/diff.py` and the managed foreign-key filtering in
+`application/dependency_resolution.py` remain local consumers of individual
+aspects, rather than importing application policy.
 
 ### Execution sequencing
 

--- a/src/delta_engine/api/delta_table.py
+++ b/src/delta_engine/api/delta_table.py
@@ -14,11 +14,11 @@ from __future__ import annotations
 from collections.abc import Iterable, Mapping, Sequence
 from dataclasses import dataclass
 from types import MappingProxyType
-from typing import Final, Literal, NamedTuple
+from typing import Final, NamedTuple
 
 from delta_engine.application.properties import DELTA_PROPERTY_POLICY, Property
+from delta_engine.application.scopes import ScopeName, managed_aspects_for
 from delta_engine.domain.model import (
-    ALL_ASPECTS,
     Array,
     Binary,
     Boolean,
@@ -33,33 +33,6 @@ from delta_engine.domain.model import (
     TableAspect,
     Variant,
 )
-
-METADATA_ASPECTS: Final[frozenset[TableAspect]] = frozenset(
-    {
-        TableAspect.TABLE_COMMENT,
-        TableAspect.COLUMN_COMMENTS,
-        TableAspect.COLUMN_TAGS,
-        TableAspect.TABLE_TAGS,
-        TableAspect.PRIMARY_KEY,
-        TableAspect.FOREIGN_KEYS,
-    }
-)
-
-TAG_ASPECTS: Final[frozenset[TableAspect]] = frozenset(
-    {
-        TableAspect.COLUMN_TAGS,
-        TableAspect.TABLE_TAGS,
-    }
-)
-
-# The public API exposes named scopes only, each mapping to an aspect set.
-# The TableAspect enum stays internal so a declaration can only manage
-# combinations the engine's safety rules are written against.
-_ASPECTS_BY_SCOPE: Final[Mapping[str, frozenset[TableAspect]]] = {
-    "full": ALL_ASPECTS,
-    "metadata": METADATA_ASPECTS,
-    "tags": TAG_ASPECTS,
-}
 
 # Delta permits these characters in column names only under column mapping.
 _CHARACTERS_REQUIRING_COLUMN_MAPPING: Final[frozenset[str]] = frozenset(" ,;{}()\n\t=")
@@ -501,7 +474,7 @@ class DeltaTable:
         clustered_by: Iterable[str] = (),
         primary_key: Sequence[str] | None = None,
         foreign_keys: Iterable[ForeignKey] | None = None,
-        scope: Literal["full", "metadata", "tags"] = "full",
+        scope: ScopeName = "full",
     ) -> None:
         """
         Initialise a DeltaTable definition.
@@ -537,12 +510,7 @@ class DeltaTable:
                 does not manage properties never compares them at all.
 
         """
-        # The Literal type catches bad scopes at type-check time; this guard
-        # covers untyped callers.
-        if scope not in _ASPECTS_BY_SCOPE:
-            expected = ", ".join(repr(known_scope) for known_scope in _ASPECTS_BY_SCOPE)
-            raise ValueError(f"Unknown scope {scope!r}; expected one of: {expected}")
-        managed_aspects = _ASPECTS_BY_SCOPE[scope]
+        managed_aspects = managed_aspects_for(scope)
 
         user_properties = dict(properties or {})
         DELTA_PROPERTY_POLICY.validate_declaration(user_properties)

--- a/src/delta_engine/application/scopes.py
+++ b/src/delta_engine/application/scopes.py
@@ -1,0 +1,52 @@
+"""
+Named ownership scopes for Delta table declarations.
+
+The domain defines the complete ``TableAspect`` vocabulary. This module owns
+the supported public combinations and resolves a scope name at the API boundary.
+"""
+
+from typing import Final, Literal
+
+from delta_engine.domain.model import ALL_ASPECTS, TableAspect
+
+type ScopeName = Literal["full", "metadata", "tags"]
+
+METADATA_ASPECTS: Final[frozenset[TableAspect]] = frozenset(
+    {
+        TableAspect.TABLE_COMMENT,
+        TableAspect.COLUMN_COMMENTS,
+        TableAspect.TABLE_TAGS,
+        TableAspect.COLUMN_TAGS,
+        TableAspect.PRIMARY_KEY,
+        TableAspect.FOREIGN_KEYS,
+    }
+)
+
+TAG_ASPECTS: Final[frozenset[TableAspect]] = frozenset(
+    {
+        TableAspect.TABLE_TAGS,
+        TableAspect.COLUMN_TAGS,
+    }
+)
+
+_ASPECTS_BY_SCOPE: Final[dict[ScopeName, frozenset[TableAspect]]] = {
+    "full": ALL_ASPECTS,
+    "metadata": METADATA_ASPECTS,
+    "tags": TAG_ASPECTS,
+}
+
+
+def managed_aspects_for(scope: ScopeName) -> frozenset[TableAspect]:
+    """
+    Return the aspects managed by a public scope name.
+
+    Raises:
+        ValueError: If an untyped caller supplies an unknown scope name.
+
+    """
+    # Keep the runtime check for untyped callers.
+    if scope not in _ASPECTS_BY_SCOPE:
+        expected = ", ".join(repr(name) for name in _ASPECTS_BY_SCOPE)
+        raise ValueError(f"Unknown scope {scope!r}; expected one of: {expected}")
+
+    return _ASPECTS_BY_SCOPE[scope]

--- a/src/delta_engine/application/validation.py
+++ b/src/delta_engine/application/validation.py
@@ -11,6 +11,7 @@ from delta_engine.application.properties import (
     Property,
     PropertyPolicy,
 )
+from delta_engine.application.scopes import TAG_ASPECTS
 from delta_engine.domain.model import (
     Byte,
     DataType,
@@ -40,10 +41,6 @@ from delta_engine.domain.plan import (
     TableDrift,
     TableMissing,
     UnsetProperty,
-)
-
-_STREAMING_TABLE_MANAGEABLE_ASPECTS: Final[frozenset[TableAspect]] = frozenset(
-    {TableAspect.TABLE_TAGS, TableAspect.COLUMN_TAGS}
 )
 
 # The widenings Delta can apply in place (observed -> desired), per the
@@ -565,6 +562,8 @@ class StreamingTableTagsOnly:
     outside it. The gate judges the declaration's claimed aspects against the
     observed kind — not the drift — so it fires even when the table is
     currently in sync, and a dry run surfaces the misdeclaration immediately.
+    ``TAG_ASPECTS`` is shared with the public ``"tags"`` scope so the two
+    policies cannot diverge.
     """
 
     name: ClassVar[str] = "StreamingTableTagsOnly"
@@ -578,7 +577,7 @@ class StreamingTableTagsOnly:
             case TableDrift() as drift:
                 if drift.observed.kind is not TableKind.STREAMING_TABLE:
                     return ()
-                if drift.desired.managed_aspects <= _STREAMING_TABLE_MANAGEABLE_ASPECTS:
+                if drift.desired.managed_aspects <= TAG_ASPECTS:
                     return ()
                 return (
                     ValidationFailure(

--- a/tests/api/test_delta_table.py
+++ b/tests/api/test_delta_table.py
@@ -2,7 +2,7 @@ from types import MappingProxyType
 
 import pytest
 
-from delta_engine.api.delta_table import METADATA_ASPECTS, TAG_ASPECTS
+from delta_engine.application.scopes import METADATA_ASPECTS, TAG_ASPECTS
 from delta_engine.domain.model import (
     ALL_ASPECTS,
     DesiredColumn as DomainColumn,

--- a/tests/application/test_scopes.py
+++ b/tests/application/test_scopes.py
@@ -1,0 +1,35 @@
+import pytest
+
+from delta_engine.application.scopes import managed_aspects_for
+from delta_engine.domain.model import ALL_ASPECTS, TableAspect
+
+
+def test_full_scope_manages_every_aspect():
+    assert managed_aspects_for("full") == ALL_ASPECTS
+
+
+def test_metadata_scope_manages_only_catalog_metadata():
+    assert managed_aspects_for("metadata") == frozenset(
+        {
+            TableAspect.TABLE_COMMENT,
+            TableAspect.COLUMN_COMMENTS,
+            TableAspect.TABLE_TAGS,
+            TableAspect.COLUMN_TAGS,
+            TableAspect.PRIMARY_KEY,
+            TableAspect.FOREIGN_KEYS,
+        }
+    )
+
+
+def test_tags_scope_manages_only_tags():
+    assert managed_aspects_for("tags") == frozenset(
+        {
+            TableAspect.TABLE_TAGS,
+            TableAspect.COLUMN_TAGS,
+        }
+    )
+
+
+def test_unknown_scope_is_rejected():
+    with pytest.raises(ValueError):
+        managed_aspects_for("everything")


### PR DESCRIPTION
## Summary

- add `application/scopes.py` as the single owner of public scope names and aspect sets
- resolve `DeltaTable.scope` through that application boundary
- reuse `TAG_ASPECTS` for streaming-table validation
- document the consolidated policy and add focused mapping tests

## Why

The definitions of `full`, `metadata`, and `tags` were split between the API and validation. In particular, streaming validation restated the tag aspect set, allowing the public `tags` scope and streaming-table allowance to diverge over time.

## Impact

This is an organizational refactor with no intended behavior change. The domain still receives only `managed_aspects`; local property and foreign-key checks remain where they act.

## Validation

- `uv run pytest` — 977 passed, 63 deselected
- `uv run ruff check .`
- `uv run ruff format --check` on changed Python files
- `uv run mypy src tests`
- `uv run lint-imports`
- `git diff --check`
