### PR TITLE
test: harden reader contract tests

### DIFF
--- a/tests/adapters/databricks/spark/test_reader.py
+++ b/tests/adapters/databricks/spark/test_reader.py
@@ -62,7 +62,9 @@ class FakeSpark:
 
     def sql(self, query):
         self.queries.append(query)
-        value = self._responses.get(query, [])
+        if query not in self._responses:
+            pytest.fail(f"unexpected SQL query: {query}", pytrace=False)
+        value = self._responses[query]
         if isinstance(value, Exception):
             raise value
         return FakeDataFrame(value)
@@ -86,13 +88,6 @@ def test_present_table_reads_via_as_json():
     state = SparkReader(SparkSqlRunner(spark)).fetch_state(QN)
     assert isinstance(state, TablePresent)
     assert state.table.columns[0].data_type == Integer()
-
-
-def test_present_table_uses_six_queries():
-    spark = FakeSpark(_responses())
-    SparkReader(SparkSqlRunner(spark)).fetch_state(QN)
-    assert len(spark.queries) == 6
-    assert spark.queries[0] == describe_json_query(QN)
 
 
 def test_missing_table_is_absent_after_confirming_the_schema_exists():

--- a/tests/adapters/databricks/sql/test_describe.py
+++ b/tests/adapters/databricks/sql/test_describe.py
@@ -194,12 +194,12 @@ def test_partitioning_and_clustering_carried_verbatim_in_order():
 
 def test_non_list_partition_columns_raises():
     # A present-but-non-list layout field is drift, not "no partitioning".
-    with pytest.raises(MetadataParseError):
+    with pytest.raises(MetadataParseError, match="partition_columns is not a list"):
         _parse(_doc(partition_columns="region"))
 
 
 def test_non_list_clustering_columns_raises():
-    with pytest.raises(MetadataParseError):
+    with pytest.raises(MetadataParseError, match="clustering_columns is not a list"):
         _parse(_doc(clustering_columns="id"))
 
 
@@ -220,7 +220,7 @@ def test_absent_table_properties_carry_as_empty():
 
 
 def test_non_object_table_properties_raises():
-    with pytest.raises(MetadataParseError):
+    with pytest.raises(MetadataParseError, match="table_properties is not an object"):
         _parse(_doc(table_properties="delta.appendOnly=true"))
 
 
@@ -228,7 +228,7 @@ def test_unsupported_column_type_fails_the_read():
     # An unknown or future type name is a column the domain cannot model. The
     # engine owns the full column set, so dropping it would read as "in sync";
     # fail the read instead.
-    with pytest.raises(MetadataParseError):
+    with pytest.raises(MetadataParseError, match="column 'weird' has an unsupported type"):
         _parse(
             _doc(
                 columns=[
@@ -241,7 +241,7 @@ def test_unsupported_column_type_fails_the_read():
 
 def test_malformed_type_object_raises():
     # A non-object type is a malformed shape, caught before type classification.
-    with pytest.raises(MetadataParseError):
+    with pytest.raises(MetadataParseError, match="column 'amount' has a malformed type object"):
         _parse(
             _doc(
                 columns=[
@@ -253,7 +253,7 @@ def test_malformed_type_object_raises():
 
 
 def test_type_object_without_name_raises():
-    with pytest.raises(MetadataParseError):
+    with pytest.raises(MetadataParseError, match="column 'amount' has a malformed type object"):
         _parse(
             _doc(
                 columns=[
@@ -267,7 +267,7 @@ def test_type_object_without_name_raises():
 def test_unsupported_nested_type_fails_the_read():
     # A nested type the domain cannot represent (here an array with no element
     # type) is unreadable just like an unknown top-level type: fail, don't drop.
-    with pytest.raises(MetadataParseError):
+    with pytest.raises(MetadataParseError, match="column 'tags' has an unsupported type"):
         _parse(
             _doc(
                 columns=[
@@ -279,33 +279,33 @@ def test_unsupported_nested_type_fails_the_read():
 
 
 def test_non_boolean_nullable_fails_the_read():
-    with pytest.raises(MetadataParseError):
+    with pytest.raises(MetadataParseError, match="column 'id' has a non-boolean nullable"):
         _parse(_doc(columns=[{"name": "id", "type": {"name": "int"}, "nullable": "false"}]))
 
 
 def test_empty_describe_result_raises():
     # The statement returns exactly one row; no rows means the table could not
     # be described, not that it is absent.
-    with pytest.raises(MetadataParseError):
+    with pytest.raises(MetadataParseError, match="DESCRIBE AS JSON returned no rows"):
         table_description_from_rows([], QN)
 
 
 def test_malformed_json_and_missing_columns_raise():
-    with pytest.raises(MetadataParseError):
+    with pytest.raises(MetadataParseError, match="DESCRIBE AS JSON was not valid JSON"):
         _parse("{not json")
     doc = json.loads(_doc())
     doc.pop("columns")
-    with pytest.raises(MetadataParseError):
+    with pytest.raises(MetadataParseError, match="AS JSON has no columns array"):
         _parse(json.dumps(doc))
 
 
 def test_non_object_document_raises():
-    with pytest.raises(MetadataParseError):
+    with pytest.raises(MetadataParseError, match="expected a JSON object"):
         _parse("[1, 2, 3]")
 
 
 def test_malformed_column_entry_raises():
-    with pytest.raises(MetadataParseError):
+    with pytest.raises(MetadataParseError, match="malformed column entry"):
         _parse(_doc(columns=[{"no_name": "x", "type": {"name": "int"}}]))
 
 
@@ -344,17 +344,18 @@ def test_unknown_describe_fields_are_ignored() -> None:
 
 
 @pytest.mark.parametrize(
-    ("field", "malformed"),
+    ("field", "malformed", "expected_message"),
     (
-        ("table_comment", False),
-        ("column_comment", 0),
-        ("layout_item", {"name": "region"}),
-        ("property_value", True),
+        ("table_comment", False, "table comment is not a string"),
+        ("column_comment", 0, "column 'id' comment is not a string"),
+        ("layout_item", {"name": "region"}, "partition_columns entries must be strings"),
+        ("property_value", True, "table_properties values must be strings"),
     ),
 )
 def test_non_string_describe_leaf_values_raise_metadata_parse_error(
     field: str,
     malformed: object,
+    expected_message: str,
 ) -> None:
     document = json.loads(_doc())
     if field == "table_comment":
@@ -366,5 +367,5 @@ def test_non_string_describe_leaf_values_raise_metadata_parse_error(
     else:
         document["table_properties"] = {"delta.appendOnly": malformed}
 
-    with pytest.raises(MetadataParseError):
+    with pytest.raises(MetadataParseError, match=expected_message):
         _parse(json.dumps(document))

--- a/tests/adapters/databricks/sql/test_describe.py
+++ b/tests/adapters/databricks/sql/test_describe.py
@@ -194,12 +194,12 @@ def test_partitioning_and_clustering_carried_verbatim_in_order():
 
 def test_non_list_partition_columns_raises():
     # A present-but-non-list layout field is drift, not "no partitioning".
-    with pytest.raises(MetadataParseError, match="partition_columns is not a list"):
+    with pytest.raises(MetadataParseError):
         _parse(_doc(partition_columns="region"))
 
 
 def test_non_list_clustering_columns_raises():
-    with pytest.raises(MetadataParseError, match="clustering_columns is not a list"):
+    with pytest.raises(MetadataParseError):
         _parse(_doc(clustering_columns="id"))
 
 
@@ -220,7 +220,7 @@ def test_absent_table_properties_carry_as_empty():
 
 
 def test_non_object_table_properties_raises():
-    with pytest.raises(MetadataParseError, match="table_properties is not an object"):
+    with pytest.raises(MetadataParseError):
         _parse(_doc(table_properties="delta.appendOnly=true"))
 
 
@@ -228,7 +228,7 @@ def test_unsupported_column_type_fails_the_read():
     # An unknown or future type name is a column the domain cannot model. The
     # engine owns the full column set, so dropping it would read as "in sync";
     # fail the read instead.
-    with pytest.raises(MetadataParseError, match="column 'weird' has an unsupported type"):
+    with pytest.raises(MetadataParseError):
         _parse(
             _doc(
                 columns=[
@@ -241,7 +241,7 @@ def test_unsupported_column_type_fails_the_read():
 
 def test_malformed_type_object_raises():
     # A non-object type is a malformed shape, caught before type classification.
-    with pytest.raises(MetadataParseError, match="column 'amount' has a malformed type object"):
+    with pytest.raises(MetadataParseError):
         _parse(
             _doc(
                 columns=[
@@ -253,7 +253,7 @@ def test_malformed_type_object_raises():
 
 
 def test_type_object_without_name_raises():
-    with pytest.raises(MetadataParseError, match="column 'amount' has a malformed type object"):
+    with pytest.raises(MetadataParseError):
         _parse(
             _doc(
                 columns=[
@@ -267,7 +267,7 @@ def test_type_object_without_name_raises():
 def test_unsupported_nested_type_fails_the_read():
     # A nested type the domain cannot represent (here an array with no element
     # type) is unreadable just like an unknown top-level type: fail, don't drop.
-    with pytest.raises(MetadataParseError, match="column 'tags' has an unsupported type"):
+    with pytest.raises(MetadataParseError):
         _parse(
             _doc(
                 columns=[
@@ -279,33 +279,33 @@ def test_unsupported_nested_type_fails_the_read():
 
 
 def test_non_boolean_nullable_fails_the_read():
-    with pytest.raises(MetadataParseError, match="column 'id' has a non-boolean nullable"):
+    with pytest.raises(MetadataParseError):
         _parse(_doc(columns=[{"name": "id", "type": {"name": "int"}, "nullable": "false"}]))
 
 
 def test_empty_describe_result_raises():
     # The statement returns exactly one row; no rows means the table could not
     # be described, not that it is absent.
-    with pytest.raises(MetadataParseError, match="DESCRIBE AS JSON returned no rows"):
+    with pytest.raises(MetadataParseError):
         table_description_from_rows([], QN)
 
 
 def test_malformed_json_and_missing_columns_raise():
-    with pytest.raises(MetadataParseError, match="DESCRIBE AS JSON was not valid JSON"):
+    with pytest.raises(MetadataParseError):
         _parse("{not json")
     doc = json.loads(_doc())
     doc.pop("columns")
-    with pytest.raises(MetadataParseError, match="AS JSON has no columns array"):
+    with pytest.raises(MetadataParseError):
         _parse(json.dumps(doc))
 
 
 def test_non_object_document_raises():
-    with pytest.raises(MetadataParseError, match="expected a JSON object"):
+    with pytest.raises(MetadataParseError):
         _parse("[1, 2, 3]")
 
 
 def test_malformed_column_entry_raises():
-    with pytest.raises(MetadataParseError, match="malformed column entry"):
+    with pytest.raises(MetadataParseError):
         _parse(_doc(columns=[{"no_name": "x", "type": {"name": "int"}}]))
 
 
@@ -344,18 +344,17 @@ def test_unknown_describe_fields_are_ignored() -> None:
 
 
 @pytest.mark.parametrize(
-    ("field", "malformed", "expected_message"),
+    ("field", "malformed"),
     (
-        ("table_comment", False, "table comment is not a string"),
-        ("column_comment", 0, "column 'id' comment is not a string"),
-        ("layout_item", {"name": "region"}, "partition_columns entries must be strings"),
-        ("property_value", True, "table_properties values must be strings"),
+        ("table_comment", False),
+        ("column_comment", 0),
+        ("layout_item", {"name": "region"}),
+        ("property_value", True),
     ),
 )
 def test_non_string_describe_leaf_values_raise_metadata_parse_error(
     field: str,
     malformed: object,
-    expected_message: str,
 ) -> None:
     document = json.loads(_doc())
     if field == "table_comment":
@@ -367,5 +366,5 @@ def test_non_string_describe_leaf_values_raise_metadata_parse_error(
     else:
         document["table_properties"] = {"delta.appendOnly": malformed}
 
-    with pytest.raises(MetadataParseError, match=expected_message):
+    with pytest.raises(MetadataParseError):
         _parse(json.dumps(document))

--- a/tests/adapters/databricks/test_read.py
+++ b/tests/adapters/databricks/test_read.py
@@ -13,7 +13,6 @@ from delta_engine.adapters.databricks.sql import (
     schema_exists_query,
     table_tags_query,
 )
-from delta_engine.adapters.databricks.sql.describe import MetadataParseError
 from delta_engine.application.errors import ReadError
 from delta_engine.application.ports import TableAbsent, TablePresent
 from delta_engine.domain.model import (
@@ -228,62 +227,53 @@ def test_missing_table_in_a_missing_schema_reads_as_failed_not_absent():
 
     error = _read_error(responses)
 
-    assert isinstance(error.__cause__, RuntimeError)
+    assert "does not exist" in str(error)
 
 
 def test_missing_table_in_an_unreadable_catalog_reads_as_failed_not_absent():
     # A nonexistent catalog also reports TABLE_OR_VIEW_NOT_FOUND on describe;
     # the schema probe then fails because <catalog>.information_schema cannot
     # resolve, and that failure is the read's outcome.
-    schema_error = RuntimeError("[SCHEMA_NOT_FOUND] cat.information_schema")
     responses = {
         describe_json_query(QN): RuntimeError("[TABLE_OR_VIEW_NOT_FOUND] nope"),
-        schema_exists_query(QN): schema_error,
+        schema_exists_query(QN): RuntimeError("[SCHEMA_NOT_FOUND] cat.information_schema"),
     }
 
-    error = _read_error(responses)
-
-    assert error.__cause__ is schema_error
+    _read_error(responses)
 
 
 def test_missing_schema_or_catalog_on_describe_reads_as_failed_not_absent():
     # Where the backend does name the missing container on the describe, that
     # is not a creatable absence either.
     for condition in ("SCHEMA_NOT_FOUND", "CATALOG_NOT_FOUND"):
-        describe_error = RuntimeError(f"[{condition}] nope")
-        responses = {describe_json_query(QN): describe_error}
+        responses = {describe_json_query(QN): RuntimeError(f"[{condition}] nope")}
 
-        error = _read_error(responses)
-
-        assert error.__cause__ is describe_error
+        _read_error(responses)
 
 
 def test_other_describe_error_reads_as_failed():
-    describe_error = RuntimeError("warehouse gone")
-    responses = {describe_json_query(QN): describe_error}
+    responses = {describe_json_query(QN): RuntimeError("warehouse gone")}
 
     error = _read_error(responses)
 
-    assert error.__cause__ is describe_error
+    assert "warehouse gone" in str(error)
+    assert isinstance(error.__cause__, RuntimeError)
 
 
 def test_empty_describe_result_reads_as_failed():
     responses = _describe_responses(**{describe_json_query(QN): []})
 
-    error = _read_error(responses)
-
-    assert isinstance(error.__cause__, MetadataParseError)
+    _read_error(responses)
 
 
 def test_missing_relation_while_reading_info_schema_reads_as_failed_not_absent():
     # Missing-relation means "table absent" only for the describe. A failure while
     # attaching tags means the table was found but the read could not complete.
-    tags_error = RuntimeError("[TABLE_OR_VIEW_NOT_FOUND] tags view")
-    responses = _describe_responses(**{table_tags_query(QN): tags_error})
+    responses = _describe_responses(
+        **{table_tags_query(QN): RuntimeError("[TABLE_OR_VIEW_NOT_FOUND] tags view")}
+    )
 
-    error = _read_error(responses)
-
-    assert error.__cause__ is tags_error
+    _read_error(responses)
 
 
 def test_an_external_delta_table_reads_as_present():
@@ -354,9 +344,7 @@ def test_unmappable_column_type_reads_as_failed_not_present():
     )
     responses = _describe_responses(**{describe_json_query(QN): [(doc,)]})
 
-    error = _read_error(responses)
-
-    assert isinstance(error.__cause__, MetadataParseError)
+    _read_error(responses)
 
 
 def test_a_streaming_table_reads_as_present_with_its_kind():

--- a/tests/adapters/databricks/test_read.py
+++ b/tests/adapters/databricks/test_read.py
@@ -242,7 +242,6 @@ def test_missing_table_in_an_unreadable_catalog_reads_as_failed_not_absent():
     error = _read_error(responses)
 
     assert error.exception_type == "RuntimeError"
-    assert "SCHEMA_NOT_FOUND" in str(error)
 
 
 def test_missing_schema_or_catalog_on_describe_reads_as_failed_not_absent():
@@ -254,7 +253,6 @@ def test_missing_schema_or_catalog_on_describe_reads_as_failed_not_absent():
         error = _read_error(responses)
 
         assert error.exception_type == "RuntimeError"
-        assert condition in str(error)
 
 
 def test_other_describe_error_reads_as_failed():
@@ -272,7 +270,6 @@ def test_empty_describe_result_reads_as_failed():
     error = _read_error(responses)
 
     assert error.exception_type == "MetadataParseError"
-    assert "DESCRIBE AS JSON returned no rows" in str(error)
 
 
 def test_missing_relation_while_reading_info_schema_reads_as_failed_not_absent():
@@ -285,7 +282,6 @@ def test_missing_relation_while_reading_info_schema_reads_as_failed_not_absent()
     error = _read_error(responses)
 
     assert error.exception_type == "RuntimeError"
-    assert "TABLE_OR_VIEW_NOT_FOUND" in str(error)
 
 
 def test_an_external_delta_table_reads_as_present():
@@ -359,7 +355,6 @@ def test_unmappable_column_type_reads_as_failed_not_present():
     error = _read_error(responses)
 
     assert error.exception_type == "MetadataParseError"
-    assert "column 'region' has an unsupported type" in str(error)
 
 
 def test_a_streaming_table_reads_as_present_with_its_kind():

--- a/tests/adapters/databricks/test_read.py
+++ b/tests/adapters/databricks/test_read.py
@@ -57,7 +57,9 @@ def _describe_responses(**overrides):
 
 def _router(responses):
     def run(query):
-        value = responses.get(query, [])
+        if query not in responses:
+            pytest.fail(f"unexpected SQL query: {query}", pytrace=False)
+        value = responses[query]
         if isinstance(value, Exception):
             raise value
         return value
@@ -193,8 +195,14 @@ def test_read_catalog_state_describes_first_then_reads_info_schema():
 
     read_catalog_state(run_query, QN)
 
-    assert calls[0] == describe_json_query(QN)
-    assert len(calls) == 6
+    assert calls == [
+        describe_json_query(QN),
+        column_tags_query(QN),
+        table_tags_query(QN),
+        primary_key_query(QN),
+        foreign_keys_query(QN),
+        referencing_foreign_keys_query(QN),
+    ]
 
 
 def test_missing_table_in_an_existing_schema_reads_as_absent():
@@ -212,7 +220,10 @@ def test_missing_table_in_a_missing_schema_reads_as_failed_not_absent():
     # absent would plan a CREATE TABLE that cannot succeed, and a dry run
     # would report that impossible plan as success. The router returns no
     # rows for the schema probe: the schema does not exist.
-    responses = {describe_json_query(QN): RuntimeError("[TABLE_OR_VIEW_NOT_FOUND] nope")}
+    responses = {
+        describe_json_query(QN): RuntimeError("[TABLE_OR_VIEW_NOT_FOUND] nope"),
+        schema_exists_query(QN): [],
+    }
 
     error = _read_error(responses)
 
@@ -228,7 +239,10 @@ def test_missing_table_in_an_unreadable_catalog_reads_as_failed_not_absent():
         schema_exists_query(QN): RuntimeError("[SCHEMA_NOT_FOUND] cat.information_schema"),
     }
 
-    _read_error(responses)
+    error = _read_error(responses)
+
+    assert error.exception_type == "RuntimeError"
+    assert "SCHEMA_NOT_FOUND" in str(error)
 
 
 def test_missing_schema_or_catalog_on_describe_reads_as_failed_not_absent():
@@ -237,7 +251,10 @@ def test_missing_schema_or_catalog_on_describe_reads_as_failed_not_absent():
     for condition in ("SCHEMA_NOT_FOUND", "CATALOG_NOT_FOUND"):
         responses = {describe_json_query(QN): RuntimeError(f"[{condition}] nope")}
 
-        _read_error(responses)
+        error = _read_error(responses)
+
+        assert error.exception_type == "RuntimeError"
+        assert condition in str(error)
 
 
 def test_other_describe_error_reads_as_failed():
@@ -252,7 +269,10 @@ def test_other_describe_error_reads_as_failed():
 def test_empty_describe_result_reads_as_failed():
     responses = _describe_responses(**{describe_json_query(QN): []})
 
-    _read_error(responses)
+    error = _read_error(responses)
+
+    assert error.exception_type == "MetadataParseError"
+    assert "DESCRIBE AS JSON returned no rows" in str(error)
 
 
 def test_missing_relation_while_reading_info_schema_reads_as_failed_not_absent():
@@ -262,7 +282,10 @@ def test_missing_relation_while_reading_info_schema_reads_as_failed_not_absent()
         **{table_tags_query(QN): RuntimeError("[TABLE_OR_VIEW_NOT_FOUND] tags view")}
     )
 
-    _read_error(responses)
+    error = _read_error(responses)
+
+    assert error.exception_type == "RuntimeError"
+    assert "TABLE_OR_VIEW_NOT_FOUND" in str(error)
 
 
 def test_an_external_delta_table_reads_as_present():
@@ -333,7 +356,10 @@ def test_unmappable_column_type_reads_as_failed_not_present():
     )
     responses = _describe_responses(**{describe_json_query(QN): [(doc,)]})
 
-    _read_error(responses)
+    error = _read_error(responses)
+
+    assert error.exception_type == "MetadataParseError"
+    assert "column 'region' has an unsupported type" in str(error)
 
 
 def test_a_streaming_table_reads_as_present_with_its_kind():

--- a/tests/adapters/databricks/test_read.py
+++ b/tests/adapters/databricks/test_read.py
@@ -13,6 +13,7 @@ from delta_engine.adapters.databricks.sql import (
     schema_exists_query,
     table_tags_query,
 )
+from delta_engine.adapters.databricks.sql.describe import MetadataParseError
 from delta_engine.application.errors import ReadError
 from delta_engine.application.ports import TableAbsent, TablePresent
 from delta_engine.domain.model import (
@@ -227,41 +228,43 @@ def test_missing_table_in_a_missing_schema_reads_as_failed_not_absent():
 
     error = _read_error(responses)
 
-    assert "does not exist" in str(error)
+    assert isinstance(error.__cause__, RuntimeError)
 
 
 def test_missing_table_in_an_unreadable_catalog_reads_as_failed_not_absent():
     # A nonexistent catalog also reports TABLE_OR_VIEW_NOT_FOUND on describe;
     # the schema probe then fails because <catalog>.information_schema cannot
     # resolve, and that failure is the read's outcome.
+    schema_error = RuntimeError("[SCHEMA_NOT_FOUND] cat.information_schema")
     responses = {
         describe_json_query(QN): RuntimeError("[TABLE_OR_VIEW_NOT_FOUND] nope"),
-        schema_exists_query(QN): RuntimeError("[SCHEMA_NOT_FOUND] cat.information_schema"),
+        schema_exists_query(QN): schema_error,
     }
 
     error = _read_error(responses)
 
-    assert error.exception_type == "RuntimeError"
+    assert error.__cause__ is schema_error
 
 
 def test_missing_schema_or_catalog_on_describe_reads_as_failed_not_absent():
     # Where the backend does name the missing container on the describe, that
     # is not a creatable absence either.
     for condition in ("SCHEMA_NOT_FOUND", "CATALOG_NOT_FOUND"):
-        responses = {describe_json_query(QN): RuntimeError(f"[{condition}] nope")}
+        describe_error = RuntimeError(f"[{condition}] nope")
+        responses = {describe_json_query(QN): describe_error}
 
         error = _read_error(responses)
 
-        assert error.exception_type == "RuntimeError"
+        assert error.__cause__ is describe_error
 
 
 def test_other_describe_error_reads_as_failed():
-    responses = {describe_json_query(QN): RuntimeError("warehouse gone")}
+    describe_error = RuntimeError("warehouse gone")
+    responses = {describe_json_query(QN): describe_error}
 
     error = _read_error(responses)
 
-    assert "warehouse gone" in str(error)
-    assert isinstance(error.__cause__, RuntimeError)
+    assert error.__cause__ is describe_error
 
 
 def test_empty_describe_result_reads_as_failed():
@@ -269,19 +272,18 @@ def test_empty_describe_result_reads_as_failed():
 
     error = _read_error(responses)
 
-    assert error.exception_type == "MetadataParseError"
+    assert isinstance(error.__cause__, MetadataParseError)
 
 
 def test_missing_relation_while_reading_info_schema_reads_as_failed_not_absent():
     # Missing-relation means "table absent" only for the describe. A failure while
     # attaching tags means the table was found but the read could not complete.
-    responses = _describe_responses(
-        **{table_tags_query(QN): RuntimeError("[TABLE_OR_VIEW_NOT_FOUND] tags view")}
-    )
+    tags_error = RuntimeError("[TABLE_OR_VIEW_NOT_FOUND] tags view")
+    responses = _describe_responses(**{table_tags_query(QN): tags_error})
 
     error = _read_error(responses)
 
-    assert error.exception_type == "RuntimeError"
+    assert error.__cause__ is tags_error
 
 
 def test_an_external_delta_table_reads_as_present():
@@ -354,7 +356,7 @@ def test_unmappable_column_type_reads_as_failed_not_present():
 
     error = _read_error(responses)
 
-    assert error.exception_type == "MetadataParseError"
+    assert isinstance(error.__cause__, MetadataParseError)
 
 
 def test_a_streaming_table_reads_as_present_with_its_kind():

--- a/tests/adapters/databricks/warehouse/test_reader.py
+++ b/tests/adapters/databricks/warehouse/test_reader.py
@@ -54,10 +54,12 @@ class RoutedCursor:
 
     def execute(self, query):
         self.queries.append(query)
-        value = self._responses.get(query)
+        if query not in self._responses:
+            pytest.fail(f"unexpected SQL query: {query}", pytrace=False)
+        value = self._responses[query]
         if isinstance(value, Exception):
             raise value
-        self._current = value if value is not None else []
+        self._current = value
 
     def fetchall(self):
         return list(self._current)
@@ -106,13 +108,6 @@ def test_present_table_reads_via_as_json():
     # The table_constraints embedded in the AS JSON doc is not read: the primary
     # key comes from information_schema, which returns nothing here.
     assert observed.primary_key is None
-
-
-def test_present_table_uses_six_queries():
-    connection = RoutedConnection(_responses())
-    _reader(connection).fetch_state(QN)
-    assert len(connection.cursor_fake.queries) == 6
-    assert connection.cursor_fake.queries[0] == describe_json_query(QN)
 
 
 def test_missing_table_is_absent_after_confirming_the_schema_exists():


### PR DESCRIPTION
## Summary

- Make Spark, Warehouse, and shared catalog reader fakes fail on unexpected SQL instead of silently returning empty results.
- Pin the shared catalog reader's complete metadata-query order and remove redundant adapter-level query-count tests.
- Keep parser and reader failure tests focused on observable outcomes, make the missing-schema fixture explicit, and avoid coupling tests to incidental exception wording.

## Why

The previous fakes treated unknown queries as empty responses, allowing query omissions or typos to pass as valid absence or failure behavior. The tests now enforce the query contract while avoiding incidental coupling to human-readable exception prose.

## Validation

- `uv run pytest -q tests/adapters/databricks --no-cov` — 209 passed
- `uv run pytest -q` — 1,006 passed, 64 credentialed-live tests deselected
- Coverage: 97.04%
- `uv run ruff check tests/adapters/databricks`
- `git diff --check`

No production code was changed.
