### PR TITLE
docs: review failure diagnostics

### DIFF
--- a/docs/explanation-architecture.md
+++ b/docs/explanation-architecture.md
@@ -64,7 +64,7 @@ through a sync.
 | `ObservedTable`    | Immutable domain snapshot of the current catalog state. Reader adapters produce this after normalizing backend details.                                     |
 | `CatalogState`     | A known catalog answer: `TablePresent` or `TableAbsent`. An unreadable state crosses the port as `ReadError`.                                               |
 | `ReadResult`       | The persistent read outcome retained by a table run: a `CatalogState` or the engine-created `ReadFailure`.                                                  |
-| `TableDiff`        | Typed desired/observed drift. It is either `TableMissing` or `TableDrift`; both state their remedies as `actions`, and a drift also carries `unresolvable`. |
+| `TableDiff`        | Typed comparison state: `TableMissing`, `TableInSync`, or non-empty `TableDrift`. Missing and drift variants state remedies as `actions`; drift may also carry `unresolvable`. |
 | `Unresolvable`     | A `TableDrift` difference no action can close: `ColumnRenameConflict`, `PropertyUndeclared`, or `PartitioningChanged`.                                      |
 | `TableAspect`      | One managed aspect of a table: existence, columns, comments, properties, tags, partitioning, clustering, primary key, or foreign keys. Internal enum.       |
 | `ValidationResult` | Lower-level validation verdict used to test policy rules in isolation.                                                                                      |
@@ -422,8 +422,9 @@ either.
 
 Planning is two pure stages connected by a typed diff. `diff_table(desired,
 observed)` produces a `TableDiff` — `TableMissing` when the table does not
-exist, else a `TableDrift` holding executable `actions` and non-action
-`unresolvable` differences as two typed tuples. Actions carry their `TableAspect` plus the
+exist, `TableInSync` when an existing table has no differences, or a non-empty
+`TableDrift` holding executable `actions` and non-action `unresolvable`
+differences as two typed tuples. Actions carry their `TableAspect` plus the
 complete desired/observed state needed by validation and reporting;
 `CreateTable` uses the table-existence aspect because it realizes a missing
 table's complete desired state rather than belonging to one schema dimension.
@@ -440,10 +441,13 @@ alternative remedies — say, a type change resolvable by an in-place widen
 or by an add-and-backfill — the difference and its remedy stop being the
 same thing, and the vocabularies must separate again for that aspect.
 
-Both arms state the complete intended transition the same way: a
+The difference-bearing variants state the complete intended transition:
 `TableMissing` exposes its creation actions — CREATE TABLE plus tag and
-foreign-key follow-ups — so accepted planning is uniformly "construct an
-`ActionPlan` from the diff's actions" for creation and drift alike.
+foreign-key follow-ups — while `TableDrift` carries the actions for an
+existing table. `TableInSync` carries the desired and observed endpoints but
+cannot carry actions or unresolvable differences. If its mandatory declaration
+and scope gates pass, planning represents the accepted no-op as an empty,
+target-bearing `ActionPlan`.
 
 For existing tables, the application planning boundary first adds any
 schema-required feature enablements to the raw domain diff, then validates the
@@ -484,15 +488,15 @@ Every `DesiredTable` carries a `managed_aspects` field: a `frozenset[TableAspect
 naming the aspects the engine reconciles for that table. The differ
 (`diff_table`) is scope-blind for every aspect except properties — the
 properties diff runs only when the declaration manages `PROPERTIES` (see
-Diff-first planning). The `TableDrift` it produces carries the `desired`
-table itself (symmetric with `TableMissing`), so the diff is self-contained
-and `validate_diff` takes only the diff. Scope awareness lives in
-validation, as a gate rather than an optional rule. Before any safety rule
-runs, `validate_diff` fails the sync once per unmanaged aspect that has
-drifted (`UnmanagedAspectDrift`) and short-circuits — so an unmanaged
-difference produces exactly the scope failure rather than also tripping
-safety rules for differences the user never requested. Because the gate runs
-first, the safety rules only ever see a fully in-scope diff and read
+Diff-first planning). Both existing-table variants carry `desired` and
+`observed` endpoints, so the diff is self-contained and `validate_diff` takes
+only the diff. Scope awareness lives in validation, as a gate rather than an
+optional rule. Before any safety rule runs, `validate_diff` checks declaration
+scope even for `TableInSync` and fails once per unmanaged aspect that has
+drifted (`UnmanagedAspectDrift`). Gate failures short-circuit safety rules, so
+an unmanaged difference produces exactly the scope failure rather than also
+tripping rules for work the user never requested. Because the gate runs first,
+the safety rules only ever see a fully in-scope `TableDrift` and read
 `drift.actions` and `drift.unresolvable` directly. If planning succeeds, every
 difference belongs to a managed aspect and the plan holds executable actions
 only.
@@ -509,7 +513,9 @@ never reconciles them, the same as `COLUMN_STRUCTURE` and `PARTITIONING`.
 `diff_table(desired, observed)` produces a `TableDiff`:
 
 - `TableMissing` means the catalog has no table at that name.
-- `TableDrift` means the table exists and carries its actions and unresolvable differences.
+- `TableInSync` means the table exists and the comparison found no differences.
+- `TableDrift` means the table exists and carries at least one action or
+  unresolvable difference.
 
 The diff produces backend-neutral commands but does not decide whether they are
 safe, and it does not talk to the backend. For an existing table, differences span
@@ -534,7 +540,9 @@ unresolvable difference types, which the current default policy rejects.
 checks that always run, and `DEFAULT_SAFETY_RULES` lists the configurable
 safety checks that run only after those gates pass. A missing table passes when
 the declaration manages table existence because creating it from the full
-declaration is safe. An eligible drift is evaluated by every default safety rule.
+declaration is safe. An in-sync table passes when its declaration and observed
+relation kind satisfy the mandatory gates. An eligible drift is evaluated by
+every default safety rule.
 The authoritative list and resolution for every current rule lives in
 [safe-change rules](reference-safe-change-rules.md); keeping the inventory in
 one place prevents this architecture overview from drifting when policy grows.
@@ -542,7 +550,8 @@ one place prevents this architecture overview from drifting when policy grows.
 The engine calls `plan_diff` once. A `PlanningFailed` leaves the run without a
 plan and records its validation failures; a `PlanningSucceeded` supplies the
 only plan the compiler can receive. A successful no-op is distinct: it carries
-an empty plan with a real target and relation kind.
+a `TableInSync` comparison followed by an empty plan with a real target and
+relation kind.
 
 ## Deterministic action plans
 
@@ -618,7 +627,7 @@ connected components to produce a dependency-first order. It reports:
 
 Each mandatory gate implements the `ScopeGate` protocol over `TableDiff`; a gate returns no failures when its check does not apply to that diff arm. Each safety rule implements the `SafetyRule` protocol: a `name` `ClassVar[str]` and an `evaluate(drift: TableDrift) -> tuple[ValidationFailure, ...]` method. Safety rules usually scan `drift.actions` or `drift.unresolvable` directly — typically matching a specific type with `isinstance` — and return all violations at once, avoiding a fix-and-rerun cycle per failure. The scope gates run before any safety rule and short-circuit the safety stage on failure, so a safety rule only ever sees differences the declaration manages and does no scope filtering of its own.
 
-`validate_diff` evaluates every gate in `MANDATORY_SCOPE_GATES` and aggregates their failures in declaration order. A `TableMissing` clears the gates when table existence is managed — creating it from its full declaration is always safe — and fails with `MissingTableUnmanaged` when it is not, so no safety rule ever sees a missing table; a `TableDrift` clears the gates when its claimed scope and observed relation kind are valid and no unmanaged aspect has drifted. Only then does `validate_diff` call every rule in `DEFAULT_SAFETY_RULES` with the drift and aggregate their failures into a `ValidationResult`. `plan_diff` fixes that default composition in place and turns the verdict into the accepted/rejected planning sum.
+`validate_diff` evaluates every gate in `MANDATORY_SCOPE_GATES` and aggregates their failures in declaration order. A `TableMissing` clears the gates when table existence is managed — creating it from its full declaration is always safe — and fails with `MissingTableUnmanaged` when it is not, so no safety rule ever sees a missing table. `TableInSync` and `TableDrift` both pass through declaration and relation-kind gates; only drift can produce unmanaged-aspect failures. Once a drift clears the gates, `validate_diff` calls every rule in `DEFAULT_SAFETY_RULES` and aggregates their failures into a `ValidationResult`; an in-sync comparison needs no safety-rule evaluation. `plan_diff` fixes that default composition in place and turns the verdict into the accepted/rejected planning sum.
 
 Execution walks the dependency-first order produced by the resolver and keeps a
 set of every table that has failed so far. Before each table executes, the engine

--- a/docs/todo/2026-07-25-failure-diagnostics-review.md
+++ b/docs/todo/2026-07-25-failure-diagnostics-review.md
@@ -54,9 +54,151 @@ therefore gaps in the current intended behaviour, not failing tests.
 | Failure | What is already useful | What is missing |
 | --- | --- | --- |
 | `ReadFailure` | Table context, backend type, backend message | Read step/query, stable backend condition, a cause-first headline, one non-duplicated presentation |
-| `ValidationFailure` | Rule code; most rules name the subject and remediation | Rejected diff; exact subjects for unmanaged drift and column-drop prerequisites |
+| `ValidationFailure` | Rule code; most rules name the subject and remediation | Comparison evidence; exact subjects for unmanaged drift and column-drop prerequisites |
 | `ForeignKeyFailure` | Owning table, local columns, referenced table, broad reason | Constraint name, referenced columns, actual key, exact type mismatches, direct upstream cause |
-| `ExecutionFailure` | Backend type/message, failed SQL, applied/planned progress | Human numbering is zero-based; truncation is silent; structured output flattens the fields |
+| `ExecutionFailure` | Backend type/message, failed SQL, applied/planned progress | Stable backend condition, one-based human numbering, explicit truncation, structured fields |
+
+## Vocabulary before implementation
+
+The current model has the right data, but `result`, `outcome`, `summary`, and
+`resolution` are too close to be useful as peer concepts. Use one generic term,
+**outcome**, for the terminal state retained from a phase:
+
+```text
+desired/observed state
+        |
+        v
+       diff
+        |
+        v
+planning judgment + declaration context
+        |
+        +----------- accepted --> plan
+        |
+        +----------- rejected --> failures
+        |
+        v
+dependency outcome
+        |
+        v
+execution outcome
+        |
+        v
+      report
+```
+
+The canonical semantic model is:
+
+| Term | Meaning | Examples and constraints |
+| --- | --- | --- |
+| **state** | A snapshot asserted by one side of the comparison | `DesiredTable` is the declared target; `ObservedTable` is normalized catalog state |
+| **difference** | One discrepancy between desired and observed state | An `Action` or `Unresolvable` inside a diff; evidence, not yet approved work |
+| **diff** | The complete comparison artifact for one table | `TableDiff`; preferably `TableInSync`, `TableMissing`, or non-empty `TableDrift` |
+| **drift** | Differences on an existing table | Reserve for the `TableDrift` arm. A missing table is a difference but not drift, so avoid a new generic `has_drift` report field |
+| **action** | A candidate remedy associated with a resolvable difference | An action becomes approved executable work only when planning accepts the complete diff into an `ActionPlan` |
+| **plan** | An accepted, ordered set of actions | `ActionPlan`; only successful planning produces one. An empty plan is a successful no-op |
+| **outcome** | The terminal state retained or derived for a phase after orchestration | Succeeded, failed, blocked, skipped, or no-op; the one generic lifecycle term instead of treating result and summary as peer concepts |
+| **failure** | A persistent, typed value explaining why a phase did not succeed | `ReadFailure`, `ValidationFailure`, `ForeignKeyFailure`, or `ExecutionFailure`; report data, not an exception |
+| **report** | The immutable public aggregate of retained outcomes and projections | `TableRunReport` and `SyncReport`; the source presented to callers after orchestration |
+| **status** | A coarse label derived from retained outcomes | `TableRunStatus`; useful for scanning and gates, but never the detailed cause |
+
+Two supporting terms stay outside the persistent model:
+
+- an **error** is an exception crossing a boundary: `ReadError` and
+  `ExecutionError` are transient adapter signals converted into failures, and
+  `SyncFailedError` carries the completed report;
+- a **diagnostic** is a human- or machine-readable projection of differences
+  and failures, such as a headline, backend condition, or raw message.
+
+`Result` adds little as a semantic category because every function returns a
+result. `Summary` should be reserved for an actually condensed projection;
+`ExecutionSummary` retains the detailed statement history and is closer to an
+execution attempt or record. `Resolution` remains useful only as
+dependency-domain vocabulary, not as another generic category.
+
+If internal names are later aligned with this vocabulary, the direction is:
+
+| Current name | Clearer role-based name |
+| --- | --- |
+| `ReadResult` | `ReadOutcome` |
+| `ValidationResult` | `ValidationVerdict` |
+| `PlanningResult` | `PlanningOutcome` |
+| `ExecutionResult` | `StatementOutcome` |
+| `ExecutionSummary` | `ExecutionAttempt` |
+| `ExecutionOutcome` | keep |
+| `TableResolution` | keep, or `DependencyOutcome` |
+| `ResolveResult` | `DependencyOutcomes`, or no named aggregate alias |
+
+These internal renames are optional consistency work, not a prerequisite for
+better diagnostics.
+
+The phase vocabulary then becomes:
+
+| Phase | Positive outcome | Negative outcome | Persistent evidence |
+| --- | --- | --- | --- |
+| Read | table present or confirmed absent | failed | `CatalogState` or `ReadFailure` |
+| Diff | comparison completed | not run after a read failure | `TableDiff`; no success/failure value is needed |
+| Plan | diff and declaration accepted, including an empty no-op plan | diff or declaration rejected | `PlanningSucceeded(ActionPlan)` or `PlanningFailed(ValidationFailure...)` |
+| Compile | statements produced, possibly none | unexpected programming defect | Compiled SQL; no expected failure value |
+| Resolve | dependencies resolved | failed or blocked | `TableResolution` and `ForeignKeyFailure` |
+| Execute | attempted statements succeeded | failed or dependency-blocked | `ExecutionSummary`, `ExecutionFailure`, or `ExecutionBlockedByDependency` |
+
+### Empty and no-op cases
+
+“Produced no actions” is not sufficient to identify a no-op. A diff containing
+only an unresolvable difference also has no actions, but planning must reject
+it. Use these distinct states:
+
+| State | Representation | Meaning |
+| --- | --- | --- |
+| Diff not run | `diff is None` after a read failure | No comparison exists |
+| In sync | Currently `TableDrift(actions=(), unresolvable=())`; preferably a `TableInSync` diff arm | Comparison completed and found no differences |
+| Actionless difference | Empty `actions`, non-empty `unresolvable` | Differences exist but no candidate remedy can close them; planning will reject |
+| No-op plan | Successful planning with an empty `ActionPlan` | The diff was accepted and there is nothing to execute |
+| In-sync declaration rejection | `TableInSync` plus `PlanningFailed`; no `ActionPlan` | There is no drift, but the declaration itself claims unsupported authority |
+| Rejected planning | `PlanningFailed`; no `ActionPlan` | The comparison or declaration was not accepted; differences need not exist |
+| Planned changes | Successful planning with a non-empty `ActionPlan` | Accepted work is ready to compile |
+
+There is value in making the in-sync case explicit, but do not call it `NoOp`:
+no-op is a planning outcome, while the diff's neutral fact is **in sync**.
+Prefer:
+
+```text
+TableDiff = TableInSync | TableMissing | TableDrift
+```
+
+`TableInSync` should retain the desired and observed endpoints needed to build
+the target-bearing empty plan. `TableDrift` should then require at least one
+action or unresolvable difference, making an empty value invalid rather than
+using emptiness as an implicit sentinel.
+
+`TableInSync` must still pass through mandatory declaration and scope gates
+before planning succeeds. `StreamingTableTagsOnly` deliberately judges the
+declaration's claimed aspects rather than its actions, so an in-sync streaming
+table declared with broader-than-tag scope remains a planning failure. Only an
+accepted `TableInSync` produces the existing empty `ActionPlan`, which remains
+the canonical no-op plan.
+
+This adds one union variant and requires an extra branch at every exhaustive
+match, but makes three states unambiguous: comparison not run (`None`),
+comparison found no differences (`TableInSync`), and comparison found
+differences (`TableMissing` or `TableDrift`). A derived `has_differences` is
+then false only for `TableInSync`; a derived `is_noop` is true only after
+planning accepts an empty plan.
+
+These distinctions also constrain report naming:
+
+- `has_changes` continues to mean that an accepted plan contains actions.
+- A rejected planning outcome has no planned changes, but may or may not have
+  differences.
+- When differences exist, user-facing language should say **rejected
+  differences**, not imply that candidate actions were planned or “would”
+  execute.
+- When an in-sync declaration is rejected, say **in sync; declaration
+  rejected** rather than inventing rejected differences.
+- If machine consumers need a predicate later, `has_differences` is the
+  accurate concept across missing tables, drift, actions, and unresolvable
+  differences. It should not be added until a concrete consumer needs it.
 
 ## Prioritized findings
 
@@ -90,32 +232,70 @@ detail is absent from both the DIFF view and the failure.
 
 #### Recommendation
 
-Carry the computed `TableDiff` into `TableRunReport` as the observed drift,
-independently of whether it became an accepted `ActionPlan`.
+Retain the computed `TableDiff` as comparison evidence independently of
+whether it became an accepted `ActionPlan`. Prefer making both
+`PlanningSucceeded` and `PlanningFailed` retain the diff they judged, then
+expose it through a read-only `TableRunReport.diff` property. The planning
+variants are internal, while `TableRunReport` is public; this preserves the
+public report constructor and makes a diff part of every post-read planning
+outcome instead of adding a defaulted report field that permits a successful
+read with no comparison.
 
 Keep the existing meaning of `has_changes`—accepted, executable changes—so CI
-gates do not silently change semantics. Add a separate `has_drift`/`drift`
-projection and render failed planning as a rejected diff, for example:
+gates do not silently change semantics. Do not add a generic `has_drift`
+predicate: `TableMissing` and unresolvable differences make that name
+inaccurate.
+
+Render a failed `TableMissing` or `TableDrift` as rejected differences, for
+example:
 
 ```text
-dev.silver.orders  (REJECTED)
-  columns
+dev.silver.orders
+  REJECTED DIFFERENCES
+  columns (unmanaged)
     + new_status     String
     - legacy_status
 
 Validation blocked: declaration does not manage column structure
-  The rejected diff would add `new_status` and drop `legacy_status`.
+  Differences: `new_status` is absent; `legacy_status` is undeclared.
   Align the declaration and live table, or explicitly use `scope="full"`
   and review that plan before applying it.
+
+  No DDL was planned.
 ```
 
-The raw diff should show all observed differences. The failure should identify
-which entries are unmanaged, so managed and unmanaged drift cannot be confused
-when both are present.
+Render a failed `TableInSync` separately:
+
+```text
+dev.silver.streaming_orders
+  (in sync; declaration rejected — no DDL was planned)
+```
+
+The raw diff is the canonical source of exact comparison evidence. Its
+projection should keep two classifications distinct: scope (managed or
+unmanaged) and remedy (candidate action or unresolvable). An unresolvable
+difference can still be inside or outside the declaration's scope. Failures
+remain the source of the rejection reason and recovery. Human renderers,
+including `SyncFailedError`, should compose those two sources rather than copy
+the same list of subjects into failure prose.
+
+Text rendering therefore needs a projection for `ColumnRenameConflict`,
+`PropertyUndeclared`, and `PartitioningChanged` as well as the existing action
+projection; merely retaining `TableDiff` is not enough. The additive machine
+projection should follow in its own change after that entry vocabulary and
+classification have settled.
 
 This is preferable to only lengthening the existing
 `UnmanagedAspectDrift.message`: exact drift is useful for every planning
 failure, and the DIFF view is its natural home.
+
+`TableRunReport` and the concrete failure dataclasses are public. Retaining the
+diff on the internal planning outcome avoids changing the public report
+constructor. If implementation constraints force a report field instead, the
+documented fallback is an additive optional field whose `None` value explicitly
+means “comparison unavailable on a manually constructed legacy report”; it
+must not be presented as the ideal domain invariant. JSON compatibility alone
+is not the whole public contract.
 
 ### 2. Read failures lose the operation context and are repeated by the CLI — high
 
@@ -169,8 +349,10 @@ Read failed while reading column tags [INSUFFICIENT_PERMISSIONS]
 
 The full section can then retain the backend message and type. Expected
 failures should render once by default through the report. Adapter tracebacks
-belong behind an explicit debug/verbose mode; engine phase logs should not
-repeat failures that the report is about to print.
+belong at debug logging level; engine phase logs should not repeat failures
+that the report is about to print. This work should not require adding a new
+CLI verbosity option: callers that configure debug logging can retain the
+traceback, while the default CLI owns one concise presentation.
 
 ### 3. The machine-readable failure record is lossy — medium-high
 
@@ -192,25 +374,26 @@ logging.
 #### Recommendation
 
 Add subtype-specific structured details to the failure record while retaining
-the current `message` for display compatibility. At minimum:
+the current `phase`, `type`, and `message` for compatibility. Prefer exact
+subtype fields over a generic code whose meaning changes by failure kind:
 
 ```text
-code                 stable rule/reason/backend condition
 summary              concise cause-first text
 raw_message          complete backend message, when applicable
 details              subtype-specific plain JSON fields
 ```
 
+The details should carry `rule_name` for validation, `reason` for foreign keys,
+and distinct `step` (read only), `condition`, and `exception_type` fields for
+backend failures. Do not fall back from a backend condition to its Python
+exception class under one supposedly stable `code`: an implementation class
+such as `ServerOperationError` is neither stable nor a semantic condition.
+
 Adding fields is already documented as backwards-compatible. Do not silently
 truncate `raw_message`; if a display is shortened, mark it as truncated and
 tell the caller where the complete diagnostic remains.
 
-The public `code` should not rely solely on Python class names. Validation rule
-names and `ForeignKeyFailureReason` are already suitable stable codes; read and
-execution failures can prefer the backend condition and fall back to the
-exception type.
-
-### 4. Headlines lead with implementation vocabulary instead of the cause — medium
+### 4. Headlines lead with implementation vocabulary instead of the cause — cross-cutting
 
 The grid intentionally omits detail messages and shows only `headline()`.
 Consequently its two most common planning/read summaries are:
@@ -237,27 +420,28 @@ Foreign key blocked: referenced table cat.sch.customers failed
 
 Keep rule and backend codes in structured output and, where useful, in
 parentheses. They are valuable for searching and support, but should not be the
-only explanation.
+only explanation. Treat this as a presentation rule applied while improving
+each failure subtype, not as an independent implementation workstream.
 
-### 5. Two validation rules omit the exact affected subjects — medium
+### 5. Some validation diagnostics omit subjects or recovery — medium
 
 Most validation rules are already specific. Type changes include the column
 and both types; partitioning includes current and requested layouts; property
 rules include keys and values; rename conflicts and primary-key blockers name
 their objects.
 
-The notable exceptions are:
-
-- `UnmanagedAspectDrift`, which reports only the aspect; and
-- `ColumnMappingRequiredForDrop`, which reports that “dropping a column”
-  requires column mapping but does not name the column or columns.
+`UnmanagedAspectDrift` currently reports only the aspect, but finding 1 should
+solve its missing subjects through the canonical comparison evidence rather
+than duplicating them in failure prose. The notable remaining rule-local
+exception is `ColumnMappingRequiredForDrop`, which reports that “dropping a
+column” requires column mapping but does not name the column or columns.
 
 `NonNullableColumnAdd` names the column but gives no recovery path, unlike the
 more complete nullability-tightening rule.
 
 #### Recommendation
 
-Require every validation diagnostic to answer:
+Use the following checklist when adding or changing a validation diagnostic:
 
 1. What exact subject differs?
 2. What are the live and declared/requested states where relevant?
@@ -265,7 +449,10 @@ Require every validation diagnostic to answer:
 4. What is the safest next action?
 
 For rules that deliberately aggregate multiple actions, list the affected
-subjects rather than returning an anonymous aggregate.
+subjects rather than returning an anonymous aggregate. In this review's scope,
+the rule-local gaps are `ColumnMappingRequiredForDrop` and the recovery text
+for `NonNullableColumnAdd`; a fresh rewrite of every validation message is not
+required.
 
 ### 6. Foreign-key structural failures lack the evidence used to decide them — medium
 
@@ -286,48 +473,206 @@ reason-specific evidence:
 - exact `(local column, local type) -> (referenced column, referenced type)`
   mismatches;
 - requested referenced columns and the registered primary-key columns; and
-- the upstream table/status for dependency blocking.
+- the direct upstream table for dependency blocking.
 
-The existing broad reason remains useful as the stable code.
+The existing broad reason remains useful as the stable code. Model
+reason-specific evidence so invalid combinations are difficult to construct;
+do not turn `ForeignKeyFailure` into a bag of unrelated optional fields. The
+upstream table's current status and cause belong to the aggregate report and
+should be composed at presentation time rather than copied into the
+foreign-key failure.
 
-### 7. Execution diagnostics are strong but have two presentation defects — low
+### 7. Execution diagnostics lack a stable condition and some presentation polish — low
 
 Execution failures are the best of the four types: they show progress, backend
-message, and exact SQL. Two details remain:
+message, and exact SQL. Three details remain:
 
+- the shared Databricks condition is not retained;
 - `statement_index` is zero-based internally and displayed directly, producing
   “statement 0” for the first statement; and
 - a message longer than five lines is truncated with no ellipsis or pointer to
   the complete value.
 
-Keep the stored index zero-based if that is the API contract, but display
-`statement_index + 1` and, ideally, `1 of N`. Mark truncated diagnostics
-explicitly.
+Retain the condition separately from the exception type. Keep the stored index
+zero-based if that is the API contract, but display `statement_index + 1`.
+Mark truncated diagnostics explicitly. A `1 of N` display would require
+total-plan context that the failure value does not own and is not part of this
+small correction.
 
-## Suggested implementation sequence
+## Scope and delivery
 
-1. Add black-box output tests for the two reported cases: a read-step failure
-   and multi-entry unmanaged drift. Pin a single concise CLI presentation.
-2. Carry `TableDiff` through `TableRunReport`; add rejected-diff rendering and
-   an additive machine-readable drift projection.
-3. Add read step and condition to `ReadError`/`ReadFailure`, then remove the
-   default duplicate traceback/error logging.
-4. Make failure records subtype-aware without removing the existing three
-   fields.
-5. Fill the remaining subject/remediation gaps in validation and foreign-key
-   diagnostics; change execution display numbering to one-based.
+The breadth is appropriate for a review, but implementing all findings as one
+change would be too large. It crosses the report state model, public
+dataclasses, rendering, adapter error normalization, CLI logging, the
+machine-readable schema, validation policy, and foreign-key resolution.
 
-## Acceptance criteria
+Keep the findings together as the diagnostic backlog, but deliver them in the
+following order. Each step should be an independently reviewable change with
+its own black-box tests; do not start by renaming every `Result` or `Summary`.
 
-- A user can identify the exact columns/properties/tags/comments behind
-  `UnmanagedAspectDrift` without recreating the diff in Python.
-- A planning failure never labels observed drift as “no changes”.
-- A read failure identifies the table, failing read step, stable condition
-  when available, backend message, and backend type.
-- The CLI shows one expected failure presentation by default and no traceback
-  unless debug output is requested.
-- `to_dict()` retains complete backend diagnostics and subtype-specific fields.
-- Every validation failure names its affected subject(s) and a safe next step.
-- Foreign-key type/key failures show the exact comparison that failed.
-- The first failed execution statement is displayed as statement 1, while any
-  stored zero-based index remains stable.
+### Step 1: Make comparison states explicit
+
+**Status:** implemented and verified.
+
+This is a domain-model change only:
+
+- add `TableInSync(desired, observed)` and include it in `TableDiff`;
+- make `diff_table()` return it when no action or unresolvable difference was
+  found;
+- reject construction of an empty `TableDrift`;
+- update every exhaustive match in validation and planning;
+- run mandatory declaration/scope gates for `TableInSync`, especially
+  `StreamingTableTagsOnly`;
+- produce an empty, target-bearing plan only when an in-sync comparison passes
+  those gates; and
+- update the architecture explanation and domain/planning tests.
+
+Do not change reports, renderers, or JSON in this step. Its purpose is to make
+comparison not run, in sync, and different impossible to confuse.
+
+Exit criteria:
+
+- an ordinary in-sync table produces `TableInSync` and an accepted empty plan;
+- an in-sync streaming table with invalid claimed scope produces
+  `TableInSync` and `PlanningFailed`;
+- an empty `TableDrift` cannot be constructed; and
+- missing-table and non-empty-drift behaviour is unchanged.
+
+### Step 2: Retain comparison evidence and fix human rendering
+
+Make planning outcomes retain the `TableDiff` they judged and expose it as a
+read-only `TableRunReport.diff` property. Validate that a successful outcome's
+plan and diff target the same table, and that a failed outcome contains at
+least one failure. This keeps the public `TableRunReport` constructor unchanged
+while making comparison evidence available after either planning outcome.
+
+Extend the shared diff-entry interpretation to cover all `Unresolvable`
+variants as well as actions. It should be the canonical source for exact
+subjects, with separate scope (managed/unmanaged) and remedy
+(candidate-action/unresolvable) classifications.
+Renderers then combine those entries with the failure's reason and recovery:
+
+- accepted `TableInSync`: in sync/no changes;
+- rejected `TableInSync`: in sync, but declaration rejected;
+- rejected `TableMissing` or `TableDrift`: rejected differences and no DDL
+  planned;
+- accepted non-empty diff: the existing planned-change presentation; and
+- read failure: comparison not run.
+
+Use one shared interpretation in `render_diff`, report headlines/counts, and
+`SyncFailedError`, but let each presentation place the full comparison block
+once. In particular, the CLI already prints `render_diff` before the report
+and must not repeat the same rejected entries in its failure section. Do not
+add the JSON projection yet.
+
+Exit criteria:
+
+- multi-entry unmanaged drift names every exact subject;
+- scope and remedy classifications remain distinct, and no candidate remedy is
+  mistaken for a planned action;
+- every unresolvable variant has a stable text projection;
+- an in-sync declaration rejection never invents rejected differences;
+- observed differences are never labelled “no changes”; and
+- `has_changes` and the public `TableRunReport` constructor remain compatible.
+
+### Step 3: Add read context and give the report presentation ownership
+
+Add an application-owned stable read-step value and an optional backend
+condition to `ReadError` and `ReadFailure`. At the shared Databricks boundary,
+identify the step around each query and expose the existing condition
+inspection safely. Preserve the backend exception type and complete raw
+message. Because condition extraction is shared by both Databricks boundaries,
+also retain the optional condition on `ExecutionError` and `ExecutionFailure`;
+leave its presentation cleanup for step 4.
+
+Move adapter tracebacks to debug logging and remove the engine-level repetition
+of a failure the completed report or `SyncFailedError` will present. Apply the
+cause-first headline rule as part of this change rather than as a separate
+headline rewrite.
+
+Exit criteria:
+
+- every supported read step has a failure test;
+- the condition is retained when supplied by either Databricks exception
+  shape for read and execution failures;
+- exception inspection cannot raise a second diagnostic exception;
+- the default CLI shows one concise read failure and no traceback; and
+- debug logging still makes the traceback available to configured callers.
+
+### Step 4: Make the small validation and execution corrections
+
+Keep this deliberately narrow:
+
+- name every affected column in `ColumnMappingRequiredForDrop`;
+- add a safe recovery to `NonNullableColumnAdd`;
+- display execution statement indexes as one-based without changing the stored
+  zero-based value;
+- include the stable backend condition in execution headlines when available;
+- mark truncated backend messages explicitly; and
+- make the touched headlines cause-first while retaining searchable technical
+  identifiers secondarily.
+
+Do not rewrite otherwise adequate validation messages.
+
+Exit criteria:
+
+- the two validation rules answer subject, reason, and recovery;
+- the first failed statement is displayed as statement 1 everywhere;
+- an execution condition is shown separately from its exception type; and
+- no shortened message can be mistaken for the complete raw diagnostic.
+
+### Step 5: Model reason-specific foreign-key evidence
+
+Add a small typed evidence union for cycle, unresolved reference, failed
+dependency, referenced-key mismatch, and type mismatch. The resolver should
+construct the reason-appropriate evidence from the complete constraint and
+registered table definitions it already owns.
+
+`ForeignKeyFailure` is public, so preserve its existing constructor fields.
+An additive optional evidence field is the compatibility concession for
+manually constructed legacy values; engine-produced failures should always
+carry evidence, and `__post_init__` should reject evidence whose variant does
+not match `reason`.
+
+Exit criteria:
+
+- type mismatches identify both columns and both types;
+- key mismatches identify requested referenced columns and the registered key;
+- dependency blocking identifies the direct upstream table, while aggregate
+  presentation supplies that table's status/cause;
+- constraint names and local-to-referenced mappings survive; and
+- incompatible reason/evidence pairs cannot be constructed.
+
+### Step 6: Add the machine-readable projections after the models settle
+
+Add a table-level `comparison` record distinct from the existing planned
+`changes`. It must distinguish comparison not run, in sync, table missing, and
+existing-table drift, and use the same difference-entry interpretation as the
+text renderers.
+
+Make failure records subtype-aware while retaining `phase`, `type`, and
+`message`. Add a concise `summary`, an untruncated `raw_message` where
+applicable, and subtype-specific plain-JSON `details`. Keep backend `condition`
+and `exception_type` separate rather than inventing one unstable generic code.
+
+This is additive under the documented schema policy, but update the run-report
+reference and pin the complete shape with deterministic serialization tests.
+
+Exit criteria:
+
+- machine consumers can distinguish not-run, in-sync, and rejected
+  comparisons without parsing prose;
+- rejected differences are structured independently of planned changes;
+- every failure subtype retains the fields needed to reconstruct its
+  diagnostic;
+- `raw_message` is complete; and
+- all existing version-2 fields retain their names, types, and meanings.
+
+### Step 7: Consider internal naming cleanup separately
+
+After the behaviour and projections are stable, decide whether the optional
+`ReadResult`/`PlanningResult`/`ExecutionSummary` renames materially improve the
+code. If so, make them as one mechanical internal cleanup with no diagnostic
+or schema changes. If the rename would create churn without reducing
+ambiguity, leave the names and rely on the canonical vocabulary in this
+document.

--- a/docs/todo/2026-07-25-failure-diagnostics-review.md
+++ b/docs/todo/2026-07-25-failure-diagnostics-review.md
@@ -1,0 +1,333 @@
+---
+tags:
+  - todo
+  - usability
+  - reporting
+---
+
+# Failure diagnostics review
+
+## Overall assessment
+
+The failure model is reliable but not yet diagnostic enough. Failures are
+typed, phase ordered, attached to the correct table, and shown in both
+exceptions and reports. Execution failures already retain the failed SQL, and
+most safety rules name the unsafe subject and suggest a recovery.
+
+The main problem is that the report is shaped around an *accepted plan*. When
+planning is rejected, the exact diff is omitted from every user-facing view.
+That makes `UnmanagedAspectDrift` especially opaque: the engine knows every
+different column, property, tag, or comment, but the output says only that an
+aspect drifted and then labels the DIFF as `no changes`.
+
+Read failures have a separate context problem. They retain the backend
+exception type and message, but not which catalog-read step failed. The CLI
+also prints an expected read failure up to three times: an adapter warning with
+a traceback, an engine error, and the final report.
+
+The first improvement should therefore be richer report evidence, not a broad
+rewrite of exception handling.
+
+## Review method
+
+This review traced the four persistent failure values from their producers
+through:
+
+- `Failure.format_lines()` and `headline()`;
+- `SyncFailedError`;
+- the status grid and full `Failures` section;
+- the CLI `plan` command; and
+- `SyncReport.to_dict()`.
+
+Focused tests passed unchanged:
+
+```text
+204 passed in 1.75s
+```
+
+The exercised files were the failure, rendering, report, validation, CLI plan,
+Databricks read, and Databricks execution test modules. The findings below are
+therefore gaps in the current intended behaviour, not failing tests.
+
+## Current diagnostic quality
+
+| Failure | What is already useful | What is missing |
+| --- | --- | --- |
+| `ReadFailure` | Table context, backend type, backend message | Read step/query, stable backend condition, a cause-first headline, one non-duplicated presentation |
+| `ValidationFailure` | Rule code; most rules name the subject and remediation | Rejected diff; exact subjects for unmanaged drift and column-drop prerequisites |
+| `ForeignKeyFailure` | Owning table, local columns, referenced table, broad reason | Constraint name, referenced columns, actual key, exact type mismatches, direct upstream cause |
+| `ExecutionFailure` | Backend type/message, failed SQL, applied/planned progress | Human numbering is zero-based; truncation is silent; structured output flattens the fields |
+
+## Prioritized findings
+
+### 1. Rejected drift is hidden and described as “no changes” — high
+
+The engine computes and retains `_TableRun.diff`, but `to_report()` does not
+carry it into `TableRunReport`. A rejected planning outcome has no `plan`, so:
+
+- `render_diff_block()` prints `(no changes — see failures)`;
+- `has_changes` is false;
+- `to_dict()["changes"]` is empty; and
+- only the validation rule's prose remains.
+
+For `UnmanagedAspectDrift`, validation then groups raw differences by
+`TableAspect` and emits one generic message per aspect. Two different columns
+produce the same output as twenty:
+
+```text
+DIFF
+====
+
+dev.silver.test
+  (no changes — see failures)
+
+Validation failed: UnmanagedAspectDrift - Operation not allowed:
+column structure has drifted but is not managed by this definition.
+```
+
+This explains why the failure cannot answer “what was being changed?” The
+detail is absent from both the DIFF view and the failure.
+
+#### Recommendation
+
+Carry the computed `TableDiff` into `TableRunReport` as the observed drift,
+independently of whether it became an accepted `ActionPlan`.
+
+Keep the existing meaning of `has_changes`—accepted, executable changes—so CI
+gates do not silently change semantics. Add a separate `has_drift`/`drift`
+projection and render failed planning as a rejected diff, for example:
+
+```text
+dev.silver.orders  (REJECTED)
+  columns
+    + new_status     String
+    - legacy_status
+
+Validation blocked: declaration does not manage column structure
+  The rejected diff would add `new_status` and drop `legacy_status`.
+  Align the declaration and live table, or explicitly use `scope="full"`
+  and review that plan before applying it.
+```
+
+The raw diff should show all observed differences. The failure should identify
+which entries are unmanaged, so managed and unmanaged drift cannot be confused
+when both are present.
+
+This is preferable to only lengthening the existing
+`UnmanagedAspectDrift.message`: exact drift is useful for every planning
+failure, and the DIFF view is its natural home.
+
+### 2. Read failures lose the operation context and are repeated by the CLI — high
+
+`read_catalog_state()` wraps the complete read in one broad error boundary.
+`ReadError` and `ReadFailure` receive only:
+
+- `exception_type`; and
+- the rendered exception `message`.
+
+A current read can fail while describing the relation, checking schema
+existence, or reading column tags, table tags, primary keys, outbound foreign
+keys, or inbound foreign keys. Unless Databricks happens to name the object in
+its message, the report cannot say which step failed.
+
+The shared exception inspector already extracts a Databricks condition for
+missing-relation classification, but that condition is discarded for all
+other errors. This leaves the compact grid showing implementation-level types
+such as:
+
+```text
+READ_FAILED  Read error: ServerOperationError
+```
+
+There is also a presentation conflict. Under the CLI's normal logging setup,
+one expected transport failure currently renders as:
+
+1. an adapter `WARNING` with the full traceback;
+2. an engine `ERROR` repeating the type and message; and
+3. the structured report repeating the failure again.
+
+The traceback is the only place that incidentally reveals that the describe
+query failed, while the actual failure value lacks that context.
+
+#### Recommendation
+
+Add explicit read context at the shared Databricks read boundary:
+
+- a small stable step value such as `DESCRIBE_TABLE`, `SCHEMA_EXISTS`,
+  `COLUMN_TAGS`, `TABLE_TAGS`, `PRIMARY_KEY`, `FOREIGN_KEYS`, or
+  `REFERENCING_FOREIGN_KEYS`;
+- the Databricks condition when available from `getCondition()` or the
+  bracketed warehouse-message prefix;
+- the backend exception type and complete raw message as diagnostics; and
+- optionally the SQL query in detailed/debug output.
+
+Use the step and condition in the headline:
+
+```text
+Read failed while reading column tags [INSUFFICIENT_PERMISSIONS]
+```
+
+The full section can then retain the backend message and type. Expected
+failures should render once by default through the report. Adapter tracebacks
+belong behind an explicit debug/verbose mode; engine phase logs should not
+repeat failures that the report is about to print.
+
+### 3. The machine-readable failure record is lossy — medium-high
+
+`_failure_records()` reduces every failure subtype to `phase`, class-name
+`type`, and one flattened rendered `message`.
+
+That discards useful structured fields already present on the values:
+
+- validation `rule_name`;
+- read/execution `exception_type`;
+- execution `statement_index` and `statement`;
+- foreign-key `reason`, local columns, and referenced table.
+
+It also silently applies the five-line display truncation to read and execution
+messages. The full message survives on the in-memory failure object, but not in
+the documented JSON intended for run-history persistence and structured
+logging.
+
+#### Recommendation
+
+Add subtype-specific structured details to the failure record while retaining
+the current `message` for display compatibility. At minimum:
+
+```text
+code                 stable rule/reason/backend condition
+summary              concise cause-first text
+raw_message          complete backend message, when applicable
+details              subtype-specific plain JSON fields
+```
+
+Adding fields is already documented as backwards-compatible. Do not silently
+truncate `raw_message`; if a display is shortened, mark it as truncated and
+tell the caller where the complete diagnostic remains.
+
+The public `code` should not rely solely on Python class names. Validation rule
+names and `ForeignKeyFailureReason` are already suitable stable codes; read and
+execution failures can prefer the backend condition and fall back to the
+exception type.
+
+### 4. Headlines lead with implementation vocabulary instead of the cause — medium
+
+The grid intentionally omits detail messages and shows only `headline()`.
+Consequently its two most common planning/read summaries are:
+
+```text
+Read error: ServerOperationError
+Validation failed: UnmanagedAspectDrift
+```
+
+These identify implementation mechanisms, not the problem. The full failure
+section is better, but users scan the grid first and automation often captures
+only compact output.
+
+#### Recommendation
+
+Make headlines cause-first and retain technical codes secondarily:
+
+```text
+Read failed: insufficient permissions while reading table tags
+Planning blocked: unmanaged column structure drift (2 differences)
+Execution failed: statement 1 rejected [DELTA_UNSUPPORTED_DROP_COLUMN]
+Foreign key blocked: referenced table cat.sch.customers failed
+```
+
+Keep rule and backend codes in structured output and, where useful, in
+parentheses. They are valuable for searching and support, but should not be the
+only explanation.
+
+### 5. Two validation rules omit the exact affected subjects — medium
+
+Most validation rules are already specific. Type changes include the column
+and both types; partitioning includes current and requested layouts; property
+rules include keys and values; rename conflicts and primary-key blockers name
+their objects.
+
+The notable exceptions are:
+
+- `UnmanagedAspectDrift`, which reports only the aspect; and
+- `ColumnMappingRequiredForDrop`, which reports that “dropping a column”
+  requires column mapping but does not name the column or columns.
+
+`NonNullableColumnAdd` names the column but gives no recovery path, unlike the
+more complete nullability-tightening rule.
+
+#### Recommendation
+
+Require every validation diagnostic to answer:
+
+1. What exact subject differs?
+2. What are the live and declared/requested states where relevant?
+3. Why is the operation blocked?
+4. What is the safest next action?
+
+For rules that deliberately aggregate multiple actions, list the affected
+subjects rather than returning an anonymous aggregate.
+
+### 6. Foreign-key structural failures lack the evidence used to decide them — medium
+
+The resolver has the complete `ForeignKeyConstraint` and both registered table
+definitions when it classifies a failure, but `_foreign_key_failure()` retains
+only local columns, referenced table, and broad reason.
+
+For `REFERENCED_COLUMN_TYPE_MISMATCH`, the user is told only that types differ.
+For `REFERENCED_COLUMNS_NOT_A_KEY`, the requested referenced columns and the
+registered primary key are absent. This forces the user to reconstruct the
+resolver's comparison manually.
+
+#### Recommendation
+
+Retain the constraint name, local-to-referenced column mapping, and
+reason-specific evidence:
+
+- exact `(local column, local type) -> (referenced column, referenced type)`
+  mismatches;
+- requested referenced columns and the registered primary-key columns; and
+- the upstream table/status for dependency blocking.
+
+The existing broad reason remains useful as the stable code.
+
+### 7. Execution diagnostics are strong but have two presentation defects — low
+
+Execution failures are the best of the four types: they show progress, backend
+message, and exact SQL. Two details remain:
+
+- `statement_index` is zero-based internally and displayed directly, producing
+  “statement 0” for the first statement; and
+- a message longer than five lines is truncated with no ellipsis or pointer to
+  the complete value.
+
+Keep the stored index zero-based if that is the API contract, but display
+`statement_index + 1` and, ideally, `1 of N`. Mark truncated diagnostics
+explicitly.
+
+## Suggested implementation sequence
+
+1. Add black-box output tests for the two reported cases: a read-step failure
+   and multi-entry unmanaged drift. Pin a single concise CLI presentation.
+2. Carry `TableDiff` through `TableRunReport`; add rejected-diff rendering and
+   an additive machine-readable drift projection.
+3. Add read step and condition to `ReadError`/`ReadFailure`, then remove the
+   default duplicate traceback/error logging.
+4. Make failure records subtype-aware without removing the existing three
+   fields.
+5. Fill the remaining subject/remediation gaps in validation and foreign-key
+   diagnostics; change execution display numbering to one-based.
+
+## Acceptance criteria
+
+- A user can identify the exact columns/properties/tags/comments behind
+  `UnmanagedAspectDrift` without recreating the diff in Python.
+- A planning failure never labels observed drift as “no changes”.
+- A read failure identifies the table, failing read step, stable condition
+  when available, backend message, and backend type.
+- The CLI shows one expected failure presentation by default and no traceback
+  unless debug output is requested.
+- `to_dict()` retains complete backend diagnostics and subtype-specific fields.
+- Every validation failure names its affected subject(s) and a safe next step.
+- Foreign-key type/key failures show the exact comparison that failed.
+- The first failed execution statement is displayed as statement 1, while any
+  stored zero-based index remains stable.

--- a/src/delta_engine/application/planning.py
+++ b/src/delta_engine/application/planning.py
@@ -9,6 +9,7 @@ from delta_engine.domain.plan import (
     ActionPlan,
     TableDiff,
     TableDrift,
+    TableInSync,
     TableMissing,
 )
 
@@ -38,9 +39,9 @@ def plan_diff(diff: TableDiff) -> PlanningResult:
     complete diff. A rejected result carries validation failures and deliberately
     has no plan, making execution of unvalidated drift unrepresentable.
     The plan carries the relation kind its actions lower against: the
-    observed kind for drift, and the default ordinary kind for a creation —
-    an absent table has no observed kind, and the engine only creates
-    ordinary tables.
+    observed kind for an existing-table comparison, and the default ordinary
+    kind for a creation — an absent table has no observed kind, and the engine
+    only creates ordinary tables.
     """
     validation = validate_diff(diff)
     if validation.failed:
@@ -51,6 +52,12 @@ def plan_diff(diff: TableDiff) -> PlanningResult:
                 target=drift.target,
                 actions=drift.actions,
                 kind=drift.observed.kind,
+            )
+        case TableInSync() as in_sync:
+            plan = ActionPlan(
+                target=in_sync.target,
+                actions=(),
+                kind=in_sync.observed.kind,
             )
         case TableMissing() as missing:
             plan = ActionPlan(

--- a/src/delta_engine/application/validation.py
+++ b/src/delta_engine/application/validation.py
@@ -39,6 +39,7 @@ from delta_engine.domain.plan import (
     SetProperty,
     TableDiff,
     TableDrift,
+    TableInSync,
     TableMissing,
     UnsetProperty,
 )
@@ -489,7 +490,7 @@ class UnmanagedAspectDrift:
     def evaluate(self, diff: TableDiff) -> tuple[ValidationFailure, ...]:
         """Flag every drifted aspect the declaration does not manage."""
         match diff:
-            case TableMissing():
+            case TableMissing() | TableInSync():
                 return ()
 
             case TableDrift() as drift:
@@ -529,7 +530,7 @@ class MissingTableUnmanaged:
     def evaluate(self, diff: TableDiff) -> tuple[ValidationFailure, ...]:
         """Flag a missing table that this declaration cannot create."""
         match diff:
-            case TableDrift():
+            case TableInSync() | TableDrift():
                 return ()
 
             case TableMissing() as missing:
@@ -574,10 +575,13 @@ class StreamingTableTagsOnly:
             case TableMissing():
                 return ()
 
-            case TableDrift() as drift:
-                if drift.observed.kind is not TableKind.STREAMING_TABLE:
+            case (
+                TableInSync(desired=desired, observed=observed)
+                | TableDrift(desired=desired, observed=observed)
+            ):
+                if observed.kind is not TableKind.STREAMING_TABLE:
                     return ()
-                if drift.desired.managed_aspects <= TAG_ASPECTS:
+                if desired.managed_aspects <= TAG_ASPECTS:
                     return ()
                 return (
                     ValidationFailure(
@@ -630,8 +634,8 @@ def validate_diff(
     user never requested. The gate cannot be suppressed via ``rules``.
 
     Past the gate every difference is in scope, so the safety rules judge
-    the managed drift. A missing table that clears the gate is a
-    fully-managed create and needs no safety judgement.
+    the managed drift. A missing or in-sync table that clears the gate needs
+    no safety judgement.
     """
     gate_failures = tuple(
         failure for gate in MANDATORY_SCOPE_GATES for failure in gate.evaluate(diff)
@@ -641,7 +645,7 @@ def validate_diff(
         return ValidationResult(failures=gate_failures)
 
     match diff:
-        case TableMissing():
+        case TableMissing() | TableInSync():
             return ValidationResult()
         case TableDrift() as drift:
             return ValidationResult(

--- a/src/delta_engine/domain/plan/__init__.py
+++ b/src/delta_engine/domain/plan/__init__.py
@@ -26,6 +26,7 @@ from delta_engine.domain.plan.actions import (
 from delta_engine.domain.plan.diff import (
     TableDiff,
     TableDrift,
+    TableInSync,
     TableMissing,
     diff_table,
 )
@@ -62,6 +63,7 @@ __all__ = [
     "SetTableTag",
     "TableDiff",
     "TableDrift",
+    "TableInSync",
     "TableMissing",
     "Unresolvable",
     "UnsetColumnTag",

--- a/src/delta_engine/domain/plan/diff.py
+++ b/src/delta_engine/domain/plan/diff.py
@@ -79,6 +79,21 @@ class TableMissing:
 
 
 @dataclass(frozen=True, slots=True)
+class TableInSync:
+    """An existing table for which the comparison found no differences."""
+
+    desired: DesiredTable
+    observed: ObservedTable
+
+    def __post_init__(self) -> None:
+        _require_same_table(self.desired, self.observed)
+
+    @property
+    def target(self) -> QualifiedName:
+        return self.desired.qualified_name
+
+
+@dataclass(frozen=True, slots=True)
 class TableDrift:
     """
     Differences separating an observed table from its declaration.
@@ -101,13 +116,15 @@ class TableDrift:
 
     def __post_init__(self) -> None:
         _require_same_table(self.desired, self.observed)
+        if not self.actions and not self.unresolvable:
+            raise ValueError("TableDrift must contain at least one difference")
 
     @property
     def target(self) -> QualifiedName:
         return self.desired.qualified_name
 
 
-type TableDiff = TableMissing | TableDrift
+type TableDiff = TableMissing | TableInSync | TableDrift
 
 
 def _require_same_table(desired: DesiredTable, observed: ObservedTable) -> None:
@@ -127,7 +144,10 @@ def diff_table(desired: DesiredTable, observed: ObservedTable | None) -> TableDi
     return _diff_existing_table(desired, observed)
 
 
-def _diff_existing_table(desired: DesiredTable, observed: ObservedTable) -> TableDrift:
+def _diff_existing_table(
+    desired: DesiredTable,
+    observed: ObservedTable,
+) -> TableInSync | TableDrift:
     """Describe every difference between two states of the same existing table."""
     _require_same_table(desired, observed)
 
@@ -142,22 +162,26 @@ def _diff_existing_table(desired: DesiredTable, observed: ObservedTable) -> Tabl
     constraint_actions = _diff_constraints(desired, observed)
     metadata_actions, metadata_unresolvable = _diff_table_metadata(desired, observed)
 
+    actions: tuple[Action, ...] = (
+        *feature_actions,
+        *renames.actions,
+        *column_actions,
+        *layout_actions,
+        *constraint_actions,
+        *metadata_actions,
+    )
+    unresolvable: tuple[Unresolvable, ...] = (
+        *renames.conflicts,
+        *metadata_unresolvable,
+        *layout_unresolvable,
+    )
+    if not actions and not unresolvable:
+        return TableInSync(desired=desired, observed=observed)
     return TableDrift(
         desired=desired,
         observed=observed,
-        actions=(
-            *feature_actions,
-            *renames.actions,
-            *column_actions,
-            *layout_actions,
-            *constraint_actions,
-            *metadata_actions,
-        ),
-        unresolvable=(
-            *renames.conflicts,
-            *metadata_unresolvable,
-            *layout_unresolvable,
-        ),
+        actions=actions,
+        unresolvable=unresolvable,
     )
 
 

--- a/tests/api/test_delta_table.py
+++ b/tests/api/test_delta_table.py
@@ -1785,7 +1785,7 @@ def test_two_locals_mapped_to_the_same_key_column_are_rejected():
 def test_reordering_the_parent_primary_key_produces_no_foreign_key_drift():
     # Regression for the parent-reorder trap: the child's mapping is explicit,
     # so a parent primary_key list reorder must be a no-op end to end.
-    from delta_engine.domain.plan.diff import TableDrift, diff_table
+    from delta_engine.domain.plan.diff import TableInSync, diff_table
 
     def child_of(parent_key_order):
         accounts = DeltaTable(
@@ -1824,6 +1824,5 @@ def test_reordering_the_parent_primary_key_produces_no_foreign_key_drift():
         foreign_keys=before.foreign_keys,
     )
     diff = diff_table(after, observed)
-    assert isinstance(diff, TableDrift)
-    assert diff.actions == ()
-    assert diff.unresolvable == ()
+
+    assert isinstance(diff, TableInSync)

--- a/tests/application/test_planning.py
+++ b/tests/application/test_planning.py
@@ -33,6 +33,7 @@ from delta_engine.domain.plan import (
     SetForeignKey,
     SetPrimaryKey,
     SetTableTag,
+    TableInSync,
     diff_table,
 )
 
@@ -149,10 +150,37 @@ def test_plan_diff_rejects_each_non_action_difference(desired, observed, expecte
 
 
 def test_plan_diff_accepts_no_op_as_an_empty_plan():
-    result = plan_diff(diff_table(_desired(), _observed()))
+    diff = diff_table(_desired(), _observed())
+    result = plan_diff(diff)
 
+    assert isinstance(diff, TableInSync)
     assert isinstance(result, PlanningSucceeded)
     assert result.plan.target == _NAME
+    assert result.plan.actions == ()
+
+
+def test_plan_diff_rejects_in_sync_streaming_table_with_full_scope():
+    diff = diff_table(_desired(), _observed(kind=TableKind.STREAMING_TABLE))
+
+    result = plan_diff(diff)
+
+    assert isinstance(diff, TableInSync)
+    assert isinstance(result, PlanningFailed)
+    assert [failure.rule_name for failure in result.failures] == ["StreamingTableTagsOnly"]
+
+
+def test_plan_diff_accepts_in_sync_streaming_table_with_tags_scope():
+    desired = _desired(
+        managed_aspects=frozenset({TableAspect.TABLE_TAGS, TableAspect.COLUMN_TAGS})
+    )
+    diff = diff_table(desired, _observed(kind=TableKind.STREAMING_TABLE))
+
+    result = plan_diff(diff)
+
+    assert isinstance(diff, TableInSync)
+    assert isinstance(result, PlanningSucceeded)
+    assert result.plan.target == _NAME
+    assert result.plan.kind is TableKind.STREAMING_TABLE
     assert result.plan.actions == ()
 
 

--- a/tests/application/test_validation.py
+++ b/tests/application/test_validation.py
@@ -45,6 +45,7 @@ from delta_engine.domain.plan import (
 )
 from delta_engine.domain.plan.diff import (
     TableDrift,
+    TableInSync,
     TableMissing,
     diff_table,
 )
@@ -106,6 +107,17 @@ def _drift(
         observed=_observed_table(kind=kind),
         actions=actions,
         unresolvable=unresolvable,
+    )
+
+
+def _in_sync(
+    *,
+    managed_aspects: frozenset[TableAspect] = ALL_ASPECTS,
+    kind: TableKind = TableKind.TABLE,
+) -> TableInSync:
+    return TableInSync(
+        desired=_desired_table(managed_aspects=managed_aspects),
+        observed=_observed_table(kind=kind),
     )
 
 
@@ -219,8 +231,11 @@ def test_validate_diff_applies_supplied_rules_to_drift():
                 ),
             )
 
-    # When validating a harmless drift with that rule
-    result = validate_diff(_drift(), rules=(AlwaysFail(),))
+    # When validating a harmless non-empty drift with that rule
+    result = validate_diff(
+        _drift(SetTableComment(desired_comment="new", observed_comment="old")),
+        rules=(AlwaysFail(),),
+    )
 
     # Then the custom rule contributes its failure
     assert result.failed is True
@@ -250,9 +265,9 @@ def test_validation_passes_when_no_rule_is_broken():
     assert result.failures == ()
 
 
-def test_empty_drift_produces_no_failures():
-    # Given an empty drift
-    result = validate_diff(_drift())
+def test_in_sync_comparison_produces_no_failures():
+    # Given an in-sync comparison
+    result = validate_diff(_in_sync())
 
     # Then validation passes
     assert result.failed is False
@@ -1046,7 +1061,7 @@ def test_streaming_table_passes_when_the_declaration_manages_only_tags():
 
 def test_streaming_table_fails_a_full_scope_declaration_even_with_zero_drift():
     # Given a fully-managed declaration over an in-sync streaming table
-    diff = _drift(managed_aspects=ALL_ASPECTS, kind=TableKind.STREAMING_TABLE)
+    diff = _in_sync(managed_aspects=ALL_ASPECTS, kind=TableKind.STREAMING_TABLE)
 
     # When validating
     result = validate_diff(diff)
@@ -1060,7 +1075,7 @@ def test_streaming_table_fails_a_full_scope_declaration_even_with_zero_drift():
 
 def test_streaming_table_fails_a_metadata_scope_declaration():
     # Given a declaration managing comments as well as tags
-    diff = _drift(
+    diff = _in_sync(
         managed_aspects=frozenset(
             {TableAspect.TABLE_TAGS, TableAspect.COLUMN_TAGS, TableAspect.TABLE_COMMENT}
         ),
@@ -1073,7 +1088,7 @@ def test_streaming_table_fails_a_metadata_scope_declaration():
 
 
 def test_streaming_table_gate_cannot_be_suppressed_by_empty_rules():
-    diff = _drift(managed_aspects=ALL_ASPECTS, kind=TableKind.STREAMING_TABLE)
+    diff = _in_sync(managed_aspects=ALL_ASPECTS, kind=TableKind.STREAMING_TABLE)
 
     result = validate_diff(diff, rules=())
 

--- a/tests/domain/plan/test_diff.py
+++ b/tests/domain/plan/test_diff.py
@@ -46,6 +46,7 @@ from delta_engine.domain.plan.actions import (
 )
 from delta_engine.domain.plan.diff import (
     TableDrift,
+    TableInSync,
     TableMissing,
     diff_table,
 )
@@ -103,19 +104,23 @@ def test_missing_table_derives_target_from_desired_table():
     assert diff.target == _QUALIFIED_NAME
 
 
-def test_equal_tables_diff_to_empty_drift():
+def test_equal_tables_diff_to_table_in_sync():
     # Given identical desired and observed definitions
-    diff = diff_table(_desired(), _observed())
+    desired = _desired()
+    observed = _observed()
 
-    # Then no changes are produced — the natural zero
-    assert isinstance(diff, TableDrift)
-    assert diff.actions == ()
-    assert diff.unresolvable == ()
+    # When diffing
+    diff = diff_table(desired, observed)
+
+    # Then the comparison has an explicit no-differences variant
+    assert diff == TableInSync(desired=desired, observed=observed)
 
 
 def test_drift_carries_the_desired_table():
-    # Given a desired table
-    desired = _desired()
+    # Given a desired table with a difference
+    desired = _desired(
+        columns=(DesiredColumn("id", Integer()), DesiredColumn("age", Integer()))
+    )
 
     # When diffing
     diff = diff_table(desired, _observed())
@@ -128,22 +133,49 @@ def test_drift_carries_the_desired_table():
 
 
 def test_drift_derives_target_from_the_shared_table_identity():
-    # Given matching desired and observed table identities
-    diff = diff_table(_desired(), _observed())
+    # Given matching desired and observed table identities with a difference
+    diff = diff_table(
+        _desired(columns=(DesiredColumn("id", Integer()), DesiredColumn("age", Integer()))),
+        _observed(),
+    )
 
     # Then the comparison exposes their one shared target
     assert isinstance(diff, TableDrift)
     assert diff.target == _QUALIFIED_NAME
 
 
-def test_drift_rejects_different_desired_and_observed_tables():
+def test_in_sync_derives_target_from_the_shared_table_identity():
+    diff = diff_table(_desired(), _observed())
+
+    assert isinstance(diff, TableInSync)
+    assert diff.target == _QUALIFIED_NAME
+
+
+def test_in_sync_rejects_different_desired_and_observed_tables():
     # Given a desired and observed referencing different tables
     desired = _desired(qualified_name=QualifiedName("cat", "sch", "customers"))
     observed = _observed(qualified_name=QualifiedName("cat", "sch", "orders"))
 
     # When / Then constructing their comparison is rejected
     with pytest.raises(ValueError, match="Cannot compare different tables"):
-        TableDrift(desired=desired, observed=observed)
+        TableInSync(desired=desired, observed=observed)
+
+
+def test_drift_rejects_different_desired_and_observed_tables():
+    desired = _desired(qualified_name=QualifiedName("cat", "sch", "customers"))
+    observed = _observed(qualified_name=QualifiedName("cat", "sch", "orders"))
+
+    with pytest.raises(ValueError, match="Cannot compare different tables"):
+        TableDrift(
+            desired=desired,
+            observed=observed,
+            actions=(AddColumn(DesiredColumn("age", Integer())),),
+        )
+
+
+def test_empty_table_drift_cannot_be_constructed():
+    with pytest.raises(ValueError, match="must contain at least one difference"):
+        TableDrift(desired=_desired(), observed=_observed())
 
 
 # ---------- column structure changes
@@ -410,9 +442,7 @@ def test_identical_column_tags_produce_no_changes():
     diff = diff_table(_desired(columns=columns), _observed(columns=columns))
 
     # Then no tag changes are produced
-    assert isinstance(diff, TableDrift)
-    assert diff.actions == ()
-    assert diff.unresolvable == ()
+    assert isinstance(diff, TableInSync)
 
 
 # ---------- table comment change
@@ -462,9 +492,7 @@ def test_declared_property_matching_catalog_produces_no_change():
     )
 
     # Then no change is produced — the property sync is idempotent
-    assert isinstance(diff, TableDrift)
-    assert diff.actions == ()
-    assert diff.unresolvable == ()
+    assert isinstance(diff, TableInSync)
 
 
 def test_none_declaration_on_present_key_produces_unset():
@@ -487,9 +515,7 @@ def test_none_declaration_on_absent_key_produces_no_change():
         _observed(properties={}),
     )
 
-    assert isinstance(diff, TableDrift)
-    assert diff.actions == ()
-    assert diff.unresolvable == ()
+    assert isinstance(diff, TableInSync)
 
 
 def test_undeclared_managed_key_produces_an_undeclared_property_finding():
@@ -530,9 +556,7 @@ def test_properties_diff_is_skipped_when_properties_unmanaged():
     )
 
     # Then no property change of any kind — no assertion was made
-    assert isinstance(diff, TableDrift)
-    assert diff.actions == ()
-    assert diff.unresolvable == ()
+    assert isinstance(diff, TableInSync)
 
 
 def test_declared_properties_are_not_compared_when_properties_unmanaged():
@@ -545,9 +569,7 @@ def test_declared_properties_are_not_compared_when_properties_unmanaged():
     )
 
     # Then the carried property makes no assertion and produces no change
-    assert isinstance(diff, TableDrift)
-    assert diff.actions == ()
-    assert diff.unresolvable == ()
+    assert isinstance(diff, TableInSync)
 
 
 def test_property_set_rejects_equal_values():
@@ -632,8 +654,7 @@ def test_reordered_clustering_keys_are_not_a_change():
         _observed(columns=columns, clustered_by=("id", "region")),
     )
     # Then no clustering change is produced — key order is immaterial
-    assert diff.actions == ()
-    assert diff.unresolvable == ()
+    assert isinstance(diff, TableInSync)
 
 
 def test_clustering_removal_produces_cluster_by_none_action():
@@ -682,9 +703,7 @@ def test_equal_primary_keys_by_column_set_produce_no_change():
     )
 
     # Then identity is column-set equality — no change
-    assert isinstance(diff, TableDrift)
-    assert diff.actions == ()
-    assert diff.unresolvable == ()
+    assert isinstance(diff, TableInSync)
 
 
 # ---------- foreign key changes
@@ -706,9 +725,7 @@ def test_equal_foreign_keys_by_signature_produce_no_change():
     )
 
     # Then identity is the content signature — no change, sync stays idempotent
-    assert isinstance(diff, TableDrift)
-    assert diff.actions == ()
-    assert diff.unresolvable == ()
+    assert isinstance(diff, TableInSync)
 
 
 # ---------- no-difference changes are unrepresentable
@@ -927,9 +944,8 @@ def test_diff_hint_is_inert_when_applied_rename_is_steady_state():
         columns=(DesiredColumn("customer_name", String(), renamed_from="customer_nm"),)
     )
     applied = _observed(columns=(DesiredColumn("customer_name", String()),))
-    drift = diff_table(desired, applied)
-    assert drift.actions == ()
-    assert drift.unresolvable == ()
+    comparison = diff_table(desired, applied)
+    assert isinstance(comparison, TableInSync)
 
 
 def test_diff_hint_is_a_plain_add_when_neither_name_is_observed():
@@ -1131,8 +1147,8 @@ def test_diff_keeps_an_unrelated_foreign_key_drop_alongside_a_rename():
     )
 
 
-def test_drift_carries_the_observed_table_it_was_computed_against():
-    # The drift's endpoints are judging context: validation's scope gate reads
+def test_in_sync_carries_the_observed_table_it_was_computed_against():
+    # The comparison's endpoints are judging context: validation's scope gate reads
     # observed facts (the relation kind) off the observed side.
     qualified_name = QualifiedName("cat", "sch", "clicks")
     desired = DesiredTable(
@@ -1147,12 +1163,12 @@ def test_drift_carries_the_observed_table_it_was_computed_against():
 
     diff = diff_table(desired, observed)
 
-    assert isinstance(diff, TableDrift)
+    assert isinstance(diff, TableInSync)
     assert diff.observed is observed
     assert diff.observed.kind is TableKind.STREAMING_TABLE
 
 
-def test_drift_against_an_ordinary_table_carries_the_table_kind():
+def test_in_sync_against_an_ordinary_table_carries_the_table_kind():
     qualified_name = QualifiedName("cat", "sch", "orders")
     desired = DesiredTable(
         qualified_name=qualified_name,
@@ -1165,5 +1181,5 @@ def test_drift_against_an_ordinary_table_carries_the_table_kind():
 
     diff = diff_table(desired, observed)
 
-    assert isinstance(diff, TableDrift)
+    assert isinstance(diff, TableInSync)
     assert diff.observed.kind is TableKind.TABLE


### PR DESCRIPTION
## Summary

- document the current user-facing failure diagnostics across read, planning, foreign-key, and execution phases
- identify why rejected drift, especially `UnmanagedAspectDrift`, does not show the exact differences
- prioritize improvements for read context, CLI duplication, structured failure records, validation evidence, and execution presentation
- define an implementation sequence and acceptance criteria

## Why

Recent READ and validation failures did not provide enough information to diagnose the problem. The review traces failure values through the report, CLI, exceptions, and `to_dict()` output and records the concrete gaps before changing the public reporting contract.

The highest-priority findings are that rejected drift is rendered as “no changes,” READ failures do not retain the failing catalog-read step, and the CLI can present the same expected READ failure three times.

## Impact

This is documentation-only. It proposes a cause-first diagnostics contract and a staged implementation plan; runtime behaviour and public APIs are unchanged.

## Validation

- `uv run pytest -q --no-cov tests/application/test_failures.py tests/application/test_rendering.py tests/application/test_report.py tests/application/test_validation.py tests/cli/test_app_plan.py tests/adapters/databricks/test_read.py tests/adapters/databricks/test_execution.py`
- 204 tests passed
- `git diff --cached --check`