### PR TITLE
refactor: make action plans self-contained

### DIFF
--- a/docs/explanation-architecture.md
+++ b/docs/explanation-architecture.md
@@ -69,7 +69,7 @@ through a sync.
 | `TableAspect`      | One managed aspect of a table: existence, columns, comments, properties, tags, partitioning, clustering, primary key, or foreign keys. Internal enum.       |
 | `ValidationResult` | Lower-level validation verdict used to test policy rules in isolation.                                                                                      |
 | `PlanningResult`   | The total application boundary: either `PlanningSucceeded(ActionPlan)` or `PlanningFailed(validation failures)`.                                            |
-| `ActionPlan`       | The ordered, table-local actions that should be executed if the table is allowed to run.                                                                    |
+| `ActionPlan`       | The qualified table target, relation kind, and ordered actions that should be executed if the table is allowed to run.                                      |
 | `ResolveResult`    | One explicit success or failure per table in dependency-first order; successful outcomes retain their resolved dependencies for execution.                  |
 | `ExecutionSummary` | The result of running a plan's compiled statements. It records successful statements and the first failed statement, if execution failed.                   |
 | `TableRunReport`   | The immutable public snapshot of a completed table run: desired state, read result, accepted plan, compiled SQL, failures, and attempted statement results.                  |
@@ -115,13 +115,14 @@ flowchart LR
 If neither state can be determined, the adapter translates its backend
 exception into the application-owned `ReadError` and raises it.
 
-`PlanExecutor` is a two-stage boundary. `compile(qualified_name, plan)` lowers
-a plan to the backend statements that apply it — the plan carries the observed
-relation kind its actions lower against, so the SQL dialect follows what the
-reader saw — and the engine calls it in the plan phase on every run, dry or
-real, recording the statements on the table's report. On a real run, the
-engine passes that same tuple to `execute(statement)` one statement at a time,
-so the previewed SQL is exactly what executes.
+`PlanExecutor` is a two-stage boundary. `compile(plan)` lowers a plan to the
+backend statements that apply it. The plan carries both its qualified table
+target and the observed relation kind its actions lower against, so neither
+identity nor SQL dialect travels as parallel context. The engine calls it in
+the plan phase on every run, dry or real, recording the statements on the
+table's report. On a real run, the engine passes that same tuple to
+`execute(statement)` one statement at a time, so the previewed SQL is exactly
+what executes.
 
 For both outbound ports, adapters translate expected backend failures into
 application-owned errors: `ReadError` or `ExecutionError`. The engine catches
@@ -269,7 +270,7 @@ sequenceDiagram
     Differ-->>Engine: TableMissing / TableDrift
     Engine->>Planner: plan_diff(diff)
     Planner-->>Engine: PlanningSucceeded(plan) / PlanningFailed(failures)
-    Engine->>Executor: compile(qualified_name, plan)
+    Engine->>Executor: compile(plan)
     Executor-->>Engine: SQL statements
     Engine->>Resolver: resolve(tables, blocked=failed_tables)
     Resolver-->>Engine: dependency order + FK failures
@@ -311,7 +312,7 @@ execution. The engine still processes other tables.
 | `DesiredTable`     | API lowering           | Domain planner, resolver, report | Target schema snapshot                      |
 | `ObservedTable`    | Reader adapter         | Domain planner, report           | Catalog schema snapshot                     |
 | `TableDiff`        | `diff_table`           | `plan_diff`                      | Direct actions and unresolvable differences |
-| `ActionPlan`       | successful `plan_diff` | Executor (`compile`), report     | Ordered, validated table-local actions      |
+| `ActionPlan`       | successful `plan_diff` | Executor (`compile`), report     | Targeted, ordered, validated actions         |
 | `CatalogState`     | Reader port            | Engine                           | Known present or absent state               |
 | `ReadResult`       | Engine                 | Report                           | Catalog state or persistent read failure    |
 | SQL statements     | Executor (`compile`)   | Engine, executor, report         | The DDL a plan lowers to                    |
@@ -517,13 +518,15 @@ The authoritative list and resolution for every current rule lives in
 [safe-change rules](reference-safe-change-rules.md); keeping the inventory in
 one place prevents this architecture overview from drifting when policy grows.
 
-The engine calls `plan_diff` once. A `PlanningFailed` keeps the run's plan empty
-and records its validation failures; a `PlanningSucceeded` supplies the only
-plan the compiler can receive.
+The engine calls `plan_diff` once. A `PlanningFailed` leaves the run without a
+plan and records its validation failures; a `PlanningSucceeded` supplies the
+only plan the compiler can receive. A successful no-op is distinct: it carries
+an empty plan with a real target and relation kind.
 
 ## Deterministic action plans
 
-An `ActionPlan` owns action ordering. Callers do not sort actions manually.
+An `ActionPlan` owns its table target, relation kind, and action ordering.
+Callers do not pass target context beside it or sort actions manually.
 
 Every action declares two ordering fields:
 

--- a/docs/explanation-sync-lifecycle.md
+++ b/docs/explanation-sync-lifecycle.md
@@ -43,7 +43,8 @@ executing one is a good idea. Ambiguous or unsupported states remain domain
 differences rather than being labelled as blockers; the application default
 policy decides to reject them. The planning boundary always validates that
 complete diff and returns either an accepted `ActionPlan` or failures; a
-rejected result has no plan.
+rejected result has no plan. An accepted plan carries the qualified table
+target and relation kind needed for compilation as well as its ordered actions.
 
 This separation is why rejections are precise: a failed sync names the exact
 rule that fired and the column or table it fired on, rather than a generic

--- a/docs/how-to-implement-adapter.md
+++ b/docs/how-to-implement-adapter.md
@@ -47,12 +47,14 @@ Execution is a two-stage boundary. `compile` turns a domain plan into the backen
 ```python
 from delta_engine.application.errors import ExecutionError
 from delta_engine.application.ports import PlanExecutor
-from delta_engine.domain.model import QualifiedName
 from delta_engine.domain.plan.actions import ActionPlan
 
 class MyExecutor:
-    def compile(self, qualified_name: QualifiedName, plan: ActionPlan) -> tuple[str, ...]:
-        return tuple(self._render(action) for action in plan.actions)
+    def compile(self, plan: ActionPlan) -> tuple[str, ...]:
+        return tuple(
+            self._render(plan.target, plan.kind, action)
+            for action in plan.actions
+        )
 ```
 
 The engine calls `compile` only with the `ActionPlan` carried by a
@@ -60,11 +62,11 @@ The engine calls `compile` only with the `ActionPlan` carried by a
 statements on the table's report. A rejected diff has no plan and never reaches
 this port. `compile` is **not** total: compiling an accepted plan is a pure,
 local operation that cannot fail against a backend, so it may raise on a
-genuine programming error rather than swallowing it. The plan carries the
-relation kind its actions lower against (`plan.kind`) — backends whose DDL
-dialect differs by kind (Databricks streaming tables take
-`ALTER STREAMING TABLE`) read it off the plan; a backend with one dialect
-may ignore it.
+genuine programming error rather than swallowing it. The plan carries both
+the qualified table target (`plan.target`) and the relation kind its actions
+lower against (`plan.kind`). Backends whose DDL dialect differs by kind
+(Databricks streaming tables take `ALTER STREAMING TABLE`) read both facts
+from the plan; a backend with one dialect may ignore the kind.
 
 The engine passes those same compiled statements to `execute` one at a time.
 The table they target is already baked into each statement. Returning normally

--- a/docs/todo/code-consolidation-review.md
+++ b/docs/todo/code-consolidation-review.md
@@ -221,6 +221,14 @@ This pairs naturally with finding 2: a phase that was never planned should be
 represented separately from a successfully planned no-op. A successful empty
 plan still has a real target and kind.
 
+### Implemented
+
+`ActionPlan` now carries its required `QualifiedName` target and rejects a
+`CreateTable` for a different name. `plan_diff` supplies that target on both
+diff arms, and `PlanExecutor.compile` plus the Databricks SQL compiler accept
+the plan alone. Reports use `plan=None` when reading or planning failed while a
+successful no-op retains an empty, target-bearing plan.
+
 ## 4. Make the creation aggregate honest
 
 ### Cause

--- a/src/delta_engine/adapters/databricks/spark/executor.py
+++ b/src/delta_engine/adapters/databricks/spark/executor.py
@@ -4,7 +4,6 @@ from pyspark.sql import SparkSession
 
 from delta_engine.adapters.databricks.execution import execute_statement
 from delta_engine.adapters.databricks.sql import compile_plan
-from delta_engine.domain.model import QualifiedName
 from delta_engine.domain.plan import ActionPlan
 
 
@@ -14,9 +13,9 @@ class SparkExecutor:
     def __init__(self, spark: SparkSession) -> None:
         self.spark = spark
 
-    def compile(self, qualified_name: QualifiedName, plan: ActionPlan) -> tuple[str, ...]:
+    def compile(self, plan: ActionPlan) -> tuple[str, ...]:
         """Compile ``plan`` to its SQL statements in execution order, without touching Spark."""
-        return compile_plan(qualified_name, plan)
+        return compile_plan(plan)
 
     def execute(self, statement: str) -> None:
         """Execute one statement, translating Spark failures at the shared boundary."""

--- a/src/delta_engine/adapters/databricks/sql/compile.py
+++ b/src/delta_engine/adapters/databricks/sql/compile.py
@@ -79,15 +79,15 @@ class _Target:
         return f"{_ALTER_CLAUSES[self.kind]} {self.name}"
 
 
-def compile_plan(qualified_name: QualifiedName, plan: ActionPlan) -> tuple[str, ...]:
+def compile_plan(plan: ActionPlan) -> tuple[str, ...]:
     """
-    Compile an :class:`ActionPlan` for ``qualified_name`` into SQL statements, in plan order.
+    Compile an :class:`ActionPlan` into SQL statements, in plan order.
 
-    The plan's relation kind selects the ALTER dialect every ALTER-family
-    statement targets ``qualified_name`` with; non-ALTER statements
-    (CREATE TABLE, COMMENT ON) are unaffected by it.
+    The plan supplies both the qualified table target and the relation kind
+    selecting the ALTER dialect. Non-ALTER statements (CREATE TABLE, COMMENT
+    ON) use the same plan target but are unaffected by the relation kind.
     """
-    target = _Target(qualified_name=qualified_name, kind=plan.kind)
+    target = _Target(qualified_name=plan.target, kind=plan.kind)
     return tuple(_compile_action(action, target) for action in plan)
 
 

--- a/src/delta_engine/adapters/databricks/warehouse/executor.py
+++ b/src/delta_engine/adapters/databricks/warehouse/executor.py
@@ -7,7 +7,6 @@ from typing import TYPE_CHECKING
 
 from delta_engine.adapters.databricks.execution import execute_statement
 from delta_engine.adapters.databricks.sql import compile_plan
-from delta_engine.domain.model import QualifiedName
 from delta_engine.domain.plan import ActionPlan
 
 if TYPE_CHECKING:
@@ -20,13 +19,13 @@ class WarehouseExecutor:
     def __init__(self, connection: Connection) -> None:
         self._connection = connection
 
-    def compile(self, qualified_name: QualifiedName, plan: ActionPlan) -> tuple[str, ...]:
+    def compile(self, plan: ActionPlan) -> tuple[str, ...]:
         """
         Compile ``plan`` to its SQL statements in execution order.
 
         Does not touch the warehouse.
         """
-        return compile_plan(qualified_name, plan)
+        return compile_plan(plan)
 
     def execute(self, statement: str) -> None:
         """

--- a/src/delta_engine/application/engine.py
+++ b/src/delta_engine/application/engine.py
@@ -191,16 +191,12 @@ class _TableRun:
 
     def to_report(self) -> TableRunReport:
         """Freeze this run into its public, immutable report."""
-        plan = self.plan
-        if plan is None:
-            plan = ActionPlan()
-
         execution = self.execution if isinstance(self.execution, ExecutionSummary) else None
 
         return TableRunReport(
             desired=self.desired,
             read=self.read,
-            plan=plan,
+            plan=self.plan,
             planned_sql_statements=self.planned_sql_statements,
             failures=self.failures,
             execution=execution,
@@ -372,7 +368,6 @@ class Engine:
                 continue
 
             run.planned_sql_statements = self.executor.compile(
-                run.qualified_name,
                 plan,
             )
             logger.info(

--- a/src/delta_engine/application/planning.py
+++ b/src/delta_engine/application/planning.py
@@ -47,9 +47,16 @@ def plan_diff(diff: TableDiff) -> PlanningResult:
         return PlanningFailed(failures=validation.failures)
     match diff:
         case TableDrift() as drift:
-            plan = ActionPlan(drift.actions, kind=drift.observed.kind)
+            plan = ActionPlan(
+                target=drift.desired.qualified_name,
+                actions=drift.actions,
+                kind=drift.observed.kind,
+            )
         case TableMissing() as missing:
-            plan = ActionPlan(missing.actions)
+            plan = ActionPlan(
+                target=missing.desired.qualified_name,
+                actions=missing.actions,
+            )
         case _ as unreachable:
             assert_never(unreachable)
     return PlanningSucceeded(plan=plan)

--- a/src/delta_engine/application/ports.py
+++ b/src/delta_engine/application/ports.py
@@ -152,13 +152,13 @@ class PlanExecutor(Protocol):
     :class:`ExecutionFailure`; unexpected programming errors still propagate.
     """
 
-    def compile(self, qualified_name: QualifiedName, plan: ActionPlan) -> tuple[str, ...]:
+    def compile(self, plan: ActionPlan) -> tuple[str, ...]:
         """
         Return the statements that apply ``plan``, in execution order.
 
-        The plan carries the relation kind its actions lower against
-        (``plan.kind``) — backends whose statements differ by kind read it
-        from the plan.
+        The plan carries the qualified table target and relation kind its
+        actions lower against (``plan.target`` and ``plan.kind``). Backends
+        read both from the plan rather than accepting parallel context.
 
         The ordering is the plan's own deterministic order, which is the order
         the application passes statements to ``execute``. An empty plan compiles

--- a/src/delta_engine/application/rendering.py
+++ b/src/delta_engine/application/rendering.py
@@ -59,13 +59,14 @@ def render_diff_block(report: TableRunReport) -> str:
     header = str(report.qualified_name)
     if isinstance(report.read, ReadFailure):
         return f"{header}\n  (could not read — no diff)"
-    if not report.plan:
+    plan = report.plan
+    if not plan:
         if report.has_failures:
             return f"{header}\n  ({_NO_CHANGES} — see failures)"
         return f"{header}\n  ({_NO_CHANGES})"
-    if _plan_creates_table(report.plan):
+    if _plan_creates_table(plan):
         header = f"{header}  (CREATE)"
-    entries = [entry for action in report.plan for entry in action_entries(action)]
+    entries = [entry for action in plan for entry in action_entries(action)]
     return "\n".join([header, *_render_entry_groups(entries)])
 
 
@@ -78,8 +79,10 @@ def _grid_statements_cell(report: TableRunReport) -> str:
     return str(len(report.planned_sql_statements))
 
 
-def _humanized_action_summary(plan: ActionPlan) -> str:
+def _humanized_action_summary(plan: ActionPlan | None) -> str:
     """Summarise a plan as per-category change counts in display order, e.g. '2 columns, 1 key'."""
+    if plan is None:
+        return _NO_CHANGES
     counts: Counter[DiffCategory] = Counter()
     for action in plan:
         for entry in action_entries(action):

--- a/src/delta_engine/application/report.py
+++ b/src/delta_engine/application/report.py
@@ -47,7 +47,7 @@ _STATUS_FOR_PHASE: Final[Mapping[FailurePhase, TableRunStatus]] = MappingProxyTy
 )
 
 
-def _change_records(plan: ActionPlan) -> list[dict[str, str]]:
+def _change_records(plan: ActionPlan | None) -> list[dict[str, str]]:
     """
     Summarise the plan as flat change records, in plan order.
 
@@ -56,6 +56,8 @@ def _change_records(plan: ActionPlan) -> list[dict[str, str]]:
     into several), and not a complete description of the change — the
     authoritative description is the planned SQL.
     """
+    if plan is None:
+        return []
     return [
         {
             "kind": entry.category.name.lower(),
@@ -87,13 +89,15 @@ class TableRunReport:
 
     The engine creates a report after all phases finish, projecting its
     canonical phase outcomes into this immutable snapshot.
+    ``plan`` is ``None`` when reading or planning failed; a successfully
+    planned no-op retains an empty, target-bearing plan.
     ``planned_sql_statements`` is populated on dry and real runs so planned
     changes remain inspectable even when execution is skipped or blocked.
     """
 
     desired: DesiredTable
     read: ReadResult
-    plan: ActionPlan
+    plan: ActionPlan | None
     planned_sql_statements: tuple[str, ...]
     failures: tuple[Failure, ...]
     execution: ExecutionSummary | None

--- a/src/delta_engine/domain/plan/actions.py
+++ b/src/delta_engine/domain/plan/actions.py
@@ -14,6 +14,7 @@ from delta_engine.domain.model import (
     ForeignKeyReference,
     ObservedColumn,
     PrimaryKeyConstraint,
+    QualifiedName,
     TableAspect,
     TableKind,
 )
@@ -400,21 +401,31 @@ class ActionPlan:
     """
     Validated executable actions held in deterministic execution order.
 
-    A plan keeps its actions sorted by execution phase and then by subject
-    name, regardless of the order they are supplied in: ordering is an
-    invariant of the plan, not a step a caller has to remember.
+    A plan carries the qualified table target its actions apply to and keeps
+    those actions sorted by execution phase and then by subject name,
+    regardless of the order they are supplied in. Target identity and ordering
+    are invariants of the plan, not context a caller has to supply later.
 
     ``kind`` is the relation kind of the table the actions lower against —
     part of what the plan means, since the same actions compile to different
     statements per kind. Defaults to the ordinary table kind.
     """
 
+    target: QualifiedName
     actions: tuple[Action, ...] = ()
     kind: TableKind = TableKind.TABLE
 
     def __post_init__(self) -> None:
-        """Sort the actions into execution order, preserving input order on ties."""
-        object.__setattr__(self, "actions", tuple(sorted(self.actions, key=_execution_order)))
+        """Validate the creation target and sort actions, preserving order on ties."""
+        ordered_actions = tuple(sorted(self.actions, key=_execution_order))
+
+        for action in ordered_actions:
+            if isinstance(action, CreateTable) and action.table.qualified_name != self.target:
+                raise ValueError(
+                    "CreateTable target does not match ActionPlan target:"
+                    f" {action.table.qualified_name} != {self.target}"
+                )
+        object.__setattr__(self, "actions", ordered_actions)
 
     def __len__(self) -> int:
         return len(self.actions)

--- a/tests/adapters/databricks/spark/test_executor.py
+++ b/tests/adapters/databricks/spark/test_executor.py
@@ -28,10 +28,10 @@ def _dummy_qualified_name() -> QualifiedName:
     return QualifiedName("cat", "sch", "tbl")
 
 
-def _apply(spark, qualified_name: QualifiedName, plan: ActionPlan) -> None:
+def _apply(spark, plan: ActionPlan) -> None:
     """Compile and execute each statement, as the engine drives the adapter."""
     executor = SparkExecutor(spark)
-    for statement in executor.compile(qualified_name, plan):
+    for statement in executor.compile(plan):
         executor.execute(statement)
 
 
@@ -78,14 +78,15 @@ def test_executor_compiles_plan_and_executes_statements_in_order():
     # Given a public executor and a two-action plan
     spark = _FakeSpark()
     plan = ActionPlan(
+        target=_dummy_qualified_name(),
         actions=(
             AddColumn(DesiredColumn("age", Integer())),
             DropColumn(ObservedColumn("legacy", Integer())),
-        )
+        ),
     )
 
     # When compiling and executing the plan
-    _apply(spark, _dummy_qualified_name(), plan)
+    _apply(spark, plan)
 
     # Then the compiled SQL is sent to Spark in action order
     assert spark.executed == [
@@ -96,11 +97,11 @@ def test_executor_compiles_plan_and_executes_statements_in_order():
 
 def test_empty_plan_executes_no_statements():
     # Given an empty plan
-    plan = ActionPlan(actions=())
+    plan = ActionPlan(target=_dummy_qualified_name())
     spark = _FakeSpark()
 
     # When compiling and executing the plan
-    _apply(spark, _dummy_qualified_name(), plan)
+    _apply(spark, plan)
 
     # Then nothing ran
     assert spark.executed == []
@@ -116,10 +117,10 @@ def test_create_table_action_creates_table_with_correct_schema(spark, temp_schem
         qualified_name=QualifiedName(TEST_CATALOG, temp_schema, "customers"),
         columns=(DesiredColumn(name="id", data_type=Integer()),),
     )
-    plan = ActionPlan(actions=(CreateTable(table=desired),))
+    plan = ActionPlan(target=desired.qualified_name, actions=(CreateTable(table=desired),))
 
     # When applying the plan
-    _apply(spark, desired.qualified_name, plan)
+    _apply(spark, plan)
 
     # Then the table exists and its schema matches exactly
     assert spark.catalog.tableExists(str(desired.qualified_name))
@@ -142,6 +143,7 @@ def test_add_column_action_adds_column_to_existing_table(spark, make_temp_table)
     full_table_name = make_temp_table("add_col", "id INT NOT NULL")
     qualified_name = QualifiedName(*full_table_name.split("."))
     plan = ActionPlan(
+        target=qualified_name,
         actions=(
             AddColumn(
                 column=DesiredColumn(
@@ -149,11 +151,11 @@ def test_add_column_action_adds_column_to_existing_table(spark, make_temp_table)
                     data_type=Integer(),
                 )
             ),
-        )
+        ),
     )
 
     # When applying the plan
-    _apply(spark, qualified_name, plan)
+    _apply(spark, plan)
 
     # Then the new column exists with the expected type
     age_field = _get_field(spark, full_table_name, "age")
@@ -168,10 +170,13 @@ def test_drop_column_action_removes_column_from_existing_table(spark, make_temp_
         tblprops={"delta.columnMapping.mode": "name"},
     )
     qualified_name = QualifiedName(*full_table_name.split("."))
-    plan = ActionPlan(actions=(DropColumn(ObservedColumn("to_remove", Integer())),))
+    plan = ActionPlan(
+        target=qualified_name,
+        actions=(DropColumn(ObservedColumn("to_remove", Integer())),),
+    )
 
     # When applying the plan
-    _apply(spark, qualified_name, plan)
+    _apply(spark, plan)
 
     # Then the column no longer exists
     assert "to_remove" not in spark.table(full_table_name).columns
@@ -183,17 +188,18 @@ def test_set_property_action_sets_table_property(spark, make_temp_table):
     qualified_name = QualifiedName(*full_table_name.split("."))
     property_name = "engine.test.setproperty"
     plan = ActionPlan(
+        target=qualified_name,
         actions=(
             SetProperty(
                 name=property_name,
                 desired_value="yes",
                 observed_value=None,
             ),
-        )
+        ),
     )
 
     # When applying the plan
-    _apply(spark, qualified_name, plan)
+    _apply(spark, plan)
 
     # Then the property exists with the expected value
     assert _get_table_props(spark, full_table_name).get(property_name) == "yes"
@@ -204,17 +210,18 @@ def test_set_column_comment_sets_comment_on_column(spark, make_temp_table):
     full_table_name = make_temp_table("col_comment", "id INT NOT NULL, name STRING")
     qualified_name = QualifiedName(*full_table_name.split("."))
     plan = ActionPlan(
+        target=qualified_name,
         actions=(
             SetColumnComment(
                 column_name="name",
                 desired_comment="customer name",
                 observed_comment="",
             ),
-        )
+        ),
     )
 
     # When applying the plan
-    _apply(spark, qualified_name, plan)
+    _apply(spark, plan)
 
     # Then the column metadata contains the new comment
     field = _get_field(spark, full_table_name, "name")
@@ -226,11 +233,12 @@ def test_set_table_comment_sets_comment_on_table(spark, make_temp_table):
     full_table_name = make_temp_table("tbl_comment", "id INT NOT NULL")
     qualified_name = QualifiedName(*full_table_name.split("."))
     plan = ActionPlan(
-        actions=(SetTableComment(desired_comment="staging table", observed_comment=""),)
+        target=qualified_name,
+        actions=(SetTableComment(desired_comment="staging table", observed_comment=""),),
     )
 
     # When applying the plan
-    _apply(spark, qualified_name, plan)
+    _apply(spark, plan)
 
     # Then the table comment is set
     assert _get_table_comment(spark, full_table_name) == "staging table"
@@ -241,17 +249,18 @@ def test_set_column_nullability_sets_nullable(spark, make_temp_table):
     full_table_name = make_temp_table("nullability", "id INT NOT NULL, name STRING")
     qualified_name = QualifiedName(*full_table_name.split("."))
     plan = ActionPlan(
+        target=qualified_name,
         actions=(
             SetColumnNullability(
                 column_name="id",
                 desired_nullable=True,
                 observed_nullable=False,
             ),
-        )
+        ),
     )
 
     # When applying the plan
-    _apply(spark, qualified_name, plan)
+    _apply(spark, plan)
 
     # Then the column becomes nullable
     assert _get_field(spark, full_table_name, "id").nullable is True
@@ -260,18 +269,22 @@ def test_set_column_nullability_sets_nullable(spark, make_temp_table):
 def test_compile_returns_the_statements_execute_would_run():
     # Given a plan with one action
     qualified_name = QualifiedName("cat", "schema", "tbl")
-    plan = ActionPlan((SetTableComment(desired_comment="hello", observed_comment=""),))
+    plan = ActionPlan(
+        target=qualified_name,
+        actions=(SetTableComment(desired_comment="hello", observed_comment=""),),
+    )
     executor = SparkExecutor(spark=None)  # type: ignore[arg-type]  # compile never touches the session
 
     # When compiling without executing
-    statements = executor.compile(qualified_name, plan)
+    statements = executor.compile(plan)
 
     # Then the statements match the SQL compiler's output, in plan order
-    assert statements == compile_plan(qualified_name, plan)
+    assert statements == compile_plan(plan)
     assert len(statements) == 1
     assert "COMMENT" in statements[0].upper()
 
 
 def test_compile_of_empty_plan_returns_no_statements():
     executor = SparkExecutor(spark=None)  # type: ignore[arg-type]
-    assert executor.compile(QualifiedName("cat", "schema", "tbl"), ActionPlan()) == ()
+    plan = ActionPlan(target=QualifiedName("cat", "schema", "tbl"))
+    assert executor.compile(plan) == ()

--- a/tests/adapters/databricks/sql/test_compile.py
+++ b/tests/adapters/databricks/sql/test_compile.py
@@ -97,8 +97,16 @@ def _create_table(
     )
 
 
+def _plan(
+    *plan_actions: Action,
+    target: QualifiedName = _TARGET,
+    kind: TableKind = TableKind.TABLE,
+) -> ActionPlan:
+    return ActionPlan(target=target, actions=plan_actions, kind=kind)
+
+
 def _compile_single(action: Action, kind: TableKind = TableKind.TABLE) -> str:
-    (statement,) = compile_plan(_TARGET, ActionPlan(actions=(action,), kind=kind))
+    (statement,) = compile_plan(_plan(action, kind=kind))
     return statement
 
 
@@ -119,21 +127,19 @@ def _concrete_action_types() -> list[type[Action]]:
 
 
 def test_compile_empty_plan_returns_empty_tuple():
-    assert compile_plan(_TARGET, ActionPlan(actions=())) == ()
+    assert compile_plan(_plan()) == ()
 
 
 def test_compile_plan_compiles_each_action_in_action_plan_order():
     # Given an ActionPlan containing three actions
-    plan = ActionPlan(
-        actions=(
-            SetTableComment(desired_comment="first", observed_comment=""),
-            SetProperty(name="second", desired_value="true", observed_value=None),
-            DropColumn(column=_observed_column("third")),
-        )
+    plan = _plan(
+        SetTableComment(desired_comment="first", observed_comment=""),
+        SetProperty(name="second", desired_value="true", observed_value=None),
+        DropColumn(column=_observed_column("third")),
     )
 
     # When compiling the plan
-    statements = compile_plan(_TARGET, plan)
+    statements = compile_plan(plan)
 
     # Then each action in the normalized ActionPlan is compiled to its SQL statement
     assert statements == tuple(_compile_single(action) for action in plan)
@@ -142,10 +148,10 @@ def test_compile_plan_compiles_each_action_in_action_plan_order():
 def test_compile_backticks_table_and_column_identifiers():
     # Given identifiers that need quoting
     target = QualifiedName("cat-alog", "sch ema", "select")
-    plan = ActionPlan(actions=(AddColumn(DesiredColumn("weird column", Integer())),))
+    plan = _plan(AddColumn(DesiredColumn("weird column", Integer())), target=target)
 
     # When compiling
-    (statement,) = compile_plan(target, plan)
+    (statement,) = compile_plan(plan)
 
     # Then table and column identifiers are backticked
     assert statement == ("ALTER TABLE `cat-alog`.`sch ema`.`select` ADD COLUMN `weird column` INT")
@@ -488,8 +494,8 @@ def test_set_property_sql_ignores_observed_value():
     )
 
     # When compiling both
-    (first_statement,) = compile_plan(_TARGET, ActionPlan(actions=(first_write,)))
-    (update_statement,) = compile_plan(_TARGET, ActionPlan(actions=(update,)))
+    (first_statement,) = compile_plan(_plan(first_write))
+    (update_statement,) = compile_plan(_plan(update))
 
     # Then observed_value has no effect on rendered SQL
     assert first_statement == update_statement
@@ -511,8 +517,11 @@ def test_every_action_type_has_a_registered_compiler():
 
 
 def test_compile_rename_column():
-    plan = ActionPlan((RenameColumn(old_name="customer_nm", new_name="customer_name"),))
-    statements = compile_plan(QualifiedName("dev", "silver", "customers"), plan)
+    plan = _plan(
+        RenameColumn(old_name="customer_nm", new_name="customer_name"),
+        target=QualifiedName("dev", "silver", "customers"),
+    )
+    statements = compile_plan(plan)
     assert statements == (
         "ALTER TABLE `dev`.`silver`.`customers` RENAME COLUMN `customer_nm` TO `customer_name`",
     )

--- a/tests/adapters/databricks/warehouse/test_executor.py
+++ b/tests/adapters/databricks/warehouse/test_executor.py
@@ -90,11 +90,14 @@ def test_execute_suppresses_cursor_close_failure_after_success():
 def test_compile_returns_backend_statements_without_touching_connection():
     connection = FakeConnection()
     executor = WarehouseExecutor(connection)
-    plan = ActionPlan((SetTableComment(desired_comment="hello", observed_comment=""),))
+    plan = ActionPlan(
+        target=QN,
+        actions=(SetTableComment(desired_comment="hello", observed_comment=""),),
+    )
 
-    statements = executor.compile(QN, plan)
+    statements = executor.compile(plan)
 
-    assert statements == compile_plan(QN, plan)
+    assert statements == compile_plan(plan)
     assert len(statements) == 1
     assert connection.cursor_requests == 0
 
@@ -102,7 +105,7 @@ def test_compile_returns_backend_statements_without_touching_connection():
 def test_compile_of_empty_plan_returns_no_statements():
     connection = FakeConnection()
 
-    statements = WarehouseExecutor(connection).compile(QN, ActionPlan())
+    statements = WarehouseExecutor(connection).compile(ActionPlan(target=QN))
 
     assert statements == ()
     assert connection.cursor_requests == 0

--- a/tests/application/test_engine.py
+++ b/tests/application/test_engine.py
@@ -267,10 +267,9 @@ class _RecordingExecutor:
         self._per_table_errors = None if per_table_errors is None else list(per_table_errors)
         self._active_table: str | None = None
 
-    def compile(self, qualified_name: QualifiedName, plan: ActionPlan) -> tuple[str, ...]:
+    def compile(self, plan: ActionPlan) -> tuple[str, ...]:
         return tuple(
-            f"STATEMENT {index} AS {plan.kind.name} FOR {qualified_name}"
-            for index in range(len(plan))
+            f"STATEMENT {index} AS {plan.kind.name} FOR {plan.target}" for index in range(len(plan))
         )
 
     def execute(self, statement: str) -> None:
@@ -304,8 +303,8 @@ class _FailingMultiStatementExecutor:
     def __init__(self) -> None:
         self.calls: list[str] = []
 
-    def compile(self, qualified_name: QualifiedName, plan: ActionPlan) -> tuple[str, ...]:
-        return tuple(f"STATEMENT {index} FOR {qualified_name}" for index in range(3))
+    def compile(self, plan: ActionPlan) -> tuple[str, ...]:
+        return tuple(f"STATEMENT {index} FOR {plan.target}" for index in range(3))
 
     def execute(self, statement: str) -> None:
         self.calls.append(statement)
@@ -568,10 +567,10 @@ def test_phase_chain_reads_compiles_resolves_then_executes_all_eligible_tables(
             return TableAbsent()
 
     class _EventRecordingExecutor:
-        def compile(self, qualified_name: QualifiedName, plan: ActionPlan) -> tuple[str, ...]:
-            events.append(f"compile:{qualified_name}")
+        def compile(self, plan: ActionPlan) -> tuple[str, ...]:
+            events.append(f"compile:{plan.target}")
             # The name is embedded so execute can recover the target table.
-            return tuple(f"STATEMENT {index} FOR {qualified_name}" for index in range(len(plan)))
+            return tuple(f"STATEMENT {index} FOR {plan.target}" for index in range(len(plan)))
 
         def execute(self, statement: str) -> None:
             events.append(f"execute:{statement.split(' FOR ', 1)[1]}")
@@ -635,7 +634,7 @@ def test_read_failure_is_reported_once_and_has_no_plan_or_execution():
     assert len(table_report.failures) == 1
     assert isinstance(table_report.read, ReadFailure)
     assert table_report.read is table_report.failures[0]
-    assert len(table_report.plan) == 0
+    assert table_report.plan is None
     assert table_report.execution is None
     assert executor.executed_names == []
 
@@ -676,6 +675,7 @@ def test_validation_failed_table_is_not_executed_but_independent_table_still_run
     table_a = _assert_status(report, "c.s.a", TableRunStatus.PLANNING_FAILED)
     table_b = _assert_status(report, "c.s.b", TableRunStatus.SUCCESS)
 
+    assert table_a.plan is None
     assert table_a.execution is None
     assert table_b.execution is not None
     assert executor.executed_names == ["c.s.b"]
@@ -741,8 +741,8 @@ def test_execution_stops_after_first_failure_and_retains_attempted_results():
 
 def test_unexpected_executor_exception_propagates():
     class BuggyExecutor:
-        def compile(self, qualified_name: QualifiedName, _plan: ActionPlan) -> tuple[str, ...]:
-            return (f"STATEMENT FOR {qualified_name}",)
+        def compile(self, plan: ActionPlan) -> tuple[str, ...]:
+            return (f"STATEMENT FOR {plan.target}",)
 
         def execute(self, _statement: str) -> None:
             raise RuntimeError("adapter bug")

--- a/tests/application/test_errors.py
+++ b/tests/application/test_errors.py
@@ -65,11 +65,16 @@ def _table_report(
         failure for failure in failures if not isinstance(failure, ReadFailure | ExecutionFailure)
     )
     execution_failures = () if execution is None else execution.failures
+    planning_failed = any(isinstance(failure, ValidationFailure) for failure in failures)
 
     return TableRunReport(
         desired=desired,
         read=read,
-        plan=ActionPlan(),
+        plan=(
+            None
+            if isinstance(read, ReadFailure) or planning_failed
+            else ActionPlan(target=desired.qualified_name)
+        ),
         planned_sql_statements=statements,
         failures=(*read_failures, *reported_failures, *execution_failures),
         execution=execution,

--- a/tests/application/test_planning.py
+++ b/tests/application/test_planning.py
@@ -77,6 +77,7 @@ def test_plan_diff_accepts_safe_actions():
     result = plan_diff(diff)
 
     assert isinstance(result, PlanningSucceeded)
+    assert result.plan.target == _NAME
     assert result.plan.actions == (AddColumn(DesiredColumn("age", Integer())),)
 
 
@@ -149,6 +150,7 @@ def test_plan_diff_accepts_no_op_as_an_empty_plan():
     result = plan_diff(diff_table(_desired(), _observed()))
 
     assert isinstance(result, PlanningSucceeded)
+    assert result.plan.target == _NAME
     assert result.plan.actions == ()
 
 
@@ -168,6 +170,7 @@ def test_plan_diff_accepts_missing_table_and_builds_follow_up_actions():
     result = plan_diff(diff_table(desired, None))
 
     assert isinstance(result, PlanningSucceeded)
+    assert result.plan.target == desired.qualified_name
     assert result.plan.actions == (
         CreateTable(desired),
         SetTableTag(name="env", value="dev"),
@@ -360,6 +363,7 @@ def test_plan_carries_the_observed_relation_kind():
 
     # Then the plan knows what its actions lower against
     assert isinstance(result, PlanningSucceeded)
+    assert result.plan.target == desired.qualified_name
     assert result.plan.kind is TableKind.STREAMING_TABLE
 
 
@@ -369,4 +373,5 @@ def test_creation_plan_carries_the_ordinary_table_kind():
     result = plan_diff(diff_table(_desired(), None))
 
     assert isinstance(result, PlanningSucceeded)
+    assert result.plan.target == _NAME
     assert result.plan.kind is TableKind.TABLE

--- a/tests/application/test_rendering.py
+++ b/tests/application/test_rendering.py
@@ -35,6 +35,7 @@ from delta_engine.domain.model import (
     String,
 )
 from delta_engine.domain.plan.actions import (
+    Action,
     ActionPlan,
     AddColumn,
     AlterClustering,
@@ -70,6 +71,13 @@ def _foreign_key(constraint_name: str = "orders_customer_id_fk") -> ForeignKeyCo
         referenced_table=QualifiedName("cat", "sch", "customers"),
         referenced_columns=("id",),
         constraint_name=constraint_name,
+    )
+
+
+def _plan(name: str, *actions: Action) -> ActionPlan:
+    return ActionPlan(
+        target=QualifiedName("cat", "sch", name),
+        actions=actions,
     )
 
 
@@ -286,15 +294,15 @@ def _report_with_empty_plan_and_failure() -> TableRunReport:
     return TableRunReport(
         desired=desired,
         read=TablePresent(table=observed),
-        plan=ActionPlan(),
+        plan=None,
         planned_sql_statements=(),
         failures=(ValidationFailure(rule_name="UnsupportedColumnTypeChange", message="nope"),),
         execution=None,
     )
 
 
-def test_diff_block_points_to_failures_when_plan_is_empty_but_failures_exist():
-    # Given a table whose only drift is unsupported — empty plan, failed validation
+def test_diff_block_points_to_failures_when_no_plan_exists_and_failures_exist():
+    # Given a table whose only drift is unsupported — no plan, failed validation
     block = render_diff_block(_report_with_empty_plan_and_failure())
 
     # Then the block does not read as a healthy no-op
@@ -307,7 +315,7 @@ def test_diff_block_shows_plain_no_changes_when_nothing_failed():
     healthy = TableRunReport(
         desired=report.desired,
         read=report.read,
-        plan=ActionPlan(),
+        plan=ActionPlan(target=report.desired.qualified_name),
         planned_sql_statements=(),
         failures=(),
         execution=None,
@@ -326,11 +334,10 @@ def test_diff_block_groups_lines_under_category_headings_in_plan_order():
     # Given a table whose plan sets the table comment and adds a column
     report = _grid_report(
         "orders",
-        plan=ActionPlan(
-            (
-                SetTableComment(desired_comment="c", observed_comment=""),
-                AddColumn(DesiredColumn("age", Integer())),
-            )
+        plan=_plan(
+            "orders",
+            SetTableComment(desired_comment="c", observed_comment=""),
+            AddColumn(DesiredColumn("age", Integer())),
         ),
     )
 
@@ -351,7 +358,7 @@ def test_diff_block_marks_a_create_in_the_header():
     # Given a plan that creates a table
     report = _grid_report(
         "orders",
-        plan=ActionPlan((CreateTable(table=_grid_report("orders").desired),)),
+        plan=_plan("orders", CreateTable(table=_grid_report("orders").desired)),
     )
 
     # Then the block header flags the table as newly created
@@ -367,7 +374,7 @@ def test_diff_block_reports_a_read_failure_instead_of_a_diff():
             qualified_name=qualified_name, columns=(DesiredColumn("id", Integer()),)
         ),
         read=failure,
-        plan=ActionPlan(),
+        plan=None,
         planned_sql_statements=(),
         failures=(failure,),
         execution=None,
@@ -386,7 +393,8 @@ def test_diff_block_reports_a_read_failure_instead_of_a_diff():
 def _grid_report(name, *, plan=None, failures=(), execution=None):
     qualified_name = QualifiedName("cat", "sch", name)
     columns = (DesiredColumn("id", Integer()),)
-    plan = plan if plan is not None else ActionPlan()
+    if plan is None and not failures:
+        plan = ActionPlan(target=qualified_name)
     execution_failures = () if execution is None else execution.failures
     return TableRunReport(
         desired=DesiredTable(qualified_name=qualified_name, columns=columns),
@@ -397,7 +405,9 @@ def _grid_report(name, *, plan=None, failures=(), execution=None):
         ),
         plan=plan,
         # One fake statement per action, as the engine would have compiled.
-        planned_sql_statements=tuple(f"SQL {index}" for index in range(len(plan))),
+        planned_sql_statements=tuple(
+            f"SQL {index}" for index in range(len(plan) if plan is not None else 0)
+        ),
         failures=(*failures, *execution_failures),
         execution=execution,
     )
@@ -424,12 +434,11 @@ def test_grid_detail_summarizes_changes_by_category_not_class_names():
     # Given a changed table with two column adds and one property set
     report = _grid_report(
         "orders",
-        plan=ActionPlan(
-            (
-                AddColumn(DesiredColumn("a", Integer())),
-                AddColumn(DesiredColumn("b", Integer())),
-                SetProperty(name="delta.appendOnly", desired_value="true", observed_value=None),
-            )
+        plan=_plan(
+            "orders",
+            AddColumn(DesiredColumn("a", Integer())),
+            AddColumn(DesiredColumn("b", Integer())),
+            SetProperty(name="delta.appendOnly", desired_value="true", observed_value=None),
         ),
     )
 
@@ -443,12 +452,11 @@ def test_grid_detail_summarizes_changes_by_category_not_class_names():
 
 def test_grid_statements_cell_shows_applied_over_planned_on_partial_failure():
     # Given a three-statement plan where two applied and one failed during execution
-    plan = ActionPlan(
-        (
-            AddColumn(DesiredColumn("a", Integer())),
-            AddColumn(DesiredColumn("b", Integer())),
-            AddColumn(DesiredColumn("c", Integer())),
-        )
+    plan = _plan(
+        "orders",
+        AddColumn(DesiredColumn("a", Integer())),
+        AddColumn(DesiredColumn("b", Integer())),
+        AddColumn(DesiredColumn("c", Integer())),
     )
     report = _grid_report(
         "orders",
@@ -499,7 +507,7 @@ def test_grid_detail_truncates_an_overlong_detail_with_an_ellipsis():
 def test_grid_aligns_the_status_column_across_header_and_rows():
     # Given two tables whose names differ in length
     changed = _grid_report(
-        "a", plan=ActionPlan((SetTableComment(desired_comment="c", observed_comment=""),))
+        "a", plan=_plan("a", SetTableComment(desired_comment="c", observed_comment=""))
     )
     failed = _grid_report(
         "a_much_longer_name",
@@ -521,7 +529,7 @@ def test_grid_aligns_the_status_column_across_header_and_rows():
 def test_run_summary_footer_counts_changed_unchanged_and_failed():
     # Given a run over one changed, one unchanged, and one failed table
     changed = _grid_report(
-        "a", plan=ActionPlan((SetTableComment(desired_comment="c", observed_comment=""),))
+        "a", plan=_plan("a", SetTableComment(desired_comment="c", observed_comment=""))
     )
     unchanged = _grid_report("b")
     failed = _grid_report("c", failures=(ValidationFailure(rule_name="R", message="m"),))
@@ -544,7 +552,7 @@ def test_run_summary_footer_counts_changed_unchanged_and_failed():
 def test_render_report_is_the_status_grid_followed_by_the_summary_footer():
     # Given a run over one changed and one failed table
     changed = _grid_report(
-        "a", plan=ActionPlan((SetTableComment(desired_comment="c", observed_comment=""),))
+        "a", plan=_plan("a", SetTableComment(desired_comment="c", observed_comment=""))
     )
     failed = _grid_report("b", failures=(ValidationFailure(rule_name="R", message="m"),))
     sync = SyncReport(
@@ -625,7 +633,7 @@ def test_render_report_failures_section_has_an_underlined_header():
 def test_render_report_has_no_failures_section_when_all_succeed():
     # Given a run where every table succeeds
     changed = _grid_report(
-        "a", plan=ActionPlan((SetTableComment(desired_comment="c", observed_comment=""),))
+        "a", plan=_plan("a", SetTableComment(desired_comment="c", observed_comment=""))
     )
     sync = SyncReport(
         started_at=datetime(2025, 1, 1, 0, 0, 0),
@@ -640,7 +648,7 @@ def test_render_report_has_no_failures_section_when_all_succeed():
 def test_render_report_shows_dry_run_banner_only_for_dry_runs():
     # Given the same run rendered as a dry run and as an applied run
     changed = _grid_report(
-        "a", plan=ActionPlan((SetTableComment(desired_comment="c", observed_comment=""),))
+        "a", plan=_plan("a", SetTableComment(desired_comment="c", observed_comment=""))
     )
     base = dict(
         started_at=datetime(2025, 1, 1, 0, 0, 0),
@@ -659,7 +667,7 @@ def test_render_report_shows_dry_run_banner_only_for_dry_runs():
 def test_render_report_is_titled():
     # Given any run
     changed = _grid_report(
-        "a", plan=ActionPlan((SetTableComment(desired_comment="c", observed_comment=""),))
+        "a", plan=_plan("a", SetTableComment(desired_comment="c", observed_comment=""))
     )
     sync = SyncReport(
         started_at=datetime(2025, 1, 1, 0, 0, 0),
@@ -677,7 +685,7 @@ def test_render_report_is_titled():
 def test_render_diff_is_titled():
     # Given any run
     first = _grid_report(
-        "a", plan=ActionPlan((SetTableComment(desired_comment="c", observed_comment=""),))
+        "a", plan=_plan("a", SetTableComment(desired_comment="c", observed_comment=""))
     )
     sync = SyncReport(
         started_at=datetime(2025, 1, 1, 0, 0, 0),
@@ -695,9 +703,9 @@ def test_render_diff_is_titled():
 def test_render_diff_joins_each_tables_change_block_in_report_order():
     # Given a run over two tables with plans
     first = _grid_report(
-        "a", plan=ActionPlan((SetTableComment(desired_comment="c", observed_comment=""),))
+        "a", plan=_plan("a", SetTableComment(desired_comment="c", observed_comment=""))
     )
-    second = _grid_report("b", plan=ActionPlan((AddColumn(DesiredColumn("age", Integer())),)))
+    second = _grid_report("b", plan=_plan("b", AddColumn(DesiredColumn("age", Integer()))))
     sync = SyncReport(
         started_at=datetime(2025, 1, 1, 0, 0, 0),
         ended_at=datetime(2025, 1, 1, 0, 0, 3),

--- a/tests/application/test_report.py
+++ b/tests/application/test_report.py
@@ -72,11 +72,21 @@ def _failed_exec(idx=0, preview="ALTER TABLE ...", exc="ValueError", msg="boom")
     )
 
 
+_PLAN_UNSET = object()
+
+
+def _plan(name: str, *actions) -> ActionPlan:
+    return ActionPlan(
+        target=QualifiedName("cat", "schema", name),
+        actions=actions,
+    )
+
+
 def _report(
     *,
     desired: DesiredTable,
     read: ReadResult,
-    plan: ActionPlan | None = None,
+    plan: ActionPlan | None | object = _PLAN_UNSET,
     planned_sql_statements: tuple[str, ...] = (),
     failures: tuple[Failure, ...] = (),
     execution: ExecutionSummary | None = None,
@@ -90,11 +100,21 @@ def _report(
         failure for failure in failures if not isinstance(failure, ReadFailure | ExecutionFailure)
     )
     execution_failures = () if execution is None else execution.failures
+    if plan is _PLAN_UNSET:
+        planning_failed = any(isinstance(failure, ValidationFailure) for failure in failures)
+        report_plan = (
+            None
+            if isinstance(read, ReadFailure) or planning_failed
+            else ActionPlan(target=desired.qualified_name)
+        )
+    else:
+        assert plan is None or isinstance(plan, ActionPlan)
+        report_plan = plan
 
     return TableRunReport(
         desired=desired,
         read=read,
-        plan=plan if plan is not None else ActionPlan(),
+        plan=report_plan,
         planned_sql_statements=planned_sql_statements,
         failures=(*read_failures, *reported_failures, *execution_failures),
         execution=execution,
@@ -146,7 +166,7 @@ def test_table_has_changes_when_plan_is_non_empty():
     report = _report(
         desired=_a_desired_table("tbl"),
         read=TablePresent(table=_an_observed_table()),
-        plan=ActionPlan((SetTableComment(desired_comment="hello", observed_comment=""),)),
+        plan=_plan("tbl", SetTableComment(desired_comment="hello", observed_comment="")),
     )
     assert report.has_changes is True
 
@@ -160,8 +180,8 @@ def test_table_has_no_changes_when_plan_is_empty():
 
 
 def test_validation_failed_table_has_failures_but_no_changes():
-    # Validation refuses the drift before planning, so the plan stays empty:
-    # the table reports failures, not changes.
+    # Validation refuses the drift before a plan exists: the table reports
+    # failures, not changes.
     report = _report(
         desired=_a_desired_table("tbl"),
         read=TablePresent(table=_an_observed_table()),
@@ -169,13 +189,14 @@ def test_validation_failed_table_has_failures_but_no_changes():
     )
     assert report.has_failures is True
     assert report.has_changes is False
+    assert report.plan is None
 
 
 def test_sync_report_has_changes_when_any_table_plans_actions():
     changed = _report(
         desired=_a_desired_table("a"),
         read=TablePresent(table=_an_observed_table()),
-        plan=ActionPlan((SetTableComment(desired_comment="hello", observed_comment=""),)),
+        plan=_plan("a", SetTableComment(desired_comment="hello", observed_comment="")),
     )
     unchanged = _report(
         desired=_a_desired_table("b"),
@@ -198,7 +219,7 @@ def test_sync_report_planned_sql_maps_dotted_names_and_omits_empty():
     with_sql = _report(
         desired=_a_desired_table("a"),
         read=TablePresent(table=_an_observed_table()),
-        plan=ActionPlan((SetTableComment(desired_comment="hello", observed_comment=""),)),
+        plan=_plan("a", SetTableComment(desired_comment="hello", observed_comment="")),
         planned_sql_statements=("ALTER TABLE a SET ...",),
     )
     without_sql = _report(
@@ -356,14 +377,14 @@ def test_table_run_report_carries_its_desired_definition():
     assert report.desired is desired
     assert report.status is TableRunStatus.SUCCESS
     assert report.failures == ()
-    assert report.plan == ActionPlan()
+    assert report.plan == ActionPlan(target=desired.qualified_name)
 
 
 def _a_changed_table_report():
     return _report(
         desired=_a_desired_table("orders"),
         read=TablePresent(table=_an_observed_table()),
-        plan=ActionPlan((SetTableComment(desired_comment="hello", observed_comment=""),)),
+        plan=_plan("orders", SetTableComment(desired_comment="hello", observed_comment="")),
         planned_sql_statements=("COMMENT ON TABLE `cat`.`schema`.`orders` IS 'hello'",),
     )
 
@@ -409,7 +430,7 @@ def test_table_to_dict_reports_execution_counts_when_executed():
     report = _report(
         desired=_a_desired_table("orders"),
         read=TablePresent(table=_an_observed_table()),
-        plan=ActionPlan((SetTableComment(desired_comment="hello", observed_comment=""),)),
+        plan=_plan("orders", SetTableComment(desired_comment="hello", observed_comment="")),
         planned_sql_statements=(statement,),
         execution=ExecutionSummary((_ok_exec(0, preview=statement),)),
     )

--- a/tests/cli/conftest.py
+++ b/tests/cli/conftest.py
@@ -51,8 +51,8 @@ class FakeReader:
 class FakeExecutor:
     """Executor that compiles one pseudo-statement per action and always succeeds."""
 
-    def compile(self, qualified_name: QualifiedName, plan: ActionPlan) -> tuple[str, ...]:
-        return tuple(f"-- {qualified_name}: {type(action).__name__}" for action in plan)
+    def compile(self, plan: ActionPlan) -> tuple[str, ...]:
+        return tuple(f"-- {plan.target}: {type(action).__name__}" for action in plan)
 
     def execute(self, statement: str) -> None:
         pass

--- a/tests/domain/plan/test_actions.py
+++ b/tests/domain/plan/test_actions.py
@@ -52,6 +52,10 @@ def _observed_column(name: str) -> ObservedColumn:
     return ObservedColumn(name=name, data_type=Integer())
 
 
+def _plan(*plan_actions: Action) -> ActionPlan:
+    return ActionPlan(target=_TARGET, actions=plan_actions)
+
+
 def _primary_key(name: str = "table_pk", columns: tuple[str, ...] = ("id",)):
     return PrimaryKeyConstraint(columns=columns, constraint_name=name)
 
@@ -97,8 +101,8 @@ def _concrete_action_types() -> list[type[Action]]:
 
 
 def test_actionplan_truthiness_and_length():
-    empty = ActionPlan(())
-    non_empty = ActionPlan((DropColumn(_observed_column("legacy")),))
+    empty = _plan()
+    non_empty = _plan(DropColumn(_observed_column("legacy")))
 
     assert not empty
     assert len(empty) == 0
@@ -106,8 +110,20 @@ def test_actionplan_truthiness_and_length():
     assert len(non_empty) == 1
 
 
+def test_actionplan_retains_its_table_target():
+    assert _plan().target == _TARGET
+
+
+def test_actionplan_rejects_create_table_for_a_different_target():
+    with pytest.raises(ValueError, match="CreateTable target does not match ActionPlan target"):
+        ActionPlan(
+            target=QualifiedName("cat", "sch", "other"),
+            actions=(_create_table_action(),),
+        )
+
+
 def test_plan_orders_within_a_phase_by_subject_name():
-    plan = ActionPlan((AddColumn(_column("b_col")), AddColumn(_column("a_col"))))
+    plan = _plan(AddColumn(_column("b_col")), AddColumn(_column("a_col")))
 
     assert [action.subject for action in plan] == ["a_col", "b_col"]
 
@@ -116,15 +132,13 @@ def test_plan_ordering_is_stable_when_phase_and_subject_tie():
     first = SetProperty(name="alpha", desired_value="1", observed_value=None)
     second = SetProperty(name="alpha", desired_value="2", observed_value=None)
 
-    assert tuple(ActionPlan((first, second))) == (first, second)
+    assert tuple(_plan(first, second)) == (first, second)
 
 
 def test_plan_ordering_ignores_non_subject_fields():
-    plan = ActionPlan(
-        (
-            SetProperty(name="b_key", desired_value="aaa", observed_value=None),
-            SetProperty(name="a_key", desired_value="zzz", observed_value=None),
-        )
+    plan = _plan(
+        SetProperty(name="b_key", desired_value="aaa", observed_value=None),
+        SetProperty(name="a_key", desired_value="zzz", observed_value=None),
     )
 
     assert [action.subject for action in plan] == ["a_key", "b_key"]
@@ -200,32 +214,30 @@ _SAMPLE_ACTIONS: list[Action] = [
 
 @given(st.permutations(_SAMPLE_ACTIONS))
 def test_actionplan_order_is_independent_of_input_permutation(shuffled: list[Action]) -> None:
-    assert tuple(ActionPlan(tuple(shuffled))) == tuple(ActionPlan(tuple(_SAMPLE_ACTIONS)))
+    assert tuple(_plan(*shuffled)) == tuple(_plan(*_SAMPLE_ACTIONS))
 
 
 def test_plan_full_phase_order_with_all_action_types():
-    plan = ActionPlan(
-        (
-            SetPrimaryKey(_primary_key()),
-            SetForeignKey(_foreign_key()),
-            SetTableComment("new", "old"),
-            AddColumn(_column("a_col")),
-            SetProperty("p_set", "1", None),
-            UnsetProperty("p_unset", "1"),
-            SetColumnNullability("nn_col", False, True),
-            DropForeignKey(_foreign_key("t_old_fk")),
-            _drop_primary_key(),
-            RenameColumn("old", "new"),
-            DropColumn(_observed_column("d_col")),
-            SetColumnTag("email", "pii", "true"),
-            UnsetColumnTag("email", "old"),
-            SetColumnComment("c_col", "new", "old"),
-            _create_table_action(),
-            SetTableTag("env", "prod"),
-            UnsetTableTag("old_tag"),
-            AlterClustering(("region",), ()),
-            AlterColumnType("w_col", Long(), Integer()),
-        )
+    plan = _plan(
+        SetPrimaryKey(_primary_key()),
+        SetForeignKey(_foreign_key()),
+        SetTableComment("new", "old"),
+        AddColumn(_column("a_col")),
+        SetProperty("p_set", "1", None),
+        UnsetProperty("p_unset", "1"),
+        SetColumnNullability("nn_col", False, True),
+        DropForeignKey(_foreign_key("t_old_fk")),
+        _drop_primary_key(),
+        RenameColumn("old", "new"),
+        DropColumn(_observed_column("d_col")),
+        SetColumnTag("email", "pii", "true"),
+        UnsetColumnTag("email", "old"),
+        SetColumnComment("c_col", "new", "old"),
+        _create_table_action(),
+        SetTableTag("env", "prod"),
+        UnsetTableTag("old_tag"),
+        AlterClustering(("region",), ()),
+        AlterColumnType("w_col", Long(), Integer()),
     )
 
     assert [type(action) for action in plan] == [
@@ -252,14 +264,12 @@ def test_plan_full_phase_order_with_all_action_types():
 
 
 def test_plan_orders_constraint_drops_before_column_work():
-    plan = ActionPlan(
-        (
-            DropColumn(_observed_column("customer_id")),
-            _drop_primary_key(),
-            DropForeignKey(_foreign_key("orders_customer_id_fk")),
-            RenameColumn("old", "new"),
-            AddColumn(_column("added")),
-        )
+    plan = _plan(
+        DropColumn(_observed_column("customer_id")),
+        _drop_primary_key(),
+        DropForeignKey(_foreign_key("orders_customer_id_fk")),
+        RenameColumn("old", "new"),
+        AddColumn(_column("added")),
     )
 
     assert [type(action) for action in plan] == [
@@ -272,24 +282,20 @@ def test_plan_orders_constraint_drops_before_column_work():
 
 
 def test_plan_orders_property_before_type_widen_and_key_set():
-    plan = ActionPlan(
-        (
-            SetPrimaryKey(_primary_key()),
-            AlterColumnType("id", Long(), Integer()),
-            SetProperty("delta.enableTypeWidening", "true", None),
-        )
+    plan = _plan(
+        SetPrimaryKey(_primary_key()),
+        AlterColumnType("id", Long(), Integer()),
+        SetProperty("delta.enableTypeWidening", "true", None),
     )
 
     assert [type(action) for action in plan] == [SetProperty, AlterColumnType, SetPrimaryKey]
 
 
 def test_plan_reclusters_after_add_and_before_drop():
-    plan = ActionPlan(
-        (
-            DropColumn(_observed_column("old_region")),
-            AlterClustering(("region",), ("old_region",)),
-            AddColumn(_column("region")),
-        )
+    plan = _plan(
+        DropColumn(_observed_column("old_region")),
+        AlterClustering(("region",), ("old_region",)),
+        AddColumn(_column("region")),
     )
 
     assert [type(action) for action in plan] == [AddColumn, AlterClustering, DropColumn]


### PR DESCRIPTION
## What changed

- Put the qualified table target on `ActionPlan`.
- Change `PlanExecutor.compile` and Databricks compilers to accept the plan alone.
- Reject `CreateTable` actions whose embedded target disagrees with the plan target.
- Represent read/planning failures with `TableRunReport.plan = None`, while retaining targeted empty plans for successful no-ops.
- Update adapters, tests, rendering, and architecture documentation.

## Why

A plan previously carried relation kind but not table identity, so callers passed a separate table name through compilation. That allowed a valid plan to be compiled against an unrelated table. The plan now owns the complete compilation target.

## Validation

- `uv run pytest -q`: 979 passed, 63 credentialed/live tests deselected
- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run mypy .`
- `uv run lint-imports`
- `uv run --group docs sphinx-build -W -b html docs docs/_build/html`