### PR TITLE
refactor: move column spelling into SQL translation

### DIFF
--- a/docs/explanation-architecture.md
+++ b/docs/explanation-architecture.md
@@ -803,9 +803,9 @@ dependency cost.
 | Add a safety rule                 | `delta_engine.application.validation`                                      | Rules inspect the drift's managed actions and unresolvable differences and return `ValidationFailure` values.                                                                                                                               |
 | Add a data type                   | `delta_engine.domain.model.data_type` and adapter type mapping             | The domain type is backend-free; SQL names and Spark parsing live in the Databricks adapter.                                                                                                                                                |
 | Change public declarations        | `delta_engine.api`, surfaced only through `delta_engine.schema`            | Keep public ergonomics in `delta_engine.schema` and lower choices into domain snapshots before the engine phases begin.                                                                                                                     |
-| Change FK planning, ordering, or blocking | `delta_engine.application.relationships` (blocking gate: `Engine._gate`) | Cross-table relationship policy — FK existence diffing, spelling, structural validation, ordering — lives in the application layer, not in the domain plan or SQL compiler.                                                                  |
+| Change FK planning, ordering, or blocking | `delta_engine.application.relationships` (blocking gate: `Engine._gate`) | Cross-table relationship policy — FK existence diffing, structural validation, ordering — lives in the application layer, not in the domain plan or SQL compiler.                                                                            |
 | Change report output              | `delta_engine.application.report` and `delta_engine.application.rendering` | Keep display formatting out of domain objects.                                                                                                                                                                                              |
-| Change Databricks SQL             | `delta_engine.adapters.databricks.sql`                                     | Compile domain actions to backend statements at the adapter boundary.                                                                                                                                                                       |
+| Change Databricks SQL             | `delta_engine.adapters.databricks.sql`                                     | Compile domain actions to backend statements at the adapter boundary; rendered column references are respelled to the catalog's spelling through `CatalogSpellings` (`respell.py`).                                                          |
 | Change CLI commands or output     | `delta_engine.cli`                                                         | Thin orchestration over `declarations.py`, `connection.py`, and the application ports; keep policy in the layers below.                                                                                                                     |
 
 ## Architectural rules
@@ -822,9 +822,9 @@ dependency cost.
   and `Column.tags` copy what the user passed, so mutating the original
   mapping later does not alter the declaration.
 - Put orchestration, safety policy, relationship resolution, and failure
-  propagation in the application layer. Constraint planning and spelling are
-  cross-table policy and live in `application/relationships.py`, consistent
-  with this rule.
+  propagation in the application layer. Constraint planning is cross-table
+  policy and lives in `application/relationships.py`, consistent with this
+  rule.
 - Put backend normalization at adapter boundaries, such as lowercasing catalog,
   schema, and table-name parts, parsing Spark types, and quoting SQL. Preserve
   column-like identifier spelling by wrapping it in `Identifier` — a `str`
@@ -836,13 +836,15 @@ dependency cost.
   clustering, primary-key, and foreign-key references resolve to their actual
   desired `Column.name` while lowering; domain table snapshots require local
   references to carry that spelling and never rewrite their contents.
-- Spell constraint SQL as the catalog does, at the two emission sites that
-  hold the right observed objects: the resolver respells `SetForeignKey`
-  through the owner's and the parent's effective spellings, and
-  `_diff_primary_key` respells `SetPrimaryKey` from its own observed table.
-  Existing columns wear the catalog's exact spelling; new or renamed columns
-  keep the declared spelling. Comparisons never need respelling —
-  `Identifier` equality already makes case invisible to matching.
+- Spelling is presentation, owned by translation. The SQL compiler respells
+  every rendered column reference through `CatalogSpellings` — the catalog's
+  spelling where the column is known, the given spelling unchanged where it
+  is not (new columns, rename targets, tables created this sync). The rule
+  is uniform across statements, so emitted DDL is correct whether or not a
+  given Databricks path resolves identifiers case-sensitively
+  (`ADD CONSTRAINT` does). Plans and reports keep declared spellings;
+  comparisons never need respelling — `Identifier` equality already makes
+  case invisible to matching.
 - Return typed failures across ports instead of raising backend exceptions.
 - Let `ActionPlan` own action ordering; callers should not sort plans manually.
 - Keep user-facing schema convenience in `delta_engine.schema`, then lower to

--- a/docs/explanation-sync-lifecycle.md
+++ b/docs/explanation-sync-lifecycle.md
@@ -26,7 +26,7 @@ read → resolve → diff → plan → compile → execute → report
 | **Resolve** | Can each declared foreign key work, and which tables go first? | Tables ordered dependency-first, with structural FK verdicts and planned FK actions |
 | **Diff**    | How does observed state differ from desired? | Direct actions and non-action differences — or no drift            |
 | **Plan**    | Is the diff, merged with the planned FK actions, accepted? | A validated action plan, or named validation failures with no plan |
-| **Compile** | What exact backend statements apply it?     | The SQL exposed on the report and passed unchanged to execution    |
+| **Compile** | What exact backend statements apply it?     | The SQL exposed on the report and passed unchanged to execution, rendered in the catalog's column spellings |
 | **Execute** | Apply the compiled statements                | Attempted results, a dependency block, or skipped on a dry run     |
 
 The result is a `SyncReport` with one entry per table. On a real run, if any

--- a/src/delta_engine/adapters/databricks/spark/executor.py
+++ b/src/delta_engine/adapters/databricks/spark/executor.py
@@ -3,6 +3,7 @@
 from delta_engine.adapters.databricks.execution import execute_statement
 from delta_engine.adapters.databricks.spark._runner import SparkSqlRunner
 from delta_engine.adapters.databricks.sql import compile_plan
+from delta_engine.application.ports import CatalogSpellings
 from delta_engine.domain.plan import ActionPlan
 
 
@@ -12,9 +13,14 @@ class SparkExecutor:
     def __init__(self, runner: SparkSqlRunner) -> None:
         self._runner = runner
 
-    def compile(self, plan: ActionPlan) -> tuple[str, ...]:
-        """Compile ``plan`` to its SQL statements in execution order, without touching Spark."""
-        return compile_plan(plan)
+    def compile(self, plan: ActionPlan, spellings: CatalogSpellings) -> tuple[str, ...]:
+        """
+        Compile ``plan`` to its SQL statements in execution order.
+
+        Statements are rendered in the catalog's column spellings, without
+        touching Spark.
+        """
+        return compile_plan(plan, spellings)
 
     def execute(self, statement: str) -> None:
         """Execute one statement, translating Spark failures at the shared boundary."""

--- a/src/delta_engine/adapters/databricks/sql/compile.py
+++ b/src/delta_engine/adapters/databricks/sql/compile.py
@@ -84,10 +84,7 @@ class _Target:
         return f"{_ALTER_CLAUSES[self.kind]} {self.name}"
 
 
-_NO_SPELLINGS: Final[CatalogSpellings] = CatalogSpellings(())
-
-
-def compile_plan(plan: ActionPlan, spellings: CatalogSpellings = _NO_SPELLINGS) -> tuple[str, ...]:
+def compile_plan(plan: ActionPlan, spellings: CatalogSpellings) -> tuple[str, ...]:
     """
     Compile an :class:`ActionPlan` into SQL statements, in plan order.
 

--- a/src/delta_engine/adapters/databricks/sql/compile.py
+++ b/src/delta_engine/adapters/databricks/sql/compile.py
@@ -2,7 +2,8 @@
 Compile domain action plans into Spark/Databricks SQL statements.
 
 Uses `functools.singledispatch` to render SQL per action type and returns the
-statements in plan order, ready to execute against a Spark session.
+statements in plan order, ready to execute against a Spark session. Statements
+are rendered in the catalog's column spellings via the respell pass.
 """
 
 from collections.abc import Mapping
@@ -16,8 +17,10 @@ from delta_engine.adapters.databricks.sql.dialect import (
     backtick_qualified_name,
     quote_literal,
 )
+from delta_engine.adapters.databricks.sql.respell import respell_plan
 from delta_engine.adapters.databricks.sql.types import render_data_type
 from delta_engine.adapters.databricks.table_features import enable_property
+from delta_engine.application.ports import CatalogSpellings
 from delta_engine.domain.model import DesiredColumn, QualifiedName, TableKind
 from delta_engine.domain.plan import (
     Action,
@@ -81,14 +84,23 @@ class _Target:
         return f"{_ALTER_CLAUSES[self.kind]} {self.name}"
 
 
-def compile_plan(plan: ActionPlan) -> tuple[str, ...]:
+_NO_SPELLINGS: Final[CatalogSpellings] = CatalogSpellings(())
+
+
+def compile_plan(plan: ActionPlan, spellings: CatalogSpellings = _NO_SPELLINGS) -> tuple[str, ...]:
     """
     Compile an :class:`ActionPlan` into SQL statements, in plan order.
 
     The plan supplies both the qualified table target and the relation kind
     selecting the ALTER dialect. Non-ALTER statements (CREATE TABLE, COMMENT
     ON) use the same plan target but are unaffected by the relation kind.
+
+    Before rendering, every column reference is respelled to the catalog's
+    spelling through ``spellings`` (declared spelling where the catalog has
+    none); the plan itself is left untouched. See
+    :mod:`delta_engine.adapters.databricks.sql.respell`.
     """
+    plan = respell_plan(plan, spellings)
     target = _Target(qualified_name=plan.target, kind=plan.kind)
     return tuple(_compile_action(action, target) for action in plan)
 

--- a/src/delta_engine/adapters/databricks/sql/respell.py
+++ b/src/delta_engine/adapters/databricks/sql/respell.py
@@ -1,0 +1,159 @@
+"""
+Normalise a plan's column spelling to the catalog's before rendering.
+
+Every column reference the compiler renders is respelled: the catalog's
+spelling where the column is known, the given spelling unchanged where it is
+not (a column added by this plan, a rename target, a table created this
+sync). The rule is uniform — no per-operation carve-outs — so emitted DDL is
+correct whether or not a given Databricks path resolves identifiers
+case-sensitively (``ADD CONSTRAINT`` does; ordinary DDL does not). Only the
+rendered statements are normalised: the stored ``ActionPlan`` keeps its
+declared, semantic spellings.
+"""
+
+from dataclasses import replace
+from functools import singledispatch
+
+from delta_engine.application.ports import CatalogSpellings
+from delta_engine.domain.model import DesiredTable, PrimaryKeyConstraint, QualifiedName
+from delta_engine.domain.plan import (
+    Action,
+    ActionPlan,
+    AddColumn,
+    AlterClustering,
+    AlterColumnType,
+    CreateTable,
+    DropColumn,
+    RenameColumn,
+    SetColumnComment,
+    SetColumnNullability,
+    SetColumnTag,
+    SetForeignKey,
+    SetPrimaryKey,
+    UnsetColumnTag,
+)
+
+
+def respell_plan(plan: ActionPlan, spellings: CatalogSpellings) -> ActionPlan:
+    """Return ``plan`` with every rendered column reference catalog-spelled."""
+    return replace(
+        plan,
+        actions=tuple(_respell(action, plan.target, spellings) for action in plan),
+    )
+
+
+@singledispatch
+def _respell(action: Action, target: QualifiedName, spellings: CatalogSpellings) -> Action:
+    """Actions that render no column references pass through unchanged."""
+    return action
+
+
+@_respell.register
+def _(action: AddColumn, target: QualifiedName, spellings: CatalogSpellings) -> Action:
+    column = action.column
+    return replace(action, column=replace(column, name=spellings.spelling(target, column.name)))
+
+
+@_respell.register
+def _(action: DropColumn, target: QualifiedName, spellings: CatalogSpellings) -> Action:
+    column = action.column
+    return replace(action, column=replace(column, name=spellings.spelling(target, column.name)))
+
+
+@_respell.register
+def _(action: RenameColumn, target: QualifiedName, spellings: CatalogSpellings) -> Action:
+    return replace(
+        action,
+        old_name=spellings.spelling(target, action.old_name),
+        new_name=spellings.spelling(target, action.new_name),
+    )
+
+
+@_respell.register
+def _(action: SetColumnComment, target: QualifiedName, spellings: CatalogSpellings) -> Action:
+    return replace(action, column_name=spellings.spelling(target, action.column_name))
+
+
+@_respell.register
+def _(action: SetColumnNullability, target: QualifiedName, spellings: CatalogSpellings) -> Action:
+    return replace(action, column_name=spellings.spelling(target, action.column_name))
+
+
+@_respell.register
+def _(action: SetColumnTag, target: QualifiedName, spellings: CatalogSpellings) -> Action:
+    return replace(action, column_name=spellings.spelling(target, action.column_name))
+
+
+@_respell.register
+def _(action: UnsetColumnTag, target: QualifiedName, spellings: CatalogSpellings) -> Action:
+    return replace(action, column_name=spellings.spelling(target, action.column_name))
+
+
+@_respell.register
+def _(action: AlterColumnType, target: QualifiedName, spellings: CatalogSpellings) -> Action:
+    return replace(action, column_name=spellings.spelling(target, action.column_name))
+
+
+@_respell.register
+def _(action: AlterClustering, target: QualifiedName, spellings: CatalogSpellings) -> Action:
+    return replace(
+        action,
+        desired_clustering=tuple(
+            spellings.spelling(target, column) for column in action.desired_clustering
+        ),
+    )
+
+
+@_respell.register
+def _(action: SetPrimaryKey, target: QualifiedName, spellings: CatalogSpellings) -> Action:
+    return replace(action, primary_key=_respell_primary_key(action.primary_key, target, spellings))
+
+
+@_respell.register
+def _(action: SetForeignKey, target: QualifiedName, spellings: CatalogSpellings) -> Action:
+    constraint = action.constraint
+    return replace(
+        action,
+        constraint=replace(
+            constraint,
+            local_columns=tuple(
+                spellings.spelling(target, column) for column in constraint.local_columns
+            ),
+            referenced_columns=tuple(
+                spellings.spelling(constraint.referenced_table, column)
+                for column in constraint.referenced_columns
+            ),
+        ),
+    )
+
+
+@_respell.register
+def _(action: CreateTable, target: QualifiedName, spellings: CatalogSpellings) -> Action:
+    return replace(action, table=_respell_created_table(action.table, spellings))
+
+
+def _respell_primary_key(
+    primary_key: PrimaryKeyConstraint, table: QualifiedName, spellings: CatalogSpellings
+) -> PrimaryKeyConstraint:
+    return replace(
+        primary_key,
+        columns=tuple(spellings.spelling(table, column) for column in primary_key.columns),
+    )
+
+
+def _respell_created_table(table: DesiredTable, spellings: CatalogSpellings) -> DesiredTable:
+    """CREATE TABLE renders columns, layout, and the PK; foreign keys are not rendered."""
+    name = table.qualified_name
+    return replace(
+        table,
+        columns=tuple(
+            replace(column, name=spellings.spelling(name, column.name)) for column in table.columns
+        ),
+        partitioned_by=tuple(spellings.spelling(name, column) for column in table.partitioned_by),
+        clustered_by=tuple(spellings.spelling(name, column) for column in table.clustered_by),
+        primary_key=(
+            _respell_primary_key(table.primary_key, name, spellings)
+            if table.primary_key is not None
+            else None
+        ),
+    )

--- a/src/delta_engine/adapters/databricks/warehouse/executor.py
+++ b/src/delta_engine/adapters/databricks/warehouse/executor.py
@@ -3,6 +3,7 @@
 from delta_engine.adapters.databricks.execution import execute_statement
 from delta_engine.adapters.databricks.sql import compile_plan
 from delta_engine.adapters.databricks.warehouse._runner import WarehouseSqlRunner
+from delta_engine.application.ports import CatalogSpellings
 from delta_engine.domain.plan import ActionPlan
 
 
@@ -12,13 +13,14 @@ class WarehouseExecutor:
     def __init__(self, runner: WarehouseSqlRunner) -> None:
         self._runner = runner
 
-    def compile(self, plan: ActionPlan) -> tuple[str, ...]:
+    def compile(self, plan: ActionPlan, spellings: CatalogSpellings) -> tuple[str, ...]:
         """
         Compile ``plan`` to its SQL statements in execution order.
 
-        Does not touch the warehouse.
+        Statements are rendered in the catalog's column spellings. Does not
+        touch the warehouse.
         """
-        return compile_plan(plan)
+        return compile_plan(plan, spellings)
 
     def execute(self, statement: str) -> None:
         """

--- a/src/delta_engine/application/engine.py
+++ b/src/delta_engine/application/engine.py
@@ -98,9 +98,12 @@ from delta_engine.domain.plan import (
 logger = logging.getLogger(__name__)
 
 
-def prepare_desired_tables(*tables: DesiredTableSource) -> tuple[DesiredTable, ...]:
+def lower_desired_tables(*tables: DesiredTableSource) -> tuple[DesiredTable, ...]:
     """
     Lower table specifications into domain tables for the phase chain.
+
+    The system lowers at both edges: specifications into domain tables here,
+    and plans into SQL at translation.
 
     Converts each source via ``to_desired_table()``, rejects duplicate
     qualified names, and returns the tables in deterministic qualified-name
@@ -252,7 +255,7 @@ class Engine:
 
         """
         run_started = datetime.now(UTC)
-        desired = prepare_desired_tables(*tables)
+        desired = lower_desired_tables(*tables)
         logger.info("Starting sync for %d table(s)", len(desired))
 
         snapshots = self._read(desired)

--- a/src/delta_engine/application/engine.py
+++ b/src/delta_engine/application/engine.py
@@ -61,6 +61,7 @@ from delta_engine.application.planning import (
     plan_diff,
 )
 from delta_engine.application.ports import (
+    CatalogSpellings,
     CatalogStateReader,
     DesiredTableSource,
     ExecutionResult,
@@ -357,15 +358,22 @@ class Engine:
         Compilation is a distinct backend boundary after planning: a dry run
         reports these statements, while a real run passes the same tuple to
         execution. Runs rejected by an earlier phase carry no compiled SQL.
+        Statements are rendered against the catalog's column spellings: one
+        :class:`CatalogSpellings` view is built over every run's declared and
+        observed columns and crosses the boundary with each plan, so the
+        dialect can respell rendered references while stored plans keep their
+        declared spellings.
         """
+        spellings = CatalogSpellings(
+            (run.desired, run.read.table if isinstance(run.read, TablePresent) else None)
+            for run in runs
+        )
         for run in runs:
             plan = run.plan
             if plan is None:
                 continue
 
-            run.planned_sql_statements = self.executor.compile(
-                plan,
-            )
+            run.planned_sql_statements = self.executor.compile(plan, spellings)
             logger.info(
                 "Compiled %d statement(s) for %s",
                 len(run.planned_sql_statements),

--- a/src/delta_engine/application/ports.py
+++ b/src/delta_engine/application/ports.py
@@ -8,11 +8,17 @@ the whole contract. ``DesiredTableSource`` is the inbound counterpart: the
 contract a user-facing declaration satisfies to enter a sync.
 """
 
+from collections.abc import Iterable
 from dataclasses import dataclass
 from typing import Protocol
 
 from delta_engine.application.failures import ExecutionFailure, ReadFailure
-from delta_engine.domain.model import DesiredTable, ObservedTable, QualifiedName
+from delta_engine.domain.model import (
+    DesiredTable,
+    Identifier,
+    ObservedTable,
+    QualifiedName,
+)
 from delta_engine.domain.plan import ActionPlan
 
 # ---------- DesiredTableSource ----------
@@ -74,6 +80,42 @@ class CatalogStateReader(Protocol):
 
         """
         ...
+
+
+# ---------- CatalogSpellings ----------
+
+
+class CatalogSpellings:
+    """
+    Column spellings as the catalog spells them, for SQL rendering.
+
+    Maps each registered table's columns to their effective spelling: the
+    catalog's where the column was observed, the declared spelling otherwise.
+    Lookups are case-insensitive (``Identifier`` identity); an unknown table
+    or column returns the given spelling unchanged, so the rule is total — a
+    referent that exists resolves to the catalog's spelling, and one that
+    does not exist yet keeps the spelling it was given.
+
+    Consumed by :meth:`PlanExecutor.compile`: a dialect with case-sensitive
+    DDL paths renders its column references through it; a dialect that does
+    not care ignores it. Spelling is presentation, never identity —
+    comparisons upstream use ``Identifier`` equality and never consult this.
+    """
+
+    def __init__(self, tables: Iterable[tuple[DesiredTable, ObservedTable | None]]) -> None:
+        self._spellings_by_table: dict[QualifiedName, dict[str, str]] = {}
+        for desired, observed in tables:
+            spellings: dict[str, str] = {column.name: column.name for column in desired.columns}
+            if observed is not None:
+                spellings |= {column.name: column.name for column in observed.columns}
+            self._spellings_by_table[desired.qualified_name] = spellings
+
+    def spelling(self, table: QualifiedName, column: str) -> str:
+        """Catalog spelling where known; the given spelling unchanged otherwise."""
+        spellings = self._spellings_by_table.get(table)
+        if spellings is None:
+            return column
+        return spellings.get(Identifier(column), column)
 
 
 # ---------- ExecutionResult ----------

--- a/src/delta_engine/application/ports.py
+++ b/src/delta_engine/application/ports.py
@@ -202,13 +202,18 @@ class PlanExecutor(Protocol):
     :class:`ExecutionFailure`; unexpected programming errors still propagate.
     """
 
-    def compile(self, plan: ActionPlan) -> tuple[str, ...]:
+    def compile(self, plan: ActionPlan, spellings: CatalogSpellings) -> tuple[str, ...]:
         """
         Return the statements that apply ``plan``, in execution order.
 
         The plan carries the qualified table target and relation kind its
         actions lower against (``plan.target`` and ``plan.kind``). Backends
         read both from the plan rather than accepting parallel context.
+
+        ``spellings`` carries the catalog's column spellings for every table
+        in the sync: a dialect with case-sensitive DDL paths respells its
+        rendered column references through it, and a dialect that does not
+        care ignores it.
 
         The ordering is the plan's own deterministic order, which is the order
         the application passes statements to ``execute``. An empty plan compiles

--- a/src/delta_engine/cli/declarations.py
+++ b/src/delta_engine/cli/declarations.py
@@ -7,7 +7,7 @@ import os
 import sys
 from types import ModuleType
 
-from delta_engine.application.engine import prepare_desired_tables
+from delta_engine.application.engine import lower_desired_tables
 from delta_engine.cli.errors import ConfigError
 from delta_engine.schema import DeltaTable
 
@@ -59,9 +59,9 @@ def load_declarations(reference: DeclarationRef) -> tuple[DeltaTable, ...]:
     module = _import_module(reference.module_name)
     value = _attribute(module, reference)
     tables = _tables_from_attribute(value, reference)
-    # The engine's own preparation step owns the duplicate-name rule; running
+    # The engine's own lowering step owns the duplicate-name rule; running
     # it here surfaces the same typed error before a connection is opened.
-    prepare_desired_tables(*tables)
+    lower_desired_tables(*tables)
     return tables
 
 

--- a/src/delta_engine/domain/plan/diff.py
+++ b/src/delta_engine/domain/plan/diff.py
@@ -19,7 +19,6 @@ from delta_engine.domain.model import (
     Map,
     ObservedColumn,
     ObservedTable,
-    PrimaryKeyConstraint,
     QualifiedName,
     Struct,
     TableAspect,
@@ -454,9 +453,9 @@ def _diff_primary_key(
     identity. The comparison runs against raw observed names, not the
     rename-projected frame used by columns and layout: renaming a constrained
     column drops the constraint, so a renamed key must surface as an explicit
-    drop and set. ``SetPrimaryKey`` respells its columns from the observed
-    table: ADD CONSTRAINT resolves column names case-sensitively, so existing
-    columns must wear the catalog's spelling.
+    drop and set. Actions are semantic values: ``SetPrimaryKey`` carries the
+    declared columns verbatim, and the SQL compiler respells rendered
+    references to the catalog's spelling.
     """
     desired_key = desired.primary_key
     observed_key = observed.primary_key
@@ -470,19 +469,8 @@ def _diff_primary_key(
     if observed_key is not None:
         actions.append(DropPrimaryKey(primary_key=observed_key))
     if desired_key is not None:
-        actions.append(SetPrimaryKey(primary_key=_respell_primary_key(desired_key, observed)))
+        actions.append(SetPrimaryKey(primary_key=desired_key))
     return tuple(actions)
-
-
-def _respell_primary_key(
-    primary_key: PrimaryKeyConstraint, observed: ObservedTable
-) -> PrimaryKeyConstraint:
-    """Existing columns wear the catalog's spelling; new columns keep the declared."""
-    spellings = {column.name: column.name for column in observed.columns}
-    return replace(
-        primary_key,
-        columns=tuple(spellings.get(name, name) for name in primary_key.columns),
-    )
 
 
 def _diff_table_metadata(

--- a/tests/adapters/databricks/spark/test_executor.py
+++ b/tests/adapters/databricks/spark/test_executor.py
@@ -3,6 +3,7 @@ import pyspark.sql.types as T
 from delta_engine.adapters.databricks.spark._runner import SparkSqlRunner
 from delta_engine.adapters.databricks.spark.executor import SparkExecutor
 from delta_engine.adapters.databricks.sql import compile_plan
+from delta_engine.application.ports import CatalogSpellings
 from delta_engine.domain.model import (
     DesiredColumn,
     DesiredTable,
@@ -24,6 +25,8 @@ from tests.config import TEST_CATALOG
 
 # ----------- Test helpers
 
+_NO_SPELLINGS = CatalogSpellings(())
+
 
 def _dummy_qualified_name() -> QualifiedName:
     return QualifiedName("cat", "sch", "tbl")
@@ -32,7 +35,7 @@ def _dummy_qualified_name() -> QualifiedName:
 def _apply(spark, plan: ActionPlan) -> None:
     """Compile and execute each statement, as the engine drives the adapter."""
     executor = SparkExecutor(SparkSqlRunner(spark))
-    for statement in executor.compile(plan):
+    for statement in executor.compile(plan, _NO_SPELLINGS):
         executor.execute(statement)
 
 
@@ -277,10 +280,10 @@ def test_compile_returns_the_statements_execute_would_run():
     executor = SparkExecutor(SparkSqlRunner(_FakeSpark()))
 
     # When compiling without executing
-    statements = executor.compile(plan)
+    statements = executor.compile(plan, _NO_SPELLINGS)
 
     # Then the statements match the SQL compiler's output, in plan order
-    assert statements == compile_plan(plan)
+    assert statements == compile_plan(plan, _NO_SPELLINGS)
     assert len(statements) == 1
     assert "COMMENT" in statements[0].upper()
 
@@ -288,4 +291,4 @@ def test_compile_returns_the_statements_execute_would_run():
 def test_compile_of_empty_plan_returns_no_statements():
     executor = SparkExecutor(SparkSqlRunner(_FakeSpark()))
     plan = ActionPlan(target=QualifiedName("cat", "schema", "tbl"))
-    assert executor.compile(plan) == ()
+    assert executor.compile(plan, _NO_SPELLINGS) == ()

--- a/tests/adapters/databricks/sql/test_compile.py
+++ b/tests/adapters/databricks/sql/test_compile.py
@@ -4,6 +4,7 @@ from hypothesis import given
 import pytest
 
 from delta_engine.adapters.databricks.sql.compile import compile_plan
+from delta_engine.application.ports import CatalogSpellings
 from delta_engine.domain.model import (
     DesiredColumn,
     DesiredTable,
@@ -48,6 +49,7 @@ from tests.adapters.databricks.sql.strategies import MANAGED_PROPERTY_MAPS
 
 _TARGET = QualifiedName("cat", "sch", "tbl")
 _REFERENCED_TABLE = QualifiedName("cat", "sch", "customers")
+_NO_SPELLINGS = CatalogSpellings(())
 
 
 def _observed_column(name: str) -> ObservedColumn:
@@ -105,7 +107,7 @@ def _plan(
 
 
 def _compile_single(action: Action, kind: TableKind = TableKind.TABLE) -> str:
-    (statement,) = compile_plan(_plan(action, kind=kind))
+    (statement,) = compile_plan(_plan(action, kind=kind), _NO_SPELLINGS)
     return statement
 
 
@@ -126,7 +128,7 @@ def _concrete_action_types() -> list[type[Action]]:
 
 
 def test_compile_empty_plan_returns_empty_tuple():
-    assert compile_plan(_plan()) == ()
+    assert compile_plan(_plan(), _NO_SPELLINGS) == ()
 
 
 def test_compile_plan_compiles_each_action_in_action_plan_order():
@@ -138,7 +140,7 @@ def test_compile_plan_compiles_each_action_in_action_plan_order():
     )
 
     # When compiling the plan
-    statements = compile_plan(plan)
+    statements = compile_plan(plan, _NO_SPELLINGS)
 
     # Then each action in the normalized ActionPlan is compiled to its SQL statement
     assert statements == tuple(_compile_single(action) for action in plan)
@@ -150,7 +152,7 @@ def test_compile_backticks_table_and_column_identifiers():
     plan = _plan(AddColumn(DesiredColumn("weird column", Integer())), target=target)
 
     # When compiling
-    (statement,) = compile_plan(plan)
+    (statement,) = compile_plan(plan, _NO_SPELLINGS)
 
     # Then table and column identifiers are backticked
     assert statement == ("ALTER TABLE `cat-alog`.`sch ema`.`select` ADD COLUMN `weird column` INT")
@@ -499,8 +501,8 @@ def test_set_property_sql_ignores_observed_value():
     )
 
     # When compiling both
-    (first_statement,) = compile_plan(_plan(first_write))
-    (update_statement,) = compile_plan(_plan(update))
+    (first_statement,) = compile_plan(_plan(first_write), _NO_SPELLINGS)
+    (update_statement,) = compile_plan(_plan(update), _NO_SPELLINGS)
 
     # Then observed_value has no effect on rendered SQL
     assert first_statement == update_statement
@@ -573,7 +575,7 @@ def test_compile_rename_column():
         RenameColumn(old_name="customer_nm", new_name="customer_name"),
         target=QualifiedName("dev", "silver", "customers"),
     )
-    statements = compile_plan(plan)
+    statements = compile_plan(plan, _NO_SPELLINGS)
     assert statements == (
         "ALTER TABLE `dev`.`silver`.`customers` RENAME COLUMN `customer_nm` TO `customer_name`",
     )
@@ -688,7 +690,7 @@ def test_set_primary_key_emits_the_exact_bound_spelling():
     )
     plan = ActionPlan(target=_TARGET, actions=(action,))
 
-    [statement] = compile_plan(plan)
+    [statement] = compile_plan(plan, _NO_SPELLINGS)
 
     assert statement == (
         "ALTER TABLE `cat`.`sch`.`tbl` ADD CONSTRAINT `tbl_pk` PRIMARY KEY (`requestId`)"
@@ -704,7 +706,7 @@ def test_create_table_emits_declared_spelling_for_columns_and_inline_key():
     )
     plan = ActionPlan(target=_TARGET, actions=(CreateTable(table),))
 
-    [statement] = compile_plan(plan)
+    [statement] = compile_plan(plan, _NO_SPELLINGS)
 
     # Then both the column definition and the inline key carry the declared spelling
     assert "`requestId` STRING NOT NULL" in statement
@@ -721,7 +723,7 @@ def test_foreign_key_emits_exact_spelling_on_both_sides():
     )
     plan = ActionPlan(target=_TARGET, actions=(SetForeignKey(constraint=constraint),))
 
-    [statement] = compile_plan(plan)
+    [statement] = compile_plan(plan, _NO_SPELLINGS)
 
     # Then both sides carry their exact declared spelling
     assert "FOREIGN KEY (`orderRef`)" in statement
@@ -737,6 +739,6 @@ def test_drop_foreign_key_emits_the_exact_observed_constraint_name():
     )
     plan = ActionPlan(target=_TARGET, actions=(DropForeignKey(constraint=constraint),))
 
-    [statement] = compile_plan(plan)
+    [statement] = compile_plan(plan, _NO_SPELLINGS)
 
     assert "DROP CONSTRAINT IF EXISTS `Legacy_FK_Name`" in statement

--- a/tests/adapters/databricks/sql/test_compile_spelling.py
+++ b/tests/adapters/databricks/sql/test_compile_spelling.py
@@ -1,0 +1,304 @@
+"""
+The uniform spelling law, observed through the public compiler.
+
+Every column reference the compiler renders is respelled: the catalog's
+spelling where the column is known, the given spelling unchanged where it
+is not. Scenarios that previously pinned respelling at the resolver and the
+differ are pinned here instead — translation owns spelling.
+"""
+
+import inspect
+
+from delta_engine.adapters.databricks.sql.compile import compile_plan
+from delta_engine.adapters.databricks.sql.respell import _respell
+from delta_engine.application.ports import CatalogSpellings
+from delta_engine.domain.model import (
+    DesiredColumn,
+    DesiredTable,
+    ObservedColumn,
+    ObservedTable,
+    QualifiedName,
+    String,
+)
+from delta_engine.domain.model.constraints import ForeignKeyConstraint, PrimaryKeyConstraint
+import delta_engine.domain.plan.actions as actions_module
+from delta_engine.domain.plan.actions import (
+    Action,
+    ActionPlan,
+    CreateTable,
+    DropForeignKey,
+    DropPrimaryKey,
+    EnableTableFeature,
+    RenameColumn,
+    SetColumnComment,
+    SetForeignKey,
+    SetPrimaryKey,
+    SetProperty,
+    SetTableComment,
+    SetTableTag,
+    UnsetProperty,
+    UnsetTableTag,
+)
+
+_ORDERS = QualifiedName("dev", "silver", "orders")
+_CUSTOMERS = QualifiedName("dev", "silver", "customers")
+_EMPLOYEES = QualifiedName("dev", "silver", "employees")
+
+
+def _desired(name: QualifiedName, *columns: str) -> DesiredTable:
+    return DesiredTable(
+        qualified_name=name,
+        columns=tuple(DesiredColumn(column, String()) for column in columns),
+    )
+
+
+def _observed(name: QualifiedName, *columns: str) -> ObservedTable:
+    return ObservedTable(
+        qualified_name=name,
+        columns=tuple(ObservedColumn(column, String()) for column in columns),
+    )
+
+
+def _sql(action: Action, spellings: CatalogSpellings, target: QualifiedName = _ORDERS) -> str:
+    (statement,) = compile_plan(ActionPlan(target=target, actions=(action,)), spellings)
+    return statement
+
+
+def test_set_primary_key_wears_the_catalog_spelling():
+    # Given a PK declared camelCase over a column the catalog spells lowercase
+    spellings = CatalogSpellings(((_desired(_ORDERS, "orderId"), _observed(_ORDERS, "orderid")),))
+    action = SetPrimaryKey(primary_key=PrimaryKeyConstraint(("orderId",), "orders_pk"))
+
+    # Then ADD CONSTRAINT carries the catalog's spelling
+    assert _sql(action, spellings) == (
+        "ALTER TABLE `dev`.`silver`.`orders` ADD CONSTRAINT `orders_pk` PRIMARY KEY (`orderid`)"
+    )
+
+
+def test_set_primary_key_keeps_the_declared_spelling_for_new_columns():
+    # Given a PK over a declared column the catalog has not seen yet
+    spellings = CatalogSpellings(((_desired(_ORDERS, "orderId"), _observed(_ORDERS, "other")),))
+    action = SetPrimaryKey(primary_key=PrimaryKeyConstraint(("orderId",), "orders_pk"))
+
+    # Then the new column keeps its declared spelling
+    assert _sql(action, spellings) == (
+        "ALTER TABLE `dev`.`silver`.`orders` ADD CONSTRAINT `orders_pk` PRIMARY KEY (`orderId`)"
+    )
+
+
+def test_set_foreign_key_wears_the_catalog_spelling_on_both_sides():
+    # Given child column "customerId" the catalog spells "customerid", referencing
+    # parent column "Id" the catalog spells "id"
+    spellings = CatalogSpellings(
+        (
+            (_desired(_ORDERS, "customerId"), _observed(_ORDERS, "customerid")),
+            (_desired(_CUSTOMERS, "Id"), _observed(_CUSTOMERS, "id")),
+        )
+    )
+    action = SetForeignKey(
+        constraint=ForeignKeyConstraint(
+            local_columns=("customerId",),
+            referenced_table=_CUSTOMERS,
+            referenced_columns=("Id",),
+            constraint_name="orders_customer_fk",
+        )
+    )
+
+    assert _sql(action, spellings) == (
+        "ALTER TABLE `dev`.`silver`.`orders` ADD CONSTRAINT `orders_customer_fk`"
+        " FOREIGN KEY (`customerid`) REFERENCES `dev`.`silver`.`customers` (`id`)"
+    )
+
+
+def test_referenced_spelling_of_a_parent_created_this_sync_is_the_declared_one():
+    # Given the referenced parent does not exist yet: declared spelling is all there is
+    spellings = CatalogSpellings(
+        (
+            (_desired(_ORDERS, "customerId"), _observed(_ORDERS, "customerid")),
+            (_desired(_CUSTOMERS, "Id"), None),
+        )
+    )
+    action = SetForeignKey(
+        constraint=ForeignKeyConstraint(
+            local_columns=("customerId",),
+            referenced_table=_CUSTOMERS,
+            referenced_columns=("Id",),
+            constraint_name="orders_customer_fk",
+        )
+    )
+
+    assert _sql(action, spellings) == (
+        "ALTER TABLE `dev`.`silver`.`orders` ADD CONSTRAINT `orders_customer_fk`"
+        " FOREIGN KEY (`customerid`) REFERENCES `dev`.`silver`.`customers` (`Id`)"
+    )
+
+
+def test_self_referencing_foreign_key_wears_its_own_catalog_spelling():
+    # Given a self-referencing key declared lowercase against camelCase catalog columns
+    spellings = CatalogSpellings(
+        ((_desired(_EMPLOYEES, "id", "managerid"), _observed(_EMPLOYEES, "Id", "ManagerId")),)
+    )
+    action = SetForeignKey(
+        constraint=ForeignKeyConstraint(
+            local_columns=("managerid",),
+            referenced_table=_EMPLOYEES,
+            referenced_columns=("id",),
+            constraint_name="employees_manager_fk",
+        )
+    )
+
+    assert _sql(action, spellings, target=_EMPLOYEES) == (
+        "ALTER TABLE `dev`.`silver`.`employees` ADD CONSTRAINT `employees_manager_fk`"
+        " FOREIGN KEY (`ManagerId`) REFERENCES `dev`.`silver`.`employees` (`Id`)"
+    )
+
+
+def test_foreign_key_to_a_renamed_parent_key_keeps_the_new_declared_name():
+    # Given a parent renaming its key column — the catalog still spells the old
+    # name — and a child referencing the declared new name
+    spellings = CatalogSpellings(
+        (
+            (_desired(_ORDERS, "ref_id"), _observed(_ORDERS, "id", "ref_id")),
+            (_desired(_CUSTOMERS, "orderNumber"), _observed(_CUSTOMERS, "OrderId")),
+        )
+    )
+    action = SetForeignKey(
+        constraint=ForeignKeyConstraint(
+            local_columns=("ref_id",),
+            referenced_table=_CUSTOMERS,
+            referenced_columns=("orderNumber",),
+            constraint_name="orders_ref_fk",
+        )
+    )
+
+    # Then the reference keeps the declared post-rename name, not the observed old one
+    assert _sql(action, spellings) == (
+        "ALTER TABLE `dev`.`silver`.`orders` ADD CONSTRAINT `orders_ref_fk`"
+        " FOREIGN KEY (`ref_id`) REFERENCES `dev`.`silver`.`customers` (`orderNumber`)"
+    )
+
+
+def test_ordinary_ddl_wears_the_catalog_spelling():
+    # Given a column comment addressed with declared casing over a drifted catalog —
+    # the law is uniform, not a constraint-DDL carve-out
+    spellings = CatalogSpellings(
+        ((_desired(_ORDERS, "CustomerID"), _observed(_ORDERS, "customerid")),)
+    )
+    action = SetColumnComment(column_name="CustomerID", desired_comment="who", observed_comment="")
+
+    assert _sql(action, spellings) == (
+        "ALTER TABLE `dev`.`silver`.`orders` ALTER COLUMN `customerid` COMMENT 'who'"
+    )
+
+
+def test_rename_column_wears_catalog_source_and_declared_target():
+    # Given a rename whose source exists in the catalog and whose target does not
+    spellings = CatalogSpellings(((_desired(_ORDERS, "OrderId"), _observed(_ORDERS, "legacyid")),))
+    action = RenameColumn(old_name="LegacyId", new_name="OrderId")
+
+    assert _sql(action, spellings) == (
+        "ALTER TABLE `dev`.`silver`.`orders` RENAME COLUMN `legacyid` TO `OrderId`"
+    )
+
+
+def test_unregistered_referenced_table_keeps_the_given_spelling():
+    # Given an FK whose referenced table is not in the spellings at all
+    spellings = CatalogSpellings(((_desired(_ORDERS, "ref_id"), _observed(_ORDERS, "ref_id")),))
+    action = SetForeignKey(
+        constraint=ForeignKeyConstraint(
+            local_columns=("ref_id",),
+            referenced_table=_CUSTOMERS,
+            referenced_columns=("Id",),
+            constraint_name="orders_ref_fk",
+        )
+    )
+
+    assert _sql(action, spellings) == (
+        "ALTER TABLE `dev`.`silver`.`orders` ADD CONSTRAINT `orders_ref_fk`"
+        " FOREIGN KEY (`ref_id`) REFERENCES `dev`.`silver`.`customers` (`Id`)"
+    )
+
+
+def test_create_table_renders_the_declared_spelling_verbatim():
+    # Given a table created this sync: its declared spelling is the only one
+    table = DesiredTable(
+        qualified_name=_ORDERS,
+        columns=(DesiredColumn("OrderId", String(), nullable=False),),
+        primary_key=PrimaryKeyConstraint(("OrderId",), "orders_pk"),
+    )
+    spellings = CatalogSpellings(((table, None),))
+
+    assert _sql(CreateTable(table), spellings) == (
+        "CREATE TABLE `dev`.`silver`.`orders`"
+        " (`OrderId` STRING NOT NULL, CONSTRAINT `orders_pk` PRIMARY KEY (`OrderId`))"
+        " USING delta"
+    )
+
+
+def test_respelling_is_idempotent_over_already_catalog_spelled_actions():
+    # Given the same constraint spelled as declared and as the catalog does —
+    # the migration-safety property: upstream may pre-respell without changing SQL
+    spellings = CatalogSpellings(
+        (
+            (_desired(_ORDERS, "customerId"), _observed(_ORDERS, "customerid")),
+            (_desired(_CUSTOMERS, "Id"), _observed(_CUSTOMERS, "id")),
+        )
+    )
+    declared = SetForeignKey(
+        constraint=ForeignKeyConstraint(("customerId",), _CUSTOMERS, ("Id",), "fk")
+    )
+    catalog = SetForeignKey(
+        constraint=ForeignKeyConstraint(("customerid",), _CUSTOMERS, ("id",), "fk")
+    )
+
+    assert _sql(declared, spellings) == _sql(catalog, spellings)
+
+
+def test_empty_spellings_render_the_declared_spelling_verbatim():
+    # Given no spellings at all, SQL is exactly what the plan declares
+    action = SetPrimaryKey(primary_key=PrimaryKeyConstraint(("orderId",), "orders_pk"))
+
+    assert _sql(action, CatalogSpellings(())) == (
+        "ALTER TABLE `dev`.`silver`.`orders` ADD CONSTRAINT `orders_pk` PRIMARY KEY (`orderId`)"
+    )
+
+
+def _concrete_action_types() -> list[type[Action]]:
+    """
+    Return every concrete Action subclass exposed by the actions module.
+
+    This uses the module namespace rather than Action.__subclasses__() because
+    dataclass(slots=True) can leave stale pre-slots class objects there.
+    """
+    return [
+        obj
+        for _, obj in inspect.getmembers(actions_module, inspect.isclass)
+        if issubclass(obj, Action)
+        and obj is not Action
+        and not getattr(obj, "__abstractmethods__", False)
+    ]
+
+
+# Actions that render no column references; everything else must be registered
+# on the respell dispatcher. A new action type lands here or there — never in
+# neither.
+_SPELLING_FREE_ACTIONS = {
+    DropForeignKey,  # renders only the constraint name
+    DropPrimaryKey,  # DROP PRIMARY KEY renders no columns
+    EnableTableFeature,
+    SetProperty,
+    SetTableComment,
+    SetTableTag,
+    UnsetProperty,
+    UnsetTableTag,
+}
+
+
+def test_every_action_type_is_respelled_or_explicitly_spelling_free():
+    respelled = set(_respell.registry) - {object}
+    unaccounted = [
+        action_type.__name__
+        for action_type in _concrete_action_types()
+        if action_type not in respelled and action_type not in _SPELLING_FREE_ACTIONS
+    ]
+    assert unaccounted == [], f"neither respelled nor declared spelling-free: {unaccounted}"

--- a/tests/adapters/databricks/warehouse/test_executor.py
+++ b/tests/adapters/databricks/warehouse/test_executor.py
@@ -8,10 +8,12 @@ from delta_engine.adapters.databricks.sql import compile_plan
 from delta_engine.adapters.databricks.warehouse._runner import WarehouseSqlRunner
 from delta_engine.adapters.databricks.warehouse.executor import WarehouseExecutor
 from delta_engine.application.errors import ExecutionError
+from delta_engine.application.ports import CatalogSpellings
 from delta_engine.domain.model import QualifiedName
 from delta_engine.domain.plan import ActionPlan, SetTableComment
 
 QN = QualifiedName("cat", "sch", "tbl")
+_NO_SPELLINGS = CatalogSpellings(())
 
 
 def _executor(connection) -> WarehouseExecutor:
@@ -107,9 +109,9 @@ def test_compile_returns_backend_statements_without_touching_connection():
         actions=(SetTableComment(desired_comment="hello", observed_comment=""),),
     )
 
-    statements = executor.compile(plan)
+    statements = executor.compile(plan, _NO_SPELLINGS)
 
-    assert statements == compile_plan(plan)
+    assert statements == compile_plan(plan, _NO_SPELLINGS)
     assert len(statements) == 1
     assert connection.cursor_requests == 0
 
@@ -117,7 +119,7 @@ def test_compile_returns_backend_statements_without_touching_connection():
 def test_compile_of_empty_plan_returns_no_statements():
     connection = FakeConnection()
 
-    statements = _executor(connection).compile(ActionPlan(target=QN))
+    statements = _executor(connection).compile(ActionPlan(target=QN), _NO_SPELLINGS)
 
     assert statements == ()
     assert connection.cursor_requests == 0

--- a/tests/application/test_engine.py
+++ b/tests/application/test_engine.py
@@ -1714,3 +1714,30 @@ def test_compile_receives_catalog_spellings_built_from_every_run():
     assert executor.spellings is not None
     assert str(executor.spellings.spelling(_qualified_name("dev.silver.orders"), "id")) == "ID"
     assert str(executor.spellings.spelling(_qualified_name("dev.silver.customers"), "id")) == "id"
+
+
+def test_planned_sql_wears_the_catalog_spelling_for_constraint_ddl():
+    # Given a declared camelCase PK over a column the catalog spells lowercase
+    spec = DeltaTable(
+        "dev",
+        "silver",
+        "orders",
+        columns=(Column("OrderId", String(), nullable=False),),
+        primary_key=["OrderId"],
+    )
+    observed = ObservedTable(
+        qualified_name=_qualified_name("dev.silver.orders"),
+        columns=(ObservedColumn("orderid", String(), nullable=False),),
+    )
+    reader = _RecordingReader({"dev.silver.orders": TablePresent(observed)})
+    executor = _SqlRecordingExecutor()
+
+    # When previewed
+    report = Engine(reader, executor).sync(spec, dry_run=True)
+
+    # Then ADD CONSTRAINT wears the catalog's spelling in the emitted SQL
+    [orders] = report.table_reports
+    assert (
+        "ALTER TABLE `dev`.`silver`.`orders` ADD CONSTRAINT `orders_pk`"
+        " PRIMARY KEY (`orderid`)" in orders.planned_sql_statements
+    )

--- a/tests/application/test_engine.py
+++ b/tests/application/test_engine.py
@@ -16,6 +16,7 @@ from delta_engine.application.failures import (
     ReadFailure,
 )
 from delta_engine.application.ports import (
+    CatalogSpellings,
     CatalogState,
     ExecutionSucceeded,
     TableAbsent,
@@ -269,7 +270,7 @@ class _RecordingExecutor:
         self._per_table_errors = None if per_table_errors is None else list(per_table_errors)
         self._active_table: str | None = None
 
-    def compile(self, plan: ActionPlan) -> tuple[str, ...]:
+    def compile(self, plan: ActionPlan, spellings: CatalogSpellings) -> tuple[str, ...]:
         return tuple(
             f"STATEMENT {index} AS {plan.kind.name} FOR {plan.target}" for index in range(len(plan))
         )
@@ -305,8 +306,8 @@ class _SqlRecordingExecutor:
     def __init__(self) -> None:
         self.executed_statements: list[str] = []
 
-    def compile(self, plan: ActionPlan) -> tuple[str, ...]:
-        return compile_plan(plan)
+    def compile(self, plan: ActionPlan, spellings: CatalogSpellings) -> tuple[str, ...]:
+        return compile_plan(plan, spellings)
 
     def execute(self, statement: str) -> None:
         self.executed_statements.append(statement)
@@ -318,7 +319,7 @@ class _FailingMultiStatementExecutor:
     def __init__(self) -> None:
         self.calls: list[str] = []
 
-    def compile(self, plan: ActionPlan) -> tuple[str, ...]:
+    def compile(self, plan: ActionPlan, spellings: CatalogSpellings) -> tuple[str, ...]:
         return tuple(f"STATEMENT {index} FOR {plan.target}" for index in range(3))
 
     def execute(self, statement: str) -> None:
@@ -567,7 +568,7 @@ def test_all_reads_complete_before_execution_and_a_read_failure_blocks_only_its_
             return TableAbsent()
 
     class _EventRecordingExecutor:
-        def compile(self, plan: ActionPlan) -> tuple[str, ...]:
+        def compile(self, plan: ActionPlan, spellings: CatalogSpellings) -> tuple[str, ...]:
             # The name is embedded so execute can recover the target table.
             return tuple(f"STATEMENT {index} FOR {plan.target}" for index in range(len(plan)))
 
@@ -734,7 +735,7 @@ def test_execution_stops_after_first_failure_and_retains_attempted_results():
 
 def test_unexpected_executor_exception_propagates():
     class BuggyExecutor:
-        def compile(self, plan: ActionPlan) -> tuple[str, ...]:
+        def compile(self, plan: ActionPlan, spellings: CatalogSpellings) -> tuple[str, ...]:
             return (f"STATEMENT FOR {plan.target}",)
 
         def execute(self, _statement: str) -> None:
@@ -1678,3 +1679,38 @@ def test_foreign_key_sql_uses_observed_names_from_both_registered_tables():
         "FOREIGN KEY (`orderRef`) REFERENCES `c`.`s`.`parent` (`OrderId`)" in statement
         for statement in child_report.planned_sql_statements
     )
+
+
+class _SpellingsRecordingExecutor:
+    """Record the spellings value crossing the compile boundary."""
+
+    def __init__(self) -> None:
+        self.spellings: CatalogSpellings | None = None
+
+    def compile(self, plan: ActionPlan, spellings: CatalogSpellings) -> tuple[str, ...]:
+        self.spellings = spellings
+        return ()
+
+    def execute(self, statement: str) -> None:
+        raise AssertionError("dry run must not execute")
+
+
+def test_compile_receives_catalog_spellings_built_from_every_run():
+    # Given a present table whose catalog spells "id" as "ID", and an absent table
+    observed = ObservedTable(
+        qualified_name=_qualified_name("dev.silver.orders"),
+        columns=(ObservedColumn("ID", String(), nullable=False),),
+    )
+    reader = _RecordingReader({"dev.silver.orders": TablePresent(observed)})
+    executor = _SpellingsRecordingExecutor()
+
+    # When synced
+    Engine(reader, executor).sync(
+        _spec("dev.silver.orders"), _spec("dev.silver.customers"), dry_run=True
+    )
+
+    # Then one spellings view crosses the boundary: catalog spelling for the
+    # observed column, declared spelling for the absent table's column
+    assert executor.spellings is not None
+    assert str(executor.spellings.spelling(_qualified_name("dev.silver.orders"), "id")) == "ID"
+    assert str(executor.spellings.spelling(_qualified_name("dev.silver.customers"), "id")) == "id"

--- a/tests/application/test_ports.py
+++ b/tests/application/test_ports.py
@@ -2,9 +2,20 @@ import pytest
 
 from delta_engine.application.failures import ExecutionFailure
 from delta_engine.application.ports import (
+    CatalogSpellings,
     ExecutionSucceeded,
     ExecutionSummary,
 )
+from delta_engine.domain.model import (
+    DesiredColumn,
+    DesiredTable,
+    ObservedColumn,
+    ObservedTable,
+    QualifiedName,
+    String,
+)
+
+_ORDERS = QualifiedName("dev", "silver", "orders")
 
 
 def _ok_exec(idx=0, preview="ALTER TABLE ..."):
@@ -61,3 +72,50 @@ def test_execution_summary_rejects_non_contiguous_statement_indexes():
 def test_execution_summary_rejects_results_after_a_failure():
     with pytest.raises(ValueError, match="after a failure"):
         ExecutionSummary((_failed_exec(0), _ok_exec(1)))
+
+
+def _desired_table(*column_names: str) -> DesiredTable:
+    return DesiredTable(
+        qualified_name=_ORDERS,
+        columns=tuple(DesiredColumn(name, String()) for name in column_names),
+    )
+
+
+def _observed_table(*column_names: str) -> ObservedTable:
+    return ObservedTable(
+        qualified_name=_ORDERS,
+        columns=tuple(ObservedColumn(name, String()) for name in column_names),
+    )
+
+
+def test_catalog_spellings_prefer_the_observed_spelling_across_casing():
+    # Given a column declared "CustomerID" that the catalog spells "customerid"
+    spellings = CatalogSpellings(((_desired_table("CustomerID"), _observed_table("customerid")),))
+
+    # Then the effective spelling is the catalog's, however the caller cases the lookup
+    assert str(spellings.spelling(_ORDERS, "CustomerID")) == "customerid"
+    assert str(spellings.spelling(_ORDERS, "CUSTOMERID")) == "customerid"
+
+
+def test_catalog_spellings_fall_back_to_the_declared_spelling_for_unobserved_columns():
+    # Given a declared column the catalog has not seen yet
+    spellings = CatalogSpellings(((_desired_table("newCol"), _observed_table("other")),))
+
+    # Then the declared spelling is returned verbatim
+    assert str(spellings.spelling(_ORDERS, "newCol")) == "newCol"
+
+
+def test_catalog_spellings_keep_the_declared_spelling_when_the_table_is_absent():
+    # Given a registered table with no observed counterpart (created this sync)
+    spellings = CatalogSpellings(((_desired_table("OrderId"), None),))
+
+    # Then the declared spelling is the only spelling there is
+    assert str(spellings.spelling(_ORDERS, "orderid")) == "OrderId"
+
+
+def test_catalog_spellings_return_the_given_spelling_for_unknown_tables_and_columns():
+    # Given an empty lookup
+    spellings = CatalogSpellings(())
+
+    # Then any spelling passes through unchanged — the rule is total
+    assert str(spellings.spelling(_ORDERS, "Whatever")) == "Whatever"

--- a/tests/cli/conftest.py
+++ b/tests/cli/conftest.py
@@ -10,6 +10,7 @@ from typer.testing import CliRunner
 from delta_engine.application.engine import Engine
 from delta_engine.application.errors import ReadError
 from delta_engine.application.ports import (
+    CatalogSpellings,
     CatalogState,
     TableAbsent,
     TablePresent,
@@ -51,7 +52,7 @@ class FakeReader:
 class FakeExecutor:
     """Executor that compiles one pseudo-statement per action and always succeeds."""
 
-    def compile(self, plan: ActionPlan) -> tuple[str, ...]:
+    def compile(self, plan: ActionPlan, spellings: CatalogSpellings) -> tuple[str, ...]:
         return tuple(f"-- {plan.target}: {type(action).__name__}" for action in plan)
 
     def execute(self, statement: str) -> None:

--- a/tests/domain/plan/test_diff.py
+++ b/tests/domain/plan/test_diff.py
@@ -741,7 +741,7 @@ def test_changed_primary_key_produces_drop_and_set_actions():
     )
 
 
-def test_set_primary_key_adopts_the_catalog_column_spelling():
+def test_set_primary_key_carries_the_declared_spelling():
     # Given a PK declared camelCase over a column the catalog spells lowercase
     desired = _desired(
         columns=(DesiredColumn("orderId", String(), nullable=False),),
@@ -752,24 +752,8 @@ def test_set_primary_key_adopts_the_catalog_column_spelling():
     # When the table is diffed
     drift = diff_table(desired, observed)
 
-    # Then ADD CONSTRAINT will carry the catalog's spelling
-    set_actions = [a for a in drift.actions if isinstance(a, SetPrimaryKey)]
-    assert len(set_actions) == 1
-    assert tuple(str(c) for c in set_actions[0].primary_key.columns) == ("orderid",)
-
-
-def test_set_primary_key_keeps_declared_spelling_for_new_columns():
-    # Given a PK over a column that does not exist in the catalog yet
-    desired = _desired(
-        columns=(DesiredColumn("orderId", String(), nullable=False),),
-        primary_key=PrimaryKeyConstraint(columns=("orderId",), constraint_name="orders_pk"),
-    )
-    observed = _observed(columns=(ObservedColumn("other", String(), nullable=False),))
-
-    # When the table is diffed
-    drift = diff_table(desired, observed)
-
-    # Then the new column keeps its declared spelling
+    # Then the action is a semantic value: declared spelling, untouched —
+    # the SQL compiler owns catalog spelling at rendering
     set_actions = [a for a in drift.actions if isinstance(a, SetPrimaryKey)]
     assert len(set_actions) == 1
     assert tuple(str(c) for c in set_actions[0].primary_key.columns) == ("orderId",)


### PR DESCRIPTION
> **Stacked on #290** (`refactor/relationship-resolver`). Retarget to `main` when #290 merges. PR 1 of the three-PR pipeline-laws staging.

## What

Column-spelling normalisation moves into the SQL compiler (translation), and the differ's respell-at-emission special case is deleted:

- `CatalogSpellings` (application/ports.py): one value answering "how does the catalog spell this column?" — the catalog's spelling where the column was observed, the given spelling unchanged otherwise (new columns, rename targets, tables created this sync, unregistered tables). Lookups are `Identifier`-keyed, so the rule is total and case-insensitive.
- The Databricks compiler runs one uniform respell pass (`sql/respell.py`) at the head of `compile_plan`: every rendered column reference is respelled — ordinary DDL and constraint DDL alike, no per-operation carve-outs. Stored `ActionPlan`s keep their declared spellings; only emitted SQL is normalised. A tripwire test forces every action type to be either registered on the respell dispatcher or explicitly declared spelling-free.
- The port grows the argument: `PlanExecutor.compile(plan, spellings)`. The engine builds one `CatalogSpellings` view per sync from every run's declared and observed columns and passes it across the boundary; both executors forward it.
- The differ's `_respell_primary_key` is deleted — `SetPrimaryKey` now carries the declared columns verbatim, like every other action. An engine-level pin proves the catalog spelling still reaches the emitted SQL end-to-end.
- `prepare_desired_tables` → `lower_desired_tables`: the system lowers at both edges — specifications into domain tables at entry, plans into SQL at translation.

## Why

Names are semantic; spelling is presentational. Case-insensitive `Identifier` equality already makes case invisible to matching, so the only place spelling matters is the rendered statement — yet it was being adjusted at two upstream emission sites (the resolver for FKs, the differ for PKs), each holding its own copy of the effective-spelling rule. Rendering it once, uniformly, at translation puts the presentation concern at the presentation boundary; emitted DDL is correct whether or not a given Databricks path resolves identifiers case-sensitively (`ADD CONSTRAINT` does).

This PR deliberately leaves the resolver's FK respell in place: the compiler's pass is idempotent over already-catalog-spelled actions, which is the migration contract that keeps SQL byte-identical. The resolver's copy dies in PR 2 with the rest of its machinery.

## Verification

- Full suite 1102 passed (baseline 1084), coverage 96.68%; ruff, format, mypy, lint-imports (7 contracts kept), sphinx `-W` all green.
- **Byte-identical SQL:** no existing SQL string assertion changed anywhere in the suite; `test_planned_sql_wears_the_catalog_spelling_for_constraint_ddl` passed before and after the differ deletion.
- **Live suites are untouched by this branch — that is the contract.** The spelling cases in `tests/live/test_sql_warehouse_live_constraints.py` (`test_foreign_key_uses_catalog_column_spelling_on_both_sides`, `test_primary_key_uses_the_catalog_column_spelling`) now exercise the compiler's respell path end-to-end and are the ones worth running with credentials before merge.
