### PR TITLE
refactor: tighten comparison boundary invariants

### DIFF
--- a/src/delta_engine/application/dependency_resolution.py
+++ b/src/delta_engine/application/dependency_resolution.py
@@ -63,9 +63,6 @@ class ResolutionSucceeded:
     qualified_name: QualifiedName
     dependencies: tuple[ResolvedDependency, ...]
 
-    def __post_init__(self) -> None:
-        object.__setattr__(self, "dependencies", tuple(self.dependencies))
-
 
 @dataclass(frozen=True, slots=True)
 class ResolutionFailed:
@@ -75,7 +72,6 @@ class ResolutionFailed:
     failures: tuple[ForeignKeyFailure, ...]
 
     def __post_init__(self) -> None:
-        object.__setattr__(self, "failures", tuple(self.failures))
         if not self.failures:
             raise ValueError("ResolutionFailed requires at least one foreign-key failure")
 

--- a/src/delta_engine/application/engine.py
+++ b/src/delta_engine/application/engine.py
@@ -91,7 +91,6 @@ class _ExecutionBlockedByDependency:
     failures: tuple[ForeignKeyFailure, ...]
 
     def __post_init__(self) -> None:
-        object.__setattr__(self, "failures", tuple(self.failures))
         if not self.failures:
             raise ValueError("Dependency blocking requires at least one failure")
 

--- a/src/delta_engine/application/planning.py
+++ b/src/delta_engine/application/planning.py
@@ -48,7 +48,7 @@ def plan_diff(diff: TableDiff) -> PlanningResult:
     match diff:
         case TableDrift() as drift:
             plan = ActionPlan(
-                target=drift.desired.qualified_name,
+                target=drift.target,
                 actions=drift.actions,
                 kind=drift.observed.kind,
             )

--- a/src/delta_engine/domain/model/table.py
+++ b/src/delta_engine/domain/model/table.py
@@ -177,13 +177,10 @@ class DesiredTable:
         representable.
 
         """
-        object.__setattr__(self, "columns", tuple(self.columns))
         object.__setattr__(self, "tags", MappingProxyType(dict(self.tags)))
         object.__setattr__(self, "partitioned_by", tuple(n.lower() for n in self.partitioned_by))
         object.__setattr__(self, "clustered_by", tuple(n.lower() for n in self.clustered_by))
-        object.__setattr__(self, "foreign_keys", tuple(self.foreign_keys))
         object.__setattr__(self, "properties", MappingProxyType(dict(self.properties)))
-        object.__setattr__(self, "managed_aspects", frozenset(self.managed_aspects))
 
         _validate_table_structure(
             columns=self.columns,
@@ -306,17 +303,10 @@ class ObservedTable:
         return self.primary_key.columns if self.primary_key is not None else ()
 
     def __post_init__(self) -> None:
-        object.__setattr__(self, "columns", tuple(self.columns))
         object.__setattr__(self, "tags", MappingProxyType(dict(self.tags)))
         object.__setattr__(self, "partitioned_by", tuple(n.lower() for n in self.partitioned_by))
         object.__setattr__(self, "clustered_by", tuple(n.lower() for n in self.clustered_by))
-        object.__setattr__(self, "foreign_keys", tuple(self.foreign_keys))
         object.__setattr__(self, "properties", MappingProxyType(dict(self.properties)))
-        object.__setattr__(
-            self,
-            "referencing_foreign_keys",
-            tuple(self.referencing_foreign_keys),
-        )
 
         _validate_table_structure(
             columns=self.columns,

--- a/src/delta_engine/domain/plan/actions.py
+++ b/src/delta_engine/domain/plan/actions.py
@@ -300,9 +300,6 @@ class DropPrimaryKey(Action):
     aspect: ClassVar[TableAspect] = TableAspect.PRIMARY_KEY
     phase: ClassVar[ActionPhase] = ActionPhase.DROP_PRIMARY_KEY
 
-    def __post_init__(self) -> None:
-        object.__setattr__(self, "referencing_foreign_keys", tuple(self.referencing_foreign_keys))
-
     @property
     def subject(self) -> str:
         return ""
@@ -361,8 +358,6 @@ class AlterClustering(Action):
     phase: ClassVar[ActionPhase] = ActionPhase.SET_CLUSTERING
 
     def __post_init__(self) -> None:
-        object.__setattr__(self, "desired_clustering", tuple(self.desired_clustering))
-        object.__setattr__(self, "observed_clustering", tuple(self.observed_clustering))
         if set(self.desired_clustering) == set(self.observed_clustering):
             raise ValueError(f"AlterClustering carries no difference: {self.desired_clustering!r}")
 

--- a/src/delta_engine/domain/plan/diff.py
+++ b/src/delta_engine/domain/plan/diff.py
@@ -21,6 +21,7 @@ from delta_engine.domain.model import (
     DesiredTable,
     ObservedColumn,
     ObservedTable,
+    QualifiedName,
     TableAspect,
 )
 from delta_engine.domain.plan.actions import (
@@ -107,6 +108,17 @@ class TableDrift:
     observed: ObservedTable
     actions: tuple[Action, ...] = ()
     unresolvable: tuple[Unresolvable, ...] = ()
+
+    def __post_init__(self) -> None:
+        if self.desired.qualified_name != self.observed.qualified_name:
+            raise ValueError(
+                "Cannot compare different tables:"
+                f" {self.desired.qualified_name} != {self.observed.qualified_name}"
+            )
+
+    @property
+    def target(self) -> QualifiedName:
+        return self.desired.qualified_name
 
 
 type TableDiff = TableMissing | TableDrift

--- a/src/delta_engine/domain/plan/unresolvable.py
+++ b/src/delta_engine/domain/plan/unresolvable.py
@@ -40,8 +40,6 @@ class PartitioningChanged:
     aspect: ClassVar[TableAspect] = TableAspect.PARTITIONING
 
     def __post_init__(self) -> None:
-        object.__setattr__(self, "desired_partitioning", tuple(self.desired_partitioning))
-        object.__setattr__(self, "observed_partitioning", tuple(self.observed_partitioning))
         if self.desired_partitioning == self.observed_partitioning:
             raise ValueError(
                 f"PartitioningChanged carries no difference: {self.desired_partitioning!r}"

--- a/tests/domain/plan/test_diff.py
+++ b/tests/domain/plan/test_diff.py
@@ -117,6 +117,25 @@ def test_drift_carries_the_desired_table():
     assert not hasattr(diff, "plan")
 
 
+def test_drift_derives_target_from_the_shared_table_identity():
+    # Given matching desired and observed table identities
+    diff = diff_table(_desired(), _observed())
+
+    # Then the comparison exposes their one shared target
+    assert isinstance(diff, TableDrift)
+    assert diff.target == _QUALIFIED_NAME
+
+
+def test_drift_rejects_different_desired_and_observed_tables():
+    # Given a desired and observed referencing different tables
+    desired = _desired(qualified_name=QualifiedName("cat", "sch", "customers"))
+    observed = _observed(qualified_name=QualifiedName("cat", "sch", "orders"))
+
+    # When / Then constructing their comparison is rejected
+    with pytest.raises(ValueError, match="Cannot compare different tables"):
+        TableDrift(desired=desired, observed=observed)
+
+
 # ---------- column structure changes
 
 


### PR DESCRIPTION
## Summary

- Make `TableDrift` reject comparisons whose desired and observed tables have different qualified names.
- Expose the shared table identity as `TableDrift.target` and use it when creating an `ActionPlan`.
- Remove redundant `object.__setattr__` tuple/frozenset coercions from typed immutable domain and application records.
- Add regression coverage for comparison identity and target derivation.

## Validation

- `uv run pytest` — 981 passed, 63 deselected
- `uv run ruff check .`
- `uv run mypy .`
- `uv run lint-imports`
- `git diff --check`