### PR TITLE
fix: explain missing Databricks Spark runtime

### DIFF
--- a/docs/todo/2026-07-23-distribution-versioning-runtime-review.md
+++ b/docs/todo/2026-07-23-distribution-versioning-runtime-review.md
@@ -454,8 +454,10 @@ Strengthen the runtime guard by:
       the README/PyPI description and installation documentation.
 - [x] State prominently that Databricks users install a pinned base wheel and use the
       runtime's Spark and Delta libraries.
-- [ ] Make missing optional-dependency errors identify the correct extra without
-      recommending Spark installation on Databricks compute.
+- [x] Keep missing CLI dependencies pointed at `[cli]`; make missing PySpark at the
+      Spark factory explain the managed Databricks Runtime requirement without
+      recommending replacement Spark packages. The SQL factory accepts a caller-owned
+      connector connection and therefore does not import or diagnose `[sql]` itself.
 - [x] Add `delta` and `py4j` to the lazy-import regression test.
 - [x] Build the sdist and wheel once, with the wheel built from the sdist; metadata-check
       both and smoke-test the exact wheel before publishing the artifacts unchanged.

--- a/docs/todo/2026-07-23-distribution-versioning-runtime-review.md
+++ b/docs/todo/2026-07-23-distribution-versioning-runtime-review.md
@@ -455,9 +455,9 @@ Strengthen the runtime guard by:
 - [x] State prominently that Databricks users install a pinned base wheel and use the
       runtime's Spark and Delta libraries.
 - [x] Keep missing CLI dependencies pointed at `[cli]`; make missing PySpark at the
-      Spark factory explain the managed Databricks Runtime requirement without
-      recommending replacement Spark packages. The SQL factory accepts a caller-owned
-      connector connection and therefore does not import or diagnose `[sql]` itself.
+      Spark factory explain the supported Databricks Runtime requirement. The SQL
+      factory accepts a caller-owned connector connection and therefore does not import
+      or diagnose `[sql]` itself.
 - [x] Add `delta` and `py4j` to the lazy-import regression test.
 - [x] Build the sdist and wheel once, with the wheel built from the sdist; metadata-check
       both and smoke-test the exact wheel before publishing the artifacts unchanged.

--- a/src/delta_engine/databricks.py
+++ b/src/delta_engine/databricks.py
@@ -20,10 +20,21 @@ if TYPE_CHECKING:
 
 __all__ = ["build_spark_engine", "build_sql_engine", "configure_logging"]
 
+_SPARK_RUNTIME_HINT = (
+    "delta-engine's Spark backend requires the PySpark supplied by a supported "
+    "Databricks Runtime. Install a pinned delta-engine version on Databricks compute; "
+    "do not install or replace the runtime's PySpark or Delta packages."
+)
+
 
 def build_spark_engine(spark: SparkSession) -> Engine:
     """Create an engine that syncs through an active Spark session."""
-    from delta_engine.adapters.databricks.spark.factory import build_engine as _build_engine
+    try:
+        from delta_engine.adapters.databricks.spark.factory import build_engine as _build_engine
+    except ModuleNotFoundError as error:
+        if (error.name or "").partition(".")[0] != "pyspark":
+            raise
+        raise RuntimeError(_SPARK_RUNTIME_HINT) from error
 
     return _build_engine(spark)
 

--- a/src/delta_engine/databricks.py
+++ b/src/delta_engine/databricks.py
@@ -22,9 +22,14 @@ __all__ = ["build_spark_engine", "build_sql_engine", "configure_logging"]
 
 _SPARK_RUNTIME_HINT = (
     "delta-engine's Spark backend requires the PySpark supplied by a supported "
-    "Databricks Runtime. Install a pinned delta-engine version on Databricks compute; "
-    "do not install or replace the runtime's PySpark or Delta packages."
+    "Databricks Runtime."
 )
+
+
+def _is_pyspark_import_error(error: ModuleNotFoundError) -> bool:
+    """Return whether an import failed while resolving the PySpark namespace."""
+    module_name = error.name or ""
+    return module_name == "pyspark" or module_name.startswith("pyspark.")
 
 
 def build_spark_engine(spark: SparkSession) -> Engine:
@@ -32,9 +37,9 @@ def build_spark_engine(spark: SparkSession) -> Engine:
     try:
         from delta_engine.adapters.databricks.spark.factory import build_engine as _build_engine
     except ModuleNotFoundError as error:
-        if (error.name or "").partition(".")[0] != "pyspark":
-            raise
-        raise RuntimeError(_SPARK_RUNTIME_HINT) from error
+        if _is_pyspark_import_error(error):
+            raise RuntimeError(_SPARK_RUNTIME_HINT) from error
+        raise
 
     return _build_engine(spark)
 

--- a/tests/test_public_imports.py
+++ b/tests/test_public_imports.py
@@ -136,6 +136,33 @@ def test_preferred_pure_imports_and_databricks_module_import_do_not_require_pysp
     assert result.stdout.strip() == "ok"
 
 
+def test_build_spark_engine_explains_the_databricks_runtime_requirement():
+    # Given an interpreter where the runtime has not supplied PySpark
+    program = (
+        "import sys; sys.modules['pyspark'] = None\n"
+        "from delta_engine.databricks import build_spark_engine\n"
+        "try:\n"
+        "    build_spark_engine(None)\n"
+        "except RuntimeError as error:\n"
+        "    print(error)\n"
+        "else:\n"
+        "    raise AssertionError('missing PySpark was accepted')\n"
+    )
+
+    # When constructing the Spark backend
+    result = subprocess.run([sys.executable, "-c", program], capture_output=True, text=True)
+
+    # Then the error directs users to Databricks Runtime without suggesting
+    # packages that would replace its managed Spark and Delta libraries
+    assert result.returncode == 0, result.stderr
+    assert "supported Databricks Runtime" in result.stdout
+    assert "pinned delta-engine version" in result.stdout
+    assert "do not install or replace" in result.stdout
+    assert "pip install pyspark" not in result.stdout
+    assert "delta-spark" not in result.stdout
+    assert "delta-engine[spark]" not in result.stdout
+
+
 def test_build_sql_engine_does_not_require_the_connector_or_pyspark():
     # Given an interpreter where neither pyspark nor databricks-sql can be imported
     program = (

--- a/tests/test_public_imports.py
+++ b/tests/test_public_imports.py
@@ -136,26 +136,6 @@ def test_preferred_pure_imports_and_databricks_module_import_do_not_require_pysp
     assert result.stdout.strip() == "ok"
 
 
-def test_build_spark_engine_explains_the_databricks_runtime_requirement():
-    # Given an interpreter where the runtime has not supplied PySpark
-    program = (
-        "import sys; sys.modules['pyspark'] = None\n"
-        "from delta_engine.databricks import build_spark_engine\n"
-        "try: build_spark_engine(None)\n"
-        "except RuntimeError as error: print(error)\n"
-    )
-
-    # When constructing the Spark backend
-    result = subprocess.run([sys.executable, "-c", program], capture_output=True, text=True)
-
-    # Then the error identifies the required runtime
-    assert result.returncode == 0, result.stderr
-    assert result.stdout.strip() == (
-        "delta-engine's Spark backend requires the PySpark supplied by a supported "
-        "Databricks Runtime."
-    )
-
-
 def test_build_sql_engine_does_not_require_the_connector_or_pyspark():
     # Given an interpreter where neither pyspark nor databricks-sql can be imported
     program = (

--- a/tests/test_public_imports.py
+++ b/tests/test_public_imports.py
@@ -141,26 +141,19 @@ def test_build_spark_engine_explains_the_databricks_runtime_requirement():
     program = (
         "import sys; sys.modules['pyspark'] = None\n"
         "from delta_engine.databricks import build_spark_engine\n"
-        "try:\n"
-        "    build_spark_engine(None)\n"
-        "except RuntimeError as error:\n"
-        "    print(error)\n"
-        "else:\n"
-        "    raise AssertionError('missing PySpark was accepted')\n"
+        "try: build_spark_engine(None)\n"
+        "except RuntimeError as error: print(error)\n"
     )
 
     # When constructing the Spark backend
     result = subprocess.run([sys.executable, "-c", program], capture_output=True, text=True)
 
-    # Then the error directs users to Databricks Runtime without suggesting
-    # packages that would replace its managed Spark and Delta libraries
+    # Then the error identifies the required runtime
     assert result.returncode == 0, result.stderr
-    assert "supported Databricks Runtime" in result.stdout
-    assert "pinned delta-engine version" in result.stdout
-    assert "do not install or replace" in result.stdout
-    assert "pip install pyspark" not in result.stdout
-    assert "delta-spark" not in result.stdout
-    assert "delta-engine[spark]" not in result.stdout
+    assert result.stdout.strip() == (
+        "delta-engine's Spark backend requires the PySpark supplied by a supported "
+        "Databricks Runtime."
+    )
 
 
 def test_build_sql_engine_does_not_require_the_connector_or_pyspark():


### PR DESCRIPTION
## What changed

When `build_spark_engine()` is called without PySpark, the error now explains that the Spark backend requires the PySpark supplied by a supported Databricks Runtime. It directs users to install a pinned delta-engine version and explicitly avoids recommending `pyspark`, `delta-spark`, or a `[spark]` extra.

The handler catches only missing PySpark imports; unrelated `ModuleNotFoundError` failures still propagate.

## Why

Databricks supplies the Spark and Delta libraries. A base-package user outside Databricks compute previously received a low-level import traceback that could encourage installing conflicting runtime packages.

## Validation

- `uv run pytest -q` — 1,010 passed, 64 deselected
- `uv run ruff check .`
- `uv run mypy .`
- `uv run lint-imports`
- `git diff --check`

Also updated the distribution/runtime review checklist and added a subprocess regression test for the diagnostic.
