### PR TITLE
refactor: consolidate execution sequencing

### DIFF
--- a/docs/explanation-architecture.md
+++ b/docs/explanation-architecture.md
@@ -116,17 +116,16 @@ flowchart LR
 a plan to the backend statements that apply it — the plan carries the observed
 relation kind its actions lower against, so the SQL dialect follows what the
 reader saw — and the engine calls it in the plan phase on every run, dry or
-real, recording the statements on the table's report. `execute(statements)` then runs that same tuple and returns an
-`ExecutionSummary` with one result per attempted statement, so the previewed
-SQL is exactly what executes.
+real, recording the statements on the table's report. On a real run, the
+engine passes that same tuple to `execute(statement)` one statement at a time,
+so the previewed SQL is exactly what executes.
 
-`fetch_state` and `execute` are **total**. Adapter implementations catch
-backend exceptions and return typed failures instead of raising
-backend-specific exceptions through the port. This is not just a convenience
-for callers. It is what lets one unreadable or unmodifiable table fail while
-the engine keeps processing the rest of the run and returns a complete report.
-`compile` is the exception: it is pure and local, cannot fail against a
-backend, and an exception from it is a programming error that propagates.
+`fetch_state` is **total**: adapters return `ReadFailed` instead of raising.
+For execution, adapters translate backend exceptions into the application-owned
+`ExecutionError`. The engine catches that specific exception, records an
+`ExecutionFailure`, stops that table's remaining statements, and continues
+with independent tables. Unexpected exceptions still propagate. `compile` is
+pure and local; an exception from it is likewise a programming error.
 
 The Databricks adapters also own backend normalization, most of it shared
 between the two backends through the `sql` core and the `read` assembly. Both
@@ -267,8 +266,11 @@ sequenceDiagram
     Executor-->>Engine: SQL statements
     Engine->>Resolver: resolve(tables, blocked=failed_tables)
     Resolver-->>Engine: dependency order + FK failures
-    Engine->>Executor: execute(statements)
-    Executor-->>Engine: ExecutionSummary
+    loop each statement until the first failure
+        Engine->>Executor: execute(statement)
+        Executor-->>Engine: success or ExecutionError
+    end
+    Engine->>Engine: build ExecutionSummary
     Engine-->>User: SyncReport or SyncFailedError(report)
 ```
 
@@ -304,8 +306,8 @@ skipped during execution. The engine still processes other tables.
 | `TableDiff`        | `diff_table`           | `plan_diff`                      | Direct actions and unresolvable differences |
 | `ActionPlan`       | successful `plan_diff` | Executor (`compile`), report     | Ordered, validated table-local actions      |
 | `CatalogState`     | Reader port            | Engine                           | Present, absent, or read-failed state       |
-| SQL statements     | Executor (`compile`)   | Executor (`execute`), report     | The DDL a plan lowers to                    |
-| `ExecutionSummary` | Executor port          | Engine, report                   | Attempted statement outcomes                |
+| SQL statements     | Executor (`compile`)   | Engine, executor, report         | The DDL a plan lowers to                    |
+| `ExecutionSummary` | Engine                 | Report                           | Attempted statement outcomes                |
 | `SyncReport`       | Engine                 | User code                        | Immutable run result                        |
 
 ## Package map
@@ -709,9 +711,9 @@ status from the earliest failing phase:
 
 The report keeps the full failure tuple, not just the status. That matters when
 a table has multiple validation failures or multiple FK failures. For execution,
-the Databricks executor stops at the first failed statement because the engine
-is not transactional and later statements may depend on earlier ones. The
-`ExecutionSummary` records all attempted statements up to that point.
+the engine stops at the first failed statement because it is not transactional
+and later statements may depend on earlier ones. The `ExecutionSummary` records
+all attempted statements up to that point.
 
 Reports also keep the plan even when execution does not happen. That makes dry
 runs useful and makes failed runs explainable: a user can inspect what would

--- a/docs/how-to-implement-adapter.md
+++ b/docs/how-to-implement-adapter.md
@@ -43,8 +43,7 @@ class MyReader:
 Execution is a two-stage boundary. `compile` turns a domain plan into the backend statements it lowers to, without touching the backend:
 
 ```python
-from delta_engine.application.ports import PlanExecutor, ExecutionSummary, ExecutionSucceeded, ExecutionFailed
-from delta_engine.application.failures import ExecutionFailure
+from delta_engine.application.ports import ExecutionError, PlanExecutor
 from delta_engine.domain.model import QualifiedName
 from delta_engine.domain.plan.actions import ActionPlan
 
@@ -64,32 +63,26 @@ dialect differs by kind (Databricks streaming tables take
 `ALTER STREAMING TABLE`) read it off the plan; a backend with one dialect
 may ignore it.
 
-`execute` then runs the statements `compile` produced — the engine passes the same tuple it recorded on the report, so what was previewed is exactly what runs. The statements are the complete unit of work; the table they target is already baked into each one by `compile`:
+The engine passes those same compiled statements to `execute` one at a time.
+The table they target is already baked into each statement. Returning normally
+means the statement succeeded; translate an expected backend failure into
+`ExecutionError`:
 
 ```python
-    def execute(self, statements: tuple[str, ...]) -> ExecutionSummary:
-        results = []
-        for i, statement in enumerate(statements):
-            try:
-                self._run(statement)
-                results.append(ExecutionSucceeded(
-                    statement_index=i,
-                    statement=statement,
-                ))
-            except Exception as exc:
-                results.append(ExecutionFailed(
-                    failure=ExecutionFailure(
-                        statement_index=i,
-                        exception_type=type(exc).__name__,
-                        message=str(exc),
-                        statement=statement,
-                    ),
-                ))
-                break  # stop at first failure — the engine is non-transactional
-        return ExecutionSummary(results=tuple(results))
+    def execute(self, statement: str) -> None:
+        try:
+            self._run(statement)
+        except Exception as exc:
+            raise ExecutionError(
+                exception_type=type(exc).__name__,
+                message=str(exc),
+            ) from exc
 ```
 
-`execute` **is** total. Stop at the first failure and return the summary — the engine records partial results and moves on to the next table.
+The application owns statement indexes, constructs the `ExecutionSummary`, and
+stops after the first `ExecutionError`. It then records the partial result and
+moves on to the next independent table. Exceptions other than
+`ExecutionError` are port-contract or programming errors and propagate.
 
 ## Wire the engine
 

--- a/docs/reference-run-report.md
+++ b/docs/reference-run-report.md
@@ -91,7 +91,7 @@ When a table executed, `execution` is:
 | `total`   | `int` | Statements planned (`planned_sql_statements`) |
 
 It is `None` for a dry run and for any table skipped by an earlier-phase
-failure. Execution runs statement by statement and stops at the first
+failure. The engine executes statement by statement and stops at the first
 failure, so `applied < total` means the trailing statements were never
 attempted.
 

--- a/docs/todo/business-logic-delta-databricks-correctness-review.md
+++ b/docs/todo/business-logic-delta-databricks-correctness-review.md
@@ -440,7 +440,7 @@ Relevant code:
 
 ### Proposed solution
 
-Remove `IF NOT EXISTS`. A concurrent create should produce an `ExecutionFailed`
+Remove `IF NOT EXISTS`. A concurrent create should produce an `ExecutionFailure`
 instead of a false success. The user can rerun synchronization, at which point
 the reader will observe and diff the table that actually exists.
 

--- a/docs/todo/policy-visibility-review.md
+++ b/docs/todo/policy-visibility-review.md
@@ -85,17 +85,19 @@ in `domain/plan/diff.py` and the managed foreign-key filtering in
 `application/dependency_resolution.py` remain local consumers of individual
 aspects, rather than importing application policy.
 
-### Execution sequencing
+### Execution sequencing — consolidated
 
-`adapters/databricks/execution.py` owns the stop-on-first-failure loop, even
-though both Databricks executors share it and adapter documentation describes
-the behavior as a general adapter contract.
+`Engine` owns the stop-on-first-failure loop and constructs each table's
+`ExecutionSummary`, including application-owned statement indexes. The
+`PlanExecutor` port executes one statement at a time: normal return means
+success, while an expected backend failure is translated to `ExecutionError`.
+The engine catches only that typed boundary error, records an
+`ExecutionFailure`, and leaves unexpected programming errors visible.
 
-If stop-on-first-failure is engine-wide policy, raise it to the application
-boundary. One possible shape is for adapters to execute and translate one
-statement, while application code owns iteration and stopping. If the policy
-is intentionally adapter-specific, the port documentation should say so
-explicitly.
+`adapters/databricks/execution.py` retains only the shared Databricks exception
+translation. Spark and warehouse adapters supply their physical one-statement
+runner, while the warehouse adapter also contains its per-statement cursor
+lifecycle.
 
 ### Constraint naming
 

--- a/src/delta_engine/adapters/databricks/execution.py
+++ b/src/delta_engine/adapters/databricks/execution.py
@@ -1,87 +1,39 @@
-"""
-Shared statement-execution loop for the Databricks backends.
+"""Translate Databricks statement failures into the application error."""
 
-Both backends execute compiled SQL statements one at a time, stop at the
-first failure, and record each statement verbatim on its result. Only one
-fact differs per backend — how a statement is physically executed — so it
-is injected as a callable. A failing exception is named by the shared
-py4j-aware resolver in :mod:`delta_engine.adapters.databricks.errors`.
-"""
-
-from collections.abc import Callable, Iterable
+from collections.abc import Callable
 import logging
 
 from delta_engine.adapters.databricks.errors import exception_message, exception_type_name
-from delta_engine.application.failures import ExecutionFailure
-from delta_engine.application.ports import (
-    ExecutionFailed,
-    ExecutionResult,
-    ExecutionSucceeded,
-    ExecutionSummary,
-)
+from delta_engine.application.ports import ExecutionError
 
 logger = logging.getLogger(__name__)
 
 
-def execute_statements(
+def execute_statement(
     execute: Callable[[str], object],
-    statements: Iterable[str],
-) -> ExecutionSummary:
-    """
-    Execute each statement in order, stopping at the first failure.
-
-    Execution stops at the first failure: the statements form a dependency
-    chain, and the engine is not transactional, so continuing past a failure
-    risks compounding a half-migrated table. The summary covers the
-    statements attempted, ending at the one that failed; statements after it
-    are left unattempted rather than run against an inconsistent table.
-    """
-    results: list[ExecutionResult] = []
-    for statement_index, statement in enumerate(statements):
-        result = _execute_statement(execute, statement_index, statement)
-        results.append(result)
-        if isinstance(result, ExecutionFailed):
-            break
-    return ExecutionSummary(tuple(results))
-
-
-def _execute_statement(
-    execute: Callable[[str], object],
-    statement_index: int,
     statement: str,
-) -> ExecutionResult:
+) -> None:
     """
-    Execute a single statement and map its outcome to an ``ExecutionResult``.
+    Execute one statement and normalize any backend exception.
 
-    The statement and any exception message are recorded verbatim — results
-    are what users debug from, so nothing is normalized or truncated here;
-    bounding long text is display policy, owned by the failure renderers.
+    The broad catch is intentional: the two Databricks clients raise different
+    exception families across runtime versions. This boundary translates all
+    of them into one application-owned error while preserving their useful
+    backend type and message. The application decides whether another
+    statement should be attempted.
 
-    The broad ``except`` is intentional: each backend raises a heterogeneous
-    set of failures that varies across runtime environments, and the
-    executor's contract is to wrap any failure in an ``ExecutionFailed`` so
-    the run can record it and stop cleanly — never to let a backend-specific
-    exception escape. Narrowing the catch would reintroduce silent
-    propagation of whichever type was missed.
+    Raises:
+        ExecutionError: The backend could not execute the statement.
+
     """
     try:
         execute(statement)
     except Exception as exception:
         message = exception_message(exception)
         logger.warning("Statement failed: %s\nSQL: %s", message, statement)
-        return ExecutionFailed(
-            failure=ExecutionFailure(
-                statement_index=statement_index,
-                exception_type=exception_type_name(exception),
-                message=message,
-                statement=statement,
-            ),
-        )
+        raise ExecutionError(
+            exception_type=exception_type_name(exception),
+            message=message,
+        ) from exception
 
-    # Per-statement narration is trace detail; the engine already reports
-    # per-table progress at INFO.
     logger.debug("Executed: %s", statement)
-    return ExecutionSucceeded(
-        statement_index=statement_index,
-        statement=statement,
-    )

--- a/src/delta_engine/adapters/databricks/read.py
+++ b/src/delta_engine/adapters/databricks/read.py
@@ -7,7 +7,7 @@ from information_schema as structured rows — Unity Catalog tags, this table's
 own primary and foreign keys, and inbound foreign keys. Only how a query is
 physically run differs per backend, so it is injected as a callable:
 ``read_catalog_state`` is the one entry point both readers call, the
-read-side twin of the write side's ``execution.execute_statements``. Each
+read-side twin of the write side's ``execution.execute_statement``. Each
 backend supplies only how a query runs (returning its rows) and owns its own
 connection resource; the describe, the acceptance policies (which relation
 kinds are read, which observed property keys become engine state), assembly,

--- a/src/delta_engine/adapters/databricks/spark/executor.py
+++ b/src/delta_engine/adapters/databricks/spark/executor.py
@@ -1,15 +1,9 @@
-"""
-Execute compiled statements on Databricks/Spark and capture results.
-
-Compiles an `ActionPlan` to SQL statements via the shared compiler, then runs
-them through the shared stop-on-first-failure loop with Spark as the runner.
-"""
+"""Compile plans and execute individual statements through Spark."""
 
 from pyspark.sql import SparkSession
 
-from delta_engine.adapters.databricks.execution import execute_statements
+from delta_engine.adapters.databricks.execution import execute_statement
 from delta_engine.adapters.databricks.sql import compile_plan
-from delta_engine.application.ports import ExecutionSummary
 from delta_engine.domain.model import QualifiedName
 from delta_engine.domain.plan import ActionPlan
 
@@ -24,6 +18,6 @@ class SparkExecutor:
         """Compile ``plan`` to its SQL statements in execution order, without touching Spark."""
         return compile_plan(qualified_name, plan)
 
-    def execute(self, statements: tuple[str, ...]) -> ExecutionSummary:
-        """Execute each statement in order via the shared stop-on-first-failure loop."""
-        return execute_statements(self.spark.sql, statements)
+    def execute(self, statement: str) -> None:
+        """Execute one statement, translating Spark failures at the shared boundary."""
+        execute_statement(self.spark.sql, statement)

--- a/src/delta_engine/adapters/databricks/sql/compile.py
+++ b/src/delta_engine/adapters/databricks/sql/compile.py
@@ -117,7 +117,7 @@ def _(action: CreateTable, target: _Target) -> str:
     # A plain CREATE TABLE (no IF NOT EXISTS). CreateTable is only emitted after
     # the reader reports the table absent, but the read and the create are not
     # atomic: if another process creates the name in that window, this statement
-    # errors and the executor reports ExecutionFailed rather than a false
+    # errors and the engine reports an ExecutionFailure rather than a false
     # success.
     parts = [
         f"CREATE TABLE {target.name}",

--- a/src/delta_engine/adapters/databricks/warehouse/executor.py
+++ b/src/delta_engine/adapters/databricks/warehouse/executor.py
@@ -1,20 +1,12 @@
-"""
-Execute compiled statements on a Databricks SQL warehouse and capture results.
-
-Compiles an `ActionPlan` to SQL via the shared compiler — byte-for-byte the
-same statements the Spark backend runs, so dry-run previews are
-backend-independent — and runs them through the shared stop-on-first-failure
-loop with a warehouse cursor as the runner.
-"""
+"""Compile plans and execute individual statements through a SQL warehouse."""
 
 from __future__ import annotations
 
 import contextlib
 from typing import TYPE_CHECKING
 
-from delta_engine.adapters.databricks.execution import execute_statements
+from delta_engine.adapters.databricks.execution import execute_statement
 from delta_engine.adapters.databricks.sql import compile_plan
-from delta_engine.application.ports import ExecutionSummary
 from delta_engine.domain.model import QualifiedName
 from delta_engine.domain.plan import ActionPlan
 
@@ -36,29 +28,24 @@ class WarehouseExecutor:
         """
         return compile_plan(qualified_name, plan)
 
-    def execute(self, statements: tuple[str, ...]) -> ExecutionSummary:
+    def execute(self, statement: str) -> None:
         """
-        Execute each statement in order via the shared stop-on-first-failure loop.
+        Execute one statement and contain the warehouse cursor lifecycle.
 
-        The cursor is acquired lazily, on the first statement, so the loop's
-        totality covers the whole cursor lifecycle as the port requires: a
-        connection that cannot produce a cursor (closed by the caller, or a
-        session that died after an earlier table's plan) is recorded as the
-        first statement's failure — the same outage one call later, inside
-        ``cursor.execute``, is already recorded that way. A close failure
-        after the loop is suppressed so it cannot discard the summary of
-        statements that actually ran.
+        Cursor acquisition happens inside the translated callable, so a closed
+        or expired connection raises the same application error as a failure
+        from ``cursor.execute``. A close failure is suppressed so it cannot
+        replace the outcome of the statement itself.
         """
         cursor: Cursor | None = None
 
         def run(statement: str) -> None:
             nonlocal cursor
-            if cursor is None:
-                cursor = self._connection.cursor()
+            cursor = self._connection.cursor()
             cursor.execute(statement)
 
         try:
-            return execute_statements(run, statements)
+            execute_statement(run, statement)
         finally:
             if cursor is not None:
                 with contextlib.suppress(Exception):

--- a/src/delta_engine/application/engine.py
+++ b/src/delta_engine/application/engine.py
@@ -47,12 +47,15 @@ from delta_engine.application.dependency_resolution import (
     resolve,
 )
 from delta_engine.application.errors import DuplicateTableDefinitionError, SyncFailedError
-from delta_engine.application.failures import Failure
+from delta_engine.application.failures import ExecutionFailure, Failure
 from delta_engine.application.planning import PlanningFailed, PlanningSucceeded, plan_diff
 from delta_engine.application.ports import (
     CatalogState,
     CatalogStateReader,
     DesiredTableSource,
+    ExecutionError,
+    ExecutionResult,
+    ExecutionSucceeded,
     ExecutionSummary,
     PlanExecutor,
     ReadFailed,
@@ -383,7 +386,7 @@ class Engine:
             if not run.plan:
                 continue
 
-            summary = self.executor.execute(run.planned_sql_statements)
+            summary = self._execute_statements(run.planned_sql_statements)
             run.execution = summary
             run.failures.extend(summary.failures)
 
@@ -398,3 +401,29 @@ class Engine:
             )
 
         return runs
+
+    def _execute_statements(self, statements: tuple[str, ...]) -> ExecutionSummary:
+        """Execute statements in order and stop after the first expected failure."""
+        results: list[ExecutionResult] = []
+        for index, statement in enumerate(statements):
+            try:
+                self.executor.execute(statement)
+            except ExecutionError as error:
+                results.append(
+                    ExecutionFailure(
+                        statement_index=index,
+                        statement=statement,
+                        exception_type=error.exception_type,
+                        message=str(error),
+                    )
+                )
+                break
+
+            results.append(
+                ExecutionSucceeded(
+                    statement_index=index,
+                    statement=statement,
+                )
+            )
+
+        return ExecutionSummary(tuple(results))

--- a/src/delta_engine/application/ports.py
+++ b/src/delta_engine/application/ports.py
@@ -79,6 +79,18 @@ class CatalogStateReader(Protocol):
         ...
 
 
+# ---------- Statement execution boundary ----------
+
+
+class ExecutionError(Exception):
+    """A normalized backend error raised while executing one statement."""
+
+    def __init__(self, exception_type: str, message: str) -> None:
+        """Initialize the error with backend-neutral diagnostic details."""
+        super().__init__(message)
+        self.exception_type = exception_type
+
+
 # ---------- ExecutionResult ----------
 
 
@@ -97,17 +109,9 @@ class ExecutionSucceeded:
     statement: str
 
 
-@dataclass(frozen=True, slots=True)
-class ExecutionFailed:
-    """A single statement that raised while executing."""
-
-    failure: ExecutionFailure
-
-
-# An executed statement either succeeds or fails. The split makes "succeeded but
-# carries a failure" (and "failed but carries none") unrepresentable, so no
-# runtime invariant guard is needed.
-type ExecutionResult = ExecutionSucceeded | ExecutionFailed
+# A completed statement is either recorded as successful or as the execution
+# failure itself.
+type ExecutionResult = ExecutionSucceeded | ExecutionFailure
 
 
 @dataclass(frozen=True, slots=True)
@@ -127,14 +131,12 @@ class ExecutionSummary:
     @property
     def failed(self) -> bool:
         """True when any statement failed."""
-        return any(isinstance(result, ExecutionFailed) for result in self.results)
+        return any(isinstance(result, ExecutionFailure) for result in self.results)
 
     @property
     def failures(self) -> tuple[ExecutionFailure, ...]:
         """The failure detail from each failed statement, in execution order."""
-        return tuple(
-            result.failure for result in self.results if isinstance(result, ExecutionFailed)
-        )
+        return tuple(result for result in self.results if isinstance(result, ExecutionFailure))
 
     @property
     def failed_count(self) -> int:
@@ -149,18 +151,19 @@ class ExecutionSummary:
 
 class PlanExecutor(Protocol):
     """
-    Compiles a plan into statements and runs them against a backing engine.
+    Compile a plan and execute individual statements against a backing engine.
 
     Execution is a two-stage boundary: ``compile`` turns a domain plan into the
-    backend statements it lowers to, and ``execute`` runs those statements. The
-    engine compiles once per invocation: a dry run exposes those statements,
-    while a real run passes that invocation's same statements to ``execute``.
+    backend statements it lowers to, and ``execute`` attempts one of those
+    statements. The engine compiles once per invocation: a dry run exposes those
+    statements, while a real run passes that invocation's same statements to
+    ``execute`` one at a time.
 
-    Like :class:`CatalogStateReader`, ``execute`` is **total**: a statement that
-    fails is captured in the returned ``ExecutionSummary`` (which records both the
-    statements that succeeded and the one that failed), not raised. The engine
-    records the summary on the table's report and moves on, so a failure executing
-    one table does not abort the others.
+    The application owns statement ordering, result construction, and stopping
+    after the first failure. An adapter contains its backend's exception types
+    and translates an expected execution failure into :class:`ExecutionError`.
+    The engine catches that specific exception and records an
+    :class:`ExecutionFailure`; unexpected programming errors still propagate.
     """
 
     def compile(self, qualified_name: QualifiedName, plan: ActionPlan) -> tuple[str, ...]:
@@ -172,7 +175,8 @@ class PlanExecutor(Protocol):
         from the plan.
 
         The ordering is the plan's own deterministic order, which is the order
-        ``execute`` runs the statements. An empty plan compiles to no statements.
+        the application passes statements to ``execute``. An empty plan compiles
+        to no statements.
 
         Pure and side-effect free: the engine calls this on every run -- dry or
         real -- to record the SQL on the table's report. Unlike ``execute``,
@@ -182,12 +186,20 @@ class PlanExecutor(Protocol):
         """
         ...
 
-    def execute(self, statements: tuple[str, ...]) -> ExecutionSummary:
+    def execute(self, statement: str) -> None:
         """
-        Run ``statements`` (from :meth:`compile`) in order.
+        Execute one statement produced by :meth:`compile`.
 
-        Total: failures are captured in the returned ``ExecutionSummary`` rather
-        than raised. The statements are the complete unit of work — the table
-        they target is already baked into each statement by ``compile``.
+        Returning normally means the statement succeeded. The application adds
+        the statement and its sequence index to the execution summary.
+
+        Args:
+            statement: The backend statement to execute verbatim.
+
+        Raises:
+            ExecutionError: The backend could not execute the statement. The
+                adapter must translate backend-specific exceptions into this
+                type.
+
         """
         ...

--- a/tests/adapters/databricks/spark/test_executor.py
+++ b/tests/adapters/databricks/spark/test_executor.py
@@ -2,7 +2,6 @@ import pyspark.sql.types as T
 
 from delta_engine.adapters.databricks.spark.executor import SparkExecutor
 from delta_engine.adapters.databricks.sql import compile_plan
-from delta_engine.application.ports import ExecutionSucceeded
 from delta_engine.domain.model import (
     DesiredColumn,
     DesiredTable,
@@ -29,10 +28,11 @@ def _dummy_qualified_name() -> QualifiedName:
     return QualifiedName("cat", "sch", "tbl")
 
 
-def _apply(spark, qualified_name: QualifiedName, plan: ActionPlan):
-    """Compile then execute, the same two-stage flow the engine drives."""
+def _apply(spark, qualified_name: QualifiedName, plan: ActionPlan) -> None:
+    """Compile and execute each statement, as the engine drives the adapter."""
     executor = SparkExecutor(spark)
-    return executor.execute(executor.compile(qualified_name, plan))
+    for statement in executor.compile(qualified_name, plan):
+        executor.execute(statement)
 
 
 class _FakeSpark:
@@ -85,31 +85,25 @@ def test_executor_compiles_plan_and_executes_statements_in_order():
     )
 
     # When compiling and executing the plan
-    summary = _apply(spark, _dummy_qualified_name(), plan)
+    _apply(spark, _dummy_qualified_name(), plan)
 
     # Then the compiled SQL is sent to Spark in action order
     assert spark.executed == [
         "ALTER TABLE `cat`.`sch`.`tbl` ADD COLUMN `age` INT",
         "ALTER TABLE `cat`.`sch`.`tbl` DROP COLUMN `legacy`",
     ]
-    assert [type(result) for result in summary.results] == [
-        ExecutionSucceeded,
-        ExecutionSucceeded,
-    ]
 
 
-def test_execute_returns_empty_summary_for_empty_plan():
+def test_empty_plan_executes_no_statements():
     # Given an empty plan
     plan = ActionPlan(actions=())
     spark = _FakeSpark()
 
     # When compiling and executing the plan
-    summary = _apply(spark, _dummy_qualified_name(), plan)
+    _apply(spark, _dummy_qualified_name(), plan)
 
-    # Then nothing ran and the summary is non-failing
+    # Then nothing ran
     assert spark.executed == []
-    assert summary.results == ()
-    assert summary.failed is False
 
 
 # ----------- Tests against real local Spark/Delta (auto-marked local_e2e via the
@@ -125,10 +119,9 @@ def test_create_table_action_creates_table_with_correct_schema(spark, temp_schem
     plan = ActionPlan(actions=(CreateTable(table=desired),))
 
     # When applying the plan
-    summary = _apply(spark, desired.qualified_name, plan)
+    _apply(spark, desired.qualified_name, plan)
 
     # Then the table exists and its schema matches exactly
-    assert summary.failed is False
     assert spark.catalog.tableExists(str(desired.qualified_name))
 
     actual_schema = spark.table(str(desired.qualified_name)).schema
@@ -160,10 +153,9 @@ def test_add_column_action_adds_column_to_existing_table(spark, make_temp_table)
     )
 
     # When applying the plan
-    summary = _apply(spark, qualified_name, plan)
+    _apply(spark, qualified_name, plan)
 
     # Then the new column exists with the expected type
-    assert summary.failed is False
     age_field = _get_field(spark, full_table_name, "age")
     assert age_field.dataType.simpleString() == "int"
 
@@ -179,10 +171,9 @@ def test_drop_column_action_removes_column_from_existing_table(spark, make_temp_
     plan = ActionPlan(actions=(DropColumn(ObservedColumn("to_remove", Integer())),))
 
     # When applying the plan
-    summary = _apply(spark, qualified_name, plan)
+    _apply(spark, qualified_name, plan)
 
     # Then the column no longer exists
-    assert summary.failed is False
     assert "to_remove" not in spark.table(full_table_name).columns
 
 
@@ -202,10 +193,9 @@ def test_set_property_action_sets_table_property(spark, make_temp_table):
     )
 
     # When applying the plan
-    summary = _apply(spark, qualified_name, plan)
+    _apply(spark, qualified_name, plan)
 
     # Then the property exists with the expected value
-    assert summary.failed is False
     assert _get_table_props(spark, full_table_name).get(property_name) == "yes"
 
 
@@ -224,10 +214,9 @@ def test_set_column_comment_sets_comment_on_column(spark, make_temp_table):
     )
 
     # When applying the plan
-    summary = _apply(spark, qualified_name, plan)
+    _apply(spark, qualified_name, plan)
 
     # Then the column metadata contains the new comment
-    assert summary.failed is False
     field = _get_field(spark, full_table_name, "name")
     assert dict(field.metadata).get("comment") == "customer name"
 
@@ -241,10 +230,9 @@ def test_set_table_comment_sets_comment_on_table(spark, make_temp_table):
     )
 
     # When applying the plan
-    summary = _apply(spark, qualified_name, plan)
+    _apply(spark, qualified_name, plan)
 
     # Then the table comment is set
-    assert summary.failed is False
     assert _get_table_comment(spark, full_table_name) == "staging table"
 
 
@@ -263,10 +251,9 @@ def test_set_column_nullability_sets_nullable(spark, make_temp_table):
     )
 
     # When applying the plan
-    summary = _apply(spark, qualified_name, plan)
+    _apply(spark, qualified_name, plan)
 
     # Then the column becomes nullable
-    assert summary.failed is False
     assert _get_field(spark, full_table_name, "id").nullable is True
 
 

--- a/tests/adapters/databricks/test_execution.py
+++ b/tests/adapters/databricks/test_execution.py
@@ -1,13 +1,15 @@
-"""Shared statement-execution loop used by both Databricks backends."""
+"""Databricks statement execution translates backend exceptions."""
 
 from types import SimpleNamespace
 
-from delta_engine.adapters.databricks.execution import execute_statements
-from delta_engine.application.ports import ExecutionFailed, ExecutionSucceeded
+import pytest
+
+from delta_engine.adapters.databricks.execution import execute_statement
+from delta_engine.application.ports import ExecutionError
 
 
 class RecordingRunner:
-    """Runs statements by recording them; fails on a marker."""
+    """Run statements by recording them and fail on a marker."""
 
     def __init__(self) -> None:
         self.executed: list[str] = []
@@ -18,33 +20,27 @@ class RecordingRunner:
             raise Exception("boom: table not found")
 
 
-def test_execute_maps_success_and_failure_without_leaking_backend_exception():
-    # Given statements where the second one fails
-    statements = ("SELECT 1", "SELECT * FROM __nope__")
+def test_execute_statement_returns_normally_after_success():
+    runner = RecordingRunner()
 
-    # When executing them
-    summary = execute_statements(RecordingRunner(), statements)
+    result = execute_statement(runner, "SELECT 1")
 
-    # Then success and failure are mapped to execution results
-    results = summary.results
-    assert isinstance(results[0], ExecutionSucceeded)
-    assert isinstance(results[1], ExecutionFailed)
-    assert results[0].statement_index == 0
-    assert results[1].failure.statement_index == 1
+    assert result is None
+    assert runner.executed == ["SELECT 1"]
 
 
-def test_execute_failure_records_exception_details_and_the_statement():
-    summary = execute_statements(RecordingRunner(), ("SELECT * FROM __nope__",))
+def test_execute_statement_raises_normalized_error_for_backend_failure():
+    runner = RecordingRunner()
 
-    [result] = summary.results
-    assert isinstance(result, ExecutionFailed)
-    assert result.failure.statement_index == 0
-    assert result.failure.exception_type == "Exception"
-    assert "boom: table not found" in result.failure.message
-    assert result.failure.statement == "SELECT * FROM __nope__"
+    with pytest.raises(ExecutionError) as exc_info:
+        execute_statement(runner, "SELECT * FROM __nope__")
+
+    assert runner.executed == ["SELECT * FROM __nope__"]
+    assert exc_info.value.exception_type == "Exception"
+    assert str(exc_info.value) == "boom: table not found"
 
 
-def test_execute_contains_an_exception_whose_message_cannot_be_rendered():
+def test_execute_statement_contains_an_exception_with_an_unrenderable_message():
     class UnrenderableError(Exception):
         def __str__(self) -> str:
             raise RuntimeError("rendering failed")
@@ -52,18 +48,16 @@ def test_execute_contains_an_exception_whose_message_cannot_be_rendered():
     def fail(_statement: str) -> None:
         raise UnrenderableError()
 
-    summary = execute_statements(fail, ("SELECT 1",))
+    with pytest.raises(ExecutionError) as exc_info:
+        execute_statement(fail, "SELECT 1")
 
-    [result] = summary.results
-    assert isinstance(result, ExecutionFailed)
-    assert result.failure.exception_type == "UnrenderableError"
-    assert result.failure.message == "<exception message unavailable>"
+    assert exc_info.value.exception_type == "UnrenderableError"
+    assert str(exc_info.value) == "<exception message unavailable>"
 
 
-def test_execute_failure_names_wrapped_jvm_exceptions_by_java_class():
-    # Given a backend failure that wraps a JVM exception, py4j-style
+def test_execute_statement_names_wrapped_jvm_exception_by_java_class():
     class WrappingRunner:
-        def __call__(self, statement: str) -> None:
+        def __call__(self, _statement: str) -> None:
             error = Exception("boom")
             error.java_exception = SimpleNamespace(  # type: ignore[attr-defined]
                 getClass=lambda: SimpleNamespace(
@@ -72,44 +66,7 @@ def test_execute_failure_names_wrapped_jvm_exceptions_by_java_class():
             )
             raise error
 
-    summary = execute_statements(WrappingRunner(), ("SELECT 1",))
+    with pytest.raises(ExecutionError) as exc_info:
+        execute_statement(WrappingRunner(), "SELECT 1")
 
-    # Then the failure carries the Java class, not the wrapper's Python class
-    [result] = summary.results
-    assert isinstance(result, ExecutionFailed)
-    assert result.failure.exception_type == "org.apache.spark.sql.AnalysisException"
-
-
-def test_execute_records_statements_verbatim_on_results():
-    # Given a statement spanning multiple lines
-    statement = "ALTER TABLE t\n  ADD COLUMN x INT"
-
-    # When executing it
-    summary = execute_statements(RecordingRunner(), (statement,))
-
-    # Then the result carries the SQL exactly as executed
-    [result] = summary.results
-    assert isinstance(result, ExecutionSucceeded)
-    assert result.statement == statement
-
-
-def test_execute_stops_at_first_failure_to_avoid_half_migrating():
-    # Given three statements whose middle one fails
-    runner = RecordingRunner()
-    statements = ("SELECT 1", "SELECT * FROM __nope__", "SELECT 2")
-
-    # When executing them
-    summary = execute_statements(runner, statements)
-
-    # Then the third statement is never attempted
-    assert runner.executed == ["SELECT 1", "SELECT * FROM __nope__"]
-    assert [type(result) for result in summary.results] == [
-        ExecutionSucceeded,
-        ExecutionFailed,
-    ]
-
-
-def test_execute_returns_empty_summary_for_no_statements():
-    summary = execute_statements(RecordingRunner(), ())
-    assert summary.results == ()
-    assert summary.failed is False
+    assert exc_info.value.exception_type == "org.apache.spark.sql.AnalysisException"

--- a/tests/adapters/databricks/warehouse/test_executor.py
+++ b/tests/adapters/databricks/warehouse/test_executor.py
@@ -1,11 +1,12 @@
-"""WarehouseExecutor: shared compilation, cursor execution, typed failures."""
+"""WarehouseExecutor compiles plans and contains each cursor execution."""
+
+import pytest
 
 from delta_engine.adapters.databricks.sql import compile_plan
 from delta_engine.adapters.databricks.warehouse.executor import WarehouseExecutor
-from delta_engine.application.ports import ExecutionFailed, ExecutionSucceeded
-from delta_engine.domain.model import DesiredColumn, ObservedColumn, QualifiedName
-from delta_engine.domain.model.data_type import Integer
-from delta_engine.domain.plan import ActionPlan, AddColumn, DropColumn, SetTableComment
+from delta_engine.application.ports import ExecutionError
+from delta_engine.domain.model import QualifiedName
+from delta_engine.domain.plan import ActionPlan, SetTableComment
 
 QN = QualifiedName("cat", "sch", "tbl")
 
@@ -38,88 +39,70 @@ class FakeConnection:
 
 
 class ClosedConnection:
-    """Connection whose cursor acquisition fails, like a closed/expired session."""
+    """Connection whose cursor acquisition fails, like a closed session."""
 
     def cursor(self):
         raise Exception("cannot create cursor from closed connection")
 
 
-def test_executor_compiles_plan_and_executes_statements_in_order():
+def test_execute_runs_one_statement_and_closes_its_cursor():
     connection = FakeConnection()
-    executor = WarehouseExecutor(connection)
-    plan = ActionPlan(
-        actions=(
-            AddColumn(DesiredColumn("age", Integer())),
-            DropColumn(ObservedColumn("legacy", Integer())),
-        )
-    )
 
-    summary = executor.execute(executor.compile(QN, plan))
+    result = WarehouseExecutor(connection).execute("SELECT 1")
 
-    assert connection.cursor_fake.executed == [
-        "ALTER TABLE `cat`.`sch`.`tbl` ADD COLUMN `age` INT",
-        "ALTER TABLE `cat`.`sch`.`tbl` DROP COLUMN `legacy`",
-    ]
-    assert [type(result) for result in summary.results] == [
-        ExecutionSucceeded,
-        ExecutionSucceeded,
-    ]
+    assert result is None
+    assert connection.cursor_requests == 1
+    assert connection.cursor_fake.executed == ["SELECT 1"]
     assert connection.cursor_fake.closed is True
 
 
-def test_execute_maps_failure_and_stops_without_leaking_backend_exception():
-    executor = WarehouseExecutor(FakeConnection())
+def test_execute_translates_statement_failure_and_closes_cursor():
+    connection = FakeConnection()
 
-    summary = executor.execute(("SELECT 1", "SELECT * FROM __nope__", "SELECT 2"))
+    with pytest.raises(ExecutionError) as exc_info:
+        WarehouseExecutor(connection).execute("SELECT * FROM __nope__")
 
-    results = summary.results
-    assert len(results) == 2  # third statement never attempted
-    assert isinstance(results[0], ExecutionSucceeded)
-    assert isinstance(results[1], ExecutionFailed)
-    assert results[1].failure.exception_type == "Exception"
-    assert "boom: permission denied" in results[1].failure.message
+    assert exc_info.value.exception_type == "Exception"
+    assert "boom: permission denied" in str(exc_info.value)
+    assert connection.cursor_fake.closed is True
 
 
-def test_execute_contains_cursor_acquisition_failure_as_a_result():
-    # Given a connection that cannot produce a cursor
+def test_execute_translates_cursor_acquisition_failure():
     executor = WarehouseExecutor(ClosedConnection())
 
-    # When executing a plan's statements
-    summary = executor.execute(("SELECT 1", "SELECT 2"))
+    with pytest.raises(ExecutionError) as exc_info:
+        executor.execute("SELECT 1")
 
-    # Then the failure is returned through the summary, not raised
-    [result] = summary.results
-    assert isinstance(result, ExecutionFailed)
-    assert result.failure.statement_index == 0
-    assert "closed connection" in result.failure.message
-    assert result.failure.statement == "SELECT 1"
+    assert exc_info.value.exception_type == "Exception"
+    assert "closed connection" in str(exc_info.value)
 
 
-def test_execute_keeps_the_summary_when_cursor_close_fails():
-    # Given a cursor that raises while closing, after a clean run
+def test_execute_suppresses_cursor_close_failure_after_success():
     connection = FakeConnection()
     connection.cursor_fake.close_raises = True
 
-    # When executing a statement
-    summary = WarehouseExecutor(connection).execute(("SELECT 1",))
+    result = WarehouseExecutor(connection).execute("SELECT 1")
 
-    # Then the successful summary survives the close failure
-    assert summary.failed is False
-    assert [type(result) for result in summary.results] == [ExecutionSucceeded]
+    assert result is None
+    assert connection.cursor_fake.closed is True
 
 
-def test_compile_returns_the_statements_execute_would_run():
-    executor = WarehouseExecutor(FakeConnection())
+def test_compile_returns_backend_statements_without_touching_connection():
+    connection = FakeConnection()
+    executor = WarehouseExecutor(connection)
     plan = ActionPlan((SetTableComment(desired_comment="hello", observed_comment=""),))
 
     statements = executor.compile(QN, plan)
 
     assert statements == compile_plan(QN, plan)
     assert len(statements) == 1
-
-
-def test_execute_of_no_statements_touches_nothing_and_reports_no_failures():
-    connection = FakeConnection()
-    summary = WarehouseExecutor(connection).execute(())
     assert connection.cursor_requests == 0
-    assert summary.failed is False
+
+
+def test_compile_of_empty_plan_returns_no_statements():
+    connection = FakeConnection()
+
+    statements = WarehouseExecutor(connection).compile(QN, ActionPlan())
+
+    assert statements == ()
+    assert connection.cursor_requests == 0

--- a/tests/application/test_engine.py
+++ b/tests/application/test_engine.py
@@ -12,10 +12,8 @@ from delta_engine.application.failures import (
 )
 from delta_engine.application.ports import (
     CatalogState,
-    ExecutionFailed,
-    ExecutionResult,
+    ExecutionError,
     ExecutionSucceeded,
-    ExecutionSummary,
     ReadFailed,
     TableAbsent,
     TablePresent,
@@ -228,27 +226,11 @@ def _existing_tag_drifted_table(fqn: str, kind: TableKind = TableKind.TABLE) -> 
     )
 
 
-def _ok_exec(statement_index: int = 0) -> ExecutionResult:
-    return ExecutionSucceeded(
-        statement_index=statement_index,
-        statement="-- ok",
-    )
-
-
-def _failed_exec(
-    statement_index: int = 0,
-    *,
+def _execution_error(
     exception_type: str = "AnalysisException",
     message: str = "boom",
-) -> ExecutionResult:
-    return ExecutionFailed(
-        failure=ExecutionFailure(
-            statement_index=statement_index,
-            exception_type=exception_type,
-            message=message,
-            statement="-- bad sql",
-        ),
-    )
+) -> ExecutionError:
+    return ExecutionError(exception_type, message)
 
 
 class _RecordingReader:
@@ -267,19 +249,20 @@ class _RecordingReader:
 
 class _RecordingExecutor:
     """
-    Records execution calls and returns configured results.
+    Record statement attempts and raise configured execution errors.
 
-    If per_call_results is None, every execution succeeds. If an explicit list
-    is supplied, each call consumes one item and unexpected extra calls fail
-    loudly.
+    Each configured item is the outcome for one table in execution order:
+    ``None`` succeeds and ``ExecutionError`` fails its first statement. Without
+    configuration, every table succeeds.
     """
 
     def __init__(
         self,
-        per_call_results: list[tuple[ExecutionResult, ...]] | None = None,
+        per_table_errors: list[ExecutionError | None] | None = None,
     ) -> None:
-        self.calls: list[tuple[str, ...]] = []
-        self._per_call_results = None if per_call_results is None else list(per_call_results)
+        self.calls: list[str] = []
+        self._per_table_errors = None if per_table_errors is None else list(per_table_errors)
+        self._active_table: str | None = None
 
     def compile(self, qualified_name: QualifiedName, plan: ActionPlan) -> tuple[str, ...]:
         return tuple(
@@ -287,22 +270,53 @@ class _RecordingExecutor:
             for index in range(len(plan))
         )
 
-    def execute(self, statements: tuple[str, ...]) -> ExecutionSummary:
-        self.calls.append(statements)
+    def execute(self, statement: str) -> None:
+        self.calls.append(statement)
+        table = statement.split(" FOR ", 1)[1]
 
-        if self._per_call_results is None:
-            return ExecutionSummary((_ok_exec(),))
+        if self._per_table_errors is None or table == self._active_table:
+            return
 
-        if not self._per_call_results:
-            raise AssertionError(f"Unexpected execution call: {statements}")
+        self._active_table = table
+        if not self._per_table_errors:
+            raise AssertionError(f"Unexpected execution call: {statement}")
 
-        return ExecutionSummary(self._per_call_results.pop(0))
+        error = self._per_table_errors.pop(0)
+        if error is not None:
+            raise error
 
     @property
     def executed_names(self) -> list[str]:
-        # compile embeds the table name in each fake statement; recover it so
-        # tests can assert which tables executed, since execute takes no name.
-        return [statements[0].split(" FOR ", 1)[1] for statements in self.calls]
+        names: list[str] = []
+        for statement in self.calls:
+            name = statement.split(" FOR ", 1)[1]
+            if not names or names[-1] != name:
+                names.append(name)
+        return names
+
+
+class _FailingMultiStatementExecutor:
+    """Compile three statements and fail the middle one for every table."""
+
+    def __init__(self) -> None:
+        self.calls: list[str] = []
+
+    def compile(self, qualified_name: QualifiedName, plan: ActionPlan) -> tuple[str, ...]:
+        return tuple(f"STATEMENT {index} FOR {qualified_name}" for index in range(3))
+
+    def execute(self, statement: str) -> None:
+        self.calls.append(statement)
+        if statement.startswith("STATEMENT 1 FOR "):
+            raise ExecutionError("AnalysisException", "boom")
+
+    @property
+    def executed_names(self) -> list[str]:
+        names: list[str] = []
+        for statement in self.calls:
+            name = statement.split(" FOR ", 1)[1]
+            if not names or names[-1] != name:
+                names.append(name)
+        return names
 
 
 def _reports_by_name(report: SyncReport) -> dict[str, TableRunReport]:
@@ -357,7 +371,7 @@ def _assert_has_fk_failure(
 def test_syncing_no_tables_returns_empty_report_without_reading_or_executing():
     # Given no tables to sync
     reader = _RecordingReader()
-    executor = _RecordingExecutor(per_call_results=[])
+    executor = _RecordingExecutor(per_table_errors=[])
     engine = Engine(reader=reader, executor=executor)
 
     # When syncing
@@ -379,12 +393,7 @@ def test_sync_returns_report_when_all_tables_succeed():
             "c.b.orders": TableAbsent(),
         }
     )
-    executor = _RecordingExecutor(
-        [
-            (_ok_exec(0),),
-            (_ok_exec(0),),
-        ]
-    )
+    executor = _RecordingExecutor([None, None])
     engine = Engine(reader=reader, executor=executor)
 
     # When syncing
@@ -445,7 +454,7 @@ def test_unchanged_table_is_reported_successful_without_execution():
     # Given the observed table already matches the desired declaration
     fqn = "c.s.same"
     reader = _RecordingReader({fqn: _existing_id_table_synced(fqn)})
-    executor = _RecordingExecutor(per_call_results=[])
+    executor = _RecordingExecutor(per_table_errors=[])
     engine = Engine(reader=reader, executor=executor)
 
     # When syncing
@@ -462,7 +471,7 @@ def test_real_run_records_the_applied_plan_on_the_report():
     # Given a new table that will be created
     fqn = "c.s.new_table"
     reader = _RecordingReader({fqn: TableAbsent()})
-    executor = _RecordingExecutor([(_ok_exec(0),)])
+    executor = _RecordingExecutor([None])
     engine = Engine(reader=reader, executor=executor)
 
     # When syncing for real
@@ -479,7 +488,7 @@ def test_tag_scoped_dry_run_plans_only_tag_actions():
     # Given a tag-scoped declaration over an existing table with tag drift
     fqn = "c.s.streaming_events"
     reader = _RecordingReader({fqn: _existing_tag_drifted_table(fqn)})
-    executor = _RecordingExecutor(per_call_results=[])
+    executor = _RecordingExecutor(per_table_errors=[])
     engine = Engine(reader=reader, executor=executor)
 
     # When syncing as a dry run
@@ -501,7 +510,7 @@ def test_dry_run_is_recorded_on_the_report():
     # Given a dry run over one table
     fqn = "c.s.new_table"
     reader = _RecordingReader({fqn: TableAbsent()})
-    executor = _RecordingExecutor(per_call_results=[])
+    executor = _RecordingExecutor(per_table_errors=[])
     engine = Engine(reader=reader, executor=executor)
 
     # When syncing as a dry run
@@ -516,7 +525,7 @@ def test_real_run_records_dry_run_false():
     # Given a normal (applied) run
     fqn = "c.s.new_table"
     reader = _RecordingReader({fqn: TableAbsent()})
-    executor = _RecordingExecutor([(_ok_exec(0),)])
+    executor = _RecordingExecutor([None])
     engine = Engine(reader=reader, executor=executor)
 
     # When syncing for real
@@ -561,9 +570,8 @@ def test_phase_chain_reads_compiles_resolves_then_executes_all_eligible_tables(
             # The name is embedded so execute can recover the target table.
             return tuple(f"STATEMENT {index} FOR {qualified_name}" for index in range(len(plan)))
 
-        def execute(self, statements: tuple[str, ...]) -> ExecutionSummary:
-            events.append(f"execute:{statements[0].split(' FOR ', 1)[1]}")
-            return ExecutionSummary((_ok_exec(0),))
+        def execute(self, statement: str) -> None:
+            events.append(f"execute:{statement.split(' FOR ', 1)[1]}")
 
     engine = Engine(
         reader=_EventRecordingReader(),
@@ -611,7 +619,7 @@ def test_read_failure_is_reported_once_and_has_no_plan_or_execution():
             fqn: ReadFailed(ReadFailure("IOError", "cannot read")),
         }
     )
-    executor = _RecordingExecutor(per_call_results=[])
+    executor = _RecordingExecutor(per_table_errors=[])
     engine = Engine(reader=reader, executor=executor)
 
     # When syncing
@@ -637,7 +645,7 @@ def test_validation_failed_table_is_not_executed_but_independent_table_still_run
             "c.s.b": TableAbsent(),
         }
     )
-    executor = _RecordingExecutor([(_ok_exec(0),)])
+    executor = _RecordingExecutor([None])
     engine = Engine(reader=reader, executor=executor)
 
     # When syncing
@@ -665,12 +673,7 @@ def test_execution_failure_is_reported_but_independent_later_table_still_execute
             "c.s.b": TableAbsent(),
         }
     )
-    executor = _RecordingExecutor(
-        [
-            (_failed_exec(0),),
-            (_ok_exec(0),),
-        ]
-    )
+    executor = _RecordingExecutor([_execution_error(), None])
     engine = Engine(reader=reader, executor=executor)
 
     # When syncing
@@ -690,31 +693,48 @@ def test_execution_failure_is_reported_but_independent_later_table_still_execute
     assert executor.executed_names == ["c.s.a", "c.s.b"]
 
 
-def test_execution_summary_is_retained_when_one_action_fails():
-    # Given execution returns a mixed summary for one table
+def test_execution_stops_after_first_failure_and_retains_attempted_results():
+    # Given one table compiles to three statements and the middle one fails
     fqn = "c.s.exec_fail"
     reader = _RecordingReader({fqn: TableAbsent()})
-    executor = _RecordingExecutor(
-        [
-            (
-                _ok_exec(0),
-                _failed_exec(1),
-                _ok_exec(2),
-            )
-        ]
-    )
+    executor = _FailingMultiStatementExecutor()
     engine = Engine(reader=reader, executor=executor)
 
     # When syncing
     with pytest.raises(SyncFailedError) as exc_info:
         engine.sync(_spec(fqn))
 
-    # Then the whole execution summary is kept on the report
+    # Then only the attempted prefix is recorded and the third statement is not run
     [table_report] = list(exc_info.value.report)
     assert table_report.status is TableRunStatus.EXECUTION_FAILED
     assert table_report.execution is not None
-    assert len(table_report.execution.results) == 3
+    assert [type(result) for result in table_report.execution.results] == [
+        ExecutionSucceeded,
+        ExecutionFailure,
+    ]
+    failure = table_report.execution.results[1]
+    assert isinstance(failure, ExecutionFailure)
+    assert failure.statement_index == 1
+    assert failure.statement == f"STATEMENT 1 FOR {fqn}"
+    assert executor.calls == [
+        f"STATEMENT 0 FOR {fqn}",
+        f"STATEMENT 1 FOR {fqn}",
+    ]
     assert executor.executed_names == [fqn]
+
+
+def test_unexpected_executor_exception_propagates():
+    class BuggyExecutor:
+        def compile(self, qualified_name: QualifiedName, _plan: ActionPlan) -> tuple[str, ...]:
+            return (f"STATEMENT FOR {qualified_name}",)
+
+        def execute(self, _statement: str) -> None:
+            raise RuntimeError("adapter bug")
+
+    engine = Engine(reader=_RecordingReader(), executor=BuggyExecutor())
+
+    with pytest.raises(RuntimeError, match="adapter bug"):
+        engine.sync(_spec("c.s.table"))
 
 
 # ---------------------------------------------------------------------------
@@ -743,7 +763,7 @@ def test_sync_processes_tables_in_fk_dependency_order():
 def test_sync_fails_table_whose_fk_references_table_not_in_the_sync():
     # Given orders references customers, but customers is not registered
     reader = _RecordingReader()
-    executor = _RecordingExecutor(per_call_results=[])
+    executor = _RecordingExecutor(per_table_errors=[])
     engine = Engine(reader=reader, executor=executor)
 
     # When syncing
@@ -771,7 +791,7 @@ def test_read_failure_in_upstream_blocks_fk_dependent():
             "cat.sch.a": ReadFailed(ReadFailure("IOError", "cannot read")),
         }
     )
-    executor = _RecordingExecutor(per_call_results=[])
+    executor = _RecordingExecutor(per_table_errors=[])
     engine = Engine(reader=reader, executor=executor)
 
     # When syncing
@@ -805,7 +825,7 @@ def test_validation_failure_in_upstream_blocks_fk_dependent():
             "cat.sch.orders": TableAbsent(),
         }
     )
-    executor = _RecordingExecutor(per_call_results=[])
+    executor = _RecordingExecutor(per_table_errors=[])
     engine = Engine(reader=reader, executor=executor)
 
     # When syncing
@@ -842,7 +862,7 @@ def test_validation_failure_in_upstream_blocks_fk_dependent():
 def test_sync_fails_fk_that_does_not_reference_a_primary_key():
     # Given orders references customers, but customers has no primary key
     reader = _RecordingReader()
-    executor = _RecordingExecutor([(_ok_exec(0),)])
+    executor = _RecordingExecutor([None])
     engine = Engine(reader=reader, executor=executor)
 
     # When syncing
@@ -877,7 +897,7 @@ def test_sync_fails_fk_whose_types_mismatch_the_registered_parent():
     # String, but the customers declaration registered for this sync types id
     # as a Long
     reader = _RecordingReader()
-    executor = _RecordingExecutor([(_ok_exec(0),)])
+    executor = _RecordingExecutor([None])
     engine = Engine(reader=reader, executor=executor)
 
     registered_customers = DeltaTable(
@@ -920,8 +940,8 @@ def test_execution_failure_in_fk_parent_blocks_dependent_before_execution():
     reader = _RecordingReader()
     executor = _RecordingExecutor(
         [
-            (_failed_exec(0),),  # customers
-            (_ok_exec(0),),  # orders should not be reached after the engine fix
+            _execution_error(),  # customers
+            None,  # orders should not be reached after the engine fix
         ]
     )
     engine = Engine(reader=reader, executor=executor)
@@ -960,7 +980,7 @@ def test_execution_failure_in_fk_parent_blocks_dependent_before_execution():
 def test_execution_failure_blocks_transitively_along_fk_chain():
     # Given c -> b -> a, and a fails during execution
     reader = _RecordingReader()
-    executor = _RecordingExecutor([(_failed_exec(0),)])  # a only; b and c must not run
+    executor = _RecordingExecutor([_execution_error()])  # a only; b and c must not run
     engine = Engine(reader=reader, executor=executor)
 
     # When syncing
@@ -996,7 +1016,7 @@ def test_execution_failure_blocks_transitively_along_fk_chain():
 def test_partial_execution_failure_in_parent_blocks_dependent():
     # Given customers' plan fails on one action among successful ones
     reader = _RecordingReader()
-    executor = _RecordingExecutor([(_ok_exec(0), _failed_exec(1))])
+    executor = _FailingMultiStatementExecutor()
     engine = Engine(reader=reader, executor=executor)
 
     # When syncing
@@ -1028,7 +1048,7 @@ def test_execution_failure_blocks_dependent_that_needed_no_changes():
     reader = _RecordingReader(
         {"cat.sch.orders": _existing_fk_table_synced("cat.sch.orders", "cat.sch.customers")}
     )
-    executor = _RecordingExecutor([(_failed_exec(0),)])  # customers only
+    executor = _RecordingExecutor([_execution_error()])  # customers only
     engine = Engine(reader=reader, executor=executor)
 
     # When syncing
@@ -1072,7 +1092,7 @@ def test_execution_failure_blocks_diamond_dependent_with_one_failure_per_fk():
     )
 
     reader = _RecordingReader()
-    executor = _RecordingExecutor([(_failed_exec(0),)])  # a only
+    executor = _RecordingExecutor([_execution_error()])  # a only
     engine = Engine(reader=reader, executor=executor)
 
     # When syncing
@@ -1110,7 +1130,7 @@ def test_execution_failure_blocks_diamond_dependent_with_one_failure_per_fk():
 def test_synced_fk_parent_with_no_work_does_not_block_dependent():
     # Given customers already matches its declaration and orders is absent
     reader = _RecordingReader({"cat.sch.customers": _existing_id_table_synced("cat.sch.customers")})
-    executor = _RecordingExecutor([(_ok_exec(0),)])  # orders only
+    executor = _RecordingExecutor([None])  # orders only
     engine = Engine(reader=reader, executor=executor)
 
     # When syncing
@@ -1134,7 +1154,7 @@ def test_synced_fk_parent_with_no_work_does_not_block_dependent():
 def test_sync_rejects_duplicate_table_names_before_reading():
     # Given duplicate table declarations
     reader = _RecordingReader()
-    executor = _RecordingExecutor(per_call_results=[])
+    executor = _RecordingExecutor(per_table_errors=[])
     engine = Engine(reader=reader, executor=executor)
 
     # When syncing
@@ -1163,7 +1183,7 @@ def test_dry_run_does_not_execute_and_reports_no_execution():
             "c.s.b": TableAbsent(),
         }
     )
-    executor = _RecordingExecutor(per_call_results=[])
+    executor = _RecordingExecutor(per_table_errors=[])
     engine = Engine(reader=reader, executor=executor)
 
     # When syncing in dry-run mode
@@ -1188,7 +1208,7 @@ def test_dry_run_exposes_the_planned_actions_on_the_report():
     # Given a table that would be created
     fqn = "c.s.new_table"
     reader = _RecordingReader({fqn: TableAbsent()})
-    executor = _RecordingExecutor(per_call_results=[])
+    executor = _RecordingExecutor(per_table_errors=[])
     engine = Engine(reader=reader, executor=executor)
 
     # When syncing in dry-run mode
@@ -1206,7 +1226,7 @@ def test_dry_run_records_the_sql_that_would_execute():
     # Given a table that would be created (dry run plans a CREATE)
     fqn = "c.s.new_table"
     reader = _RecordingReader({fqn: TableAbsent()})
-    executor = _RecordingExecutor(per_call_results=[])
+    executor = _RecordingExecutor(per_table_errors=[])
     engine = Engine(reader=reader, executor=executor)
 
     # When syncing in dry-run mode
@@ -1224,7 +1244,7 @@ def test_failed_table_records_no_planned_sql():
     # Given a table whose read fails, so no plan is built
     fqn = "c.s.unreadable"
     reader = _RecordingReader({fqn: ReadFailed(ReadFailure("IOError", "cannot read"))})
-    executor = _RecordingExecutor(per_call_results=[])
+    executor = _RecordingExecutor(per_table_errors=[])
     engine = Engine(reader=reader, executor=executor)
 
     # When syncing in dry-run mode
@@ -1241,7 +1261,7 @@ def test_fk_failed_table_still_reports_its_planned_sql_without_executing():
     # FK resolution runs after planning and compilation, so the plan and its
     # SQL are already legitimate facts — only the dependency check failed.
     reader = _RecordingReader()
-    executor = _RecordingExecutor(per_call_results=[])
+    executor = _RecordingExecutor(per_table_errors=[])
     engine = Engine(reader=reader, executor=executor)
 
     # When performing a dry run
@@ -1262,7 +1282,7 @@ def test_dry_run_returns_validation_failures_without_raising_or_executing():
     # Given a table that would fail validation
     fqn = "c.s.val_fail"
     reader = _RecordingReader({fqn: _existing_id_table(fqn)})
-    executor = _RecordingExecutor(per_call_results=[])
+    executor = _RecordingExecutor(per_table_errors=[])
     engine = Engine(reader=reader, executor=executor)
 
     # When syncing in dry-run mode
@@ -1282,7 +1302,7 @@ def test_dry_run_returns_validation_failures_without_raising_or_executing():
 def test_dry_run_returns_fk_failures_without_raising_or_executing():
     # Given orders references customers, but customers is not registered
     reader = _RecordingReader()
-    executor = _RecordingExecutor(per_call_results=[])
+    executor = _RecordingExecutor(per_table_errors=[])
     engine = Engine(reader=reader, executor=executor)
 
     # When syncing in dry-run mode
@@ -1314,7 +1334,7 @@ def test_metadata_scoped_sync_applies_metadata_when_schema_matches():
     # Given a live table whose schema matches the declaration
     fqn = "cat.sch.orders"
     reader = _RecordingReader({fqn: _existing_matching_table(fqn)})
-    executor = _RecordingExecutor([(_ok_exec(0),)])
+    executor = _RecordingExecutor([None])
     engine = Engine(reader=reader, executor=executor)
 
     # When syncing a metadata-only declaration
@@ -1333,7 +1353,7 @@ def test_metadata_scoped_sync_fails_when_table_is_missing():
     # Given a metadata-only declaration for a missing table
     fqn = "cat.sch.orders"
     reader = _RecordingReader({fqn: TableAbsent()})
-    executor = _RecordingExecutor(per_call_results=[])
+    executor = _RecordingExecutor(per_table_errors=[])
     engine = Engine(reader=reader, executor=executor)
 
     # When syncing
@@ -1362,7 +1382,7 @@ def test_sync_fails_at_validation_when_dropping_column_without_column_mapping():
             )
         }
     )
-    engine = Engine(reader=reader, executor=_RecordingExecutor(per_call_results=[]))
+    engine = Engine(reader=reader, executor=_RecordingExecutor(per_table_errors=[]))
     spec = DeltaTable(catalog, schema, name, columns=(Column("id", String()),))
 
     # When syncing (the plan would drop `stale`)
@@ -1390,7 +1410,7 @@ def test_sync_fails_loud_on_undeclared_managed_property():
             )
         }
     )
-    engine = Engine(reader=reader, executor=_RecordingExecutor(per_call_results=[]))
+    engine = Engine(reader=reader, executor=_RecordingExecutor(per_table_errors=[]))
     spec = DeltaTable(catalog, schema, name, columns=(Column("id", String()),))
 
     # When / Then the sync stops at validation naming the key
@@ -1416,7 +1436,7 @@ def test_metadata_scoped_column_removal_fails_without_drop_precondition():
             )
         }
     )
-    engine = Engine(reader=reader, executor=_RecordingExecutor(per_call_results=[]))
+    engine = Engine(reader=reader, executor=_RecordingExecutor(per_table_errors=[]))
 
     # When syncing
     with pytest.raises(SyncFailedError) as excinfo:
@@ -1436,7 +1456,7 @@ def test_planned_sql_targets_the_observed_relation_kind():
     reader = _RecordingReader(
         {fqn: _existing_tag_drifted_table(fqn, kind=TableKind.STREAMING_TABLE)}
     )
-    executor = _RecordingExecutor(per_call_results=[])
+    executor = _RecordingExecutor(per_table_errors=[])
     engine = Engine(reader=reader, executor=executor)
 
     # When syncing as a dry run
@@ -1457,7 +1477,7 @@ def test_created_tables_compile_as_ordinary_tables():
     # engine only creates ordinary tables
     fqn = "c.s.new_table"
     reader = _RecordingReader({fqn: TableAbsent()})
-    executor = _RecordingExecutor(per_call_results=[])
+    executor = _RecordingExecutor(per_table_errors=[])
     engine = Engine(reader=reader, executor=executor)
 
     # When syncing as a dry run

--- a/tests/application/test_errors.py
+++ b/tests/application/test_errors.py
@@ -11,7 +11,6 @@ from delta_engine.application.failures import (
 )
 from delta_engine.application.ports import (
     CatalogState,
-    ExecutionFailed,
     ExecutionSummary,
     ReadFailed,
     TableAbsent,
@@ -121,13 +120,11 @@ def test_message_renders_every_validation_failure_when_a_table_breaks_several_ru
 
 def test_message_renders_execution_failure_detail_with_sql():
     # Given a table whose execution phase failed on one action
-    failed_result = ExecutionFailed(
-        failure=ExecutionFailure(
-            statement_index=2,
-            exception_type="SparkException",
-            message="boom",
-            statement="ALTER TABLE cat.sch.tbl ADD COLUMN x INT",
-        ),
+    failed_result = ExecutionFailure(
+        statement_index=2,
+        exception_type="SparkException",
+        message="boom",
+        statement="ALTER TABLE cat.sch.tbl ADD COLUMN x INT",
     )
     report = _table_report(
         read=TableAbsent(),

--- a/tests/application/test_ports.py
+++ b/tests/application/test_ports.py
@@ -2,7 +2,7 @@ from hypothesis import given, strategies as st
 
 from delta_engine.application.failures import ExecutionFailure, ReadFailure
 from delta_engine.application.ports import (
-    ExecutionFailed,
+    ExecutionError,
     ExecutionResult,
     ExecutionSucceeded,
     ExecutionSummary,
@@ -29,10 +29,11 @@ def _ok_exec(idx=0, preview="ALTER TABLE ..."):
 
 
 def _failed_exec(idx=0, preview="ALTER TABLE ...", exc="ValueError", msg="boom"):
-    return ExecutionFailed(
-        failure=ExecutionFailure(
-            statement_index=idx, exception_type=exc, message=msg, statement=preview
-        ),
+    return ExecutionFailure(
+        statement_index=idx,
+        exception_type=exc,
+        message=msg,
+        statement=preview,
     )
 
 
@@ -108,28 +109,24 @@ def test_execution_summary_defaults_to_an_empty_unattempted_run():
 def test_execution_outcome_variants_carry_the_right_payload():
     # Given the two execution outcomes
     succeeded = ExecutionSucceeded(statement_index=0, statement="SQL")
-    failed = ExecutionFailed(
-        failure=ExecutionFailure(
-            statement_index=1, exception_type="E", message="m", statement="SQL"
-        ),
+    failed = ExecutionFailure(
+        statement_index=1,
+        exception_type="E",
+        message="m",
+        statement="SQL",
     )
 
-    # Then a failure is only representable on the failed variant
-    assert failed.failure.exception_type == "E"
-    assert not hasattr(succeeded, "failure")
+    # Then success and failure carry only the fields appropriate to their arm
+    assert failed.exception_type == "E"
+    assert not hasattr(succeeded, "exception_type")
 
 
-def test_execution_failed_carries_index_only_on_its_failure_detail():
-    # Given a failed action
-    failed = ExecutionFailed(
-        failure=ExecutionFailure(
-            statement_index=3, exception_type="E", message="m", statement="SQL"
-        ),
-    )
+def test_execution_error_is_a_regular_exception_with_normalized_details():
+    error = ExecutionError(exception_type="SparkException", message="boom")
 
-    # Then the index lives on the failure detail, not duplicated on the carrier
-    assert failed.failure.statement_index == 3
-    assert not hasattr(failed, "statement_index")
+    assert isinstance(error, Exception)
+    assert error.exception_type == "SparkException"
+    assert str(error) == "boom"
 
 
 # ---------- property: ExecutionSummary internal consistency ----------
@@ -142,14 +139,11 @@ _EXECUTION_RESULT = st.one_of(
         statement=st.just("ALTER TABLE ..."),
     ),
     st.builds(
-        ExecutionFailed,
-        failure=st.builds(
-            ExecutionFailure,
-            statement_index=st.integers(min_value=0, max_value=100),
-            exception_type=st.just("SparkException"),
-            message=st.text(max_size=40),
-            statement=st.just("ALTER TABLE ..."),
-        ),
+        ExecutionFailure,
+        statement_index=st.integers(min_value=0, max_value=100),
+        exception_type=st.just("SparkException"),
+        message=st.text(max_size=40),
+        statement=st.just("ALTER TABLE ..."),
     ),
 )
 

--- a/tests/application/test_rendering.py
+++ b/tests/application/test_rendering.py
@@ -10,7 +10,6 @@ from delta_engine.application.diff_entries import (
 )
 from delta_engine.application.failures import ExecutionFailure, ReadFailure, ValidationFailure
 from delta_engine.application.ports import (
-    ExecutionFailed,
     ExecutionSucceeded,
     ExecutionSummary,
     ReadFailed,
@@ -399,13 +398,11 @@ def _execution(*, applied: int, failed: int) -> ExecutionSummary:
         ExecutionSucceeded(statement_index=index, statement="SQL") for index in range(applied)
     )
     failures = tuple(
-        ExecutionFailed(
-            failure=ExecutionFailure(
-                statement_index=applied + index,
-                exception_type="AnalysisException",
-                message="boom",
-                statement="SQL",
-            ),
+        ExecutionFailure(
+            statement_index=applied + index,
+            exception_type="AnalysisException",
+            message="boom",
+            statement="SQL",
         )
         for index in range(failed)
     )

--- a/tests/application/test_report.py
+++ b/tests/application/test_report.py
@@ -9,7 +9,6 @@ from delta_engine.application.failures import (
     ValidationFailure,
 )
 from delta_engine.application.ports import (
-    ExecutionFailed,
     ExecutionSucceeded,
     ExecutionSummary,
     ReadFailed,
@@ -64,10 +63,11 @@ def _ok_exec(idx=0, preview="ALTER TABLE ..."):
 
 
 def _failed_exec(idx=0, preview="ALTER TABLE ...", exc="ValueError", msg="boom"):
-    return ExecutionFailed(
-        failure=ExecutionFailure(
-            statement_index=idx, exception_type=exc, message=msg, statement=preview
-        ),
+    return ExecutionFailure(
+        statement_index=idx,
+        exception_type=exc,
+        message=msg,
+        statement=preview,
     )
 
 

--- a/tests/cli/conftest.py
+++ b/tests/cli/conftest.py
@@ -10,8 +10,6 @@ from typer.testing import CliRunner
 from delta_engine.application.engine import Engine
 from delta_engine.application.ports import (
     CatalogState,
-    ExecutionSucceeded,
-    ExecutionSummary,
     TableAbsent,
     TablePresent,
 )
@@ -52,13 +50,8 @@ class FakeExecutor:
     def compile(self, qualified_name: QualifiedName, plan: ActionPlan) -> tuple[str, ...]:
         return tuple(f"-- {qualified_name}: {type(action).__name__}" for action in plan)
 
-    def execute(self, statements: tuple[str, ...]) -> ExecutionSummary:
-        return ExecutionSummary(
-            results=tuple(
-                ExecutionSucceeded(statement_index=index, statement=statement)
-                for index, statement in enumerate(statements)
-            )
-        )
+    def execute(self, statement: str) -> None:
+        pass
 
 
 class _StubConnection:


### PR DESCRIPTION
## Summary

- move statement sequencing and stop-on-first-failure policy into the application engine
- reduce `PlanExecutor` to executing one statement at a time
- normalize expected backend failures as `ExecutionError` and report them directly as `ExecutionFailure`
- update Spark and Warehouse adapters, black-box tests, architecture guidance, and the policy review documentation

## Why

Execution ordering, statement indexes, and continuation policy are application concerns. Previously, adapters constructed application-level summaries and duplicated sequencing responsibilities. This made the port wider than necessary and blurred the boundary between orchestration and backend execution.

## Impact

Custom `PlanExecutor` implementations must now implement `execute(statement: str) -> None` and raise `ExecutionError` for expected backend failures. Unexpected exceptions continue to propagate.

## Validation

- `uv run pytest` — 975 passed, 63 deselected; 97.69% coverage
- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run mypy src tests`
- `uv run lint-imports`
- `git diff --check`