### PR TITLE
refactor: consolidate run outcomes and creation reporting

### DIFF
--- a/docs/explanation-architecture.md
+++ b/docs/explanation-architecture.md
@@ -720,15 +720,16 @@ status from the earliest failing phase:
 - `EXECUTION_FAILED`
 - `SUCCESS`
 
-When the run is frozen, the engine projects its canonical phase outcomes once
-into the report's immutable fields. That matters when a table has multiple
-validation failures or multiple FK failures: callers receive the complete
-failure tuple without another mutable source of run truth. For execution,
-the engine stops at the first failed statement because it is not transactional
-and later statements may depend on earlier ones. The `ExecutionSummary` records
-all attempted statements up to that point. Runtime dependency blocking remains
-private engine state; the report exposes its foreign-key failures and keeps
-`execution` as `None` because no statement was attempted.
+When the run is frozen, the report retains its canonical phase outcomes. Its
+plan, failure tuple, status, and attempted execution summary are derived views.
+That matters when a table has multiple validation failures or multiple FK
+failures: callers receive the complete failure tuple without another mutable
+source of run truth. For execution, the engine stops at the first failed
+statement because it is not transactional and later statements may depend on
+earlier ones. The `ExecutionSummary` records all attempted statements up to
+that point. Runtime dependency blocking is retained as an execution outcome;
+the report exposes its foreign-key failures and keeps `execution` as `None`
+because no statement was attempted.
 
 Reports also keep the plan even when execution does not happen. That makes dry
 runs useful and makes failed runs explainable: a user can inspect what would

--- a/docs/how-to-add-action-type.md
+++ b/docs/how-to-add-action-type.md
@@ -121,7 +121,8 @@ Use `backtick` for identifiers and `quote_literal` for string literals (both in 
 In `src/delta_engine/application/diff_entries.py`, register a `singledispatch`
 arm on `action_entries` so the action shows up in reports. Return one or more
 `DiffEntry` values — each tags the line with a `DiffCategory` (columns, keys,
-properties, tags, comments), a `+`/`-`/`~` symbol, and its aligned cells:
+clustering, partitioning, properties, tags, comments), a `+`/`-`/`~` symbol,
+and its aligned cells:
 
 ```python
 @action_entries.register

--- a/docs/reference-run-report.md
+++ b/docs/reference-run-report.md
@@ -66,7 +66,7 @@ description is `planned_sql_statements`:
 
 | Field       | Type  | Meaning                                                                            |
 | ----------- | ----- | ---------------------------------------------------------------------------------- |
-| `kind`      | `str` | Change category: `columns`, `keys`, `clustering`, `properties`, `tags`, `comments` |
+| `kind`      | `str` | Change category: `columns`, `keys`, `clustering`, `partitioning`, `properties`, `tags`, `comments` |
 | `operation` | `str` | `add`, `remove`, or `change`                                                       |
 | `subject`   | `str` | What the change targets, e.g. a column name or `table: '...'`                      |
 | `detail`    | `str` | Extra detail, e.g. `Integer → Long`; empty when there is none                      |

--- a/docs/todo/code-consolidation-review.md
+++ b/docs/todo/code-consolidation-review.md
@@ -296,6 +296,16 @@ less truthful. Instead:
 The domain action remains the owner of what a create means; SQL and rendering
 remain separate consumers of that meaning.
 
+### Implemented
+
+Creation remains a single `CreateTable` aggregate. Its semantic diff projection
+now reports every declared fact embedded in the create statement: columns and
+nullability, primary key, partitioning or clustering, valued properties, column
+comments, and the table comment. Tags and foreign keys remain visible through
+their explicit follow-up actions. Coverage exercises a populated creation in
+both semantic reporting and compiled SQL; property absence assertions are
+correctly omitted because a new table already satisfies them.
+
 ## 5. Put key identity on the key values
 
 ### Cause

--- a/docs/todo/code-consolidation-review.md
+++ b/docs/todo/code-consolidation-review.md
@@ -189,6 +189,15 @@ Do not introduce one public class per lifecycle phase merely to eliminate
 that derives report status, eligibility, and the flattened failure stream from
 those outcomes.
 
+### Implemented
+
+`_TableRun` and `TableRunReport` now retain the read, planning, resolution, and
+execution outcomes directly. The public plan, execution summary, failure list,
+status, and table identity are derived projections, so they cannot disagree
+with those outcomes. Completed reports reject impossible phase histories, and
+`ExecutionSummary` enforces contiguous, stop-on-first-failure execution whose
+statements must match the compiled statement prefix.
+
 ## 3. Put the table target on `ActionPlan`
 
 ### Cause

--- a/src/delta_engine/application/diff_entries.py
+++ b/src/delta_engine/application/diff_entries.py
@@ -57,9 +57,10 @@ class DiffCategory(IntEnum):
     COLUMNS = 1
     KEYS = 2
     CLUSTERING = 3
-    PROPERTIES = 4
-    TAGS = 5
-    COMMENTS = 6
+    PARTITIONING = 4
+    PROPERTIES = 5
+    TAGS = 6
+    COMMENTS = 7
 
 
 # (singular, plural) nouns per category: the plural names the diff group heading;
@@ -69,6 +70,7 @@ CATEGORY_NOUN: Final[Mapping[DiffCategory, tuple[str, str]]] = MappingProxyType(
         DiffCategory.COLUMNS: ("column", "columns"),
         DiffCategory.KEYS: ("key", "keys"),
         DiffCategory.CLUSTERING: ("clustering", "clustering"),
+        DiffCategory.PARTITIONING: ("partitioning", "partitioning"),
         DiffCategory.PROPERTIES: ("property", "properties"),
         DiffCategory.TAGS: ("tag", "tags"),
         DiffCategory.COMMENTS: ("comment", "comments"),
@@ -122,14 +124,35 @@ def action_entries(action: Action) -> tuple[DiffEntry, ...]:
 @action_entries.register
 def _(action: CreateTable) -> tuple[DiffEntry, ...]:
     entries = [_column_add_entry(column) for column in action.table.columns]
+
     primary_key_columns = action.table.primary_key_columns
     if primary_key_columns:
         entries.append(
             DiffEntry(DiffCategory.KEYS, "+", (f"primary key ({', '.join(primary_key_columns)})",))
         )
+
     if action.table.clustered_by:
         columns = ", ".join(action.table.clustered_by)
         entries.append(DiffEntry(DiffCategory.CLUSTERING, "+", (f"clustering ({columns})",)))
+
+    if action.table.partitioned_by:
+        columns = ", ".join(action.table.partitioned_by)
+        entries.append(DiffEntry(DiffCategory.PARTITIONING, "+", (f"partitioning ({columns})",)))
+
+    entries.extend(
+        DiffEntry(DiffCategory.PROPERTIES, "+", (f"{name} = '{value}'",))
+        for name, value in sorted(action.table.properties.items())
+        if value is not None
+    )
+
+    entries.extend(
+        DiffEntry(DiffCategory.COMMENTS, "+", (f"column {column.name}: '{column.comment}'",))
+        for column in action.table.columns
+        if column.comment
+    )
+    if action.table.comment:
+        entries.append(DiffEntry(DiffCategory.COMMENTS, "+", (f"table: '{action.table.comment}'",)))
+
     return tuple(entries)
 
 

--- a/src/delta_engine/application/engine.py
+++ b/src/delta_engine/application/engine.py
@@ -51,12 +51,7 @@ from delta_engine.application.errors import (
     ReadError,
     SyncFailedError,
 )
-from delta_engine.application.failures import (
-    ExecutionFailure,
-    Failure,
-    ForeignKeyFailure,
-    ReadFailure,
-)
+from delta_engine.application.failures import ExecutionFailure, ReadFailure
 from delta_engine.application.planning import (
     PlanningFailed,
     PlanningResult,
@@ -75,6 +70,8 @@ from delta_engine.application.ports import (
     TablePresent,
 )
 from delta_engine.application.report import (
+    ExecutionBlockedByDependency,
+    ExecutionOutcome,
     SyncReport,
     TableRunReport,
 )
@@ -82,20 +79,6 @@ from delta_engine.domain.model import DesiredTable, QualifiedName
 from delta_engine.domain.plan import ActionPlan, TableDiff, diff_table
 
 logger = logging.getLogger(__name__)
-
-
-@dataclass(frozen=True, slots=True)
-class _ExecutionBlockedByDependency:
-    """Execution was not attempted because a referenced table failed during execution."""
-
-    failures: tuple[ForeignKeyFailure, ...]
-
-    def __post_init__(self) -> None:
-        if not self.failures:
-            raise ValueError("Dependency blocking requires at least one failure")
-
-
-type _ExecutionOutcome = ExecutionSummary | _ExecutionBlockedByDependency
 
 
 def prepare_desired_tables(*tables: DesiredTableSource) -> tuple[DesiredTable, ...]:
@@ -142,7 +125,7 @@ class _TableRun:
     planning: PlanningResult | None = None
     planned_sql_statements: tuple[str, ...] = ()
     resolution: TableResolution | None = None
-    execution: _ExecutionOutcome | None = None
+    execution: ExecutionOutcome | None = None
 
     @property
     def qualified_name(self) -> QualifiedName:
@@ -159,46 +142,27 @@ class _TableRun:
                 assert_never(unreachable)
 
     @property
-    def failures(self) -> tuple[Failure, ...]:
-        failures: list[Failure] = []
-
-        if isinstance(self.read, ReadFailure):
-            failures.append(self.read)
-
-        if isinstance(self.planning, PlanningFailed):
-            failures.extend(self.planning.failures)
-
-        if isinstance(self.resolution, ResolutionFailed):
-            failures.extend(self.resolution.failures)
-
-        match self.execution:
-            case ExecutionSummary() as summary:
-                failures.extend(summary.failures)
-            case _ExecutionBlockedByDependency(failures=blocked):
-                failures.extend(blocked)
-            case None:
-                pass
-            case _ as unreachable:
-                assert_never(unreachable)
-
-        return tuple(failures)
-
-    @property
     def has_failures(self) -> bool:
         """True when any completed phase has failed for this table."""
-        return bool(self.failures)
+        return (
+            isinstance(self.read, ReadFailure)
+            or isinstance(self.planning, PlanningFailed)
+            or isinstance(self.resolution, ResolutionFailed)
+            or isinstance(self.execution, ExecutionBlockedByDependency)
+            or (isinstance(self.execution, ExecutionSummary) and self.execution.failed)
+        )
 
     def to_report(self) -> TableRunReport:
         """Freeze this run into its public, immutable report."""
-        execution = self.execution if isinstance(self.execution, ExecutionSummary) else None
-
+        if self.resolution is None:
+            raise RuntimeError(f"Completed table run was not resolved: {self.qualified_name}")
         return TableRunReport(
             desired=self.desired,
             read=self.read,
-            plan=self.plan,
+            planning=self.planning,
             planned_sql_statements=self.planned_sql_statements,
-            failures=self.failures,
-            execution=execution,
+            resolution=self.resolution,
+            execution_outcome=self.execution,
         )
 
 
@@ -435,7 +399,7 @@ class Engine:
                 if dependency.referenced_table in failed_during_execution
             )
             if blocking_failures:
-                run.execution = _ExecutionBlockedByDependency(blocking_failures)
+                run.execution = ExecutionBlockedByDependency(blocking_failures)
                 failed_during_execution.add(run.qualified_name)
                 logger.error(
                     "Execution blocked for %s (%d foreign key failure(s))",

--- a/src/delta_engine/application/ports.py
+++ b/src/delta_engine/application/ports.py
@@ -113,6 +113,14 @@ class ExecutionSummary:
 
     results: tuple[ExecutionResult, ...] = ()
 
+    def __post_init__(self) -> None:
+        """Reject histories that the stop-at-first-failure executor cannot produce."""
+        for expected_index, result in enumerate(self.results):
+            if result.statement_index != expected_index:
+                raise ValueError("Execution result indexes must be contiguous")
+            if expected_index and isinstance(self.results[expected_index - 1], ExecutionFailure):
+                raise ValueError("Execution cannot continue after a failure")
+
     @property
     def failed(self) -> bool:
         """True when any statement failed."""

--- a/src/delta_engine/application/report.py
+++ b/src/delta_engine/application/report.py
@@ -10,12 +10,25 @@ from dataclasses import dataclass
 from datetime import datetime
 from enum import StrEnum
 from types import MappingProxyType
-from typing import Any, Final
+from typing import Any, Final, assert_never
 
+from delta_engine.application.dependency_resolution import (
+    ResolutionFailed,
+    ResolutionSucceeded,
+    TableResolution,
+)
 from delta_engine.application.diff_entries import action_entries
 from delta_engine.application.failures import (
     Failure,
     FailurePhase,
+    ForeignKeyFailure,
+    ForeignKeyFailureReason,
+    ReadFailure,
+)
+from delta_engine.application.planning import (
+    PlanningFailed,
+    PlanningResult,
+    PlanningSucceeded,
 )
 from delta_engine.application.ports import ExecutionSummary, ReadResult
 from delta_engine.domain.model import DesiredTable, QualifiedName
@@ -83,6 +96,25 @@ def _failure_records(failures: tuple[Failure, ...]) -> list[dict[str, str]]:
 
 
 @dataclass(frozen=True, slots=True)
+class ExecutionBlockedByDependency:
+    """Execution was skipped because a referenced table failed while executing."""
+
+    failures: tuple[ForeignKeyFailure, ...]
+
+    def __post_init__(self) -> None:
+        if not self.failures:
+            raise ValueError("Dependency blocking requires at least one failure")
+        if any(
+            failure.reason is not ForeignKeyFailureReason.BLOCKED_BY_FAILED_DEPENDENCY
+            for failure in self.failures
+        ):
+            raise ValueError("Execution blocking requires dependency-blocking failures")
+
+
+type ExecutionOutcome = ExecutionSummary | ExecutionBlockedByDependency
+
+
+@dataclass(frozen=True, slots=True)
 class TableRunReport:
     """
     Frozen public projection of one completed table run.
@@ -97,10 +129,88 @@ class TableRunReport:
 
     desired: DesiredTable
     read: ReadResult
-    plan: ActionPlan | None
+    planning: PlanningResult | None
     planned_sql_statements: tuple[str, ...]
-    failures: tuple[Failure, ...]
-    execution: ExecutionSummary | None
+    resolution: TableResolution
+    execution_outcome: ExecutionOutcome | None
+
+    def __post_init__(self) -> None:
+        read_failed = isinstance(self.read, ReadFailure)
+        planning_failed = isinstance(self.planning, PlanningFailed)
+        resolution_failed = isinstance(self.resolution, ResolutionFailed)
+
+        if self.resolution.qualified_name != self.qualified_name:
+            raise ValueError("Resolution outcome must belong to the reported table")
+        if read_failed and self.planning is not None:
+            raise ValueError("Planning cannot follow a failed read")
+        if not read_failed and self.planning is None:
+            raise ValueError("A successful read requires a planning outcome")
+
+        plan = self.plan
+        if plan is not None and plan.target != self.qualified_name:
+            raise ValueError("Planned action target must match the reported table")
+        if self.planned_sql_statements and plan is None:
+            raise ValueError("Compiled statements require a successful planning outcome")
+        if self.execution_outcome is not None and (
+            read_failed or planning_failed or resolution_failed
+        ):
+            raise ValueError("Execution cannot follow a failed earlier phase")
+        if isinstance(self.execution_outcome, ExecutionBlockedByDependency) and not isinstance(
+            self.resolution, ResolutionSucceeded
+        ):
+            raise ValueError("Execution blocking requires successful dependency resolution")
+
+        execution = self.execution
+        if execution is not None:
+            executed = tuple(result.statement for result in execution.results)
+            if executed != self.planned_sql_statements[: len(executed)]:
+                raise ValueError("Execution results must match the planned statement prefix")
+
+    @property
+    def plan(self) -> ActionPlan | None:
+        """The accepted plan, or ``None`` when reading or planning failed."""
+        match self.planning:
+            case PlanningSucceeded(plan=plan):
+                return plan
+            case PlanningFailed() | None:
+                return None
+            case _ as unreachable:
+                assert_never(unreachable)
+
+    @property
+    def execution(self) -> ExecutionSummary | None:
+        """The attempted statements, excluding dependency-blocked execution."""
+        match self.execution_outcome:
+            case ExecutionSummary() as summary:
+                return summary
+            case ExecutionBlockedByDependency() | None:
+                return None
+            case _ as unreachable:
+                assert_never(unreachable)
+
+    @property
+    def failures(self) -> tuple[Failure, ...]:
+        """Flatten canonical phase outcomes into lifecycle order for callers."""
+        failures: list[Failure] = []
+
+        if isinstance(self.read, ReadFailure):
+            failures.append(self.read)
+        if isinstance(self.planning, PlanningFailed):
+            failures.extend(self.planning.failures)
+        if isinstance(self.resolution, ResolutionFailed):
+            failures.extend(self.resolution.failures)
+
+        match self.execution_outcome:
+            case ExecutionSummary() as summary:
+                failures.extend(summary.failures)
+            case ExecutionBlockedByDependency(failures=blocked):
+                failures.extend(blocked)
+            case None:
+                pass
+            case _ as unreachable:
+                assert_never(unreachable)
+
+        return tuple(failures)
 
     @property
     def qualified_name(self) -> QualifiedName:

--- a/tests/adapters/databricks/sql/test_compile.py
+++ b/tests/adapters/databricks/sql/test_compile.py
@@ -196,25 +196,29 @@ def test_add_column_rejects_non_nullable_column():
         _compile_single(action)
 
 
-def test_create_table_renders_columns_nullability_comments_table_comment_and_properties():
-    # Given a CREATE TABLE with column metadata, table comment, and property
+def test_create_table_renders_all_state_embedded_in_creation():
+    # Given a CREATE TABLE with structure, comments, properties, partitioning, and a key
     action = _create_table(
-        DesiredColumn("id", Integer(), nullable=False),
-        DesiredColumn("name", String(), comment="customer"),
+        DesiredColumn("id", Integer(), nullable=False, comment="identifier"),
+        DesiredColumn("day", String(), comment="partition date"),
         comment="core table",
         properties={"delta.appendOnly": "true"},
+        partitioned_by=("day",),
+        primary_key=_primary_key(),
     )
 
     # When compiling
     statement = _compile_single(action)
 
-    # Then all CREATE TABLE clauses are rendered
+    # Then all state embedded in the creation aggregate is rendered
     assert statement == (
         "CREATE TABLE `cat`.`sch`.`tbl`"
-        " (`id` INT NOT NULL, `name` STRING COMMENT 'customer')"
+        " (`id` INT NOT NULL COMMENT 'identifier', `day` STRING COMMENT 'partition date',"
+        " CONSTRAINT `tbl_pk` PRIMARY KEY (`id`))"
         " USING delta"
         " COMMENT 'core table'"
         " TBLPROPERTIES ('delta.appendOnly'='true')"
+        " PARTITIONED BY (`day`)"
     )
 
 

--- a/tests/application/test_errors.py
+++ b/tests/application/test_errors.py
@@ -1,5 +1,9 @@
 from datetime import UTC, datetime
 
+from delta_engine.application.dependency_resolution import (
+    ResolutionFailed,
+    ResolutionSucceeded,
+)
 from delta_engine.application.errors import (
     DuplicateTableDefinitionError,
     ExecutionError,
@@ -14,6 +18,7 @@ from delta_engine.application.failures import (
     ReadFailure,
     ValidationFailure,
 )
+from delta_engine.application.planning import PlanningFailed, PlanningSucceeded
 from delta_engine.application.ports import (
     ExecutionSucceeded,
     ExecutionSummary,
@@ -60,24 +65,32 @@ def _table_report(
     statements = (
         () if execution is None else tuple(result.statement for result in execution.results)
     )
-    read_failures = (read,) if isinstance(read, ReadFailure) else ()
-    reported_failures = tuple(
-        failure for failure in failures if not isinstance(failure, ReadFailure | ExecutionFailure)
+    planning_failures = tuple(
+        failure for failure in failures if isinstance(failure, ValidationFailure)
     )
-    execution_failures = () if execution is None else execution.failures
-    planning_failed = any(isinstance(failure, ValidationFailure) for failure in failures)
+    resolution_failures = tuple(
+        failure for failure in failures if isinstance(failure, ForeignKeyFailure)
+    )
+    planning = (
+        None
+        if isinstance(read, ReadFailure)
+        else PlanningFailed(planning_failures)
+        if planning_failures
+        else PlanningSucceeded(ActionPlan(target=desired.qualified_name))
+    )
+    resolution = (
+        ResolutionFailed(desired.qualified_name, resolution_failures)
+        if resolution_failures
+        else ResolutionSucceeded(desired.qualified_name, ())
+    )
 
     return TableRunReport(
         desired=desired,
         read=read,
-        plan=(
-            None
-            if isinstance(read, ReadFailure) or planning_failed
-            else ActionPlan(target=desired.qualified_name)
-        ),
+        planning=planning,
         planned_sql_statements=statements,
-        failures=(*read_failures, *reported_failures, *execution_failures),
-        execution=execution,
+        resolution=resolution,
+        execution_outcome=execution,
     )
 
 

--- a/tests/application/test_ports.py
+++ b/tests/application/test_ports.py
@@ -1,3 +1,5 @@
+import pytest
+
 from delta_engine.application.failures import ExecutionFailure, ReadFailure
 from delta_engine.application.ports import (
     ExecutionSucceeded,
@@ -99,6 +101,16 @@ def test_execution_summary_defaults_to_an_empty_unattempted_run():
     assert summary.failed is False
     assert summary.failed_count == 0
     assert summary.applied_count == 0
+
+
+def test_execution_summary_rejects_non_contiguous_statement_indexes():
+    with pytest.raises(ValueError, match="contiguous"):
+        ExecutionSummary((_ok_exec(1),))
+
+
+def test_execution_summary_rejects_results_after_a_failure():
+    with pytest.raises(ValueError, match="after a failure"):
+        ExecutionSummary((_failed_exec(0), _ok_exec(1)))
 
 
 def test_execution_outcome_variants_carry_the_right_payload():

--- a/tests/application/test_rendering.py
+++ b/tests/application/test_rendering.py
@@ -2,12 +2,14 @@ from datetime import datetime
 
 import pytest
 
+from delta_engine.application.dependency_resolution import ResolutionSucceeded
 from delta_engine.application.diff_entries import (
     DiffCategory,
     DiffEntry,
     action_entries,
 )
 from delta_engine.application.failures import ExecutionFailure, ReadFailure, ValidationFailure
+from delta_engine.application.planning import PlanningFailed, PlanningSucceeded
 from delta_engine.application.ports import (
     ExecutionSucceeded,
     ExecutionSummary,
@@ -315,10 +317,12 @@ def _report_with_empty_plan_and_failure() -> TableRunReport:
     return TableRunReport(
         desired=desired,
         read=TablePresent(table=observed),
-        plan=None,
+        planning=PlanningFailed(
+            (ValidationFailure(rule_name="UnsupportedColumnTypeChange", message="nope"),)
+        ),
         planned_sql_statements=(),
-        failures=(ValidationFailure(rule_name="UnsupportedColumnTypeChange", message="nope"),),
-        execution=None,
+        resolution=ResolutionSucceeded(qualified_name, ()),
+        execution_outcome=None,
     )
 
 
@@ -336,10 +340,10 @@ def test_diff_block_shows_plain_no_changes_when_nothing_failed():
     healthy = TableRunReport(
         desired=report.desired,
         read=report.read,
-        plan=ActionPlan(target=report.desired.qualified_name),
+        planning=PlanningSucceeded(ActionPlan(target=report.desired.qualified_name)),
         planned_sql_statements=(),
-        failures=(),
-        execution=None,
+        resolution=report.resolution,
+        execution_outcome=None,
     )
 
     block = render_diff_block(healthy)
@@ -395,10 +399,10 @@ def test_diff_block_reports_a_read_failure_instead_of_a_diff():
             qualified_name=qualified_name, columns=(DesiredColumn("id", Integer()),)
         ),
         read=failure,
-        plan=None,
+        planning=None,
         planned_sql_statements=(),
-        failures=(failure,),
-        execution=None,
+        resolution=ResolutionSucceeded(qualified_name, ()),
+        execution_outcome=None,
     )
 
     # When rendering the diff block
@@ -416,7 +420,10 @@ def _grid_report(name, *, plan=None, failures=(), execution=None):
     columns = (DesiredColumn("id", Integer()),)
     if plan is None and not failures:
         plan = ActionPlan(target=qualified_name)
-    execution_failures = () if execution is None else execution.failures
+    planning_failures = tuple(
+        failure for failure in failures if isinstance(failure, ValidationFailure)
+    )
+    planning = PlanningFailed(planning_failures) if planning_failures else PlanningSucceeded(plan)
     return TableRunReport(
         desired=DesiredTable(qualified_name=qualified_name, columns=columns),
         read=TablePresent(
@@ -424,13 +431,13 @@ def _grid_report(name, *, plan=None, failures=(), execution=None):
                 qualified_name=qualified_name, columns=(ObservedColumn("id", Integer()),)
             )
         ),
-        plan=plan,
+        planning=planning,
         # One fake statement per action, as the engine would have compiled.
         planned_sql_statements=tuple(
             f"SQL {index}" for index in range(len(plan) if plan is not None else 0)
         ),
-        failures=(*failures, *execution_failures),
-        execution=execution,
+        resolution=ResolutionSucceeded(qualified_name, ()),
+        execution_outcome=execution,
     )
 
 

--- a/tests/application/test_rendering.py
+++ b/tests/application/test_rendering.py
@@ -284,6 +284,39 @@ def test_create_table_entries_include_clustering_without_optimize_hint():
     assert clustering == [DiffEntry(DiffCategory.CLUSTERING, "+", ("clustering (region)",))]
 
 
+def test_create_table_entries_include_all_state_embedded_in_create():
+    # Given a CREATE TABLE carrying structural, layout, property, and comment state
+    action = CreateTable(
+        table=DesiredTable(
+            qualified_name=QualifiedName("cat", "sch", "tbl"),
+            columns=(
+                DesiredColumn("id", Integer(), nullable=False, comment="identifier"),
+                DesiredColumn("day", String(), comment="partition date"),
+            ),
+            comment="daily orders",
+            properties={
+                "delta.appendOnly": "true",
+                "delta.logRetentionDuration": None,
+            },
+            partitioned_by=("day",),
+            primary_key=_primary_key(),
+        )
+    )
+
+    # Then reporting states every fact that CREATE TABLE establishes. A None
+    # property asserts absence and is therefore not a creation change.
+    assert action_entries(action) == (
+        DiffEntry(DiffCategory.COLUMNS, "+", ("id", "Integer", "NOT NULL")),
+        DiffEntry(DiffCategory.COLUMNS, "+", ("day", "String")),
+        DiffEntry(DiffCategory.KEYS, "+", ("primary key (id)",)),
+        DiffEntry(DiffCategory.PARTITIONING, "+", ("partitioning (day)",)),
+        DiffEntry(DiffCategory.PROPERTIES, "+", ("delta.appendOnly = 'true'",)),
+        DiffEntry(DiffCategory.COMMENTS, "+", ("column id: 'identifier'",)),
+        DiffEntry(DiffCategory.COMMENTS, "+", ("column day: 'partition date'",)),
+        DiffEntry(DiffCategory.COMMENTS, "+", ("table: 'daily orders'",)),
+    )
+
+
 def test_every_action_type_has_registered_diff_entries():
     # Given every concrete Action subclass the plan vocabulary defines
     import inspect

--- a/tests/application/test_report.py
+++ b/tests/application/test_report.py
@@ -1,6 +1,12 @@
 from datetime import datetime
 import json
 
+import pytest
+
+from delta_engine.application.dependency_resolution import (
+    ResolutionFailed,
+    ResolutionSucceeded,
+)
 from delta_engine.application.failures import (
     ExecutionFailure,
     Failure,
@@ -9,6 +15,7 @@ from delta_engine.application.failures import (
     ReadFailure,
     ValidationFailure,
 )
+from delta_engine.application.planning import PlanningFailed, PlanningSucceeded
 from delta_engine.application.ports import (
     ExecutionSucceeded,
     ExecutionSummary,
@@ -17,6 +24,7 @@ from delta_engine.application.ports import (
     TablePresent,
 )
 from delta_engine.application.report import (
+    ExecutionBlockedByDependency,
     SyncReport,
     TableRunReport,
     TableRunStatus,
@@ -90,34 +98,52 @@ def _report(
     planned_sql_statements: tuple[str, ...] = (),
     failures: tuple[Failure, ...] = (),
     execution: ExecutionSummary | None = None,
+    execution_blocked: bool = False,
 ) -> TableRunReport:
     """Construct a frozen report snapshot from concise test inputs."""
     if execution is not None and not planned_sql_statements:
         planned_sql_statements = tuple(result.statement for result in execution.results)
 
-    read_failures = (read,) if isinstance(read, ReadFailure) else ()
-    reported_failures = tuple(
-        failure for failure in failures if not isinstance(failure, ReadFailure | ExecutionFailure)
+    planning_failures = tuple(
+        failure for failure in failures if isinstance(failure, ValidationFailure)
     )
-    execution_failures = () if execution is None else execution.failures
+    resolution_failures = tuple(
+        failure for failure in failures if isinstance(failure, ForeignKeyFailure)
+    )
     if plan is _PLAN_UNSET:
-        planning_failed = any(isinstance(failure, ValidationFailure) for failure in failures)
         report_plan = (
             None
-            if isinstance(read, ReadFailure) or planning_failed
+            if isinstance(read, ReadFailure) or planning_failures
             else ActionPlan(target=desired.qualified_name)
         )
     else:
         assert plan is None or isinstance(plan, ActionPlan)
         report_plan = plan
 
+    if isinstance(read, ReadFailure):
+        planning = None
+    elif planning_failures:
+        planning = PlanningFailed(planning_failures)
+    else:
+        assert isinstance(report_plan, ActionPlan)
+        planning = PlanningSucceeded(report_plan)
+
+    resolution = (
+        ResolutionFailed(desired.qualified_name, resolution_failures)
+        if resolution_failures and not execution_blocked
+        else ResolutionSucceeded(desired.qualified_name, ())
+    )
+    execution_outcome = (
+        ExecutionBlockedByDependency(resolution_failures) if execution_blocked else execution
+    )
+
     return TableRunReport(
         desired=desired,
         read=read,
-        plan=report_plan,
+        planning=planning,
         planned_sql_statements=planned_sql_statements,
-        failures=(*read_failures, *reported_failures, *execution_failures),
-        execution=execution,
+        resolution=resolution,
+        execution_outcome=execution_outcome,
     )
 
 
@@ -358,6 +384,7 @@ def test_runtime_dependency_block_is_failure_but_not_statement_execution():
         desired=desired,
         read=TablePresent(table=_an_observed_table()),
         failures=(failure,),
+        execution_blocked=True,
     )
 
     assert report.status is TableRunStatus.FOREIGN_KEY_FAILED
@@ -378,6 +405,54 @@ def test_table_run_report_carries_its_desired_definition():
     assert report.status is TableRunStatus.SUCCESS
     assert report.failures == ()
     assert report.plan == ActionPlan(target=desired.qualified_name)
+
+
+def test_table_run_report_rejects_planning_after_a_failed_read():
+    desired = _a_desired_table("orders")
+
+    with pytest.raises(ValueError, match="Planning cannot follow a failed read"):
+        TableRunReport(
+            desired=desired,
+            read=ReadFailure("IOError", "boom"),
+            planning=PlanningSucceeded(ActionPlan(target=desired.qualified_name)),
+            planned_sql_statements=(),
+            resolution=ResolutionSucceeded(desired.qualified_name, ()),
+            execution_outcome=None,
+        )
+
+
+def test_table_run_report_rejects_execution_after_failed_resolution():
+    desired = _a_desired_table("orders")
+    failure = ForeignKeyFailure(
+        table=desired.qualified_name,
+        local_columns=("customer_id",),
+        references=QualifiedName("cat", "schema", "customers"),
+        reason=ForeignKeyFailureReason.UNRESOLVABLE_REFERENCE,
+    )
+
+    with pytest.raises(ValueError, match="Execution cannot follow a failed earlier phase"):
+        TableRunReport(
+            desired=desired,
+            read=TablePresent(table=_an_observed_table()),
+            planning=PlanningSucceeded(ActionPlan(target=desired.qualified_name)),
+            planned_sql_statements=("SQL",),
+            resolution=ResolutionFailed(desired.qualified_name, (failure,)),
+            execution_outcome=ExecutionSummary((_ok_exec(0, "SQL"),)),
+        )
+
+
+def test_table_run_report_rejects_execution_unrelated_to_planned_sql():
+    desired = _a_desired_table("orders")
+
+    with pytest.raises(ValueError, match="planned statement prefix"):
+        TableRunReport(
+            desired=desired,
+            read=TablePresent(table=_an_observed_table()),
+            planning=PlanningSucceeded(ActionPlan(target=desired.qualified_name)),
+            planned_sql_statements=("PLANNED SQL",),
+            resolution=ResolutionSucceeded(desired.qualified_name, ()),
+            execution_outcome=ExecutionSummary((_ok_exec(0, "OTHER SQL"),)),
+        )
 
 
 def _a_changed_table_report():


### PR DESCRIPTION
## What changed

- Make phase outcomes the canonical source of truth for table runs.
- Derive plans, failures, status, change state, and execution summaries from those outcomes.
- Represent dependency-blocked execution as an explicit execution outcome.
- Enforce valid phase ordering and execution-result invariants at the report boundaries.
- Make `CreateTable`'s semantic diff entries cover all state embedded in creation SQL, including partitioning, properties, and comments.
- Update architecture documentation and black-box tests.

## Why

Previously, `TableRunReport` retained parallel representations of the same run state (`plan`, `failures`, and execution data). Those representations could drift apart. Creation reporting also omitted some state that was present in the SQL, so reports understated the operation. This change gives each phase one authoritative outcome and makes both run state and creation changes truthful.

## Validation

- Focused application tests: 133 passed.
- Non-Spark suite: 960 passed, 98 deselected.
- `mypy`, Ruff, import contracts, documentation build, and `git diff --check` passed.
- Full default tests remain blocked only by the local Spark fixture failing to write to the sandboxed Ivy cache.
