### PR TITLE
refactor: complete the diff and judge declarations before reading the catalog

### DIFF
--- a/docs/explanation-architecture.md
+++ b/docs/explanation-architecture.md
@@ -274,22 +274,22 @@ Failures and status are derived from those outcomes.
 sequenceDiagram
     participant User
     participant Engine
-    participant Reader as CatalogStateReader
     participant Resolver as relationships.resolve
+    participant Reader as CatalogStateReader
     participant Differ as diff_table
     participant Planner as plan_diff
     participant Executor as PlanExecutor
 
     User->>Engine: sync(customers, orders)
-    Engine->>Engine: prepare desired tables
+    Engine->>Engine: lower desired tables
+    Engine->>Resolver: resolve(desired tables)
+    Resolver-->>Engine: dependency order + dependency edges + structural verdicts
     Engine->>Reader: fetch_state(qualified_name)
     Reader-->>Engine: TablePresent / TableAbsent / ReadError
     Engine->>Engine: ReadError → ReadFailure
-    Engine->>Resolver: resolve((desired, read) pairs)
-    Resolver-->>Engine: dependency order + structural verdicts + FK actions
     Engine->>Differ: diff_table(desired, observed_or_none)
     Differ-->>Engine: TableMissing / TableDrift
-    Engine->>Planner: plan_diff(diff, relationship_actions)
+    Engine->>Planner: plan_diff(diff)
     Planner-->>Engine: PlanningSucceeded(plan) / PlanningFailed(failures)
     Engine->>Executor: compile(plan)
     Executor-->>Engine: SQL statements
@@ -301,29 +301,30 @@ sequenceDiagram
     Engine-->>User: SyncReport or SyncFailedError(report)
 ```
 
-The full run, with preparation first and reporting last bracketing the six
-phases:
+The full run, with reporting last:
 
-1. **Prepare** (before the chain): lower user-facing table declarations to
-   `DesiredTable` values and reject duplicate qualified names.
-2. **Read**: ask the reader port for the current catalog state of each table.
-3. **Resolve**: order tables dependency-first with `relationships.resolve`,
+1. **Lower**: lower user-facing table declarations to `DesiredTable` values and
+   reject duplicate qualified names.
+2. **Resolve**: order tables dependency-first with `relationships.resolve`,
    judging each declared foreign key structurally (referenced spelling
-   included) and planning the set/drop actions — declared spellings
-   verbatim — that converge it.
-4. **Diff**: compute the typed `TableDiff` with `diff_table`.
-5. **Plan**: call the total `plan_diff` boundary with the diff and the
-   resolver's relationship actions; validation always applies the default
-   policy to the merged stream. A rejected result contributes validation
-   failures and has no plan; an accepted result carries the privately
-   constructed `ActionPlan` into the next phase.
+   included) and retaining each table's dependency edges. This is pure
+   declaration analysis, so it precedes the read: a run is born knowing its
+   position, its edges, and its verdicts, before any catalog state exists.
+3. **Read**: ask the reader port for the current catalog state of each table.
+4. **Diff**: compute the typed `TableDiff` with `diff_table`, foreign-key
+   existence included.
+5. **Plan**: call the total `plan_diff` boundary with the complete diff;
+   validation always applies the default policy to that one stream. A rejected
+   result contributes validation failures and has no plan; an accepted result
+   carries the privately constructed `ActionPlan` into the next phase.
 6. **Compile**: lower every accepted plan through the executor port and record
    the exact statements used for both dry-run preview and real execution.
-7. **Execute**: walk the dependency-ordered runs, blocking every run whose
-   dependency will not reach desired state this sync, then run the compiled
-   statements of tables with a non-empty plan and no failures. Dry runs walk
-   the same gate without executing, so blocking stays visible in previews.
-8. **Report** (after the chain): return `SyncReport`, or raise
+7. **Gate**: walk the dependency-ordered runs, blocking every run whose
+   dependency will not reach desired state this sync. Dry runs walk the same
+   gate, so blocking stays visible in previews.
+8. **Execute**: run the compiled statements of tables with a non-empty plan and
+   no failures (real runs only).
+9. **Report** (after the chain): return `SyncReport`, or raise
    `SyncFailedError` with the report on real runs that failed.
 
 Execution is gated by failures derived from the retained phase outcomes. A
@@ -608,6 +609,11 @@ flowchart LR
     Orders --> OrderLines
 ```
 
+Which foreign keys a table needs set or dropped is a difference like any
+other, computed by the differ from that table's own snapshot. The resolver
+answers the cross-table question instead: what one table's declaration means
+for another's.
+
 The resolver builds a graph from desired foreign keys and uses strongly
 connected components to produce a dependency-first order. It judges each
 declared foreign key structurally and reports:
@@ -618,6 +624,8 @@ declared foreign key structurally and reports:
   referenced table's primary key.
 - `REFERENCED_COLUMN_TYPE_MISMATCH` when a foreign-key column's type does not
   match the referenced column's type on the table registered for the sync.
+- `REFERENCED_COLUMN_CASE_MISMATCH` when the referenced columns are the
+  registered parent's key but spelled with different case.
 - `CYCLE` for true multi-table FK cycles.
 
 Whether a table is *blocked* by another table's failure is not a resolution
@@ -633,8 +641,8 @@ Each mandatory gate implements the `ScopeGate` protocol over `TableDiff`; a gate
 Execution walks the dependency-first order produced by the resolver and keeps a
 set of every table that will not converge — seeded with the tables that failed
 an earlier phase, then grown as tables fail or are blocked during the walk.
-Before each table executes, the engine applies the blocking rule the resolution
-value carries (`blocking_failures`) to its foreign-key dependencies. An
+Before each table executes, the engine walks the dependency edges its
+resolution retained and blocks on any that will not converge. An
 execution failure in a parent therefore gives every later dependent a
 `BLOCKED_BY_FAILED_DEPENDENCY` failure in the same run, including a dependent
 whose own plan is empty. One pass suffices because the resolver already placed
@@ -746,11 +754,11 @@ keeps downstream planning focused on schema facts.
 ## Reporting and failure semantics
 
 Failures are phase-tagged application values. A `TableRunReport` derives its
-status from the earliest failing phase:
+status from the earliest failing phase, in pipeline order:
 
+- `FOREIGN_KEY_FAILED`
 - `READ_FAILED`
 - `PLANNING_FAILED`
-- `FOREIGN_KEY_FAILED`
 - `EXECUTION_FAILED`
 - `SUCCESS`
 
@@ -799,12 +807,12 @@ dependency cost.
 | Change                            | Main location                                                              | Notes                                                                                                                                                                                                                                       |
 | --------------------------------- | -------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | Add a new backend                 | `delta_engine.adapters`                                                    | Implement `CatalogStateReader` and `PlanExecutor`; keep backend exceptions inside the adapter.                                                                                                                                              |
-| Add a new executable difference   | `delta_engine.domain.plan.actions`, differ, and adapter compiler           | Define the rich action, its aspect and phase in `actions.py`; emit it directly from the relevant `_diff_*` helper; add policy rules if needed; compile it in the backend adapter.                                                           |
+| Add a new executable difference   | `delta_engine.domain.plan.actions`, differ, and adapter compiler           | Define the rich action, its aspect and phase in `actions.py`; emit it directly from the relevant `_diff_*` helper (foreign-key existence included); add policy rules if needed; compile it in the backend adapter.                          |
 | Add a new unresolvable difference | `delta_engine.domain.plan.unresolvable` and application validation         | Add the frozen domain difference to `Unresolvable`, emit it into the diff's `unresolvable` tuple from `diff.py`, then make the rejection or acceptance decision in application policy. Successful planning must still contain actions only. |
 | Add a safety rule                 | `delta_engine.application.validation`                                      | Rules inspect the drift's managed actions and unresolvable differences and return `ValidationFailure` values.                                                                                                                               |
 | Add a data type                   | `delta_engine.domain.model.data_type` and adapter type mapping             | The domain type is backend-free; SQL names and Spark parsing live in the Databricks adapter.                                                                                                                                                |
 | Change public declarations        | `delta_engine.api`, surfaced only through `delta_engine.schema`            | Keep public ergonomics in `delta_engine.schema` and lower choices into domain snapshots before the engine phases begin.                                                                                                                     |
-| Change FK planning, ordering, or blocking | `delta_engine.application.relationships` (blocking gate: `Engine._gate`) | Cross-table relationship policy — FK existence diffing, structural validation, ordering — lives in the application layer, not in the domain plan or SQL compiler.                                                                  |
+| Change FK ordering, verdicts, or blocking | `delta_engine.application.relationships` (blocking gate: `Engine._gate`) | Cross-table relationship judgment — dependency ordering and structural validation (exact referenced spelling included) — lives in the application layer; FK *existence* is a difference like any other and lives in the differ.       |
 | Change report output              | `delta_engine.application.report` and `delta_engine.application.rendering` | Keep display formatting out of domain objects.                                                                                                                                                                                              |
 | Change Databricks SQL             | `delta_engine.adapters.databricks.sql`                                     | Compile domain actions to backend statements at the adapter boundary.                                                                                                                                                                       |
 | Change CLI commands or output     | `delta_engine.cli`                                                         | Thin orchestration over `declarations.py`, `connection.py`, and the application ports; keep policy in the layers below.                                                                                                                     |
@@ -823,9 +831,10 @@ dependency cost.
   and `Column.tags` copy what the user passed, so mutating the original
   mapping later does not alter the declaration.
 - Put orchestration, safety policy, relationship resolution, and failure
-  propagation in the application layer. Constraint planning is cross-table
-  policy and lives in `application/relationships.py`, consistent with this
-  rule.
+  propagation in the application layer. Cross-table relationship judgment —
+  dependency ordering, structural verdicts — lives in
+  `application/relationships.py`; single-table differences, foreign-key
+  existence among them, stay in the domain differ.
 - Put backend normalization at adapter boundaries, such as lowercasing catalog,
   schema, and table-name parts, parsing Spark types, and quoting SQL. Preserve
   column-like identifier spelling by wrapping it in `Identifier` — a `str`

--- a/docs/explanation-safety-model.md
+++ b/docs/explanation-safety-model.md
@@ -85,7 +85,7 @@ protects it from the rest of the run: a table only executes when every table
 its foreign keys reference can be trusted to reach its desired state this
 sync.
 
-A table blocked by this layer reports `FOREIGN_KEY_FAILED`, with one of five
+A table blocked by this layer reports `FOREIGN_KEY_FAILED`, with one of six
 reasons in its failure message:
 
 | Failure reason                    | Fires when                                                                                                   |
@@ -94,9 +94,10 @@ reasons in its failure message:
 | `CYCLE`                           | The table is part of a foreign-key dependency cycle                                                          |
 | `REFERENCED_COLUMNS_NOT_A_KEY`    | The referenced columns are not the referenced table's primary key                                            |
 | `REFERENCED_COLUMN_TYPE_MISMATCH` | A foreign-key column's type does not match the referenced column's type on the table registered for the sync |
+| `REFERENCED_COLUMN_CASE_MISMATCH` | The referenced columns are that key, but spelled with different case than the registered declaration         |
 | `BLOCKED_BY_FAILED_DEPENDENCY`    | A referenced table failed this run — at any of the layers above, or while executing                          |
 
-The first four are structural problems with the declarations themselves —
+The first five are structural problems with the declarations themselves —
 validation in spirit, run separately only because they need to see every table
 in the sync at once. The last is failure propagation: the declaration is fine,
 but the state its foreign keys depend on won't exist, so the table is blocked

--- a/docs/explanation-sync-lifecycle.md
+++ b/docs/explanation-sync-lifecycle.md
@@ -17,17 +17,23 @@ one table's failure does not take down the rest of the run.
 Every sync runs the same chain of phases over every table in the call:
 
 ```text
-read → resolve → diff → plan → compile → execute → report
+lower → resolve → read → diff → plan → compile → execute → report
 ```
 
 | Phase       | Question it answers                          | Outcome                                                            |
 | ----------- | -------------------------------------------- | ------------------------------------------------------------------ |
+| **Lower**   | What tables does the declaration set define? | Domain tables, deduplicated, in deterministic order                |
+| **Resolve** | Can each declared foreign key work, and which tables go first? | Tables ordered dependency-first, with structural FK verdicts and their dependency edges |
 | **Read**    | What does the table look like right now?     | Present (with its observed state), absent, or a read failure       |
-| **Resolve** | Can each declared foreign key work, and which tables go first? | Tables ordered dependency-first, with structural FK verdicts and planned FK actions |
-| **Diff**    | How does observed state differ from desired? | Direct actions and non-action differences — or no drift            |
-| **Plan**    | Is the diff, merged with the planned FK actions, accepted? | A validated action plan, or named validation failures with no plan |
+| **Diff**    | How does observed state differ from desired? | Direct actions and non-action differences — foreign-key existence included — or no drift |
+| **Plan**    | Is the complete diff accepted?               | A validated action plan, or named validation failures with no plan |
 | **Compile** | What exact backend statements apply it?     | The SQL exposed on the report and passed unchanged to execution    |
 | **Execute** | Apply the compiled statements                | Attempted results, a dependency block, or skipped on a dry run     |
+
+Resolution comes before read because it needs nothing from the catalog: it
+judges the declarations against each other, so every table starts its worldly
+phases already knowing its position, its dependency edges, and whether its
+relationships are sound.
 
 The result is a `SyncReport` with one entry per table. On a real run, if any
 table failed, the engine raises `SyncFailedError` with that report attached; a
@@ -77,7 +83,10 @@ independent — see the next section.
 
 A foreign key can only be created if the table it references already exists
 with its primary key in place. The resolve phase therefore orders tables so
-referenced tables are executed before the tables that reference them.
+referenced tables are executed before the tables that reference them. The
+foreign keys a table needs set or dropped are a difference like any other, so
+the diff states them; resolve judges only what one table's declaration means
+for another's.
 
 The same dependency logic propagates failure: if a table fails — at any phase,
 including mid-execution — every table whose foreign keys depend on it is
@@ -89,8 +98,8 @@ declaration side.
 
 ## Dry runs execute nothing
 
-`sync(..., dry_run=True)` runs every phase but attempts no statements: read,
-resolve, diff, accepted/rejected planning, and compilation all happen, and the
+`sync(..., dry_run=True)` runs every phase but attempts no statements: resolve,
+read, diff, accepted/rejected planning, and compilation all happen, and the
 execution gate still records which tables a failure would block. You get every
 action and SQL statement planned from the catalog snapshot it read, plus any
 read, validation, foreign-key, or dependency-blocking failure the run found.

--- a/src/delta_engine/application/engine.py
+++ b/src/delta_engine/application/engine.py
@@ -40,7 +40,6 @@ is skipped by execution, so all tables are attempted and the report is always
 complete.
 """
 
-from collections.abc import Set as AbstractSet
 from dataclasses import dataclass
 from datetime import UTC, datetime
 import logging
@@ -54,8 +53,6 @@ from delta_engine.application.errors import (
 )
 from delta_engine.application.failures import (
     ExecutionFailure,
-    ForeignKeyFailure,
-    ForeignKeyFailureReason,
     ReadFailure,
 )
 from delta_engine.application.planning import (
@@ -181,22 +178,6 @@ class _TableRun:
             resolution=self.resolution,
             execution_outcome=self.execution,
         )
-
-
-def _blocking_failures(
-    run: _TableRun, failed: AbstractSet[QualifiedName]
-) -> tuple[ForeignKeyFailure, ...]:
-    """Return the failures blocking this run, given tables that will not converge."""
-    return tuple(
-        ForeignKeyFailure(
-            table=run.qualified_name,
-            local_columns=dependency.local_columns,
-            references=dependency.referenced_table,
-            reason=ForeignKeyFailureReason.BLOCKED_BY_FAILED_DEPENDENCY,
-        )
-        for dependency in run.resolution.dependencies
-        if dependency.referenced_table in failed
-    )
 
 
 class Engine:
@@ -416,7 +397,7 @@ class Engine:
             if run.has_failures:
                 continue
 
-            blocking_failures = _blocking_failures(run, failed)
+            blocking_failures = run.resolution.blocked_by(failed)
             if blocking_failures:
                 run.execution = ExecutionBlockedByDependency(blocking_failures)
                 failed.add(run.qualified_name)
@@ -445,7 +426,7 @@ class Engine:
             if run.has_failures:
                 continue
 
-            blocking_failures = _blocking_failures(run, failed_during_execution)
+            blocking_failures = run.resolution.blocked_by(failed_during_execution)
             if blocking_failures:
                 run.execution = ExecutionBlockedByDependency(blocking_failures)
                 failed_during_execution.add(run.qualified_name)

--- a/src/delta_engine/application/engine.py
+++ b/src/delta_engine/application/engine.py
@@ -35,6 +35,7 @@ is skipped by execution, so all tables are attempted and the report is always
 complete.
 """
 
+from collections.abc import Set as AbstractSet
 from dataclasses import dataclass
 from datetime import UTC, datetime
 import logging
@@ -46,7 +47,12 @@ from delta_engine.application.errors import (
     ReadError,
     SyncFailedError,
 )
-from delta_engine.application.failures import ExecutionFailure, ReadFailure
+from delta_engine.application.failures import (
+    ExecutionFailure,
+    ForeignKeyFailure,
+    ForeignKeyFailureReason,
+    ReadFailure,
+)
 from delta_engine.application.planning import (
     PlanningFailed,
     PlanningResult,
@@ -64,13 +70,7 @@ from delta_engine.application.ports import (
     TableAbsent,
     TablePresent,
 )
-from delta_engine.application.relationships import (
-    ResolutionFailed,
-    ResolutionSucceeded,
-    TableResolution,
-    TableSnapshot,
-    resolve,
-)
+from delta_engine.application.relationships import TableResolution, resolve
 from delta_engine.application.report import (
     ExecutionBlockedByDependency,
     ExecutionOutcome,
@@ -158,7 +158,7 @@ class _TableRun:
         return (
             isinstance(self.read, ReadFailure)
             or isinstance(self.planning, PlanningFailed)
-            or isinstance(self.resolution, ResolutionFailed)
+            or bool(self.resolution.structural_failures)
             or isinstance(self.execution, ExecutionBlockedByDependency)
             or (isinstance(self.execution, ExecutionSummary) and self.execution.failed)
         )
@@ -175,18 +175,20 @@ class _TableRun:
         )
 
 
-def _successful_resolution(run: _TableRun) -> ResolutionSucceeded:
-    """
-    Narrow a gate-eligible run's resolution to the successful variant.
-
-    Runs with a failed resolution carry that failure and are skipped before
-    this is called, so a failed variant here is an engine sequencing bug, not
-    a table outcome.
-    """
-    resolution = run.resolution
-    if not isinstance(resolution, ResolutionSucceeded):
-        raise RuntimeError(f"Executable table was not successfully resolved: {run.qualified_name}")
-    return resolution
+def _blocking_failures(
+    run: _TableRun, failed: AbstractSet[QualifiedName]
+) -> tuple[ForeignKeyFailure, ...]:
+    """Return the failures blocking this run, given tables that will not converge."""
+    return tuple(
+        ForeignKeyFailure(
+            table=run.qualified_name,
+            local_columns=dependency.local_columns,
+            references=dependency.referenced_table,
+            reason=ForeignKeyFailureReason.BLOCKED_BY_FAILED_DEPENDENCY,
+        )
+        for dependency in run.resolution.dependencies
+        if dependency.referenced_table in failed
+    )
 
 
 class Engine:
@@ -276,9 +278,11 @@ class Engine:
 
         return report
 
-    def _read(self, tables: tuple[DesiredTable, ...]) -> tuple[TableSnapshot, ...]:
+    def _read(
+        self, tables: tuple[DesiredTable, ...]
+    ) -> tuple[tuple[DesiredTable, ReadResult], ...]:
         """Fetch the current catalog state of every table, as (desired, read) pairs."""
-        snapshots: list[TableSnapshot] = []
+        snapshots: list[tuple[DesiredTable, ReadResult]] = []
         for desired in tables:
             read: ReadResult
             try:
@@ -366,17 +370,19 @@ class Engine:
                 run.qualified_name,
             )
 
-    def _resolve(self, snapshots: tuple[TableSnapshot, ...]) -> tuple[_TableRun, ...]:
+    def _resolve(
+        self, snapshots: tuple[tuple[DesiredTable, ReadResult], ...]
+    ) -> tuple[_TableRun, ...]:
         """
         Birth one run per table, dependency-first, with its resolution outcome.
 
-        Resolution is structural: it judges declared relationships against the
-        read snapshots and plans their actions. Whether a table is *blocked*
+        Resolution is structural: it judges the declarations against each
+        other, with no catalog state involved. Whether a table is *blocked*
         by another's failure is decided later, by the gating walk in
         ``_gate``. Every run carries a resolution from birth, so no later
         phase has to consider a half-resolved table.
         """
-        ordered_resolutions = resolve(snapshots)
+        ordered_resolutions = resolve(tuple(desired for desired, _ in snapshots))
 
         snapshot_by_name = {desired.qualified_name: (desired, read) for desired, read in snapshots}
 
@@ -386,7 +392,7 @@ class Engine:
             desired, read = snapshot_by_name[resolution.qualified_name]
             runs.append(_TableRun(desired=desired, read=read, resolution=resolution))
 
-            if isinstance(resolution, ResolutionFailed):
+            if resolution.structural_failures:
                 logger.error("Foreign key resolution failed for %s", resolution.qualified_name)
 
         return tuple(runs)
@@ -409,7 +415,7 @@ class Engine:
             if run.has_failures:
                 continue
 
-            blocking_failures = _successful_resolution(run).blocking_failures(failed)
+            blocking_failures = _blocking_failures(run, failed)
             if blocking_failures:
                 run.execution = ExecutionBlockedByDependency(blocking_failures)
                 failed.add(run.qualified_name)
@@ -438,9 +444,7 @@ class Engine:
             if run.has_failures:
                 continue
 
-            blocking_failures = _successful_resolution(run).blocking_failures(
-                failed_during_execution
-            )
+            blocking_failures = _blocking_failures(run, failed_during_execution)
             if blocking_failures:
                 run.execution = ExecutionBlockedByDependency(blocking_failures)
                 failed_during_execution.add(run.qualified_name)

--- a/src/delta_engine/application/engine.py
+++ b/src/delta_engine/application/engine.py
@@ -1,25 +1,30 @@
 """
 High-level orchestration of planning and execution.
 
-`Engine.sync` threads one private table run through six phases. Each run retains
-the canonical outcome of every completed phase; failures, status, and public
-report views are derived from those outcomes rather than copied into parallel
-fields. On a real run, if any table fails, `SyncFailedError` is raised with a
-formatted summary.
+`Engine.sync` threads one private table run through eight phases. Each run
+retains the canonical outcome of every completed phase; failures, status, and
+public report views are derived from those outcomes rather than copied into
+parallel fields. On a real run, if any table fails, `SyncFailedError` is raised
+with a formatted summary.
 
 The phases are:
-  1. Read     — fetch the current catalog state of every declared table
-  2. Resolve  — birth one run per table, FK-dependency-first, retaining its
-                structural verdict and planned foreign-key actions
-  3. Diff     — compute direct actions and non-action differences in place
-  4. Plan     — retain an accepted plan of the complete diff, or the
+  1. Lower    — lower the declaration set into domain tables, deduplicated
+  2. Resolve  — birth one run per table, FK-dependency-first, carrying its
+                dependency edges and structural verdicts
+  3. Read     — fetch the current catalog state of every declared table
+  4. Diff     — compute direct actions and non-action differences in place
+  5. Plan     — retain an accepted plan of the complete diff, or the
                 rejected planning outcome
-  5. Compile  — retain the exact backend statements for every accepted plan
-  6. Execute  — gate dependents of failed tables (dry and real runs), then
-                retain attempted statement results (real runs only)
+  6. Compile  — retain the exact backend statements for every accepted plan
+  7. Gate     — block dependents of failed tables (dry and real runs)
+  8. Execute  — retain attempted statement results (real runs only)
 
-Resolution is a pure structural judgment of the declarations and their read
-snapshots (CYCLE, UNRESOLVABLE_REFERENCE, ...). Whether a table is *blocked*
+The declaration set is judged before the world is consulted: resolution reads
+only declarations, so a run is born knowing its position, its edges, and its
+structural verdicts, and no later phase has to narrow a union to reach them.
+
+Resolution is a pure structural judgment of the declarations against each
+other (CYCLE, UNRESOLVABLE_REFERENCE, ...). Whether a table is *blocked*
 by another table's failure is decided later, at the execution gate: walking
 the dependency-ordered runs, a run whose resolved dependency will not reach
 desired state this sync — a failed read, a rejected plan, a failed
@@ -123,16 +128,17 @@ class _TableRun:
     """
     Mutable scratch pad threaded through the sync phases.
 
-    Born in the resolve phase with its read and resolution outcomes already
-    decided, it accretes its diff, planning outcome, compiled SQL, and
-    execution outcome as the phases proceed, then is frozen into a public
-    :class:`TableRunReport` once complete. Kept private to the engine so the
+    Born in the resolve phase, in dependency order, carrying its static facts:
+    the declaration, its dependency edges, and its structural verdicts. Its
+    read, diff, planning outcome, compiled SQL, and execution outcome accrete
+    as the worldly phases run, each written once, then the run is frozen into
+    a public :class:`TableRunReport`. Kept private to the engine so the
     published report stays immutable while the phases mutate in place.
     """
 
     desired: DesiredTable
-    read: ReadResult
     resolution: TableResolution
+    read: ReadResult | None = None
     diff: TableDiff | None = None
     planning: PlanningResult | None = None
     planned_sql_statements: tuple[str, ...] = ()
@@ -165,6 +171,8 @@ class _TableRun:
 
     def to_report(self) -> TableRunReport:
         """Freeze this run into its public, immutable report."""
+        if self.read is None:
+            raise RuntimeError(f"Run was frozen before its read completed: {self.qualified_name}")
         return TableRunReport(
             desired=self.desired,
             read=self.read,
@@ -213,11 +221,11 @@ class Engine:
         """
         Synchronize all registered tables to their desired state.
 
-        Runs read → resolve → diff → plan → compile → execute. Resolution
-        births one private run per table in dependency-first order, the middle
-        phases enrich the runs in place, the execution gate blocks dependents
-        of failed tables, and the completed outcomes are finally frozen into
-        ``TableRunReport`` values.
+        Runs lower → resolve → read → diff → plan → compile → gate → execute.
+        Resolution births one private run per table in dependency-first order
+        carrying its static facts, the worldly phases enrich the runs in
+        place, the gate blocks dependents of failed tables, and the completed
+        outcomes are finally frozen into ``TableRunReport`` values.
 
         A table that fails an early phase carries that failure forward and is
         skipped by execution; its partial run is still included in the report.
@@ -251,8 +259,8 @@ class Engine:
         desired = lower_desired_tables(*tables)
         logger.info("Starting sync for %d table(s)", len(desired))
 
-        snapshots = self._read(desired)
-        runs = self._resolve(snapshots)
+        runs = self._resolve(desired)
+        self._read(runs)
         self._diff(runs)
         self._plan(runs)
         self._compile(runs)
@@ -278,45 +286,40 @@ class Engine:
 
         return report
 
-    def _read(
-        self, tables: tuple[DesiredTable, ...]
-    ) -> tuple[tuple[DesiredTable, ReadResult], ...]:
-        """Fetch the current catalog state of every table, as (desired, read) pairs."""
-        snapshots: list[tuple[DesiredTable, ReadResult]] = []
-        for desired in tables:
+    def _read(self, runs: tuple[_TableRun, ...]) -> None:
+        """Fetch the current catalog state of every run's table."""
+        for run in runs:
             read: ReadResult
             try:
-                read = self.reader.fetch_state(desired.qualified_name)
+                read = self.reader.fetch_state(run.qualified_name)
             except ReadError as error:
                 read = ReadFailure(
                     exception_type=error.exception_type,
                     message=str(error),
                 )
 
-            snapshots.append((desired, read))
+            run.read = read
 
             match read:
                 case ReadFailure() as failure:
                     logger.error(
                         "Read failed for %s: %s - %s",
-                        desired.qualified_name,
+                        run.qualified_name,
                         failure.exception_type,
                         failure.message,
                     )
                 case TablePresent():
-                    logger.info("Table present: %s", desired.qualified_name)
+                    logger.info("Table present: %s", run.qualified_name)
                 case TableAbsent():
-                    logger.info("Table absent: %s", desired.qualified_name)
+                    logger.info("Table absent: %s", run.qualified_name)
                 case _ as unreachable:
                     assert_never(unreachable)
-
-        return tuple(snapshots)
 
     def _diff(self, runs: tuple[_TableRun, ...]) -> None:
         """Diff each readable run; read-failed runs carry no diff."""
         for run in runs:
             match run.read:
-                case ReadFailure():
+                case ReadFailure() | None:
                     continue
                 case TablePresent(table=observed_table):
                     run.diff = diff_table(run.desired, observed_table)
@@ -370,27 +373,25 @@ class Engine:
                 run.qualified_name,
             )
 
-    def _resolve(
-        self, snapshots: tuple[tuple[DesiredTable, ReadResult], ...]
-    ) -> tuple[_TableRun, ...]:
+    def _resolve(self, tables: tuple[DesiredTable, ...]) -> tuple[_TableRun, ...]:
         """
         Birth one run per table, dependency-first, with its resolution outcome.
 
         Resolution is structural: it judges the declarations against each
-        other, with no catalog state involved. Whether a table is *blocked*
-        by another's failure is decided later, by the gating walk in
+        other, before any catalog state is fetched. Whether a table is
+        *blocked* by another's failure is decided later, by the gating walk in
         ``_gate``. Every run carries a resolution from birth, so no later
         phase has to consider a half-resolved table.
         """
-        ordered_resolutions = resolve(tuple(desired for desired, _ in snapshots))
+        ordered_resolutions = resolve(tables)
 
-        snapshot_by_name = {desired.qualified_name: (desired, read) for desired, read in snapshots}
+        desired_by_name = {table.qualified_name: table for table in tables}
 
         runs: list[_TableRun] = []
 
         for resolution in ordered_resolutions:
-            desired, read = snapshot_by_name[resolution.qualified_name]
-            runs.append(_TableRun(desired=desired, read=read, resolution=resolution))
+            desired = desired_by_name[resolution.qualified_name]
+            runs.append(_TableRun(desired=desired, resolution=resolution))
 
             if resolution.structural_failures:
                 logger.error("Foreign key resolution failed for %s", resolution.qualified_name)

--- a/src/delta_engine/application/engine.py
+++ b/src/delta_engine/application/engine.py
@@ -12,18 +12,11 @@ The phases are:
   2. Resolve  — birth one run per table, FK-dependency-first, retaining its
                 structural verdict and planned foreign-key actions
   3. Diff     — compute direct actions and non-action differences in place
-  4. Plan     — retain an accepted plan of the merged diff and relationship
-                stream, or the rejected planning outcome
+  4. Plan     — retain an accepted plan of the complete diff, or the
+                rejected planning outcome
   5. Compile  — retain the exact backend statements for every accepted plan
   6. Execute  — gate dependents of failed tables (dry and real runs), then
                 retain attempted statement results (real runs only)
-
-Resolution deliberately precedes planning. The resolver plans each table's
-foreign-key actions, and the validated planning boundary must judge those
-merged with the table's own diff — the PK-drop exemption has to see this
-table's foreign-key drops wherever they were planned. Planning and
-compilation still run for resolution-failed tables, so a resolution failure
-does not erase a valid preview.
 
 Resolution is a pure structural judgment of the declarations and their read
 snapshots (CYCLE, UNRESOLVABLE_REFERENCE, ...). Whether a table is *blocked*
@@ -332,8 +325,7 @@ class Engine:
         """
         Accept or reject each diff according to the default planning policy.
 
-        The diff is judged merged with the resolver's relationship actions, so
-        validation sees one complete stream. Rejected runs retain
+        Each diff is judged as one complete stream. Rejected runs retain
         ``PlanningFailed``; accepted runs retain ``PlanningSucceeded`` with the
         validated action plan.
         """
@@ -341,7 +333,7 @@ class Engine:
             if run.diff is None:
                 continue
 
-            planning = plan_diff(run.diff, relationship_actions=run.resolution.actions)
+            planning = plan_diff(run.diff)
             run.planning = planning
 
             match planning:

--- a/src/delta_engine/application/failures.py
+++ b/src/delta_engine/application/failures.py
@@ -18,9 +18,9 @@ from delta_engine.domain.model import QualifiedName
 class FailurePhase(IntEnum):
     """The sync phase that produced a failure. Ordered so the earliest wins."""
 
-    READ = 1
-    PLANNING = 2
-    FOREIGN_KEY = 3
+    FOREIGN_KEY = 1
+    READ = 2
+    PLANNING = 3
     EXECUTION = 4
 
 

--- a/src/delta_engine/application/planning.py
+++ b/src/delta_engine/application/planning.py
@@ -1,14 +1,12 @@
 """Validated boundary from complete table diffs to executable action plans."""
 
-from dataclasses import dataclass, replace
+from dataclasses import dataclass
 from typing import assert_never
 
 from delta_engine.application.failures import ValidationFailure
 from delta_engine.application.validation import validate_diff
 from delta_engine.domain.plan import (
     ActionPlan,
-    DropForeignKey,
-    SetForeignKey,
     TableDiff,
     TableDrift,
     TableMissing,
@@ -32,43 +30,26 @@ class PlanningFailed:
 type PlanningResult = PlanningSucceeded | PlanningFailed
 
 
-def plan_diff(
-    diff: TableDiff,
-    relationship_actions: tuple[SetForeignKey | DropForeignKey, ...] = (),
-) -> PlanningResult:
+def plan_diff(diff: TableDiff) -> PlanningResult:
     """
-    Validate ``diff`` plus the resolver's relationship actions; accept or reject.
+    Validate ``diff``; accept or reject.
 
-    Relationship actions are merged into the drift before validation so the
-    scope gate and the safety rules judge one complete stream — the PK-drop
-    exemption must see this table's foreign-key drops, wherever they were
-    planned. For a missing table the actions join the plan after the gates:
-    safety rules never run on a creation. This remains the only boundary that
-    constructs an :class:`ActionPlan`; a rejected result carries validation
-    failures and deliberately has no plan, making execution of unvalidated
-    drift unrepresentable. The plan carries the relation kind its actions
-    lower against: the observed kind for drift, and the default ordinary kind
-    for a creation.
+    The diff is complete — foreign-key existence included — so policy judges
+    exactly one stream with no side channels. This remains the only boundary
+    that constructs an :class:`ActionPlan`; a rejected result carries
+    validation failures and deliberately has no plan, making execution of
+    unvalidated drift unrepresentable. The plan carries the relation kind its
+    actions lower against: the observed kind for drift, and the default
+    ordinary kind for a creation.
     """
+    validation = validate_diff(diff)
+    if validation.failed:
+        return PlanningFailed(failures=validation.failures)
     match diff:
         case TableDrift() as drift:
-            merged = replace(drift, actions=(*drift.actions, *relationship_actions))
-            validation = validate_diff(merged)
-            if validation.failed:
-                return PlanningFailed(failures=validation.failures)
-            plan = ActionPlan(
-                target=merged.target,
-                actions=merged.actions,
-                kind=merged.observed.kind,
-            )
+            plan = ActionPlan(target=drift.target, actions=drift.actions, kind=drift.observed.kind)
         case TableMissing() as missing:
-            validation = validate_diff(missing)
-            if validation.failed:
-                return PlanningFailed(failures=validation.failures)
-            plan = ActionPlan(
-                target=missing.target,
-                actions=(*missing.actions, *relationship_actions),
-            )
+            plan = ActionPlan(target=missing.target, actions=missing.actions)
         case _ as unreachable:
             assert_never(unreachable)
     return PlanningSucceeded(plan=plan)

--- a/src/delta_engine/application/relationships.py
+++ b/src/delta_engine/application/relationships.py
@@ -6,8 +6,8 @@ and returns one `TableResolution` per table in dependency-first order. It is
 pure declaration analysis: no catalog state is consulted, and no work is
 planned — differences are the differ's. Each resolution carries the table's
 dependency edges (the declared constraints themselves) and its structural
-foreign-key verdicts; blocking is inherited at enactment along those edges by
-the engine's gating walk.
+foreign-key verdicts, and states through `blocked_by` which of those edges
+block it once the caller knows which tables will not converge.
 
 For example, given these declared foreign keys (child ──► parent)::
 
@@ -24,9 +24,10 @@ For example, given these declared foreign keys (child ──► parent)::
     TableResolution(payments,    dependencies=(fk → invoices,))
     TableResolution(refunds,     failures=(UNRESOLVABLE_REFERENCE,))
 
-Healthy tables execute in that order; whether a table is *blocked* by another's
-failure is the engine's gating walk following the retained edges in that same
-order.
+Healthy tables execute in that order. Whether a table is *blocked* by another's
+failure depends on how the run goes, so the caller supplies the tables that
+will not converge and each resolution names its own blocked edges — folded
+over the tables in that same order, the block propagates along FK chains.
 
 All graph-traversal implementation details (adjacency map, Tarjan's
 strongly-connected-components algorithm) are hidden behind that interface.
@@ -67,6 +68,27 @@ class TableResolution:
     dependencies: tuple[ForeignKeyConstraint, ...]
     structural_failures: tuple[ForeignKeyFailure, ...]
 
+    def blocked_by(self, unconverged: AbstractSet[QualifiedName]) -> tuple[ForeignKeyFailure, ...]:
+        """
+        Return one failure per dependency edge that will not converge this sync.
+
+        Empty when no edge points into ``unconverged``, which is what a caller
+        walking tables in dependency order treats as "free to enact". Which
+        tables will not converge is a fact about the run, not about the
+        declarations, so it is supplied rather than resolved: the caller
+        accumulates it as reads, plans, and statements fail.
+        """
+        return tuple(
+            ForeignKeyFailure(
+                table=self.qualified_name,
+                local_columns=dependency.local_columns,
+                references=dependency.referenced_table,
+                reason=ForeignKeyFailureReason.BLOCKED_BY_FAILED_DEPENDENCY,
+            )
+            for dependency in self.dependencies
+            if dependency.referenced_table in unconverged
+        )
+
 
 def resolve(tables: tuple[DesiredTable, ...]) -> tuple[TableResolution, ...]:
     """
@@ -76,7 +98,8 @@ def resolve(tables: tuple[DesiredTable, ...]) -> tuple[TableResolution, ...]:
     each managed foreign key structurally, and retains each table's
     dependency edges as the declared constraints themselves. No catalog
     state is consulted, and no work is planned — differences are the
-    differ's, and blocking is inherited at enactment along these edges.
+    differ's, and blocking is inherited at enactment along these edges via
+    :meth:`TableResolution.blocked_by`.
     """
     registered_names = {table.qualified_name for table in tables}
     dependencies_by_table = _build_dependencies(tables, registered_names)

--- a/src/delta_engine/application/relationships.py
+++ b/src/delta_engine/application/relationships.py
@@ -1,31 +1,31 @@
 """
-Cross-table relationship resolution: ordering, classification, and FK planning.
+Cross-table relationship resolution: ordering, edges, and structural verdicts.
 
-The public entry point is `resolve`, which takes each registered table with its
-read snapshot and returns one explicit success or failure per table in
-dependency-first order. A successful resolution carries the planned set/drop
-foreign-key actions — declared spellings verbatim; validation has already
-required declared spelling to match the catalog's — and retains its
-resolved dependencies so the engine's gating walk can block dependents of
-tables that fail, without reinterpreting the desired table declaration.
+The public entry point is `resolve`, which takes the registered desired tables
+and returns one `TableResolution` per table in dependency-first order. It is
+pure declaration analysis: no catalog state is consulted, and no work is
+planned — differences are the differ's. Each resolution carries the table's
+dependency edges (the declared constraints themselves) and its structural
+foreign-key verdicts; blocking is inherited at enactment along those edges by
+the engine's gating walk.
 
 For example, given these declared foreign keys (child ──► parent)::
 
     order_items ──► orders ──► customers      invoices ◄──► ledger
     payments ──► invoices                     refunds ──► archive (not registered)
 
-`resolve` orders every table dependency-first and classifies its outcome::
+`resolve` orders every table dependency-first and judges each declaration::
 
-    ResolutionSucceeded(customers)
-    ResolutionSucceeded(orders, actions=(SetForeignKey(...),))
-    ResolutionSucceeded(order_items, actions=(SetForeignKey(...),))
-    ResolutionFailed(invoices, CYCLE)
-    ResolutionFailed(ledger, CYCLE)
-    ResolutionSucceeded(payments, dependencies=(invoices,))
-    ResolutionFailed(refunds, UNRESOLVABLE_REFERENCE)
+    TableResolution(customers)
+    TableResolution(orders,      dependencies=(fk → customers,))
+    TableResolution(order_items, dependencies=(fk → orders,))
+    TableResolution(invoices,    dependencies=(fk → ledger,),   failures=(CYCLE,))
+    TableResolution(ledger,      dependencies=(fk → invoices,), failures=(CYCLE,))
+    TableResolution(payments,    dependencies=(fk → invoices,))
+    TableResolution(refunds,     failures=(UNRESOLVABLE_REFERENCE,))
 
 Healthy tables execute in that order; whether a table is *blocked* by another's
-failure is the engine's gating walk applying ``blocking_failures`` in that same
+failure is the engine's gating walk following the retained edges in that same
 order.
 
 All graph-traversal implementation details (adjacency map, Tarjan's
@@ -38,9 +38,7 @@ from dataclasses import dataclass
 from delta_engine.application.failures import (
     ForeignKeyFailure,
     ForeignKeyFailureReason,
-    ReadFailure,
 )
-from delta_engine.application.ports import ReadResult, TablePresent
 from delta_engine.domain.model import (
     DataType,
     DesiredTable,
@@ -48,7 +46,6 @@ from delta_engine.domain.model import (
     QualifiedName,
     TableAspect,
 )
-from delta_engine.domain.plan import DropForeignKey, SetForeignKey
 
 # TODO: Replace the recursive SCC traversal with an iterative implementation.
 # Its call depth follows dependency depth, so a chain near Python's recursion
@@ -57,94 +54,45 @@ from delta_engine.domain.plan import DropForeignKey, SetForeignKey
 
 
 @dataclass(frozen=True, slots=True)
-class ResolvedDependency:
-    """An execution-ready dependency edge produced by foreign-key resolution."""
+class TableResolution:
+    """
+    One table's static relationship facts, in dependency order by tuple position.
 
-    referenced_table: QualifiedName
-    blocked_failure: ForeignKeyFailure
-
-
-@dataclass(frozen=True, slots=True)
-class ResolutionSucceeded:
-    """A table placed in dependency order with its planned relationship work."""
+    ``dependencies`` are the retained dependency edges — the managed foreign
+    keys themselves, declared constraints verbatim. Empty
+    ``structural_failures`` means the table is structurally sound.
+    """
 
     qualified_name: QualifiedName
-    dependencies: tuple[ResolvedDependency, ...]
-    actions: tuple[SetForeignKey | DropForeignKey, ...] = ()
-
-    def blocking_failures(
-        self, failed: AbstractSet[QualifiedName]
-    ) -> tuple[ForeignKeyFailure, ...]:
-        """Return the failures blocking this table, given names that will not converge."""
-        return tuple(
-            dependency.blocked_failure
-            for dependency in self.dependencies
-            if dependency.referenced_table in failed
-        )
+    dependencies: tuple[ForeignKeyConstraint, ...]
+    structural_failures: tuple[ForeignKeyFailure, ...]
 
 
-@dataclass(frozen=True, slots=True)
-class ResolutionFailed:
-    """A table placed in dependency order that cannot sync because of its foreign keys."""
-
-    qualified_name: QualifiedName
-    failures: tuple[ForeignKeyFailure, ...]
-    actions: tuple[SetForeignKey | DropForeignKey, ...] = ()
-
-    def __post_init__(self) -> None:
-        if not self.failures:
-            raise ValueError("ResolutionFailed requires at least one foreign-key failure")
-
-
-type TableResolution = ResolutionSucceeded | ResolutionFailed
-type ResolveResult = tuple[TableResolution, ...]
-type TableSnapshot = tuple[DesiredTable, ReadResult]
-
-
-def resolve(tables: tuple[TableSnapshot, ...]) -> tuple[TableResolution, ...]:
+def resolve(tables: tuple[DesiredTable, ...]) -> tuple[TableResolution, ...]:
     """
     Resolve cross-table relationships for one sync.
 
-    Pure function of the read snapshots: orders every table dependency-first,
-    judges each declared foreign key structurally, and plans the set/drop
-    actions that converge each table's foreign keys — carrying declared
-    spellings verbatim, because the declaration is the executable truth once
-    validation has required it to match the catalog.
-    Blocking is not computed here: successful resolutions expose
-    ``blocking_failures`` and the engine's gating walk applies it.
+    Pure declaration analysis: orders every table dependency-first, judges
+    each managed foreign key structurally, and retains each table's
+    dependency edges as the declared constraints themselves. No catalog
+    state is consulted, and no work is planned — differences are the
+    differ's, and blocking is inherited at enactment along these edges.
     """
-    desired_tables = tuple(desired for desired, _ in tables)
-    registered_names = {table.qualified_name for table in desired_tables}
-    read_by_name = {desired.qualified_name: read for desired, read in tables}
-
-    resolved_dependencies = _build_resolved_dependencies(desired_tables, registered_names)
-    components = _strongly_connected_components(_build_dependency_graph(resolved_dependencies))
+    registered_names = {table.qualified_name for table in tables}
+    dependencies_by_table = _build_dependencies(tables, registered_names)
+    components = _strongly_connected_components(_build_dependency_graph(dependencies_by_table))
     cycle_partners = _cycle_partners_by_table(components)
-    ordered = _order_tables(desired_tables, components)
-    failures_by_table = _classify_structural_failures(
-        desired_tables, registered_names, cycle_partners
-    )
+    ordered = _order_tables(tables, components)
+    failures_by_table = _classify_structural_failures(tables, registered_names, cycle_partners)
 
-    resolutions: list[TableResolution] = []
-    for table in ordered:
-        qualified_name = table.qualified_name
-        actions = _foreign_key_actions(table, read_by_name[qualified_name])
-        failures = failures_by_table.get(qualified_name)
-        if failures is None:
-            resolutions.append(
-                ResolutionSucceeded(
-                    qualified_name=qualified_name,
-                    dependencies=resolved_dependencies[qualified_name],
-                    actions=actions,
-                )
-            )
-        else:
-            resolutions.append(
-                ResolutionFailed(
-                    qualified_name=qualified_name, failures=tuple(failures), actions=actions
-                )
-            )
-    return tuple(resolutions)
+    return tuple(
+        TableResolution(
+            qualified_name=table.qualified_name,
+            dependencies=dependencies_by_table[table.qualified_name],
+            structural_failures=failures_by_table.get(table.qualified_name, ()),
+        )
+        for table in ordered
+    )
 
 
 def _managed_foreign_keys(table: DesiredTable) -> tuple[ForeignKeyConstraint, ...]:
@@ -152,26 +100,6 @@ def _managed_foreign_keys(table: DesiredTable) -> tuple[ForeignKeyConstraint, ..
     if TableAspect.FOREIGN_KEYS not in table.managed_aspects:
         return ()
     return table.foreign_keys
-
-
-def _foreign_key_actions(
-    desired: DesiredTable,
-    read: ReadResult,
-) -> tuple[SetForeignKey | DropForeignKey, ...]:
-    """Set/drop actions converging the table's declared foreign keys, declared-spelled."""
-    if isinstance(read, ReadFailure):
-        return ()
-    observed_constraints = read.table.foreign_keys if isinstance(read, TablePresent) else ()
-    desired_by_signature = {fk.signature: fk for fk in desired.foreign_keys}
-    observed_by_signature = {fk.signature: fk for fk in observed_constraints}
-    actions: list[SetForeignKey | DropForeignKey] = []
-    for signature, constraint in desired_by_signature.items():
-        if signature not in observed_by_signature:
-            actions.append(SetForeignKey(constraint=constraint))
-    for signature, constraint in observed_by_signature.items():
-        if signature not in desired_by_signature:
-            actions.append(DropForeignKey(constraint=constraint))
-    return tuple(actions)
 
 
 def _foreign_key_failure(
@@ -203,12 +131,12 @@ def _foreign_key_types_match(
     )
 
 
-def _build_resolved_dependencies(
+def _build_dependencies(
     tables: tuple[DesiredTable, ...],
     registered_names: AbstractSet[QualifiedName],
-) -> dict[QualifiedName, tuple[ResolvedDependency, ...]]:
+) -> dict[QualifiedName, tuple[ForeignKeyConstraint, ...]]:
     """
-    Build execution-ready dependency edges for every table.
+    Build the dependency edges for every table.
 
     Only references to tables in this sync are included; FK references to tables
     outside it are omitted here and classified as UNRESOLVABLE_REFERENCE later.
@@ -216,32 +144,24 @@ def _build_resolved_dependencies(
     create the table, then add the constraint. It cannot block its own execution,
     so it is excluded from the dependency edges.
     """
-    dependencies_by_table: dict[QualifiedName, tuple[ResolvedDependency, ...]] = {}
-    for table in tables:
-        table_name = table.qualified_name
-        dependencies_by_table[table_name] = tuple(
-            ResolvedDependency(
-                referenced_table=foreign_key.referenced_table,
-                blocked_failure=_foreign_key_failure(
-                    table,
-                    foreign_key,
-                    ForeignKeyFailureReason.BLOCKED_BY_FAILED_DEPENDENCY,
-                ),
-            )
+    return {
+        table.qualified_name: tuple(
+            foreign_key
             for foreign_key in _managed_foreign_keys(table)
             if foreign_key.referenced_table in registered_names
-            and foreign_key.referenced_table != table_name
+            and foreign_key.referenced_table != table.qualified_name
         )
-    return dependencies_by_table
+        for table in tables
+    }
 
 
 def _build_dependency_graph(
-    resolved_dependencies_by_table: dict[QualifiedName, tuple[ResolvedDependency, ...]],
+    dependencies_by_table: dict[QualifiedName, tuple[ForeignKeyConstraint, ...]],
 ) -> dict[QualifiedName, set[QualifiedName]]:
-    """Project resolved dependency edges into the adjacency map used for ordering."""
+    """Project dependency edges into the adjacency map used for ordering."""
     return {
-        table_name: {dependency.referenced_table for dependency in dependencies}
-        for table_name, dependencies in resolved_dependencies_by_table.items()
+        table_name: {foreign_key.referenced_table for foreign_key in dependencies}
+        for table_name, dependencies in dependencies_by_table.items()
     }
 
 

--- a/src/delta_engine/application/report.py
+++ b/src/delta_engine/application/report.py
@@ -26,11 +26,7 @@ from delta_engine.application.planning import (
     PlanningSucceeded,
 )
 from delta_engine.application.ports import ExecutionSummary, ReadResult
-from delta_engine.application.relationships import (
-    ResolutionFailed,
-    ResolutionSucceeded,
-    TableResolution,
-)
+from delta_engine.application.relationships import TableResolution
 from delta_engine.domain.model import DesiredTable, QualifiedName
 from delta_engine.domain.plan import ActionPlan
 
@@ -137,7 +133,7 @@ class TableRunReport:
     def __post_init__(self) -> None:
         read_failed = isinstance(self.read, ReadFailure)
         planning_failed = isinstance(self.planning, PlanningFailed)
-        resolution_failed = isinstance(self.resolution, ResolutionFailed)
+        resolution_failed = bool(self.resolution.structural_failures)
 
         if self.resolution.qualified_name != self.qualified_name:
             raise ValueError("Resolution outcome must belong to the reported table")
@@ -155,10 +151,8 @@ class TableRunReport:
             read_failed or planning_failed or resolution_failed
         ):
             raise ValueError("Execution cannot follow a failed earlier phase")
-        if isinstance(self.execution_outcome, ExecutionBlockedByDependency) and not isinstance(
-            self.resolution, ResolutionSucceeded
-        ):
-            raise ValueError("Execution blocking requires successful dependency resolution")
+        if isinstance(self.execution_outcome, ExecutionBlockedByDependency) and resolution_failed:
+            raise ValueError("Execution blocking requires a structurally sound resolution")
 
         execution = self.execution
         if execution is not None:
@@ -197,8 +191,7 @@ class TableRunReport:
             failures.append(self.read)
         if isinstance(self.planning, PlanningFailed):
             failures.extend(self.planning.failures)
-        if isinstance(self.resolution, ResolutionFailed):
-            failures.extend(self.resolution.failures)
+        failures.extend(self.resolution.structural_failures)
 
         match self.execution_outcome:
             case ExecutionSummary() as summary:

--- a/src/delta_engine/application/report.py
+++ b/src/delta_engine/application/report.py
@@ -184,14 +184,18 @@ class TableRunReport:
 
     @property
     def failures(self) -> tuple[Failure, ...]:
-        """Flatten canonical phase outcomes into lifecycle order for callers."""
+        """
+        Flatten canonical phase outcomes for callers.
+
+        Lifecycle order: structural, read, planning, execution.
+        """
         failures: list[Failure] = []
 
+        failures.extend(self.resolution.structural_failures)
         if isinstance(self.read, ReadFailure):
             failures.append(self.read)
         if isinstance(self.planning, PlanningFailed):
             failures.extend(self.planning.failures)
-        failures.extend(self.resolution.structural_failures)
 
         match self.execution_outcome:
             case ExecutionSummary() as summary:

--- a/src/delta_engine/domain/plan/diff.py
+++ b/src/delta_engine/domain/plan/diff.py
@@ -1,10 +1,11 @@
 """
 Compare desired and observed table state.
 
-The differ reports every single-table discrepancy as either an executable
-action or an unresolvable difference. Cross-table relationships (foreign
-keys) are planned by ``application/relationships.py``; validation, safety
-policy, execution ordering, and backend compilation live elsewhere.
+The differ reports every single-table discrepancy — foreign-key existence
+included — as either an executable action or an unresolvable difference.
+Cross-table judgment (dependency ordering, structural foreign-key verdicts)
+lives in ``application/relationships.py``; validation, safety policy,
+execution ordering, and backend compilation live elsewhere.
 """
 
 from collections.abc import Iterable, Mapping
@@ -33,12 +34,14 @@ from delta_engine.domain.plan.actions import (
     AlterColumnType,
     CreateTable,
     DropColumn,
+    DropForeignKey,
     DropPrimaryKey,
     EnableTableFeature,
     RenameColumn,
     SetColumnComment,
     SetColumnNullability,
     SetColumnTag,
+    SetForeignKey,
     SetPrimaryKey,
     SetProperty,
     SetTableComment,
@@ -140,7 +143,10 @@ def _diff_existing_table(desired: DesiredTable, observed: ObservedTable) -> Tabl
     column_actions = _diff_columns(desired.columns, renames.columns)
     case_drift = _column_case_drift(desired, observed, renames)
     layout_actions, layout_unresolvable = _diff_layout(desired, renames)
-    constraint_actions = _diff_primary_key(desired, observed)
+    constraint_actions = (
+        *_diff_primary_key(desired, observed),
+        *_diff_foreign_keys(desired, observed),
+    )
     metadata_actions, metadata_unresolvable = _diff_table_metadata(desired, observed)
 
     return TableDrift(
@@ -198,8 +204,9 @@ def _actions_for_missing_table(desired: DesiredTable) -> tuple[Action, ...]:
     Return every action needed to realize a missing table.
 
     CREATE TABLE establishes columns, comment, properties, layout, and the
-    primary key. Unity Catalog tags require follow-up actions; foreign keys
-    are planned by the relationship resolver.
+    primary key. Unity Catalog tags and foreign keys need follow-up actions;
+    ``SET_FOREIGN_KEY`` phases after ``CREATE_TABLE``, so a self-referential
+    key sequences correctly by action phasing alone.
     """
     table_tag_actions = tuple(
         SetTableTag(name=name, desired_value=value, observed_value=None)
@@ -219,6 +226,7 @@ def _actions_for_missing_table(desired: DesiredTable) -> tuple[Action, ...]:
         CreateTable(desired),
         *table_tag_actions,
         *column_tag_actions,
+        *(SetForeignKey(constraint=foreign_key) for foreign_key in desired.foreign_keys),
     )
 
 
@@ -504,6 +512,32 @@ def _diff_primary_key(
         actions.append(DropPrimaryKey(primary_key=observed_key))
     if desired_key is not None:
         actions.append(SetPrimaryKey(primary_key=desired_key))
+    return tuple(actions)
+
+
+def _diff_foreign_keys(
+    desired: DesiredTable, observed: ObservedTable
+) -> tuple[SetForeignKey | DropForeignKey, ...]:
+    """
+    Return set/drop actions converging the table's foreign keys.
+
+    Constraints are matched by content signature (columns and referenced
+    table; names excluded), so a generated name and a catalog name still
+    match. A declared-but-absent constraint is set carrying the declaration
+    verbatim; an observed-but-undeclared one is dropped carrying the observed
+    constraint — drops go by name. Everything here reads the child's own
+    snapshot; whether the referenced table can hold up its end is the
+    relationship resolver's judgment, not a difference.
+    """
+    desired_by_signature = {fk.signature: fk for fk in desired.foreign_keys}
+    observed_by_signature = {fk.signature: fk for fk in observed.foreign_keys}
+    actions: list[SetForeignKey | DropForeignKey] = []
+    for signature, constraint in desired_by_signature.items():
+        if signature not in observed_by_signature:
+            actions.append(SetForeignKey(constraint=constraint))
+    for signature, constraint in observed_by_signature.items():
+        if signature not in desired_by_signature:
+            actions.append(DropForeignKey(constraint=constraint))
     return tuple(actions)
 
 

--- a/tests/application/test_engine.py
+++ b/tests/application/test_engine.py
@@ -22,7 +22,6 @@ from delta_engine.application.ports import (
     TableAbsent,
     TablePresent,
 )
-from delta_engine.application.relationships import ResolutionFailed, ResolutionSucceeded
 from delta_engine.application.report import (
     ExecutionBlockedByDependency,
     SyncReport,
@@ -783,7 +782,7 @@ def test_sync_fails_table_whose_fk_references_table_not_in_the_sync():
     # Then orders is FK-failed on the resolution slot and not executed
     [orders] = list(exc_info.value.report)
     assert orders.status is TableRunStatus.FOREIGN_KEY_FAILED
-    assert isinstance(orders.resolution, ResolutionFailed)
+    assert orders.resolution.structural_failures != ()
     assert orders.execution is None
     assert executor.executed_names == []
 
@@ -817,7 +816,7 @@ def test_read_failure_in_upstream_blocks_fk_dependent():
     table_a = _assert_status(report, "cat.sch.a", TableRunStatus.READ_FAILED)
     table_b = _assert_status(report, "cat.sch.b", TableRunStatus.FOREIGN_KEY_FAILED)
 
-    assert isinstance(table_b.resolution, ResolutionSucceeded)
+    assert table_b.resolution.structural_failures == ()
     assert isinstance(table_b.execution_outcome, ExecutionBlockedByDependency)
     _assert_has_fk_failure(
         table_b,
@@ -861,7 +860,7 @@ def test_validation_failure_in_upstream_blocks_fk_dependent():
         TableRunStatus.FOREIGN_KEY_FAILED,
     )
 
-    assert isinstance(orders.resolution, ResolutionSucceeded)
+    assert orders.resolution.structural_failures == ()
     assert isinstance(orders.execution_outcome, ExecutionBlockedByDependency)
     _assert_has_fk_failure(
         orders,
@@ -892,8 +891,8 @@ def test_structural_fk_failure_in_upstream_blocks_fk_dependent():
     table_a = _assert_status(report, "cat.sch.a", TableRunStatus.FOREIGN_KEY_FAILED)
     table_b = _assert_status(report, "cat.sch.b", TableRunStatus.FOREIGN_KEY_FAILED)
 
-    assert isinstance(table_a.resolution, ResolutionFailed)
-    assert isinstance(table_b.resolution, ResolutionSucceeded)
+    assert table_a.resolution.structural_failures != ()
+    assert table_b.resolution.structural_failures == ()
     assert isinstance(table_b.execution_outcome, ExecutionBlockedByDependency)
     _assert_has_fk_failure(
         table_b,
@@ -1414,7 +1413,7 @@ def test_foreign_key_failed_table_still_carries_its_planned_sql():
 
     # Then resolution failed but the preview still includes the constraint SQL
     [orders] = list(report)
-    assert isinstance(orders.resolution, ResolutionFailed)
+    assert orders.resolution.structural_failures != ()
     assert orders.planned_sql_statements != ()
     assert any("ADD CONSTRAINT" in statement for statement in orders.planned_sql_statements)
     assert executor.executed_statements == []

--- a/tests/application/test_engine.py
+++ b/tests/application/test_engine.py
@@ -794,6 +794,26 @@ def test_sync_fails_table_whose_fk_references_table_not_in_the_sync():
     )
 
 
+def test_structural_verdicts_are_recorded_even_when_every_read_fails():
+    # Given orders references a table that is not registered, and its read errors
+    reader = _RecordingReader(
+        {
+            "cat.sch.orders": ReadError("IOError", "cannot read"),
+        }
+    )
+    executor = _RecordingExecutor(per_table_errors=[])
+    engine = Engine(reader=reader, executor=executor)
+
+    # When syncing
+    report = engine.sync(_spec_with_fk("cat.sch.orders", "cat.sch.ghost"), dry_run=True)
+
+    # Then the declaration was judged without consulting the world: the
+    # structural verdict and the read failure both stand on the run
+    [orders] = list(report)
+    assert orders.resolution.structural_failures != ()
+    assert isinstance(orders.read, ReadFailure)
+
+
 def test_read_failure_in_upstream_blocks_fk_dependent():
     # Given a fails to read and b depends on a
     reader = _RecordingReader(

--- a/tests/application/test_errors.py
+++ b/tests/application/test_errors.py
@@ -21,10 +21,7 @@ from delta_engine.application.ports import (
     ReadResult,
     TableAbsent,
 )
-from delta_engine.application.relationships import (
-    ResolutionFailed,
-    ResolutionSucceeded,
-)
+from delta_engine.application.relationships import TableResolution
 from delta_engine.application.report import (
     SyncReport,
     TableRunReport,
@@ -78,10 +75,10 @@ def _table_report(
         if planning_failures
         else PlanningSucceeded(ActionPlan(target=desired.qualified_name))
     )
-    resolution = (
-        ResolutionFailed(desired.qualified_name, resolution_failures)
-        if resolution_failures
-        else ResolutionSucceeded(desired.qualified_name, ())
+    resolution = TableResolution(
+        qualified_name=desired.qualified_name,
+        dependencies=(),
+        structural_failures=resolution_failures,
     )
 
     return TableRunReport(

--- a/tests/application/test_failures.py
+++ b/tests/application/test_failures.py
@@ -133,7 +133,8 @@ def test_failure_headlines_summarize_without_the_detail_message():
 
 def test_each_failure_kind_declares_its_producing_phase():
     # Given the four failure kinds
-    # Then each declares the phase that produced it, ordered read < planning < fk < execution
+    # Then each declares the phase that produced it, ordered as the pipeline
+    # runs them: fk < read < planning < execution
     assert ReadFailure("E", "m").phase is FailurePhase.READ
     assert ValidationFailure("R", "m").phase is FailurePhase.PLANNING
     assert (
@@ -150,9 +151,9 @@ def test_each_failure_kind_declares_its_producing_phase():
         is FailurePhase.EXECUTION
     )
     assert (
-        FailurePhase.READ
+        FailurePhase.FOREIGN_KEY
+        < FailurePhase.READ
         < FailurePhase.PLANNING
-        < FailurePhase.FOREIGN_KEY
         < FailurePhase.EXECUTION
     )
 

--- a/tests/application/test_planning.py
+++ b/tests/application/test_planning.py
@@ -170,11 +170,8 @@ def test_plan_diff_accepts_missing_table_and_builds_follow_up_actions():
         foreign_keys=(foreign_key,),
     )
 
-    # When planning with the resolver's FK action
-    result = plan_diff(
-        diff_table(desired, None),
-        relationship_actions=(SetForeignKey(constraint=foreign_key),),
-    )
+    # When planning
+    result = plan_diff(diff_table(desired, None))
 
     # Then the create is followed by tag and constraint actions
     assert isinstance(result, PlanningSucceeded)
@@ -296,14 +293,8 @@ def test_plan_diff_replaces_a_foreign_key_explicitly_across_a_rename():
         columns=(ObservedColumn("parent", Integer()),), foreign_keys=(observed_key,)
     )
 
-    # When planning with the resolver's replacement actions
-    result = plan_diff(
-        diff_table(desired, observed),
-        relationship_actions=(
-            SetForeignKey(constraint=desired_key),
-            DropForeignKey(constraint=observed_key),
-        ),
-    )
+    # When planning
+    result = plan_diff(diff_table(desired, observed))
 
     # Then the plan drops the old key, renames, then sets the new key
     assert isinstance(result, PlanningSucceeded)
@@ -340,14 +331,8 @@ def test_plan_diff_replaces_a_self_referencing_foreign_key_explicitly_across_a_r
         foreign_keys=(observed_key,),
     )
 
-    # When planning with the resolver's replacement actions
-    result = plan_diff(
-        diff_table(desired, observed),
-        relationship_actions=(
-            SetForeignKey(constraint=desired_key),
-            DropForeignKey(constraint=observed_key),
-        ),
-    )
+    # When planning
+    result = plan_diff(diff_table(desired, observed))
 
     # Then the plan drops the old key, renames, then sets the new key
     assert isinstance(result, PlanningSucceeded)
@@ -377,11 +362,8 @@ def test_plan_diff_drops_an_observed_only_foreign_key_alongside_a_rename():
         foreign_keys=(unrelated_key,),
     )
 
-    # When planning with the resolver's drop
-    result = plan_diff(
-        diff_table(desired, observed),
-        relationship_actions=(DropForeignKey(constraint=unrelated_key),),
-    )
+    # When planning
+    result = plan_diff(diff_table(desired, observed))
 
     # Then the drop still lands alongside the rename
     assert isinstance(result, PlanningSucceeded)
@@ -451,8 +433,8 @@ def test_foreign_key_to_an_unregistered_parent_keeps_its_declared_referenced_spe
     )
     diff = diff_table(desired, _observed())
 
-    # When planning with the resolver's FK action
-    result = plan_diff(diff, relationship_actions=(SetForeignKey(constraint=constraint),))
+    # When planning
+    result = plan_diff(diff)
 
     # Then the referenced spelling passes through planning untouched
     assert isinstance(result, PlanningSucceeded)
@@ -479,30 +461,38 @@ def test_created_table_uses_its_columns_spelling_for_internal_references():
     assert tuple(str(c) for c in create.table.clustered_by) == ("requestId",)
 
 
-# ---------- relationship actions from the resolver ----------
+# ---------- foreign-key actions ----------
 
 
-def test_relationship_actions_join_the_validated_plan_in_phase_order():
-    # Given an in-scope drift with no single-table work and a resolver-supplied FK
+def test_foreign_key_actions_join_the_validated_plan_in_phase_order():
+    # Given an in-scope drift whose only difference is a declared foreign key
     fk = _foreign_key(
         local_columns=("customer_id",),
         referenced_table=QualifiedName("dev", "silver", "customers"),
         referenced_columns=("id",),
         constraint_name="orders_customers_fk",
     )
-    diff = diff_table(_desired(), _observed())
+    diff = diff_table(
+        _desired(
+            columns=(DesiredColumn("id", Integer()), DesiredColumn("customer_id", Integer())),
+            foreign_keys=(fk,),
+        ),
+        _observed(
+            columns=(ObservedColumn("id", Integer()), ObservedColumn("customer_id", Integer())),
+        ),
+    )
 
-    # When planning with the relationship stream
-    result = plan_diff(diff, relationship_actions=(SetForeignKey(constraint=fk),))
+    # When planning
+    result = plan_diff(diff)
 
-    # Then the accepted plan carries the resolver's action
+    # Then the accepted plan carries the foreign-key action
     assert isinstance(result, PlanningSucceeded)
     assert result.plan.actions == (SetForeignKey(constraint=fk),)
 
 
-def test_pk_drop_exemption_sees_resolver_supplied_foreign_key_drops():
+def test_pk_drop_exemption_sees_same_sync_foreign_key_drops():
     # Given a drift dropping its PK while this table's own FK references it,
-    # and the resolver dropping that FK in the same sync
+    # with that FK dropped in the same diff
     reference = ForeignKeyReference(
         constraint_name="test_parent_id_fk",
         referencing_table=_NAME,
@@ -514,52 +504,69 @@ def test_pk_drop_exemption_sees_resolver_supplied_foreign_key_drops():
         constraint_name="test_parent_id_fk",
     )
     diff = diff_table(
-        _desired(),
+        _desired(
+            columns=(DesiredColumn("id", Integer()), DesiredColumn("parent_id", Integer())),
+        ),
         _observed(
+            columns=(ObservedColumn("id", Integer()), ObservedColumn("parent_id", Integer())),
             primary_key=PrimaryKeyConstraint(("id",), "test_pk"),
+            foreign_keys=(own_fk,),
             referencing_foreign_keys=(reference,),
         ),
     )
 
-    # When planning with the resolver's DropForeignKey
-    result = plan_diff(diff, relationship_actions=(DropForeignKey(constraint=own_fk),))
+    # When planning
+    result = plan_diff(diff)
 
-    # Then the exemption found the drop in the merged stream, and the plan
+    # Then the exemption found the drop in the same stream, and the plan
     # phases the FK drop before the PK drop
     assert isinstance(result, PlanningSucceeded)
     assert [type(action) for action in result.plan.actions] == [DropForeignKey, DropPrimaryKey]
 
 
-def test_relationship_actions_on_an_unmanaged_aspect_fail_the_scope_gate():
-    # Given a declaration that does not manage foreign keys
+def test_foreign_key_drift_on_an_unmanaged_aspect_fails_the_scope_gate():
+    # Given a declaration that does not manage foreign keys but declares one
     fk = _foreign_key(
         local_columns=("customer_id",),
         referenced_table=QualifiedName("dev", "silver", "customers"),
         referenced_columns=("id",),
         constraint_name="orders_customers_fk",
     )
-    diff = diff_table(_desired(managed_aspects=frozenset({TableAspect.TABLE_COMMENT})), _observed())
+    diff = diff_table(
+        _desired(
+            columns=(DesiredColumn("id", Integer()), DesiredColumn("customer_id", Integer())),
+            foreign_keys=(fk,),
+            managed_aspects=frozenset({TableAspect.TABLE_COMMENT}),
+        ),
+        _observed(
+            columns=(ObservedColumn("id", Integer()), ObservedColumn("customer_id", Integer())),
+        ),
+    )
 
-    # When planning with a resolver-supplied SetForeignKey
-    result = plan_diff(diff, relationship_actions=(SetForeignKey(constraint=fk),))
+    # When planning
+    result = plan_diff(diff)
 
     # Then the scope gate rejects the unmanaged work
     assert isinstance(result, PlanningFailed)
     assert [failure.rule_name for failure in result.failures] == ["UnmanagedAspectDrift"]
 
 
-def test_missing_table_plan_appends_relationship_actions():
-    # Given a missing table and one resolver-supplied FK
+def test_missing_table_plan_contains_the_declared_foreign_keys():
+    # Given a missing table declaring one foreign key
     fk = _foreign_key(
         local_columns=("customer_id",),
         referenced_table=QualifiedName("dev", "silver", "customers"),
         referenced_columns=("id",),
         constraint_name="orders_customers_fk",
     )
-    diff = diff_table(_desired(), None)
+    desired = _desired(
+        columns=(DesiredColumn("id", Integer()), DesiredColumn("customer_id", Integer())),
+        foreign_keys=(fk,),
+    )
+    diff = diff_table(desired, None)
 
-    # When planning with the relationship stream
-    result = plan_diff(diff, relationship_actions=(SetForeignKey(constraint=fk),))
+    # When planning
+    result = plan_diff(diff)
 
     # Then the accepted plan creates the table and then adds the constraint
     assert isinstance(result, PlanningSucceeded)

--- a/tests/application/test_relationships.py
+++ b/tests/application/test_relationships.py
@@ -3,11 +3,11 @@ Unit tests for relationships.resolve().
 
 These tests exercise the public resolver API rather than the graph traversal
 implementation details. They cover dependency-first ordering, structural FK
-failure classification, cycle detection, self-reference handling, and the
-dependency edges each resolution retains. The resolver is pure declaration
-analysis — the world is consulted later, and blocking is inherited at
-enactment along the retained edges by the engine's gating walk, tested with
-the engine.
+failure classification, cycle detection, self-reference handling, the
+dependency edges each resolution retains, and the blocking those edges name
+for a given set of tables that will not converge. The resolver is pure
+declaration analysis — the world is consulted later, so how blocking
+propagates across a whole run is tested with the engine.
 """
 
 from delta_engine.application.failures import ForeignKeyFailure, ForeignKeyFailureReason
@@ -972,3 +972,67 @@ def test_foreign_key_referenced_spelling_matching_exactly_is_sound():
     resolutions = resolve((parent, child))
 
     _sound_resolution(resolutions, "dev.silver.orders")
+
+
+def test_a_resolution_is_blocked_by_each_dependency_that_will_not_converge():
+    # Given orders depends on customers, and customers will not converge this sync
+    resolutions = resolve(
+        (
+            _table_with_fk("cat.sch.orders", "cat.sch.customers"),
+            _table("cat.sch.customers"),
+        )
+    )
+    orders = _sound_resolution(resolutions, "cat.sch.orders")
+
+    # When asked what blocks it
+    blocking = orders.blocked_by({_qualified_name("cat.sch.customers")})
+
+    # Then the blocked edge is named as a dependency-blocking failure
+    assert blocking == (
+        ForeignKeyFailure(
+            table=_qualified_name("cat.sch.orders"),
+            local_columns=("ref_id",),
+            references=_qualified_name("cat.sch.customers"),
+            reason=ForeignKeyFailureReason.BLOCKED_BY_FAILED_DEPENDENCY,
+        ),
+    )
+
+
+def test_a_resolution_is_blocked_only_by_the_tables_it_depends_on():
+    # Given orders depends on customers, alongside an unrelated table
+    resolutions = resolve(
+        (
+            _table_with_fk("cat.sch.orders", "cat.sch.customers"),
+            _table("cat.sch.customers"),
+            _table("cat.sch.unrelated"),
+        )
+    )
+    orders = _sound_resolution(resolutions, "cat.sch.orders")
+
+    # When tables it does not depend on will not converge
+    # Then nothing blocks it
+    assert orders.blocked_by({_qualified_name("cat.sch.unrelated")}) == ()
+    assert orders.blocked_by(set()) == ()
+
+
+def test_a_resolution_names_every_blocked_dependency_separately():
+    # Given shipments depends on both orders and customers, and both fail
+    resolutions = resolve(
+        (
+            _table_with_fks("cat.sch.shipments", "cat.sch.orders", "cat.sch.customers"),
+            _table("cat.sch.orders"),
+            _table("cat.sch.customers"),
+        )
+    )
+    shipments = _sound_resolution(resolutions, "cat.sch.shipments")
+
+    # When both dependencies will not converge
+    blocking = shipments.blocked_by(
+        {_qualified_name("cat.sch.orders"), _qualified_name("cat.sch.customers")}
+    )
+
+    # Then each blocked edge is reported on its own, naming its own columns
+    assert {(failure.references, failure.local_columns) for failure in blocking} == {
+        (_qualified_name("cat.sch.orders"), ("orders_id",)),
+        (_qualified_name("cat.sch.customers"), ("customers_id",)),
+    }

--- a/tests/application/test_relationships.py
+++ b/tests/application/test_relationships.py
@@ -4,24 +4,17 @@ Unit tests for relationships.resolve().
 These tests exercise the public resolver API rather than the graph traversal
 implementation details. They cover dependency-first ordering, structural FK
 failure classification, cycle detection, self-reference handling, and the
-planned foreign-key actions carried on each resolution. Blocking dependents
-of failed tables is the engine's gating walk, tested with the engine.
+dependency edges each resolution retains. The resolver is pure declaration
+analysis — the world is consulted later, and blocking is inherited at
+enactment along the retained edges by the engine's gating walk, tested with
+the engine.
 """
 
-import pytest
-
-from delta_engine.application.failures import ForeignKeyFailureReason, ReadFailure
-from delta_engine.application.ports import TableAbsent, TablePresent
-from delta_engine.application.relationships import (
-    ResolutionFailed,
-    ResolutionSucceeded,
-    ResolveResult,
-    resolve,
-)
-from delta_engine.domain.model import ObservedColumn, ObservedTable, QualifiedName
+from delta_engine.application.failures import ForeignKeyFailure, ForeignKeyFailureReason
+from delta_engine.application.relationships import TableResolution, resolve
+from delta_engine.domain.model import QualifiedName
 from delta_engine.domain.model.constraints import ForeignKeyConstraint, PrimaryKeyConstraint
 from delta_engine.domain.model.table import DesiredTable
-from delta_engine.domain.plan import DropForeignKey, SetForeignKey
 from delta_engine.schema import Column, DeltaTable, ForeignKey, Long, Self, String
 
 
@@ -172,50 +165,46 @@ def _tag_scoped_table_with_fk(fqn: str, references: str) -> DesiredTable:
     ).to_desired_table()
 
 
-def _names(result: ResolveResult) -> list[str]:
+def _names(result: tuple[TableResolution, ...]) -> list[str]:
     return [str(resolution.qualified_name) for resolution in result]
 
 
-def _failures_for(result: ResolveResult, fqn: str) -> tuple:
+def _resolution_for(result: tuple[TableResolution, ...], fqn: str) -> TableResolution:
     qualified_name = _qualified_name(fqn)
     for resolution in result:
-        if resolution.qualified_name != qualified_name:
-            continue
-        if isinstance(resolution, ResolutionFailed):
-            return resolution.failures
-        return ()
-    raise AssertionError(f"No resolution for {qualified_name}")
-
-
-def _failed_resolutions(result: ResolveResult) -> tuple[ResolutionFailed, ...]:
-    return tuple(resolution for resolution in result if isinstance(resolution, ResolutionFailed))
-
-
-def _successful_resolution(result: ResolveResult, fqn: str) -> ResolutionSucceeded:
-    qualified_name = _qualified_name(fqn)
-    for resolution in result:
-        if resolution.qualified_name != qualified_name:
-            continue
-        if isinstance(resolution, ResolutionSucceeded):
+        if resolution.qualified_name == qualified_name:
             return resolution
-        raise AssertionError(f"Expected successful resolution for {qualified_name}")
     raise AssertionError(f"No resolution for {qualified_name}")
+
+
+def _failures_for(result: tuple[TableResolution, ...], fqn: str) -> tuple[ForeignKeyFailure, ...]:
+    return _resolution_for(result, fqn).structural_failures
+
+
+def _failed_resolutions(result: tuple[TableResolution, ...]) -> tuple[TableResolution, ...]:
+    return tuple(resolution for resolution in result if resolution.structural_failures)
+
+
+def _sound_resolution(result: tuple[TableResolution, ...], fqn: str) -> TableResolution:
+    resolution = _resolution_for(result, fqn)
+    assert resolution.structural_failures == ()
+    return resolution
 
 
 def _failure_reasons_for(
-    result: ResolveResult,
+    result: tuple[TableResolution, ...],
     fqn: str,
 ) -> list[ForeignKeyFailureReason]:
     return [failure.reason for failure in _failures_for(result, fqn)]
 
 
-def _assert_before(result: ResolveResult, parent: str, child: str) -> None:
+def _assert_before(result: tuple[TableResolution, ...], parent: str, child: str) -> None:
     names = _names(result)
     assert names.index(parent) < names.index(child)
 
 
 def _assert_has_failure(
-    result: ResolveResult,
+    result: tuple[TableResolution, ...],
     fqn: str,
     *,
     reason: ForeignKeyFailureReason,
@@ -241,29 +230,13 @@ def _assert_has_failure(
     assert matching_failures
 
 
-def _resolve_declared(tables: tuple[DesiredTable, ...]) -> ResolveResult:
-    """Resolve declarations as if every table were absent from the catalog."""
-    return resolve(tuple((table, TableAbsent()) for table in tables))
-
-
 def test_resolve_with_empty_tables_returns_empty_result():
     # Given no registered tables
     # When resolving dependencies
-    result = _resolve_declared(())
+    result = resolve(())
 
     # Then the result is empty
     assert result == ()
-
-
-def test_resolution_failed_requires_at_least_one_failure():
-    with pytest.raises(
-        ValueError,
-        match="ResolutionFailed requires at least one foreign-key failure",
-    ):
-        ResolutionFailed(
-            qualified_name=_qualified_name("cat.sch.orders"),
-            failures=(),
-        )
 
 
 def test_resolve_with_no_fks_preserves_prepared_input_order():
@@ -275,11 +248,11 @@ def test_resolve_with_no_fks_preserves_prepared_input_order():
     )
 
     # When resolving dependencies
-    result = _resolve_declared(tables)
+    result = resolve(tables)
 
     # Then the independent tables stay in prepared input order
     assert _names(result) == ["cat.sch.a", "cat.sch.b", "cat.sch.c"]
-    assert all(isinstance(resolution, ResolutionSucceeded) for resolution in result)
+    assert not _failed_resolutions(result)
 
 
 def test_resolve_ignores_foreign_keys_on_tag_scoped_declarations():
@@ -287,7 +260,7 @@ def test_resolve_ignores_foreign_keys_on_tag_scoped_declarations():
     tables = (_tag_scoped_table_with_fk("cat.sch.orders", "cat.sch.customers"),)
 
     # When resolving dependencies
-    result = _resolve_declared(tables)
+    result = resolve(tables)
 
     # Then the carried FK does not produce an unresolvable-reference failure
     assert _names(result) == ["cat.sch.orders"]
@@ -302,7 +275,7 @@ def test_resolve_does_not_order_by_unmanaged_foreign_keys():
     )
 
     # When resolving dependencies
-    result = _resolve_declared(tables)
+    result = resolve(tables)
 
     # Then the unmanaged FK does not impose parent-before-child ordering
     assert _names(result) == ["cat.sch.orders", "cat.sch.customers"]
@@ -317,19 +290,16 @@ def test_resolve_orders_referenced_table_before_dependent():
     )
 
     # When resolving dependencies
-    result = _resolve_declared(tables)
+    result = resolve(tables)
 
     # Then customers appears before orders
     _assert_before(result, "cat.sch.customers", "cat.sch.orders")
     assert not _failed_resolutions(result)
 
-    # And orders retains the resolved edge needed during execution
-    [dependency] = _successful_resolution(result, "cat.sch.orders").dependencies
+    # And orders retains the dependency edge — the declared constraint itself
+    [dependency] = _sound_resolution(result, "cat.sch.orders").dependencies
     assert dependency.referenced_table == _qualified_name("cat.sch.customers")
-    assert dependency.blocked_failure.table == _qualified_name("cat.sch.orders")
-    assert dependency.blocked_failure.local_columns == ("ref_id",)
-    assert dependency.blocked_failure.references == _qualified_name("cat.sch.customers")
-    assert dependency.blocked_failure.reason is ForeignKeyFailureReason.BLOCKED_BY_FAILED_DEPENDENCY
+    assert tuple(str(column) for column in dependency.local_columns) == ("ref_id",)
 
 
 def test_resolve_orders_referenced_tag_scoped_table_before_dependent():
@@ -356,7 +326,7 @@ def test_resolve_orders_referenced_tag_scoped_table_before_dependent():
     tables = (orders, customers.to_desired_table())
 
     # When resolving dependencies
-    result = _resolve_declared(tables)
+    result = resolve(tables)
 
     # Then the referenced tag-scoped table is ordered before its managed dependent
     _assert_before(result, "cat.sch.customers", "cat.sch.orders")
@@ -372,7 +342,7 @@ def test_resolve_handles_chain_of_dependencies():
     )
 
     # When resolving dependencies
-    result = _resolve_declared(tables)
+    result = resolve(tables)
 
     # Then dependencies are ordered before their dependents
     _assert_before(result, "cat.sch.a", "cat.sch.b")
@@ -389,7 +359,7 @@ def test_resolve_orders_table_after_all_fk_parents():
     )
 
     # When resolving dependencies
-    result = _resolve_declared(tables)
+    result = resolve(tables)
 
     # Then both parent tables appear before the dependent table
     _assert_before(result, "cat.sch.orders", "cat.sch.order_items")
@@ -402,7 +372,7 @@ def test_resolve_fails_table_with_unresolvable_reference():
     tables = (_table_with_fk("cat.sch.orders", "cat.sch.customers"),)
 
     # When resolving dependencies
-    result = _resolve_declared(tables)
+    result = resolve(tables)
 
     # Then orders has one unresolvable-reference failure with the FK details
     failures = _failures_for(result, "cat.sch.orders")
@@ -422,7 +392,7 @@ def test_resolve_records_one_failure_per_unresolvable_fk():
     shipments = _table_with_fks("cat.sch.shipments", "cat.sch.orders", "cat.sch.customers")
 
     # When resolving dependencies
-    result = _resolve_declared((shipments,))
+    result = resolve((shipments,))
 
     # Then both failed FK relationships are reported
     failures = _failures_for(result, "cat.sch.shipments")
@@ -451,7 +421,7 @@ def test_resolve_fails_both_members_of_a_mutual_cycle_and_still_orders_them():
     )
 
     # When resolving dependencies
-    result = _resolve_declared(tables)
+    result = resolve(tables)
 
     # Then both cycle members fail and both still appear in the ordering
     _assert_has_failure(
@@ -478,7 +448,7 @@ def test_resolve_fails_all_members_of_three_table_cycle():
     )
 
     # When resolving dependencies
-    result = _resolve_declared(tables)
+    result = resolve(tables)
 
     # Then every cycle member fails with a cycle failure
     for table_name in ("cat.sch.a", "cat.sch.b", "cat.sch.c"):
@@ -500,7 +470,7 @@ def test_resolve_records_cycle_failure_only_for_fk_inside_the_cycle():
     )
 
     # When resolving dependencies
-    result = _resolve_declared(tables)
+    result = resolve(tables)
 
     # Then a's FK into the cycle fails, but its FK to the healthy table does not
     failures_for_a = _failures_for(result, "cat.sch.a")
@@ -561,7 +531,7 @@ def test_resolve_reports_invalid_fk_target_over_cycle_for_the_same_fk():
     )
 
     # When resolving dependencies
-    result = _resolve_declared((a, b))
+    result = resolve((a, b))
 
     # Then a's single failure is the invalid FK target, not a cycle failure
     _assert_has_failure(
@@ -584,7 +554,7 @@ def test_resolve_does_not_fail_an_unrelated_sibling():
     )
 
     # When resolving dependencies
-    result = _resolve_declared(tables)
+    result = resolve(tables)
 
     # Then only orders fails
     _assert_has_failure(
@@ -616,12 +586,12 @@ def test_resolve_treats_self_referential_fk_as_applicable():
     ).to_desired_table()
 
     # When resolving dependencies
-    result = _resolve_declared((employees,))
+    result = resolve((employees,))
 
     # Then the self-reference does not prevent the table from executing
     assert _names(result) == ["cat.sch.employees"]
     assert _failures_for(result, "cat.sch.employees") == ()
-    assert _successful_resolution(result, "cat.sch.employees").dependencies == ()
+    assert _resolution_for(result, "cat.sch.employees").dependencies == ()
 
 
 def test_resolve_fails_when_referenced_table_has_no_primary_key():
@@ -634,7 +604,7 @@ def test_resolve_fails_when_referenced_table_has_no_primary_key():
     orders = _table_with_fk("cat.sch.orders", "cat.sch.customers")
 
     # When resolving dependencies
-    result = _resolve_declared((orders, customers))
+    result = resolve((orders, customers))
 
     # Then orders fails because its FK does not target the parent's primary key
     _assert_has_failure(
@@ -678,7 +648,7 @@ def test_resolve_fails_fk_whose_referenced_columns_are_not_the_pk():
     )
 
     # When resolving dependencies
-    result = _resolve_declared((orders, customers))
+    result = resolve((orders, customers))
 
     # Then orders is rejected because email is not customers' primary key
     _assert_has_failure(
@@ -711,7 +681,7 @@ def test_resolve_fails_fk_whose_types_mismatch_the_registered_parent():
     customers = _long_id_table("cat.sch.customers")
 
     # When resolving dependencies
-    result = _resolve_declared((orders, customers))
+    result = resolve((orders, customers))
 
     # Then orders fails because ref_id's type does not match the registered
     # customers' primary key type, and customers itself is unaffected
@@ -749,7 +719,7 @@ def test_resolve_reports_type_mismatch_over_cycle_for_the_same_fk():
     ).to_desired_table()
 
     # When resolving dependencies
-    result = _resolve_declared((a, b))
+    result = resolve((a, b))
 
     # Then a's single failure is the type mismatch, not a cycle failure,
     # while b's FK back into the cycle still fails as a cycle
@@ -780,7 +750,7 @@ def test_resolve_valid_chain_where_middle_table_has_pk_and_fk_executes():
     )
 
     # When resolving dependencies
-    result = _resolve_declared(tables)
+    result = resolve(tables)
 
     # Then the whole chain is valid and dependency-first ordered
     _assert_before(result, "cat.sch.b", "cat.sch.a")
@@ -802,7 +772,7 @@ def test_resolve_passes_when_fk_targets_composite_primary_key():
     )
 
     # When resolving dependencies
-    result = _resolve_declared((orders, customers))
+    result = resolve((orders, customers))
 
     # Then the composite-key FK is valid
     _assert_before(result, "cat.sch.customers", "cat.sch.orders")
@@ -834,7 +804,7 @@ def test_resolve_fails_when_fk_references_only_part_of_composite_primary_key():
     )
 
     # When resolving dependencies
-    result = _resolve_declared((orders, customers))
+    result = resolve((orders, customers))
 
     # Then the FK is rejected because it does not target the full parent PK
     _assert_has_failure(
@@ -872,227 +842,30 @@ def test_resolve_treats_composite_pk_referenced_column_order_as_irrelevant():
     )
 
     # When resolving dependencies
-    result = _resolve_declared((orders, customers))
+    result = resolve((orders, customers))
 
     # Then the FK is valid because the referenced column set is the parent's PK
     _assert_before(result, "cat.sch.customers", "cat.sch.orders")
     assert not _failed_resolutions(result)
 
 
-# ---------- resolve(): planned FK actions over read snapshots ----------
+# ---------- resolve(): dependency edges over declarations ----------
 
 
-def _absent(desired: DesiredTable) -> tuple[DesiredTable, TableAbsent]:
-    return (desired, TableAbsent())
-
-
-def _present(desired: DesiredTable, observed: ObservedTable) -> tuple[DesiredTable, TablePresent]:
-    return (desired, TablePresent(table=observed))
-
-
-def _unreadable(desired: DesiredTable) -> tuple[DesiredTable, ReadFailure]:
-    return (desired, ReadFailure(exception_type="ReadError", message="boom"))
-
-
-def _observed(
-    fqn: str,
-    column_names: tuple[str, ...],
-    foreign_keys: tuple[ForeignKeyConstraint, ...] = (),
-) -> ObservedTable:
-    return ObservedTable(
-        qualified_name=_qualified_name(fqn),
-        columns=tuple(ObservedColumn(name, String()) for name in column_names),
-        foreign_keys=foreign_keys,
-    )
-
-
-def test_absent_table_plans_every_declared_foreign_key():
-    # Given a child declaring one FK, with both tables absent from the catalog
+def test_every_table_contributes_edges_regardless_of_catalog_state():
+    # Given a child declaring an FK — resolve sees only declarations, so no
+    # catalog state can add or remove an edge
     parent = _referenced_table("dev.silver.customers").to_desired_table()
     child = _table_with_fk("dev.silver.orders", "dev.silver.customers")
 
     # When resolved
-    resolutions = resolve((_absent(parent), _absent(child)))
+    resolutions = resolve((parent, child))
 
-    # Then the child's resolution plans the declared FK
-    child_resolution = _successful_resolution(resolutions, "dev.silver.orders")
-    assert [type(action) for action in child_resolution.actions] == [SetForeignKey]
-
-
-def test_present_table_diffs_foreign_keys_by_signature():
-    # Given a child declaring FKs to customers and products, while the catalog
-    # holds the customers FK (under a legacy name) plus one undeclared FK
-    customers = _referenced_table("dev.silver.customers").to_desired_table()
-    products = _referenced_table("dev.silver.products").to_desired_table()
-    child = _table_with_fks("dev.silver.orders", "dev.silver.customers", "dev.silver.products")
-    child_observed = _observed(
-        "dev.silver.orders",
-        ("id", "customers_id", "products_id", "legacy_ref"),
-        foreign_keys=(
-            ForeignKeyConstraint(
-                local_columns=("customers_id",),
-                referenced_table=_qualified_name("dev.silver.customers"),
-                referenced_columns=("id",),
-                constraint_name="legacy_customers_fk",
-            ),
-            ForeignKeyConstraint(
-                local_columns=("legacy_ref",),
-                referenced_table=_qualified_name("dev.silver.archive"),
-                referenced_columns=("id",),
-                constraint_name="legacy_archive_fk",
-            ),
-        ),
-    )
-
-    # When resolved
-    resolutions = resolve((_absent(customers), _absent(products), _present(child, child_observed)))
-
-    # Then the declared-and-present FK yields no action, the declared-but-absent
-    # FK yields SetForeignKey, and the undeclared observed FK yields DropForeignKey
-    child_resolution = _successful_resolution(resolutions, "dev.silver.orders")
-    set_actions = [a for a in child_resolution.actions if isinstance(a, SetForeignKey)]
-    drop_actions = [a for a in child_resolution.actions if isinstance(a, DropForeignKey)]
-    assert [str(a.constraint.referenced_table) for a in set_actions] == ["dev.silver.products"]
-    assert [a.constraint.constraint_name for a in drop_actions] == ["legacy_archive_fk"]
-
-
-def test_set_foreign_key_carries_the_declared_spelling_on_both_sides():
-    # Given child declares local column "customerId" that the catalog spells
-    # "customerid", referencing parent column "Id" that the catalog spells "id"
-    parent = _referenced_table(
-        "dev.silver.customers", primary_key_columns=("Id",)
-    ).to_desired_table()
-    child = _table_with_fk(
-        "dev.silver.orders",
-        "dev.silver.customers",
-        local_columns=("customerId",),
-        referenced_primary_key_columns=("Id",),
-    )
-    parent_observed = _observed("dev.silver.customers", ("id",))
-    child_observed = _observed("dev.silver.orders", ("id", "customerid"))
-
-    # When resolved
-    resolutions = resolve((_present(parent, parent_observed), _present(child, child_observed)))
-
-    # Then the emitted SetForeignKey is a semantic value wearing the declared
-    # spellings; each table's case drift is rejected by validation separately
-    child_resolution = _successful_resolution(resolutions, "dev.silver.orders")
-    (action,) = child_resolution.actions
-    assert isinstance(action, SetForeignKey)
-    assert tuple(str(column) for column in action.constraint.local_columns) == ("customerId",)
-    assert tuple(str(column) for column in action.constraint.referenced_columns) == ("Id",)
-
-
-def test_referenced_spelling_of_a_parent_created_this_sync_is_the_declared_one():
-    # Given the referenced parent does not exist yet, so its declared spelling
-    # is the only spelling there is
-    parent = _referenced_table(
-        "dev.silver.customers", primary_key_columns=("Id",)
-    ).to_desired_table()
-    child = _table_with_fk(
-        "dev.silver.orders",
-        "dev.silver.customers",
-        referenced_primary_key_columns=("Id",),
-    )
-
-    # When resolved
-    resolutions = resolve((_absent(parent), _absent(child)))
-
-    # Then the referenced side keeps the declared spelling
-    child_resolution = _successful_resolution(resolutions, "dev.silver.orders")
-    (action,) = child_resolution.actions
-    assert isinstance(action, SetForeignKey)
-    assert tuple(str(column) for column in action.constraint.referenced_columns) == ("Id",)
-
-
-def test_self_referencing_foreign_key_keeps_its_declared_spelling():
-    # Given a self-referencing key declared lowercase against camelCase catalog columns
-    employees = DeltaTable(
-        "dev",
-        "silver",
-        "employees",
-        columns=(
-            Column("id", String(), nullable=False),
-            Column("managerid", String()),
-        ),
-        primary_key=["id"],
-        foreign_keys=[ForeignKey(columns={"managerid": "id"}, references=Self)],
-    ).to_desired_table()
-    observed = _observed("dev.silver.employees", ("Id", "ManagerId"))
-
-    # When resolved
-    resolutions = resolve((_present(employees, observed),))
-
-    # Then both sides wear the declared spelling; the columns' case drift is
-    # rejected by validation separately
-    employees_resolution = _successful_resolution(resolutions, "dev.silver.employees")
-    (action,) = employees_resolution.actions
-    assert isinstance(action, SetForeignKey)
-    assert tuple(str(column) for column in action.constraint.local_columns) == ("managerid",)
-    assert tuple(str(column) for column in action.constraint.referenced_columns) == ("id",)
-
-
-def test_foreign_key_to_a_renamed_parent_key_keeps_the_new_declared_name():
-    # Given a parent renaming its key column — the catalog still spells the old
-    # name — and a child referencing the declared new name
-    parent = _referenced_table(
-        "dev.silver.customers", primary_key_columns=("orderNumber",)
-    ).to_desired_table()
-    child = _table_with_fk(
-        "dev.silver.orders",
-        "dev.silver.customers",
-        referenced_primary_key_columns=("orderNumber",),
-    )
-    parent_observed = _observed("dev.silver.customers", ("OrderId",))
-    child_observed = _observed("dev.silver.orders", ("id", "ref_id"))
-
-    # When resolved
-    resolutions = resolve((_present(parent, parent_observed), _present(child, child_observed)))
-
-    # Then the reference keeps the declared post-rename name, not the observed old one
-    child_resolution = _successful_resolution(resolutions, "dev.silver.orders")
-    (action,) = child_resolution.actions
-    assert isinstance(action, SetForeignKey)
-    assert tuple(str(column) for column in action.constraint.referenced_columns) == ("orderNumber",)
-
-
-def test_unreadable_table_contributes_edges_but_no_actions():
-    # Given a child declaring an FK whose own catalog state could not be read
-    parent = _referenced_table("dev.silver.customers").to_desired_table()
-    child = _table_with_fk("dev.silver.orders", "dev.silver.customers")
-
-    # When resolved
-    resolutions = resolve((_absent(parent), _unreadable(child)))
-
-    # Then no actions are planned against unknown state, but the dependency
-    # edge still exists so gating can block on the parent's outcome
-    child_resolution = _successful_resolution(resolutions, "dev.silver.orders")
-    assert child_resolution.actions == ()
+    # Then the dependency edge exists for the gating walk to block on later
+    child_resolution = _sound_resolution(resolutions, "dev.silver.orders")
     assert [str(d.referenced_table) for d in child_resolution.dependencies] == [
         "dev.silver.customers"
     ]
-    blocking = child_resolution.blocking_failures({_qualified_name("dev.silver.customers")})
-    assert [failure.reason for failure in blocking] == [
-        ForeignKeyFailureReason.BLOCKED_BY_FAILED_DEPENDENCY
-    ]
-    assert child_resolution.blocking_failures(frozenset()) == ()
-
-
-def test_structural_failure_still_carries_planned_actions_for_the_preview():
-    # Given a child whose FK references an unregistered table
-    child = _table_with_fk("dev.silver.orders", "dev.silver.archive")
-
-    # When resolved
-    resolutions = resolve((_absent(child),))
-
-    # Then the failure is structural and the planned action is still stated,
-    # declared-spelled, for the report preview
-    (resolution,) = resolutions
-    assert isinstance(resolution, ResolutionFailed)
-    assert [failure.reason for failure in resolution.failures] == [
-        ForeignKeyFailureReason.UNRESOLVABLE_REFERENCE
-    ]
-    assert [type(action) for action in resolution.actions] == [SetForeignKey]
 
 
 def test_resolutions_come_dependency_first():
@@ -1101,31 +874,30 @@ def test_resolutions_come_dependency_first():
     child = _table_with_fk("dev.silver.orders", "dev.silver.customers")
 
     # When resolved with the child first
-    resolutions = resolve((_absent(child), _absent(parent)))
+    resolutions = resolve((child, parent))
 
     # Then the parent still precedes the child
     _assert_before(resolutions, "dev.silver.customers", "dev.silver.orders")
 
 
-def test_unmanaged_foreign_keys_create_no_edges_but_actions_are_still_stated():
+def test_unmanaged_foreign_keys_create_no_edges():
     # Given a tag-scoped table declaring an FK it does not manage
     table = _tag_scoped_table_with_fk("dev.silver.orders", "dev.silver.customers")
 
     # When resolved
-    resolutions = resolve((_absent(table),))
+    resolutions = resolve((table,))
 
-    # Then no dependency edge exists and nothing failed structurally, but the
-    # action is still stated for validation's scope gate to judge
+    # Then no dependency edge exists and nothing failed structurally; the FK
+    # difference itself is the differ's to state and the scope gate's to judge
     (resolution,) = resolutions
-    assert isinstance(resolution, ResolutionSucceeded)
+    assert resolution.structural_failures == ()
     assert resolution.dependencies == ()
-    assert [type(action) for action in resolution.actions] == [SetForeignKey]
 
 
 def test_resolve_classifies_the_four_structural_reasons():
     # Unresolvable reference: the parent is not registered in this sync
     orphan = _table_with_fk("dev.silver.orders", "dev.silver.archive")
-    result = resolve((_absent(orphan),))
+    result = resolve((orphan,))
     _assert_has_failure(
         result, "dev.silver.orders", reason=ForeignKeyFailureReason.UNRESOLVABLE_REFERENCE
     )
@@ -1135,7 +907,7 @@ def test_resolve_classifies_the_four_structural_reasons():
     odd_parent = _referenced_table(
         "dev.silver.customers", primary_key_columns=("customer_key",)
     ).to_desired_table()
-    result = resolve((_absent(child), _absent(odd_parent)))
+    result = resolve((child, odd_parent))
     _assert_has_failure(
         result, "dev.silver.orders", reason=ForeignKeyFailureReason.REFERENCED_COLUMNS_NOT_A_KEY
     )
@@ -1149,7 +921,7 @@ def test_resolve_classifies_the_four_structural_reasons():
         columns=(Column("id", Long(), nullable=False),),
         primary_key=["id"],
     ).to_desired_table()
-    result = resolve((_absent(child), _absent(long_parent)))
+    result = resolve((child, long_parent))
     _assert_has_failure(
         result,
         "dev.silver.orders",
@@ -1159,7 +931,7 @@ def test_resolve_classifies_the_four_structural_reasons():
     # Cycle: two tables reference each other
     invoices = _table_with_fk("dev.silver.invoices", "dev.silver.ledger")
     ledger = _table_with_fk("dev.silver.ledger", "dev.silver.invoices")
-    result = resolve((_absent(invoices), _absent(ledger)))
+    result = resolve((invoices, ledger))
     _assert_has_failure(result, "dev.silver.invoices", reason=ForeignKeyFailureReason.CYCLE)
     _assert_has_failure(result, "dev.silver.ledger", reason=ForeignKeyFailureReason.CYCLE)
 
@@ -1177,13 +949,11 @@ def test_foreign_key_referenced_column_case_must_match_the_registered_declaratio
     )
 
     # When resolved
-    resolutions = resolve((_absent(parent), _absent(child)))
+    resolutions = resolve((parent, child))
 
     # Then the FK fails structurally: ADD CONSTRAINT resolves case-sensitively,
     # so the reference must wear the registered declaration's exact spelling
-    [child_resolution] = [r for r in resolutions if str(r.qualified_name) == "dev.silver.orders"]
-    assert isinstance(child_resolution, ResolutionFailed)
-    assert [failure.reason for failure in child_resolution.failures] == [
+    assert _failure_reasons_for(resolutions, "dev.silver.orders") == [
         ForeignKeyFailureReason.REFERENCED_COLUMN_CASE_MISMATCH
     ]
 
@@ -1199,6 +969,6 @@ def test_foreign_key_referenced_spelling_matching_exactly_is_sound():
         referenced_primary_key_columns=("OrderId",),
     )
 
-    resolutions = resolve((_absent(parent), _absent(child)))
+    resolutions = resolve((parent, child))
 
-    assert _successful_resolution(resolutions, "dev.silver.orders")
+    _sound_resolution(resolutions, "dev.silver.orders")

--- a/tests/application/test_rendering.py
+++ b/tests/application/test_rendering.py
@@ -14,7 +14,7 @@ from delta_engine.application.ports import (
     ExecutionSummary,
     TablePresent,
 )
-from delta_engine.application.relationships import ResolutionSucceeded
+from delta_engine.application.relationships import TableResolution
 from delta_engine.application.rendering import (
     render_diff,
     render_diff_block,
@@ -356,7 +356,7 @@ def _report_with_empty_plan_and_failure() -> TableRunReport:
             (ValidationFailure(rule_name="UnsupportedColumnTypeChange", message="nope"),)
         ),
         planned_sql_statements=(),
-        resolution=ResolutionSucceeded(qualified_name, ()),
+        resolution=TableResolution(qualified_name, (), ()),
         execution_outcome=None,
     )
 
@@ -436,7 +436,7 @@ def test_diff_block_reports_a_read_failure_instead_of_a_diff():
         read=failure,
         planning=None,
         planned_sql_statements=(),
-        resolution=ResolutionSucceeded(qualified_name, ()),
+        resolution=TableResolution(qualified_name, (), ()),
         execution_outcome=None,
     )
 
@@ -471,7 +471,7 @@ def _grid_report(name, *, plan=None, failures=(), execution=None):
         planned_sql_statements=tuple(
             f"SQL {index}" for index in range(len(plan) if plan is not None else 0)
         ),
-        resolution=ResolutionSucceeded(qualified_name, ()),
+        resolution=TableResolution(qualified_name, (), ()),
         execution_outcome=execution,
     )
 

--- a/tests/application/test_report.py
+++ b/tests/application/test_report.py
@@ -320,7 +320,7 @@ def test_table_run_report_status_is_planning_failed_when_only_validation_failure
     assert report.has_failures is True
 
 
-def test_table_run_report_status_is_planning_failed_when_both_fk_and_validation_present():
+def test_table_run_report_status_is_foreign_key_failed_when_both_fk_and_validation_present():
     # Given a table with both a validation failure and an FK failure
     report = _report(
         desired=_a_desired_table("orders"),
@@ -336,9 +336,31 @@ def test_table_run_report_status_is_planning_failed_when_both_fk_and_validation_
         ),
     )
 
-    # Then PLANNING_FAILED wins: it is the earlier phase and the actionable root cause
-    assert report.status is TableRunStatus.PLANNING_FAILED
+    # Then FOREIGN_KEY_FAILED wins: resolution judges the declaration set
+    # before any single table is diffed, so it is the earlier phase and the
+    # root cause — the plan cannot be right while the relationships are broken
+    assert report.status is TableRunStatus.FOREIGN_KEY_FAILED
     assert len(report.failures) == 2
+
+
+def test_multi_phase_failure_reports_the_earliest_pipeline_phase():
+    # Given a table that failed resolution (structural FK) and also failed its read
+    desired = _a_desired_table("orders")
+    report = _report(
+        desired=desired,
+        read=ReadFailure("IOError", "boom"),
+        failures=(
+            ForeignKeyFailure(
+                table=desired.qualified_name,
+                local_columns=("customer_id",),
+                references=QualifiedName("cat", "schema", "customers"),
+                reason=ForeignKeyFailureReason.UNRESOLVABLE_REFERENCE,
+            ),
+        ),
+    )
+
+    # Then the earliest pipeline phase wins: resolution precedes read
+    assert report.status is TableRunStatus.FOREIGN_KEY_FAILED
 
 
 def test_table_run_report_with_no_failures_is_success():

--- a/tests/application/test_report.py
+++ b/tests/application/test_report.py
@@ -19,10 +19,7 @@ from delta_engine.application.ports import (
     TableAbsent,
     TablePresent,
 )
-from delta_engine.application.relationships import (
-    ResolutionFailed,
-    ResolutionSucceeded,
-)
+from delta_engine.application.relationships import TableResolution
 from delta_engine.application.report import (
     ExecutionBlockedByDependency,
     SyncReport,
@@ -133,10 +130,10 @@ def _report(
         assert isinstance(report_plan, ActionPlan)
         planning = PlanningSucceeded(report_plan)
 
-    resolution = (
-        ResolutionFailed(desired.qualified_name, resolution_failures)
-        if resolution_failures and not execution_blocked
-        else ResolutionSucceeded(desired.qualified_name, ())
+    resolution = TableResolution(
+        qualified_name=desired.qualified_name,
+        dependencies=(),
+        structural_failures=() if execution_blocked else resolution_failures,
     )
     execution_outcome = (
         ExecutionBlockedByDependency(resolution_failures) if execution_blocked else execution
@@ -421,7 +418,7 @@ def test_table_run_report_rejects_planning_after_a_failed_read():
             read=ReadFailure("IOError", "boom"),
             planning=PlanningSucceeded(ActionPlan(target=desired.qualified_name)),
             planned_sql_statements=(),
-            resolution=ResolutionSucceeded(desired.qualified_name, ()),
+            resolution=TableResolution(desired.qualified_name, (), ()),
             execution_outcome=None,
         )
 
@@ -441,7 +438,7 @@ def test_table_run_report_rejects_execution_after_failed_resolution():
             read=TablePresent(table=_an_observed_table()),
             planning=PlanningSucceeded(ActionPlan(target=desired.qualified_name)),
             planned_sql_statements=("SQL",),
-            resolution=ResolutionFailed(desired.qualified_name, (failure,)),
+            resolution=TableResolution(desired.qualified_name, (), (failure,)),
             execution_outcome=ExecutionSummary((_ok_exec(0, "SQL"),)),
         )
 
@@ -455,7 +452,7 @@ def test_table_run_report_rejects_execution_unrelated_to_planned_sql():
             read=TablePresent(table=_an_observed_table()),
             planning=PlanningSucceeded(ActionPlan(target=desired.qualified_name)),
             planned_sql_statements=("PLANNED SQL",),
-            resolution=ResolutionSucceeded(desired.qualified_name, ()),
+            resolution=TableResolution(desired.qualified_name, (), ()),
             execution_outcome=ExecutionSummary((_ok_exec(0, "OTHER SQL"),)),
         )
 

--- a/tests/domain/plan/test_diff.py
+++ b/tests/domain/plan/test_diff.py
@@ -28,12 +28,14 @@ from delta_engine.domain.plan.actions import (
     AlterColumnType,
     CreateTable,
     DropColumn,
+    DropForeignKey,
     DropPrimaryKey,
     EnableTableFeature,
     RenameColumn,
     SetColumnComment,
     SetColumnNullability,
     SetColumnTag,
+    SetForeignKey,
     SetPrimaryKey,
     SetProperty,
     SetTableComment,
@@ -56,6 +58,7 @@ from delta_engine.domain.plan.unresolvable import (
 from tests.builders import as_observed_columns
 
 _QUALIFIED_NAME = QualifiedName("dev", "silver", "test")
+_PARENT_NAME = QualifiedName("dev", "silver", "other")
 
 
 def _desired(**overrides) -> DesiredTable:
@@ -70,11 +73,16 @@ def _observed(**overrides) -> ObservedTable:
     return ObservedTable(**merged)
 
 
-def _foreign_key(constraint_name: str = "test_id_fk") -> ForeignKeyConstraint:
+def _foreign_key(
+    constraint_name: str = "test_id_fk",
+    local_columns: tuple[str, ...] = ("id",),
+    referenced_columns: tuple[str, ...] = ("id",),
+    referenced_table: QualifiedName = _PARENT_NAME,
+) -> ForeignKeyConstraint:
     return ForeignKeyConstraint(
-        local_columns=("id",),
-        referenced_table=QualifiedName("dev", "silver", "other"),
-        referenced_columns=("id",),
+        local_columns=local_columns,
+        referenced_table=referenced_table,
+        referenced_columns=referenced_columns,
         constraint_name=constraint_name,
     )
 
@@ -692,17 +700,104 @@ def test_equal_primary_keys_by_column_set_produce_no_change():
 # ---------- constraint changes
 
 
-def test_foreign_keys_are_not_the_differs_concern():
-    # Given declared and observed foreign keys that disagree
-    diff = diff_table(
-        _desired(foreign_keys=(_foreign_key("declared_fk"),)),
-        _observed(),
+def test_present_table_diffs_foreign_keys_by_signature():
+    # Given one FK declared-and-present, one declared-but-absent,
+    # and one observed-but-undeclared
+    shared = _foreign_key("orders_customer_fk", local_columns=("customer_id",))
+    declared_only = _foreign_key("orders_billing_fk", local_columns=("billing_id",))
+    observed_only = _foreign_key("legacy_archive_fk", local_columns=("legacy_id",))
+    desired = _desired(
+        columns=(
+            DesiredColumn("customer_id", String()),
+            DesiredColumn("billing_id", String()),
+            DesiredColumn("legacy_id", String()),
+        ),
+        foreign_keys=(shared, declared_only),
+    )
+    observed = _observed(
+        columns=(
+            ObservedColumn("customer_id", String()),
+            ObservedColumn("billing_id", String()),
+            ObservedColumn("legacy_id", String()),
+        ),
+        foreign_keys=(shared, observed_only),
     )
 
-    # Then the differ states no FK action — relationships are planned by the
-    # resolver, the one module holding both endpoints
-    assert isinstance(diff, TableDrift)
-    assert diff.actions == ()
+    # When the table is diffed
+    drift = diff_table(desired, observed)
+
+    # Then the absent declaration is set and the undeclared observation dropped
+    assert isinstance(drift, TableDrift)
+    set_actions = [a for a in drift.actions if isinstance(a, SetForeignKey)]
+    drop_actions = [a for a in drift.actions if isinstance(a, DropForeignKey)]
+    assert [a.constraint for a in set_actions] == [declared_only]
+    assert [a.constraint.constraint_name for a in drop_actions] == ["legacy_archive_fk"]
+
+
+def test_set_foreign_key_carries_the_declared_spelling():
+    # Given a declared FK whose catalog columns are spelled differently
+    declared = _foreign_key("orders_customer_fk", local_columns=("CustomerId",))
+    desired = _desired(
+        columns=(DesiredColumn("CustomerId", String()),),
+        foreign_keys=(declared,),
+    )
+    observed = _observed(columns=(ObservedColumn("customerid", String()),))
+
+    drift = diff_table(desired, observed)
+
+    # Then the action is a semantic value: declared spelling, untouched.
+    # The case drift itself is stated separately (ColumnCaseDrift) and
+    # rejected by ColumnSpellingMustMatchCatalog — stating both is the
+    # differ's job; judging is validation's.
+    (action,) = [a for a in drift.actions if isinstance(a, SetForeignKey)]
+    assert tuple(str(c) for c in action.constraint.local_columns) == ("CustomerId",)
+
+
+def test_missing_table_actions_include_every_declared_foreign_key():
+    # Given a missing table declaring an outbound FK and a self-referential FK
+    outbound = _foreign_key("orders_customer_fk", local_columns=("customer_id",))
+    self_ref = _foreign_key(
+        "orders_parent_fk",
+        local_columns=("parent_order_id",),
+        referenced_columns=("id",),
+        referenced_table=_QUALIFIED_NAME,
+    )
+    desired = _desired(
+        columns=(
+            DesiredColumn("id", String(), nullable=False),
+            DesiredColumn("customer_id", String()),
+            DesiredColumn("parent_order_id", String()),
+        ),
+        primary_key=PrimaryKeyConstraint(columns=("id",), constraint_name="orders_pk"),
+        foreign_keys=(outbound, self_ref),
+    )
+
+    diff = diff_table(desired, observed=None)
+
+    # Then creation is stated first and every declared FK follows
+    assert isinstance(diff, TableMissing)
+    assert isinstance(diff.actions[0], CreateTable)
+    fk_actions = [a for a in diff.actions if isinstance(a, SetForeignKey)]
+    assert {str(a.constraint.constraint_name) for a in fk_actions} == {
+        "orders_customer_fk",
+        "orders_parent_fk",
+    }
+
+
+def test_foreign_key_drift_is_stated_even_when_unmanaged():
+    # Given a declaration that does not manage foreign keys but declares one
+    declared = _foreign_key("orders_customer_fk", local_columns=("customer_id",))
+    desired = _desired(
+        columns=(DesiredColumn("customer_id", String()),),
+        foreign_keys=(declared,),
+        managed_aspects=ALL_ASPECTS - frozenset({TableAspect.FOREIGN_KEYS}),
+    )
+    observed = _observed(columns=(ObservedColumn("customer_id", String()),))
+
+    drift = diff_table(desired, observed)
+
+    # Then the difference is stated; rejecting it is the scope gate's job
+    assert any(isinstance(a, SetForeignKey) for a in drift.actions)
 
 
 def test_observed_only_primary_key_produces_removed_change():


### PR DESCRIPTION
> **Stacked on #290** (`refactor/relationship-resolver`), like #295 before it. Retarget to `main` when #290 merges. PR 2 of the three-PR pipeline-laws staging; PR 3 (derived blocking) follows.

## What

Two laws, each dissolving a special case:

**The diff is complete.** Foreign-key existence is a difference like any other, so the differ states it — `_diff_foreign_keys` matches declared against observed by content signature, exactly as `_diff_primary_key` already did, and `TableMissing.actions` carries every declared key. `plan_diff(diff)` therefore judges one stream: the `relationship_actions` side channel, the drift/missing merge arms, and the `replace()` that rebuilt the drift are gone. The PK-drop exemption no longer needs to be told where the FK drops came from — they are in the diff it already reads.

**Static before worldly.** Resolution consults no catalog state, so it runs before the read: `lower → resolve → read → diff → plan → compile → gate → execute`. A run is born at resolve carrying its static facts (declaration, dependency edges, structural verdicts) and accretes `read`, `diff`, `planning`, SQL, and `execution` as the worldly phases run.

Consequences:

- **The resolver slims to pure declaration analysis.** `resolve(tables)` takes desired tables and returns one `TableResolution(qualified_name, dependencies, structural_failures)` each. The `ResolutionSucceeded`/`ResolutionFailed` union, `ResolvedDependency`, `_foreign_key_actions`, the `TableSnapshot`/`ResolveResult` aliases, and the engine's `_successful_resolution` narrowing are all deleted — "failed" is now definitional (non-empty `structural_failures`), so there is no variant to narrow and no invariant to enforce. Dependency edges are the declared constraints themselves, and `TableResolution.blocked_by(unconverged)` builds the same `BLOCKED_BY_FAILED_DEPENDENCY` values on demand instead of the resolver pre-building one per edge.
- **A resolution names its own blocked dependencies.** Blocking is not a static fact — it depends on which tables fail their read, plan, or statements this run — but translating a dependency edge into a `ForeignKeyFailure` is relationship vocabulary, so it belongs with the edges. `blocked_by` takes the tables that will not converge and returns the failures; the caller owns only the walk that accumulates that set. `engine.py` no longer imports `ForeignKeyFailure` or `ForeignKeyFailureReason` at all.
- **`FailurePhase` follows the pipeline:** `FOREIGN_KEY = 1, READ = 2, PLANNING = 3, EXECUTION = 4`, and `TableRunReport.failures` flattens structural → read → planning → execution. Enum names and status strings are unchanged.

Net: 729 lines deleted, 653 added.

## Why

Both special cases existed because FK work lived in the wrong module. The resolver had to see read snapshots (to diff FKs), so resolution had to follow the read; and because it produced actions the differ didn't know about, planning needed a second input to validate the true stream. Moving existence into the differ leaves the resolver with only what genuinely needs every table at once — ordering and structural verdicts — which needs no catalog state at all. The phase order then follows from the data, not from a scheduling choice.

## Behaviour changes

Two, both in *which* status a multi-failure table reports; the failures themselves are unchanged and all still appear in `failures`.

1. A table that fails resolution **and** read now reports `FOREIGN_KEY_FAILED`, not `READ_FAILED` (spec delta 4). Pinned by `test_multi_phase_failure_reports_the_earliest_pipeline_phase`.
2. A table that fails resolution **and** planning now reports `FOREIGN_KEY_FAILED`, not `PLANNING_FAILED`. This follows necessarily from `FOREIGN_KEY = 1` and was not called out separately in the plan — the full suite surfaced it as exactly one failing test, the precedence pin that asserted the old order, which is rewritten with the new rationale: resolution judges the declaration set before any single table is diffed, so it is both the earlier phase and the root cause.

Everything else holds: same failures, same blocked tables, same statuses for single-failure tables, and SQL is byte-identical — differ-born FK actions carry the declared constraints verbatim, exactly as the resolver's did, and `ActionPlan` still orders by `ActionPhase`.

## Verification

- Full suite **1096 passed** (same count as the base — the resolver lost 8 tests whose subjects moved to the differ or ceased to exist, and gained the pins below); coverage 96.60%; ruff, format, mypy, lint-imports (7 contracts), sphinx `-W` all green.
- New pins: four differ FK tests (signature matching, declared spelling carried verbatim, missing-table keys including the self-referential case, drift stated even when the aspect is unmanaged), three `blocked_by` tests (each blocked edge named, only depended-on tables block, one failure per blocked edge), the engine's static-before-worldly pin (structural verdicts recorded even when the read fails), and the precedence pin above.
- End-state greps clean: `relationship_actions`, `ResolutionSucceeded|ResolutionFailed|ResolvedDependency|TableSnapshot|ResolveResult`, `_successful_resolution`, `_blocking_failures`, and the resolver's `_foreign_key_actions` all return nothing in `src` and `tests`.
- **`tests/live/` is untouched** — `git diff` against the base is empty. No live-suite handoff needed for this PR: it changes no SQL and no live-observable behaviour.
- Docs updated: sync-lifecycle phase table and order, architecture sequence diagram, phase list, resolver section and "where to make changes" rows. Two stale entries from #295 corrected in passing — `REFERENCED_COLUMN_CASE_MISMATCH` was missing from the verdict lists in the architecture and safety-model pages.
