### PR TITLE
refactor: make constraint naming explicit

### DIFF
--- a/docs/todo/policy-visibility-review.md
+++ b/docs/todo/policy-visibility-review.md
@@ -116,16 +116,14 @@ translation. Spark and warehouse adapters supply their physical one-statement
 runner, while the warehouse adapter also contains its per-statement cursor
 lifecycle.
 
-### Constraint naming
+### Constraint naming — consolidated
 
-The documentation describes constraint names as API-generated, but
-`PrimaryKeyConstraint.generate()` and `ForeignKeyConstraint.generate()` live
-in the domain model. Naming physical catalog objects is deployment policy, not
-a domain invariant.
-
-Move the generation helpers beside `DeltaTable`/`ForeignKey` lowering. The
-domain constraint should validate a supplied name; the API lowering should
-choose it.
+Constraint names are deployment policy, not a domain invariant. The API
+lowering in `api/delta_table.py` now owns the generated `{table}_pk` and
+`{table}_{local_columns}_fk` names before constructing the domain values.
+`PrimaryKeyConstraint` and `ForeignKeyConstraint` only validate and
+canonicalize the supplied name, so observed catalog names and future explicit
+names follow the same domain contract.
 
 ### Declaration validation boundary
 

--- a/src/delta_engine/api/delta_table.py
+++ b/src/delta_engine/api/delta_table.py
@@ -86,11 +86,6 @@ class _SelfReference:
 Self: Final = _SelfReference()
 
 
-def _primary_key_constraint_name(table_name: str) -> str:
-    """Return the physical name used for a table's generated primary key."""
-    return f"{table_name}_pk"
-
-
 def _foreign_key_constraint_name(
     *,
     owner_table_name: str,
@@ -491,7 +486,7 @@ class DeltaTable:
         partitioned_by: Iterable[str] = (),
         clustered_by: Iterable[str] = (),
         primary_key: Sequence[str] | None = None,
-        foreign_keys: Iterable[ForeignKey | ForeignKeyConstraint] | None = None,
+        foreign_keys: Iterable[ForeignKey] | None = None,
         scope: ScopeName = "full",
     ) -> None:
         """
@@ -512,9 +507,7 @@ class DeltaTable:
                 ``partitioned_by``.
             primary_key: Column names forming the table's primary key, in the
                 order the constraint is rendered; None means no key.
-            foreign_keys: Foreign key relationships declared on this table. A
-                previously lowered ``ForeignKeyConstraint`` is also accepted,
-                which makes the public ``foreign_keys`` value round-trip safely.
+            foreign_keys: Foreign key relationships declared on this table.
             scope: What this declaration manages. ``"full"`` (the default)
                 manages the whole table. ``"metadata"`` restricts the sync to
                 catalog metadata: comments, tags, and primary/foreign key
@@ -559,7 +552,7 @@ class DeltaTable:
         primary_key_constraint = (
             PrimaryKeyConstraint(
                 columns=tuple(primary_key),
-                constraint_name=_primary_key_constraint_name(name),
+                constraint_name=f"{name}_pk",
             )
             if primary_key is not None
             else None
@@ -570,11 +563,10 @@ class DeltaTable:
 
         qualified_name = QualifiedName(catalog, schema, name)
         _validate_object_name_parts(qualified_name)
+        foreign_key_declarations = tuple(foreign_keys or ())
         lowered_foreign_keys = tuple(
-            declaration
-            if isinstance(declaration, ForeignKeyConstraint)
-            else declaration._to_constraint(qualified_name, columns, primary_key_columns)
-            for declaration in (foreign_keys or ())
+            declaration._to_constraint(qualified_name, columns, primary_key_columns)
+            for declaration in foreign_key_declarations
         )
 
         # Building DesiredTable here enforces all domain invariants (non-empty
@@ -593,6 +585,7 @@ class DeltaTable:
             foreign_keys=lowered_foreign_keys,
             managed_aspects=managed_aspects,
         )
+        self._foreign_keys = foreign_key_declarations
 
     @property
     def catalog(self) -> str:
@@ -649,9 +642,9 @@ class DeltaTable:
         return self._desired_table.primary_key_columns
 
     @property
-    def foreign_keys(self) -> tuple[ForeignKeyConstraint, ...]:
-        """Foreign key constraints declared on this table."""
-        return self._desired_table.foreign_keys
+    def foreign_keys(self) -> tuple[ForeignKey, ...]:
+        """Foreign key relationships supplied in the declaration."""
+        return self._foreign_keys
 
     def to_desired_table(self) -> DesiredTable:
         """Return the domain :class:`DesiredTable` for this table definition."""

--- a/src/delta_engine/api/delta_table.py
+++ b/src/delta_engine/api/delta_table.py
@@ -86,6 +86,21 @@ class _SelfReference:
 Self: Final = _SelfReference()
 
 
+def _primary_key_constraint_name(table_name: str) -> str:
+    """Return the physical name used for a table's generated primary key."""
+    return f"{table_name}_pk"
+
+
+def _foreign_key_constraint_name(
+    *,
+    owner_table_name: str,
+    local_columns: tuple[str, ...],
+) -> str:
+    """Return the physical name used for a generated foreign key."""
+    columns = "_".join(sorted(local_columns))
+    return f"{owner_table_name}_{columns}_fk"
+
+
 def _validate_object_name_parts(qualified_name: QualifiedName) -> None:
     """Reject catalog, schema, or table name parts Unity Catalog cannot store."""
     for label, part in zip(("catalog", "schema", "name"), qualified_name.parts, strict=True):
@@ -386,11 +401,14 @@ class ForeignKey:
                     f" is {referenced_type}"
                 )
 
-        return ForeignKeyConstraint.generate(
-            owner_table_name=owner_name.name,
+        return ForeignKeyConstraint(
             local_columns=local_columns,
             referenced_table=referenced.table,
             referenced_columns=referenced_columns,
+            constraint_name=_foreign_key_constraint_name(
+                owner_table_name=owner_name.name,
+                local_columns=local_columns,
+            ),
         )
 
     def _resolve_reference(
@@ -473,7 +491,7 @@ class DeltaTable:
         partitioned_by: Iterable[str] = (),
         clustered_by: Iterable[str] = (),
         primary_key: Sequence[str] | None = None,
-        foreign_keys: Iterable[ForeignKey] | None = None,
+        foreign_keys: Iterable[ForeignKey | ForeignKeyConstraint] | None = None,
         scope: ScopeName = "full",
     ) -> None:
         """
@@ -494,7 +512,9 @@ class DeltaTable:
                 ``partitioned_by``.
             primary_key: Column names forming the table's primary key, in the
                 order the constraint is rendered; None means no key.
-            foreign_keys: Foreign key relationships declared on this table.
+            foreign_keys: Foreign key relationships declared on this table. A
+                previously lowered ``ForeignKeyConstraint`` is also accepted,
+                which makes the public ``foreign_keys`` value round-trip safely.
             scope: What this declaration manages. ``"full"`` (the default)
                 manages the whole table. ``"metadata"`` restricts the sync to
                 catalog metadata: comments, tags, and primary/foreign key
@@ -537,7 +557,10 @@ class DeltaTable:
             )
 
         primary_key_constraint = (
-            PrimaryKeyConstraint.generate(table_name=name, columns=tuple(primary_key))
+            PrimaryKeyConstraint(
+                columns=tuple(primary_key),
+                constraint_name=_primary_key_constraint_name(name),
+            )
             if primary_key is not None
             else None
         )
@@ -548,7 +571,9 @@ class DeltaTable:
         qualified_name = QualifiedName(catalog, schema, name)
         _validate_object_name_parts(qualified_name)
         lowered_foreign_keys = tuple(
-            declaration._to_constraint(qualified_name, columns, primary_key_columns)
+            declaration
+            if isinstance(declaration, ForeignKeyConstraint)
+            else declaration._to_constraint(qualified_name, columns, primary_key_columns)
             for declaration in (foreign_keys or ())
         )
 

--- a/src/delta_engine/domain/model/constraints.py
+++ b/src/delta_engine/domain/model/constraints.py
@@ -1,7 +1,6 @@
 """Domain value objects representing key constraints (primary and foreign)."""
 
 from dataclasses import dataclass
-from typing import Self
 
 from delta_engine.domain.model.qualified_name import QualifiedName
 
@@ -41,11 +40,6 @@ class PrimaryKeyConstraint:
             raise ValueError("constraint_name must not be blank")
         object.__setattr__(self, "constraint_name", self.constraint_name.lower())
 
-    @classmethod
-    def generate(cls, *, table_name: str, columns: tuple[str, ...]) -> Self:
-        """Return a constraint over ``columns`` named ``{table_name}_pk``."""
-        return cls(columns=columns, constraint_name=f"{table_name}_pk")
-
 
 @dataclass(frozen=True, slots=True)
 class ForeignKeyConstraint:
@@ -74,24 +68,6 @@ class ForeignKeyConstraint:
     referenced_table: QualifiedName
     referenced_columns: tuple[str, ...]
     constraint_name: str
-
-    @classmethod
-    def generate(
-        cls,
-        *,
-        owner_table_name: str,
-        local_columns: tuple[str, ...],
-        referenced_table: QualifiedName,
-        referenced_columns: tuple[str, ...],
-    ) -> Self:
-        """Return a constraint named ``{owner_table_name}_{local_columns}_fk`` (canonical order)."""
-        columns = "_".join(sorted(local_columns))
-        return cls(
-            local_columns=local_columns,
-            referenced_table=referenced_table,
-            referenced_columns=referenced_columns,
-            constraint_name=f"{owner_table_name}_{columns}_fk",
-        )
 
     def __post_init__(self) -> None:
         if not self.local_columns:

--- a/tests/adapters/databricks/sql/test_compile.py
+++ b/tests/adapters/databricks/sql/test_compile.py
@@ -285,10 +285,7 @@ def test_create_table_inlines_primary_key_constraint():
     action = _create_table(
         DesiredColumn("id", Integer(), nullable=False),
         DesiredColumn("name", String()),
-        primary_key=PrimaryKeyConstraint.generate(
-            table_name=_TARGET.name,
-            columns=("id",),
-        ),
+        primary_key=PrimaryKeyConstraint(columns=("id",), constraint_name=f"{_TARGET.name}_pk"),
     )
 
     # When compiling

--- a/tests/api/test_delta_table.py
+++ b/tests/api/test_delta_table.py
@@ -625,6 +625,36 @@ def test_delta_table_defaults_to_no_foreign_keys():
     assert table.foreign_keys == ()
 
 
+def test_delta_table_accepts_its_lowered_foreign_keys():
+    # Given a table whose public foreign_keys value contains lowered constraints
+    customers = DeltaTable(
+        catalog="cat",
+        schema="sch",
+        name="customers",
+        columns=[Column("id", Integer(), nullable=False)],
+        primary_key=["id"],
+    )
+    original = DeltaTable(
+        catalog="cat",
+        schema="sch",
+        name="orders",
+        columns=[Column("customer_id", Integer())],
+        foreign_keys=[ForeignKey(columns="customer_id", references=customers)],
+    )
+
+    # When reusing that value in another declaration
+    copy = DeltaTable(
+        catalog="cat",
+        schema="sch",
+        name="orders_copy",
+        columns=[Column("customer_id", Integer())],
+        foreign_keys=original.foreign_keys,
+    )
+
+    # Then the lowered relationship remains intact
+    assert copy.foreign_keys == original.foreign_keys
+
+
 def test_delta_table_rejects_fk_with_unknown_local_column():
     # Given a referenced table and a FK whose local column is not declared
     customers = DeltaTable(

--- a/tests/api/test_delta_table.py
+++ b/tests/api/test_delta_table.py
@@ -605,7 +605,7 @@ def test_delta_table_accepts_foreign_keys_parameter():
     )
 
     # Then the FK is lowered to an internal constraint carrying its generated name
-    [foreign_key] = table.foreign_keys
+    [foreign_key] = table.to_desired_table().foreign_keys
     assert foreign_key.local_columns == ("customer_id",)
     assert foreign_key.referenced_table == QualifiedName("cat", "sch", "customers")
     assert foreign_key.referenced_columns == ("id",)
@@ -625,8 +625,8 @@ def test_delta_table_defaults_to_no_foreign_keys():
     assert table.foreign_keys == ()
 
 
-def test_delta_table_accepts_its_lowered_foreign_keys():
-    # Given a table whose public foreign_keys value contains lowered constraints
+def test_delta_table_foreign_keys_round_trip_as_declarations():
+    # Given a table with a public foreign-key declaration
     customers = DeltaTable(
         catalog="cat",
         schema="sch",
@@ -642,7 +642,7 @@ def test_delta_table_accepts_its_lowered_foreign_keys():
         foreign_keys=[ForeignKey(columns="customer_id", references=customers)],
     )
 
-    # When reusing that value in another declaration
+    # When reusing that declaration on another table
     copy = DeltaTable(
         catalog="cat",
         schema="sch",
@@ -651,8 +651,10 @@ def test_delta_table_accepts_its_lowered_foreign_keys():
         foreign_keys=original.foreign_keys,
     )
 
-    # Then the lowered relationship remains intact
+    # Then the public declarations round-trip and lowering uses the new owner
     assert copy.foreign_keys == original.foreign_keys
+    [constraint] = copy.to_desired_table().foreign_keys
+    assert constraint.constraint_name == "orders_copy_customer_id_fk"
 
 
 def test_delta_table_rejects_fk_with_unknown_local_column():
@@ -1229,7 +1231,7 @@ def test_single_column_string_foreign_key_infers_and_normalizes_parent_column():
         foreign_keys=[declaration],
     )
 
-    [foreign_key] = orders.foreign_keys
+    [foreign_key] = orders.to_desired_table().foreign_keys
 
     assert declaration.columns == ("customer_id",)
     assert foreign_key.local_columns == ("customer_id",)
@@ -1254,7 +1256,7 @@ def test_single_column_sequence_infers_and_normalizes_parent_column():
         foreign_keys=[declaration],
     )
 
-    [foreign_key] = orders.foreign_keys
+    [foreign_key] = orders.to_desired_table().foreign_keys
 
     assert declaration.columns == ("customer_id",)
     assert foreign_key.local_columns == ("customer_id",)
@@ -1290,7 +1292,7 @@ def test_same_name_composite_foreign_key_is_inferred_by_normalized_name():
         ],
     )
 
-    [foreign_key] = entries.foreign_keys
+    [foreign_key] = entries.to_desired_table().foreign_keys
 
     assert foreign_key.local_columns == ("account_id", "tenant_id")
     assert foreign_key.referenced_columns == ("account_id", "tenant_id")
@@ -1381,7 +1383,7 @@ def test_delta_table_stores_composite_foreign_key_canonically():
     )
 
     # Then pairs are stored canonically (sorted by local column), pairing intact
-    [foreign_key] = orders.foreign_keys
+    [foreign_key] = orders.to_desired_table().foreign_keys
     assert foreign_key.local_columns == ("customer_id", "tenant_id")
     assert foreign_key.referenced_columns == ("id", "tenant_id")
 
@@ -1401,7 +1403,7 @@ def test_delta_table_supports_self_referential_foreign_key():
     )
 
     # Then the FK targets the table's own qualified name and primary key
-    [foreign_key] = employee.foreign_keys
+    [foreign_key] = employee.to_desired_table().foreign_keys
     assert foreign_key.referenced_table == QualifiedName("cat", "sch", "employee")
     assert foreign_key.referenced_columns == ("id",)
 
@@ -1609,7 +1611,7 @@ def test_foreign_key_with_matching_types_still_lowers():
     )
 
     # Then the foreign key lowers normally
-    assert orders.foreign_keys[0].local_columns == ("customer_id",)
+    assert orders.to_desired_table().foreign_keys[0].local_columns == ("customer_id",)
 
 
 def test_foreign_key_accepts_columns_as_any_mapping():
@@ -1626,7 +1628,7 @@ def test_foreign_key_accepts_columns_as_any_mapping():
 
     # Then the declaration copies the mapping and the lowered constraint holds an immutable tuple
     assert dict(declaration.columns) == {"customer_id": "id"}
-    [constraint] = orders.foreign_keys
+    [constraint] = orders.to_desired_table().foreign_keys
     assert constraint.local_columns == ("customer_id",)
 
 
@@ -1640,7 +1642,7 @@ def test_mapping_lowers_single_column_foreign_key():
         foreign_keys=[ForeignKey(columns={"customer_id": "id"}, references=customers)],
     )
 
-    [foreign_key] = orders.foreign_keys
+    [foreign_key] = orders.to_desired_table().foreign_keys
     assert foreign_key.local_columns == ("customer_id",)
     assert foreign_key.referenced_table == QualifiedName("cat", "sch", "customers")
     assert foreign_key.referenced_columns == ("id",)
@@ -1672,7 +1674,7 @@ def test_mapping_lowers_composite_foreign_key_with_stated_pairing():
     )
 
     # Stored canonically (sorted by local column), pairing exactly as stated
-    [foreign_key] = orders.foreign_keys
+    [foreign_key] = orders.to_desired_table().foreign_keys
     assert foreign_key.local_columns == ("customer_id", "tenant_id")
     assert foreign_key.referenced_columns == ("id", "tenant_id")
 
@@ -1690,13 +1692,14 @@ def test_mapping_insertion_order_is_irrelevant():
     )
 
     def orders_with(mapping):
-        return DeltaTable(
+        table = DeltaTable(
             catalog="cat",
             schema="sch",
             name="orders",
             columns=[Column("tenant_id", Integer()), Column("customer_id", Integer())],
             foreign_keys=[ForeignKey(columns=mapping, references=accounts)],
-        ).foreign_keys[0]
+        )
+        return table.to_desired_table().foreign_keys[0]
 
     one = orders_with({"tenant_id": "tenant_id", "customer_id": "id"})
     two = orders_with({"customer_id": "id", "tenant_id": "tenant_id"})

--- a/tests/application/test_dependency_resolution.py
+++ b/tests/application/test_dependency_resolution.py
@@ -582,13 +582,13 @@ def test_resolve_reports_invalid_fk_target_over_cycle_for_the_same_fk():
             Column("email", String()),
             Column("ref_id", String()),
         ),
-        primary_key=PrimaryKeyConstraint.generate(table_name="b", columns=("id",)),
+        primary_key=PrimaryKeyConstraint(columns=("id",), constraint_name="b_pk"),
         foreign_keys=(
-            ForeignKeyConstraint.generate(
-                owner_table_name="b",
+            ForeignKeyConstraint(
                 local_columns=("ref_id",),
                 referenced_table=_qualified_name("cat.sch.a"),
                 referenced_columns=("id",),
+                constraint_name="b_ref_id_fk",
             ),
         ),
     )
@@ -598,13 +598,13 @@ def test_resolve_reports_invalid_fk_target_over_cycle_for_the_same_fk():
             Column("id", String(), nullable=False),
             Column("ref_email", String()),
         ),
-        primary_key=PrimaryKeyConstraint.generate(table_name="a", columns=("id",)),
+        primary_key=PrimaryKeyConstraint(columns=("id",), constraint_name="a_pk"),
         foreign_keys=(
-            ForeignKeyConstraint.generate(
-                owner_table_name="a",
+            ForeignKeyConstraint(
                 local_columns=("ref_email",),
                 referenced_table=_qualified_name("cat.sch.b"),
                 referenced_columns=("email",),
+                constraint_name="a_ref_email_fk",
             ),
         ),
     )
@@ -858,16 +858,13 @@ def test_resolve_fails_fk_whose_referenced_columns_are_not_the_pk():
             Column("id", String(), nullable=False),
             Column("ref_email", String()),
         ),
-        primary_key=PrimaryKeyConstraint.generate(
-            table_name="orders",
-            columns=("id",),
-        ),
+        primary_key=PrimaryKeyConstraint(columns=("id",), constraint_name="orders_pk"),
         foreign_keys=(
-            ForeignKeyConstraint.generate(
-                owner_table_name="orders",
+            ForeignKeyConstraint(
                 local_columns=("ref_email",),
                 referenced_table=_qualified_name("cat.sch.customers"),
                 referenced_columns=("email",),
+                constraint_name="orders_ref_email_fk",
             ),
         ),
     )
@@ -1070,16 +1067,13 @@ def test_resolve_fails_when_fk_references_only_part_of_composite_primary_key():
             Column("id", String(), nullable=False),
             Column("customer_id", String()),
         ),
-        primary_key=PrimaryKeyConstraint.generate(
-            table_name="orders",
-            columns=("id",),
-        ),
+        primary_key=PrimaryKeyConstraint(columns=("id",), constraint_name="orders_pk"),
         foreign_keys=(
-            ForeignKeyConstraint.generate(
-                owner_table_name="orders",
+            ForeignKeyConstraint(
                 local_columns=("customer_id",),
                 referenced_table=_qualified_name("cat.sch.customers"),
                 referenced_columns=("customer_id",),
+                constraint_name="orders_customer_id_fk",
             ),
         ),
     )
@@ -1111,16 +1105,13 @@ def test_resolve_treats_composite_pk_referenced_column_order_as_irrelevant():
             Column("customer_id", String()),
             Column("country_code", String()),
         ),
-        primary_key=PrimaryKeyConstraint.generate(
-            table_name="orders",
-            columns=("id",),
-        ),
+        primary_key=PrimaryKeyConstraint(columns=("id",), constraint_name="orders_pk"),
         foreign_keys=(
-            ForeignKeyConstraint.generate(
-                owner_table_name="orders",
+            ForeignKeyConstraint(
                 local_columns=("country_code", "customer_id"),
                 referenced_table=_qualified_name("cat.sch.customers"),
                 referenced_columns=("country_code", "customer_id"),
+                constraint_name="orders_country_code_customer_id_fk",
             ),
         ),
     )

--- a/tests/application/test_engine.py
+++ b/tests/application/test_engine.py
@@ -153,10 +153,7 @@ def _existing_id_table_synced(fqn: str) -> TablePresent:
         table=ObservedTable(
             qualified_name=QualifiedName(catalog, schema, table_name),
             columns=(ObservedColumn("id", String(), nullable=False),),
-            primary_key=PrimaryKeyConstraint.generate(
-                table_name=table_name,
-                columns=("id",),
-            ),
+            primary_key=PrimaryKeyConstraint(columns=("id",), constraint_name=f"{table_name}_pk"),
         )
     )
 

--- a/tests/domain/model/test_foreign_key.py
+++ b/tests/domain/model/test_foreign_key.py
@@ -127,20 +127,6 @@ def test_foreign_key_constraint_is_frozen():
         constraint.referenced_table = _customers()  # type: ignore[misc]
 
 
-def test_generate_names_constraint_from_table_and_local_columns():
-    # Given a table name and foreign key content
-    # When the engine generates the constraint
-    constraint = ForeignKeyConstraint.generate(
-        owner_table_name="orders",
-        local_columns=("customer_id",),
-        referenced_table=_customers(),
-        referenced_columns=("id",),
-    )
-
-    # Then the name follows {table}_{local_cols}_fk
-    assert constraint.constraint_name == "orders_customer_id_fk"
-
-
 def test_construction_canonicalizes_pair_order_by_local_column():
     # Given pairs declared in non-canonical order: b->y, a->x
     constraint = ForeignKeyConstraint(
@@ -172,26 +158,6 @@ def test_signature_ignores_declared_pair_order():
 
     # Then they are the same constraint — order is not part of identity
     assert one.signature == two.signature
-
-
-def test_generate_names_identically_for_permuted_pairs():
-    # Given the same relationship generated from two pair orders
-    one = ForeignKeyConstraint.generate(
-        owner_table_name="orders",
-        local_columns=("a", "b"),
-        referenced_table=_customers(),
-        referenced_columns=("x", "y"),
-    )
-    two = ForeignKeyConstraint.generate(
-        owner_table_name="orders",
-        local_columns=("b", "a"),
-        referenced_table=_customers(),
-        referenced_columns=("y", "x"),
-    )
-
-    # Then the generated name is order-independent and canonical
-    assert one.constraint_name == "orders_a_b_fk"
-    assert two.constraint_name == "orders_a_b_fk"
 
 
 def test_mixed_case_columns_and_name_normalize_to_lowercase():

--- a/tests/domain/model/test_primary_key.py
+++ b/tests/domain/model/test_primary_key.py
@@ -29,16 +29,6 @@ def test_equal_by_value():
     )
 
 
-def test_generate_names_constraint_from_table():
-    # Given a table name and key columns
-    # When the engine generates the constraint
-    constraint = PrimaryKeyConstraint.generate(table_name="orders", columns=("id",))
-
-    # Then the name follows {table}_pk and the columns are carried through
-    assert constraint.constraint_name == "orders_pk"
-    assert constraint.columns == ("id",)
-
-
 def test_mixed_case_columns_and_name_normalize_to_lowercase():
     pk = PrimaryKeyConstraint(columns=("OrderId",), constraint_name="Orders_PK")
     assert pk.columns == ("orderid",)

--- a/tests/domain/model/test_table.py
+++ b/tests/domain/model/test_table.py
@@ -119,9 +119,7 @@ def test_desired_table_rejects_pk_column_not_in_columns():
         DesiredTable(
             qualified_name=_QN,
             columns=(_COL,),
-            primary_key=PrimaryKeyConstraint.generate(
-                table_name="orders", columns=("missing_col",)
-            ),
+            primary_key=PrimaryKeyConstraint(columns=("missing_col",), constraint_name="orders_pk"),
         )
 
 
@@ -144,7 +142,7 @@ def test_desired_table_rejects_nullable_primary_key_column():
         DesiredTable(
             qualified_name=_QN,
             columns=(DesiredColumn("id", Integer(), nullable=True),),
-            primary_key=PrimaryKeyConstraint.generate(table_name="orders", columns=("id",)),
+            primary_key=PrimaryKeyConstraint(columns=("id",), constraint_name="orders_pk"),
         )
 
 
@@ -158,8 +156,8 @@ def test_desired_table_reports_the_offending_nullable_primary_key_column():
                 DesiredColumn("id", Integer(), nullable=False),
                 DesiredColumn("tenant_id", Integer(), nullable=True),
             ),
-            primary_key=PrimaryKeyConstraint.generate(
-                table_name="orders", columns=("id", "tenant_id")
+            primary_key=PrimaryKeyConstraint(
+                columns=("id", "tenant_id"), constraint_name="orders_pk"
             ),
         )
 
@@ -190,11 +188,11 @@ def test_desired_table_defaults_to_no_foreign_keys():
 
 def test_desired_table_stores_foreign_keys():
     # Given a foreign key referencing another table (name generated at the API layer)
-    fk = ForeignKeyConstraint.generate(
-        owner_table_name="orders",
+    fk = ForeignKeyConstraint(
         local_columns=("customer_id",),
         referenced_table=QualifiedName("cat", "sch", "customers"),
         referenced_columns=("id",),
+        constraint_name="orders_customer_id_fk",
     )
     table = DesiredTable(
         qualified_name=QualifiedName("cat", "sch", "orders"),
@@ -216,11 +214,11 @@ def test_desired_table_stores_foreign_keys():
 
 def test_desired_table_rejects_fk_referencing_unknown_local_column():
     # Given a FK whose local column is not declared (name provided so construction succeeds)
-    fk = ForeignKeyConstraint.generate(
-        owner_table_name="orders",
+    fk = ForeignKeyConstraint(
         local_columns=("nonexistent",),
         referenced_table=QualifiedName("cat", "sch", "customers"),
         referenced_columns=("id",),
+        constraint_name="orders_nonexistent_fk",
     )
 
     # When / Then the DesiredTable rejects the FK referencing a column that does not exist
@@ -285,17 +283,17 @@ def test_desired_table_rejects_two_foreign_keys_over_the_same_local_columns():
 def test_desired_table_rejects_foreign_keys_whose_generated_names_collide():
     # Given two FKs over different local columns whose generated names collide:
     # ('a', 'b_c') and ('a_b', 'c') both derive t_a_b_c_fk
-    first = ForeignKeyConstraint.generate(
-        owner_table_name="t",
+    first = ForeignKeyConstraint(
         local_columns=("a", "b_c"),
         referenced_table=QualifiedName("cat", "sch", "p1"),
         referenced_columns=("x", "y"),
+        constraint_name="t_a_b_c_fk",
     )
-    second = ForeignKeyConstraint.generate(
-        owner_table_name="t",
+    second = ForeignKeyConstraint(
         local_columns=("a_b", "c"),
         referenced_table=QualifiedName("cat", "sch", "p2"),
         referenced_columns=("x", "y"),
+        constraint_name="t_a_b_c_fk",
     )
 
     # When / Then the collision is rejected, naming both column tuples
@@ -709,9 +707,7 @@ def test_desired_table_rejects_a_primary_key_on_a_rename_source() -> None:
                     "customer_name", String(), nullable=False, renamed_from="customer_nm"
                 ),
             ),
-            primary_key=PrimaryKeyConstraint.generate(
-                table_name="orders", columns=("customer_nm",)
-            ),
+            primary_key=PrimaryKeyConstraint(columns=("customer_nm",), constraint_name="orders_pk"),
         )
 
 


### PR DESCRIPTION
## What changed

- Move generated PK/FK naming policy out of domain constraint classes and into API lowering.
- Declare `PrimaryKeyConstraint` and `ForeignKeyConstraint` inline with explicit names.
- Keep domain constraints focused on validation and canonicalization.
- Keep `DeltaTable.foreign_keys` at the public declaration level; lowered constraints are available through `to_desired_table()`.
- Update policy documentation and tests.

## Why

Constraint construction helpers obscured deployment naming policy inside domain values. The API also exposed lowered foreign-key constraints from a property whose constructor accepts public `ForeignKey` declarations, making the interface inconsistent.

The revised boundary keeps declarations public and lowering internal. Reusing `table.foreign_keys` therefore re-runs lowering for the new owner and generates the correct physical constraint name.

## Impact

Domain callers must now supply physical names when constructing `PrimaryKeyConstraint` or `ForeignKeyConstraint`. Public schema declarations continue using `DeltaTable` and `ForeignKey`; `DeltaTable.foreign_keys` now returns the original normalized declarations, while `DeltaTable.to_desired_table().foreign_keys` returns lowered constraints.

## Validation

- `uv run pytest` — 974 passed, 63 deselected
- `uv run pytest tests/api/test_delta_table.py --no-cov` — 123 passed
- `uv run mypy src tests`
- `uv run ruff check src tests`
- `uv run ruff format --check src tests`
- `git diff --check`