### PR TITLE
test: make live capability skips trustworthy

### DIFF
--- a/tests/live/capabilities.py
+++ b/tests/live/capabilities.py
@@ -1,0 +1,62 @@
+"""Capability handling shared by credentialed Databricks tests."""
+
+from collections.abc import Callable, Collection
+import re
+import time
+
+from databricks.sql.exc import ServerOperationError
+import pytest
+
+_CONDITION_NAME = r"[A-Z][A-Z0-9_]*(?:\.[A-Z][A-Z0-9_]*)*"
+_RENDERED_CONDITION = re.compile(rf"^\[({_CONDITION_NAME})\]")
+
+type RetryReporter = Callable[[str, float], None]
+
+
+def databricks_error_condition(error: ServerOperationError) -> str | None:
+    """Return the stable Databricks error condition, excluding mutable prose."""
+    # The kernel transport exposes the condition directly. The Thrift transport
+    # currently exposes the same condition only as the leading bracketed token.
+    structured_condition = getattr(error, "error_code", None)
+    if isinstance(structured_condition, str) and re.fullmatch(
+        _CONDITION_NAME, structured_condition
+    ):
+        return structured_condition
+
+    if not isinstance(error.message, str):
+        return None
+    match = _RENDERED_CONDITION.match(error.message)
+    return match.group(1) if match else None
+
+
+def require_databricks_capability(
+    operation: Callable[[], None],
+    *,
+    capability: str,
+    unavailable_conditions: Collection[str],
+    retry_conditions: Collection[str] = (),
+    retry_timeout_seconds: float = 0,
+    retry_interval_seconds: float = 1,
+    clock: Callable[[], float] = time.monotonic,
+    pause: Callable[[float], None] = time.sleep,
+    report_retry: RetryReporter | None = None,
+) -> None:
+    """Run a probe, skipping only named capability conditions after bounded retries."""
+    deadline = clock() + retry_timeout_seconds
+
+    while True:
+        try:
+            operation()
+            return
+        except ServerOperationError as error:
+            condition = databricks_error_condition(error)
+            now = clock()
+            if condition in retry_conditions and now < deadline:
+                delay = min(retry_interval_seconds, deadline - now)
+                if report_retry is not None:
+                    report_retry(condition, delay)
+                pause(delay)
+                continue
+            if condition in unavailable_conditions or condition in retry_conditions:
+                pytest.skip(f"{capability} is unavailable ({condition})")
+            raise

--- a/tests/live/test_sql_warehouse_live_streaming_tables.py
+++ b/tests/live/test_sql_warehouse_live_streaming_tables.py
@@ -23,8 +23,6 @@ workflow's ``--dist loadgroup``) and tests share a provisioned table where
 the facts allow.
 """
 
-import time
-
 import pytest
 
 pytest.importorskip("databricks.sql")
@@ -38,6 +36,7 @@ from delta_engine.application.ports import TablePresent
 from delta_engine.databricks import build_sql_engine
 from delta_engine.domain.model import QualifiedName, TableKind
 from delta_engine.schema import Column, DeltaTable, Integer
+from tests.live.capabilities import require_databricks_capability
 from tests.live.sql_warehouse_live_helpers import (
     execute_sql,
     fetch_rows,
@@ -48,9 +47,22 @@ from tests.live.sql_warehouse_live_helpers import (
 
 pytestmark = pytest.mark.xdist_group("streaming_table")
 
-_QUOTA_ERROR_MARKER = "QUOTA_EXCEEDED_EXCEPTION"
-_QUOTA_RETRY_ATTEMPTS = 6
+_QUOTA_ERROR_CONDITION = "QUOTA_EXCEEDED_EXCEPTION"
+_QUOTA_RETRY_TIMEOUT_SECONDS = 100
 _QUOTA_RETRY_WAIT_SECONDS = 20
+_STREAMING_TABLE_UNAVAILABLE_CONDITIONS = {
+    "FEATURE_NOT_ENABLED",
+    "FEATURE_NOT_ON_CLASSIC_WAREHOUSE",
+    "FEATURE_UNAVAILABLE",
+    "STREAMING_TABLE_NOT_SUPPORTED",
+}
+
+
+def _report_quota_retry(condition: str, delay: float) -> None:
+    print(
+        f"streaming-table capability probe hit {condition}; retrying in {delay:g}s",
+        flush=True,
+    )
 
 
 def _create_streaming_table(live_connection, live_tables) -> str:
@@ -65,22 +77,19 @@ def _create_streaming_table(live_connection, live_tables) -> str:
         f"CREATE STREAMING TABLE {qualified_table(table_name)} "
         f"AS SELECT id FROM STREAM({qualified_table(source_name)})"
     )
-    # The one-pipeline quota releases asynchronously after a previous test's
-    # DROP TABLE, so a quota rejection is retried before concluding the
-    # workspace cannot create streaming tables at all. Plain DROP TABLE drops
-    # a streaming table (verified live), so the live_tables teardown owns the
-    # cleanup; the source is dropped after it.
-    attempt = 1
-    while True:
-        try:
-            execute_sql(live_connection, create_statement)
-            return table_name
-        except Exception as exc:  # intentional broad except: environment capability probe
-            if _QUOTA_ERROR_MARKER in str(exc) and attempt < _QUOTA_RETRY_ATTEMPTS:
-                attempt += 1
-                time.sleep(_QUOTA_RETRY_WAIT_SECONDS)
-                continue
-            pytest.skip(f"workspace cannot create a streaming table here: {exc}")
+    # The one-pipeline quota releases asynchronously after a previous DROP TABLE,
+    # so retry that condition against a deadline. The live_tables teardown owns
+    # cleanup for both the streaming table and its source.
+    require_databricks_capability(
+        lambda: execute_sql(live_connection, create_statement),
+        capability="streaming tables",
+        unavailable_conditions=_STREAMING_TABLE_UNAVAILABLE_CONDITIONS,
+        retry_conditions={_QUOTA_ERROR_CONDITION},
+        retry_timeout_seconds=_QUOTA_RETRY_TIMEOUT_SECONDS,
+        retry_interval_seconds=_QUOTA_RETRY_WAIT_SECONDS,
+        report_retry=_report_quota_retry,
+    )
+    return table_name
 
 
 def _table_tags(live_connection, table_name: str) -> dict[str, str]:

--- a/tests/live/test_sql_warehouse_live_supported_relations.py
+++ b/tests/live/test_sql_warehouse_live_supported_relations.py
@@ -17,12 +17,19 @@ from delta_engine.adapters.databricks.warehouse.reader import WarehouseReader
 from delta_engine.application.errors import ReadError
 from delta_engine.application.ports import CatalogState
 from delta_engine.domain.model import QualifiedName
+from tests.live.capabilities import require_databricks_capability
 from tests.live.sql_warehouse_live_helpers import (
     execute_sql,
     live_catalog,
     live_schema,
     qualified_table,
 )
+
+_ICEBERG_UNAVAILABLE_CONDITIONS = {
+    "UC_DATASOURCE_NOT_SUPPORTED",
+    "UC_MANAGED_ICEBERG_UNSUPPORTED",
+    "UNSUPPORTED_MANAGED_TABLE_CREATION",
+}
 
 
 def _read(live_connection, table_name: str) -> CatalogState:
@@ -54,17 +61,19 @@ def test_a_view_is_not_read_as_a_table(live_connection, live_tables):
 
 def test_a_non_delta_table_is_not_read_as_engine_state(live_connection, live_tables):
     """An Iceberg table fails the read: the engine reads Delta tables only."""
-    # An ordinary managed table in a format the engine's DDL cannot manage.
-    # Skip cleanly if the workspace cannot create one.
+    # Given an ordinary managed table in a format the engine's DDL cannot manage
     table_name = live_tables("relation_iceberg")
-    try:
-        execute_sql(
+    require_databricks_capability(
+        lambda: execute_sql(
             live_connection,
             f"CREATE TABLE {qualified_table(table_name)} (id INT) USING ICEBERG",
-        )
-    except Exception as exc:  # intentional broad except: environment capability probe
-        pytest.skip(f"workspace cannot create an Iceberg table here: {exc}")
+        ),
+        capability="managed Iceberg tables",
+        unavailable_conditions=_ICEBERG_UNAVAILABLE_CONDITIONS,
+    )
 
+    # When the engine reads the non-Delta relation
+    # Then it rejects the relation instead of treating it as manageable state
     with pytest.raises(ReadError) as exc_info:
         _read(live_connection, table_name)
 

--- a/tests/test_live_capabilities.py
+++ b/tests/test_live_capabilities.py
@@ -1,0 +1,160 @@
+"""Tests for failure handling in credentialed capability probes."""
+
+from databricks.sql.exc import OperationalError, ServerOperationError
+import pytest
+
+from tests.live.capabilities import (
+    databricks_error_condition,
+    require_databricks_capability,
+)
+
+_QUOTA = "QUOTA_EXCEEDED_EXCEPTION"
+
+
+def _server_error(condition: str, detail: str = "detail") -> ServerOperationError:
+    return ServerOperationError(f"[{condition}] {detail}")
+
+
+def test_error_condition_is_independent_of_message_prose():
+    # Given two rendered errors with the same stable condition but different prose
+    first = _server_error(_QUOTA, "the old explanation")
+    second = _server_error(_QUOTA, "a localized or revised explanation")
+
+    # When their conditions are extracted
+    conditions = (databricks_error_condition(first), databricks_error_condition(second))
+
+    # Then only the stable condition determines the result
+    assert conditions == (_QUOTA, _QUOTA)
+
+
+def test_structured_error_condition_is_preferred_when_available():
+    # Given a connector error with a structured condition and unrelated rendered text
+    error = ServerOperationError("rendered text without a condition prefix")
+    error.error_code = _QUOTA
+
+    # When its condition is extracted
+    condition = databricks_error_condition(error)
+
+    # Then the connector's structured field is used
+    assert condition == _QUOTA
+
+
+@pytest.mark.parametrize(
+    "error",
+    [
+        _server_error("INSUFFICIENT_PERMISSIONS"),
+        _server_error("PARSE_SYNTAX_ERROR"),
+        OperationalError("warehouse connection failed"),
+    ],
+)
+def test_unrecognized_failures_are_propagated(error: Exception):
+    # Given a capability probe that raises a non-capability failure
+    def operation() -> None:
+        raise error
+
+    # When the probe runs
+    # Then the original failure escapes unchanged
+    with pytest.raises(type(error)) as exc_info:
+        require_databricks_capability(
+            operation,
+            capability="streaming tables",
+            unavailable_conditions={"STREAMING_TABLE_NOT_SUPPORTED"},
+        )
+
+    assert exc_info.value is error
+
+
+def test_recognized_unavailable_condition_skips_the_probe():
+    # Given a probe rejected because the requested feature is unavailable
+    def operation() -> None:
+        raise _server_error("STREAMING_TABLE_NOT_SUPPORTED")
+
+    # When the probe runs
+    # Then pytest records a skip instead of a failure
+    with pytest.raises(pytest.skip.Exception):
+        require_databricks_capability(
+            operation,
+            capability="streaming tables",
+            unavailable_conditions={"STREAMING_TABLE_NOT_SUPPORTED"},
+        )
+
+
+def test_retryable_condition_can_recover_before_the_deadline():
+    # Given a quota-bound operation that succeeds on its third attempt
+    attempts = 0
+    now = 0.0
+    delays: list[float] = []
+    retries: list[tuple[str, float]] = []
+
+    def operation() -> None:
+        nonlocal attempts
+        attempts += 1
+        if attempts < 3:
+            raise _server_error(_QUOTA)
+
+    def clock() -> float:
+        return now
+
+    def pause(delay: float) -> None:
+        nonlocal now
+        delays.append(delay)
+        now += delay
+
+    def report_retry(condition: str, delay: float) -> None:
+        retries.append((condition, delay))
+
+    # When the probe retries against a monotonic deadline
+    require_databricks_capability(
+        operation,
+        capability="streaming tables",
+        unavailable_conditions=set(),
+        retry_conditions={_QUOTA},
+        retry_timeout_seconds=5,
+        retry_interval_seconds=2,
+        clock=clock,
+        pause=pause,
+        report_retry=report_retry,
+    )
+
+    # Then it stops retrying as soon as the operation succeeds
+    assert attempts == 3
+    assert delays == [2, 2]
+    assert retries == [(_QUOTA, 2), (_QUOTA, 2)]
+
+
+def test_retryable_condition_skips_at_the_deadline():
+    # Given a quota-bound operation that cannot succeed within its deadline
+    attempts = 0
+    now = 0.0
+    delays: list[float] = []
+
+    def operation() -> None:
+        nonlocal attempts
+        attempts += 1
+        raise _server_error(_QUOTA)
+
+    def clock() -> float:
+        return now
+
+    def pause(delay: float) -> None:
+        nonlocal now
+        delays.append(delay)
+        now += delay
+
+    # When the deadline is exhausted
+    # Then pytest records a skip without waiting beyond that deadline
+    with pytest.raises(pytest.skip.Exception):
+        require_databricks_capability(
+            operation,
+            capability="streaming tables",
+            unavailable_conditions=set(),
+            retry_conditions={_QUOTA},
+            retry_timeout_seconds=5,
+            retry_interval_seconds=2,
+            clock=clock,
+            pause=pause,
+        )
+
+    assert attempts > 1
+    assert sum(delays) == 5
+    assert all(0 < delay <= 2 for delay in delays)


### PR DESCRIPTION
## What changed

- Added shared live-test capability handling that extracts stable Databricks error conditions and skips only explicit capability failures.
- Replaced broad exception swallowing in Iceberg and streaming-table probes.
- Replaced fixed quota retry counts with a monotonic deadline and concise retry diagnostics.
- Added Given/When/Then-structured unit tests for condition parsing, recognized skips, retries, deadlines, and propagation of permission, syntax, and connection failures.

## Why

The live probes previously converted unexpected authentication, networking, syntax, permission, and unknown failures into skips. That could make a broken live suite appear healthy.

The new behavior keeps capability-dependent tests skippable while preserving failures that indicate a real defect or environment problem.

## Validation

- `uv run pytest`: 1,014 passed, 64 deselected
- `uv run pytest tests/live --collect-only -m databricks_e2e --no-cov`: 64 tests collected
- `uv run pytest tests/test_live_capabilities.py --no-cov`: 8 passed
- `uv run ruff check tests`: passed

Credentialed live execution still requires a configured Databricks SQL Warehouse.