### PR TITLE
fix: bound optional dependency majors

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,10 +28,11 @@ pip install delta-engine
 The base package is pure Python with no runtime dependencies: declaring and
 planning schemas needs no PySpark. Running a sync needs either a Spark
 session supplied by Databricks Runtime or a Databricks SQL warehouse
-connection. On Databricks compute, install only a pinned version of the base
-package and use the runtime's Spark and Delta libraries. Outside Databricks
-compute, install the `[sql]` extra to sync through a SQL warehouse — for
-example, schema sync from CI without a Spark session or cluster. See the
+connection. Pin the Delta Engine release and lock the complete environment for
+repeatable production deployments. On Databricks compute, install only the
+base package and use the runtime's Spark and Delta libraries. Outside
+Databricks compute, install the `[sql]` extra to sync through a SQL warehouse
+— for example, schema sync from CI without a Spark session or cluster. See the
 [installation guide](https://tomoscorbin.github.io/delta-engine/installation.html)
 for the supported installation paths and their requirements.
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -25,6 +25,12 @@ needs no PySpark at all.
 pip install delta-engine
 ```
 
+The unpinned commands in this guide are convenient for evaluation. For a
+repeatable job or application deployment, pin the Delta Engine release (for
+example, `delta-engine[cli]==X.Y.Z`) and commit the complete environment to
+your application's lock file. Delta Engine's dependency ranges select
+supported major lines; they are not a replacement for an application lock.
+
 In a Databricks notebook:
 
 ```python

--- a/docs/todo/2026-07-23-distribution-versioning-runtime-review.md
+++ b/docs/todo/2026-07-23-distribution-versioning-runtime-review.md
@@ -11,14 +11,20 @@ PySpark and `delta-spark` remain development dependencies for the repository's
 credential-free local integration suite; that suite substitutes a test-only reader and
 is not a supported consumer installation path.
 
+**Dependency decision, 2026-07-23:** Published optional dependencies now have
+upper-major review gates. Dependency validation remains lean: the normal suite uses the
+lock, the existing focused CLI smoke verifies its minimum direct dependencies, and
+periodic lock refreshes reuse the normal suite instead of introducing a version matrix.
+
 ## Conclusions
 
 The distribution design is sound: the base wheel is pure Python, has no runtime
 dependencies, and can expose the declaration and planning APIs without importing a
 backend. The main risks are narrower:
 
-1. The published optional-dependency ranges are open-ended and therefore promise more
-   compatibility than is tested.
+1. The published optional dependencies are limited to reviewed major lines. Releases
+   within those lines can still introduce incompatibilities, so bounds and periodic lock
+   refreshes have complementary roles.
 2. The original `typer>=0.12` floor was too low for the current Click ecosystem. It has
    since been raised to the first version verified by the installed-wheel compatibility
    test.
@@ -62,8 +68,8 @@ users an exact, documented version combination they can keep running.
 
   | Extra | Current requirements | Intended environment |
   | --- | --- | --- |
-  | `sql` | `databricks-sql-connector>=4.0.0` | Plain Python process using a SQL warehouse |
-  | `cli` | `typer>=0.15.4`, `databricks-sdk>=0.70.0`, `databricks-sql-connector>=4.0.0` | Read-only CLI using a SQL warehouse |
+  | `sql` | `databricks-sql-connector>=4.0.0,<5` | Plain Python process using a SQL warehouse |
+  | `cli` | `typer>=0.15.4,<1`, `databricks-sdk>=0.70.0,<1`, `databricks-sql-connector>=4.0.0,<5` | Read-only CLI using a SQL warehouse |
 
 - PySpark and `delta-spark` are development dependencies only. They support the local
   integration suite and are not part of the published consumer contract.
@@ -181,15 +187,15 @@ An upper bound would prevent installation on a new Databricks Runtime even when 
 Python package works. Add a Python upper bound only for a demonstrated incompatibility,
 and expand the CI matrix as supported versions appear.
 
-Published backend and CLI dependencies should describe tested compatible major lines
-rather than accepting every future major. Candidate boundaries to verify are:
+Published backend and CLI dependencies describe reviewed major lines rather than
+accepting every future major:
 
 ```toml
-sql = ["databricks-sql-connector>=4,<5"]
+sql = ["databricks-sql-connector>=4.0.0,<5"]
 cli = [
   "typer>=0.15.4,<1",
-  "databricks-sdk>=0.70,<1",
-  "databricks-sql-connector>=4,<5",
+  "databricks-sdk>=0.70.0,<1",
+  "databricks-sql-connector>=4.0.0,<5",
 ]
 ```
 
@@ -202,13 +208,16 @@ PySpark and `delta-spark` do not need published bounds because they are not cons
 dependencies. Their compatible pair is owned by the development lock and local
 integration suite.
 
-CI should cover:
+Dependency validation is deliberately not a Cartesian compatibility matrix:
 
-- Python 3.12 and 3.13;
-- the lowest supported direct dependency set;
-- the normal locked set;
-- a separately resolved newest-compatible set;
-- installation and smoke tests from the built wheel, not only the editable source tree.
+- the normal pull-request suite exercises the reproducible locked environment;
+- the focused installed-wheel CLI smoke verifies the declared minimum direct CLI set;
+- periodic lock refreshes bring in the newest versions inside the declared ranges and
+  use the existing suite rather than a separate newest-version job;
+- there is no maximum-version job: the exclusive upper bounds are metadata review gates.
+
+Python 3.12 and 3.13 coverage and live Databricks Runtime coverage remain separate
+environment-compatibility concerns.
 
 ## Databricks Runtime compatibility
 
@@ -438,7 +447,7 @@ Strengthen the runtime guard by:
 ### Before the next release
 
 - [x] Correct the Typer floor and add minimum-version CLI smoke tests.
-- [ ] Add tested upper-major boundaries to the published optional dependencies.
+- [x] Add tested upper-major boundaries to the published optional dependencies.
 - [x] Remove the unsupported consumer `spark` extra while retaining the locked local
       Spark/Delta integration environment for repository tests.
 - [x] Add a concise installation chooser for base, SQL, CLI, and Databricks compute to
@@ -457,8 +466,8 @@ Strengthen the runtime guard by:
 ### Compatibility infrastructure
 
 - [ ] Test Python 3.12 and 3.13 in CI.
-- [ ] Add minimum, locked, and newest-compatible dependency jobs, including installed
-      CLI and SQL smoke tests.
+- [ ] Refresh the dependency lock periodically and validate updates with the normal
+      suite; do not add separate minimum, maximum, or newest-compatible matrices.
 - [x] Keep local Spark/Delta coverage as an internal locked integration suite rather than
       a published compatibility promise.
 - [ ] Add live Spark-backend smoke tests for the documented Databricks Runtime matrix.

--- a/docs/todo/2026-07-23-release-artifact-validation-plan.md
+++ b/docs/todo/2026-07-23-release-artifact-validation-plan.md
@@ -69,13 +69,14 @@ exact-version download and base smoke test.
 ## Checks kept outside this gate
 
 Optional dependencies are compatibility concerns, not archive-format concerns. Test
-them independently so an upstream release does not make the basic artifact job
-non-deterministic:
+them without turning the basic artifact job into a version matrix:
 
-- CLI and SQL minimum supported versions;
-- newest versions inside the declared ranges;
-- Python 3.12 and 3.13;
-- supported Databricks Runtime versions through live scheduled tests.
+- the normal suite exercises the locked environment;
+- the existing installed-wheel CLI smoke verifies the minimum direct CLI set;
+- periodic lock refreshes exercise newer versions inside the declared ranges through
+  the normal suite;
+- Python 3.12 and 3.13, and supported Databricks Runtime versions, remain separate
+  environment-compatibility checks.
 
 The repository's local Spark/Delta suite is an internal locked test
 environment, not a published optional-dependency compatibility promise.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,8 +31,12 @@ dynamic = ["version"]
 dependencies = []
 
 [project.optional-dependencies]
-sql = ["databricks-sql-connector>=4.0.0"]
-cli = ["typer>=0.15.4", "databricks-sdk>=0.70.0", "databricks-sql-connector>=4.0.0"]
+sql = ["databricks-sql-connector>=4.0.0,<5"]
+cli = [
+  "typer>=0.15.4,<1",
+  "databricks-sdk>=0.70.0,<1",
+  "databricks-sql-connector>=4.0.0,<5",
+]
 
 [project.urls]
 Homepage = "https://github.com/Tomoscorbin/delta-engine"

--- a/tests/test_packaging.py
+++ b/tests/test_packaging.py
@@ -5,6 +5,7 @@ import subprocess
 import sys
 
 from packaging.requirements import Requirement
+from packaging.specifiers import SpecifierSet
 
 
 def test_base_distribution_has_no_unconditional_runtime_dependencies():
@@ -20,22 +21,25 @@ def test_distribution_exposes_only_supported_extras():
     assert set(extras) == {"cli", "sql"}
 
 
-def test_cli_extra_contains_the_sdk_connector_and_typer():
-    requirements = requires("delta-engine") or []
-    cli_requirements = [
-        requirement for requirement in requirements if "extra == 'cli'" in requirement
+def test_optional_dependency_ranges_match_the_supported_major_lines():
+    parsed_requirements = [
+        Requirement(requirement) for requirement in requires("delta-engine") or []
     ]
 
-    assert any(requirement.startswith("databricks-sdk>=0.70.0") for requirement in cli_requirements)
-    assert any(
-        requirement.startswith("databricks-sql-connector>=4.0.0")
-        for requirement in cli_requirements
-    )
-    assert any(requirement.startswith("typer>=0.15.4") for requirement in cli_requirements)
-    assert {Requirement(requirement).name for requirement in cli_requirements} == {
-        "databricks-sdk",
-        "databricks-sql-connector",
-        "typer",
+    def requirements_for(extra: str) -> dict[str, SpecifierSet]:
+        return {
+            requirement.name: requirement.specifier
+            for requirement in parsed_requirements
+            if requirement.marker is not None and requirement.marker.evaluate({"extra": extra})
+        }
+
+    assert requirements_for("sql") == {
+        "databricks-sql-connector": SpecifierSet(">=4.0.0,<5"),
+    }
+    assert requirements_for("cli") == {
+        "databricks-sdk": SpecifierSet(">=0.70.0,<1"),
+        "databricks-sql-connector": SpecifierSet(">=4.0.0,<5"),
+        "typer": SpecifierSet(">=0.15.4,<1"),
     }
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -569,10 +569,10 @@ docs = [
 
 [package.metadata]
 requires-dist = [
-    { name = "databricks-sdk", marker = "extra == 'cli'", specifier = ">=0.70.0" },
-    { name = "databricks-sql-connector", marker = "extra == 'cli'", specifier = ">=4.0.0" },
-    { name = "databricks-sql-connector", marker = "extra == 'sql'", specifier = ">=4.0.0" },
-    { name = "typer", marker = "extra == 'cli'", specifier = ">=0.15.4" },
+    { name = "databricks-sdk", marker = "extra == 'cli'", specifier = ">=0.70.0,<1" },
+    { name = "databricks-sql-connector", marker = "extra == 'cli'", specifier = ">=4.0.0,<5" },
+    { name = "databricks-sql-connector", marker = "extra == 'sql'", specifier = ">=4.0.0,<5" },
+    { name = "typer", marker = "extra == 'cli'", specifier = ">=0.15.4,<1" },
 ]
 provides-extras = ["cli", "sql"]
 


### PR DESCRIPTION
## Summary

- constrain the published SQL connector to `>=4.0.0,<5`, Typer to `>=0.15.4,<1`, and the Databricks SDK to `>=0.70.0,<1`
- keep Python open-ended above 3.12 and leave development-only Spark dependencies under the repository lock
- document exact Delta Engine pins plus a complete application lock for repeatable deployments
- assert the exact supported optional-dependency ranges in installed package metadata
- replace the proposed dependency-version matrix with the lean policy we agreed: normal locked CI, the existing focused minimum CLI smoke, and periodic lock refreshes through the normal suite

## Why

The existing lower-only ranges allowed a future unreviewed dependency major to be selected by a fresh installation of an old Delta Engine release. Upper-major bounds provide an explicit review gate without exact-pinning reusable package metadata or adding a Cartesian compatibility matrix.

Bounds do not prove every release inside a major line works, so routine lock refreshes still need to run the ordinary suite. Application deployments remain responsible for pinning Delta Engine and locking their complete resolved environment.

## User impact

Current supported dependency lines remain installable. A future Typer 1.x, Databricks SDK 1.x, or SQL connector 5.x will require a Delta Engine compatibility review and release before pip may select it through the corresponding extra. The dependency-free base installation and Databricks Runtime Spark installation contract are unchanged.

## Validation

- `uv lock --check`
- `uv run pytest tests/test_packaging.py -q --no-cov` — 5 passed
- `uv run pytest -q` — 1009 passed, 64 deselected, 96.65% coverage
- `uv run ruff check .`
- `uv run mypy .` — 149 source files
- `uv run lint-imports` — 7 contracts kept
- `uv run --group docs sphinx-build -W -b html docs docs/_build/html`
- `uv build`
- `uvx twine check --strict dist/*`
- isolated base-wheel smoke
- isolated CLI smoke with the exact minimum direct dependency set
- isolated CLI smoke with the newest versions resolved inside the declared ranges
- `git diff --check`