### PR TITLE
test: repair CLI fixtures and boundary coverage

### DIFF
--- a/tests/adapters/databricks/spark/test_build_engine.py
+++ b/tests/adapters/databricks/spark/test_build_engine.py
@@ -7,20 +7,10 @@ from delta_engine.adapters.databricks.log_config import (
     configure_logging,
 )
 from delta_engine.adapters.databricks.spark.factory import build_engine
-from delta_engine.application.engine import Engine
 
 
 class _DummySpark:
     """Stand-in for a SparkSession; the factory only stores it on the adapters."""
-
-
-def test_build_engine_returns_an_engine():
-    # Given a Spark session
-    # When building the engine
-    engine = build_engine(_DummySpark())
-
-    # Then a wired Engine is returned
-    assert isinstance(engine, Engine)
 
 
 def test_build_engine_does_not_touch_root_logging():

--- a/tests/cli/conftest.py
+++ b/tests/cli/conftest.py
@@ -17,7 +17,7 @@ from delta_engine.application.ports import (
 import delta_engine.cli.app as cli_app
 from delta_engine.cli.connection import Target
 from delta_engine.domain.model import (
-    DesiredColumn,
+    ObservedColumn,
     ObservedTable,
     QualifiedName,
     String,
@@ -30,7 +30,7 @@ def observed_orders() -> TablePresent:
     return TablePresent(
         table=ObservedTable(
             qualified_name=QualifiedName("dev", "silver", "orders"),
-            columns=(DesiredColumn("id", String()),),
+            columns=(ObservedColumn("id", String()),),
         )
     )
 

--- a/tests/cli/test_app_plan.py
+++ b/tests/cli/test_app_plan.py
@@ -262,23 +262,37 @@ def test_help_and_version_keep_the_minimal_public_surface(runner):
     assert delta_engine.__version__ in version_result.stdout
 
 
-def test_output_never_contains_connection_credentials(
-    runner, fake_engine, databricks_env, write_module, monkeypatch
+def test_connection_configuration_errors_do_not_expose_credentials(
+    runner, databricks_env, write_module, monkeypatch
 ):
+    # Given credentials that appear in an SDK configuration error
+    from databricks.sdk import core as sdk_core
+
+    class BrokenConfig:
+        def __init__(self, **kwargs) -> None:
+            raise ValueError("bad token test-access-token and secret test-client-secret")
+
     monkeypatch.setenv("DATABRICKS_TOKEN", "test-access-token")
     monkeypatch.setenv("DATABRICKS_CLIENT_SECRET", "test-client-secret")
+    monkeypatch.setattr(sdk_core, "Config", BrokenConfig)
+    monkeypatch.setattr(cli_app, "open_connection", real_open_connection)
     module = write_module("plan_no_credentials", ORDERS_ONLY)
 
+    # When the CLI reports the connection failure
     result = runner.invoke(app, ["plan", f"{module}:all_tables"])
 
+    # Then it fails cleanly with the credential values redacted
+    assert result.exit_code == 1
     combined = result.stdout + result.stderr
     assert "test-access-token" not in combined
     assert "test-client-secret" not in combined
+    assert "<redacted>" in result.stderr
 
 
 def test_engine_logging_state_does_not_leak_across_invocations(
     runner, fake_engine, databricks_env, write_module
 ):
+    # Given the caller's logging state before a CLI invocation
     package_logger = logging.getLogger("delta_engine")
     root_logger = logging.getLogger()
     package_handlers_before = list(package_logger.handlers)
@@ -286,8 +300,11 @@ def test_engine_logging_state_does_not_leak_across_invocations(
     package_propagate_before = package_logger.propagate
     module = write_module("plan_logging", ORDERS_ONLY)
 
-    runner.invoke(app, ["plan", f"{module}:all_tables"])
+    # When a successful plan completes
+    result = runner.invoke(app, ["plan", f"{module}:all_tables"])
 
+    # Then it reports success and restores the caller's logging state
+    assert result.exit_code == 0
     assert package_logger.handlers == package_handlers_before
     assert root_logger.handlers == root_handlers_before
     assert package_logger.propagate is package_propagate_before


### PR DESCRIPTION
## Summary

- model the CLI's observed table fixture with `ObservedColumn`
- remove the Spark factory type-assertion test that only mirrored its trivial implementation
- make CLI logging coverage require a successful invocation
- exercise credential redaction through the real connection configuration failure path instead of a fake connection
- add explicit Given/When/Then sections to the affected scenario tests

## Why

The fixture represented observed catalog state with a declaration-only column type. The Spark factory test asserted construction details without proving useful behaviour. The CLI logging and credential tests could also pass without exercising their intended boundary: one ignored the exit code and the other used a fake connection that bypassed redaction entirely.

The remaining tests focus on observable behaviour. The redaction placeholder assertion is intentional because credential sanitization is a user-facing security contract, not incidental exception prose.

## Validation

- `uv run pytest tests/adapters/databricks/spark/test_build_engine.py tests/cli --no-cov` — 71 passed
- `uv run pytest tests/e2e --no-cov -q` — 20 passed
- `uv run ruff check tests`
- `uv run ruff format --check tests`
- `git diff --check`

## Dependency

This is stacked on #277 and targets `test/live-capability-skips` so the item 3 diff stays isolated. After #277 merges, retarget this PR to `main`.