### PR TITLE
ci: test supported Python endpoints

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -152,23 +152,18 @@ jobs:
           enable-cache: true
           cache-dependency-glob: uv.lock
 
-      - name: Set up Python endpoints
-        run: uv python install 3.12 3.14
+      - name: Set up Python
+        run: uv python install 3.12
 
       - name: Build sdist and wheel
-        run: uv build --python 3.12
+        run: uv build
 
       - name: Check distribution metadata
         run: uvx twine check --strict dist/*
 
-      - name: Smoke-test wheel on minimum Python
+      - name: Smoke-test wheel
         run: |
           uv run --isolated --no-project --python 3.12 --with ./dist/*.whl \
-            python -I tests/distribution/smoke_test.py
-
-      - name: Smoke-test wheel on latest stable Python
-        run: |
-          uv run --isolated --no-project --python 3.14 --with ./dist/*.whl \
             python -I tests/distribution/smoke_test.py
 
       - name: Smoke-test minimum CLI dependencies

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -97,6 +97,10 @@ jobs:
 
   test:
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.12", "3.14"]
     steps:
       - uses: actions/checkout@v5
 
@@ -107,13 +111,13 @@ jobs:
           cache-dependency-glob: uv.lock
 
       - name: Set up Python
-        run: uv python install 3.12
+        run: uv python install "${{ matrix.python-version }}"
 
       - name: Install dependencies
-        run: uv sync --locked --group dev
+        run: uv sync --locked --group dev --python "${{ matrix.python-version }}"
 
       - name: Test
-        run: uv run pytest -q
+        run: uv run --python "${{ matrix.python-version }}" pytest -q
 
   docs:
     runs-on: ubuntu-latest
@@ -148,18 +152,23 @@ jobs:
           enable-cache: true
           cache-dependency-glob: uv.lock
 
-      - name: Set up Python
-        run: uv python install 3.12
+      - name: Set up Python endpoints
+        run: uv python install 3.12 3.14
 
       - name: Build sdist and wheel
-        run: uv build
+        run: uv build --python 3.12
 
       - name: Check distribution metadata
         run: uvx twine check --strict dist/*
 
-      - name: Smoke-test wheel
+      - name: Smoke-test wheel on minimum Python
         run: |
           uv run --isolated --no-project --python 3.12 --with ./dist/*.whl \
+            python -I tests/distribution/smoke_test.py
+
+      - name: Smoke-test wheel on latest stable Python
+        run: |
+          uv run --isolated --no-project --python 3.14 --with ./dist/*.whl \
             python -I tests/distribution/smoke_test.py
 
       - name: Smoke-test minimum CLI dependencies

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -46,11 +46,11 @@ jobs:
           enable-cache: true
           cache-dependency-glob: uv.lock
 
-      - name: Set up Python
-        run: uv python install 3.12
+      - name: Set up Python endpoints
+        run: uv python install 3.12 3.14
 
       - name: Install dev dependencies
-        run: uv sync --locked --group dev
+        run: uv sync --locked --group dev --python 3.12
 
       - name: Determine mode
         id: mode
@@ -108,16 +108,24 @@ jobs:
 
       - name: Build sdist and wheel
         if: steps.mode.outputs.publish == 'true'
-        run: uv build
+        run: uv build --python 3.12
 
       - name: Check distribution metadata
         if: steps.mode.outputs.publish == 'true'
         run: uvx twine check --strict dist/*
 
-      - name: Smoke-test wheel
+      - name: Smoke-test wheel on minimum Python
         if: steps.mode.outputs.publish == 'true'
         run: |
           uv run --isolated --no-project --python 3.12 --with ./dist/*.whl \
+            python -I tests/distribution/smoke_test.py \
+            --expected-version "${{ steps.notes.outputs.version }}"
+
+      - name: Smoke-test wheel on latest stable Python
+        # Existing tags retain the compatibility validation from their own release.
+        if: steps.mode.outputs.publish == 'true' && inputs.tag == ''
+        run: |
+          uv run --isolated --no-project --python 3.14 --with ./dist/*.whl \
             python -I tests/distribution/smoke_test.py \
             --expected-version "${{ steps.notes.outputs.version }}"
 

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -46,11 +46,11 @@ jobs:
           enable-cache: true
           cache-dependency-glob: uv.lock
 
-      - name: Set up Python endpoints
-        run: uv python install 3.12 3.14
+      - name: Set up Python
+        run: uv python install 3.12
 
       - name: Install dev dependencies
-        run: uv sync --locked --group dev --python 3.12
+        run: uv sync --locked --group dev
 
       - name: Determine mode
         id: mode
@@ -108,24 +108,16 @@ jobs:
 
       - name: Build sdist and wheel
         if: steps.mode.outputs.publish == 'true'
-        run: uv build --python 3.12
+        run: uv build
 
       - name: Check distribution metadata
         if: steps.mode.outputs.publish == 'true'
         run: uvx twine check --strict dist/*
 
-      - name: Smoke-test wheel on minimum Python
+      - name: Smoke-test wheel
         if: steps.mode.outputs.publish == 'true'
         run: |
           uv run --isolated --no-project --python 3.12 --with ./dist/*.whl \
-            python -I tests/distribution/smoke_test.py \
-            --expected-version "${{ steps.notes.outputs.version }}"
-
-      - name: Smoke-test wheel on latest stable Python
-        # Existing tags retain the compatibility validation from their own release.
-        if: steps.mode.outputs.publish == 'true' && inputs.tag == ''
-        run: |
-          uv run --isolated --no-project --python 3.14 --with ./dist/*.whl \
             python -I tests/distribution/smoke_test.py \
             --expected-version "${{ steps.notes.outputs.version }}"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,7 @@ classifiers = [
   "Programming Language :: Python :: 3",
   "Programming Language :: Python :: 3.12",
   "Programming Language :: Python :: 3.13",
+  "Programming Language :: Python :: 3.14",
   "Topic :: Database",
   "Typing :: Typed",
 ]

--- a/tests/test_packaging.py
+++ b/tests/test_packaging.py
@@ -8,6 +8,10 @@ from packaging.requirements import Requirement
 from packaging.specifiers import SpecifierSet
 
 
+def test_distribution_requires_supported_python_floor_without_an_upper_bound():
+    assert metadata("delta-engine")["Requires-Python"] == ">=3.12"
+
+
 def test_base_distribution_has_no_unconditional_runtime_dependencies():
     requirements = requires("delta-engine") or []
 


### PR DESCRIPTION
## What changed

- run the full test job on the minimum supported Python (3.12) and latest stable Python (3.14)
- keep lint, type checking, documentation, artifact construction, and artifact smoke testing anchored to the 3.12 floor
- advertise Python 3.14 alongside the supported intermediate 3.13 classifier
- assert the `Requires-Python: >=3.12` lower-bound/no-upper-bound policy in the installed metadata tests

## Why

Delta Engine is pure Python, has no base dependencies, and contains no Python-version-specific branches. Testing the supported endpoints gives proportionate coverage: 3.12 prevents newer-only syntax or APIs from entering, while 3.14 catches forward-compatibility problems. Intermediate 3.13 remains supported without a dedicated job because it has no distinct compatibility path.

The full test matrix supplies the Python compatibility evidence. The existing single-version artifact smoke separately proves that the universal wheel installs and works without the repository checkout masking packaging mistakes. Repeating that smoke on both interpreters would not prove a distinct property.

Spark notebook compatibility remains separate and will be exercised by real Databricks Runtime smoke tests using the Python and PySpark versions supplied by Databricks.

## Impact

No runtime API or dependency changes. Pull-request CI gains one additional full-suite job but no additional artifact smoke. Release validation remains unchanged. Production metadata remains open-ended at Python 3.12 or later.

## Checks

- Python 3.12: `1097 passed, 72 deselected`
- Python 3.14: `1097 passed, 72 deselected`
- focused installed-metadata tests on both Python endpoints
- built `py3-none-any` wheel and sdist with Python 3.12
- `uvx twine check --strict dist/*`
- exact-wheel consumer smoke on Python 3.12
- `uv lock --check`
- `ruff check .`
- parsed both edited workflow YAML files
- `git diff --check`
