### PR TITLE
docs: reconcile stale backlog entries

### DIFF
--- a/docs/todo/roadmap.md
+++ b/docs/todo/roadmap.md
@@ -9,11 +9,11 @@ this document supersedes their prioritisation but not their detail.
 
 | #   | Item                                              | Tier | Effort | Tracking       |
 | --- | ------------------------------------------------- | ---- | ------ | -------------- |
-| 1   | Type widening                                     | 1    | M      | tracked        |
+| 1   | Type widening                                     | 1    | M      | shipped        |
 | 2   | Column renames (`renamed_from`)                   | 1    | M      | shipped        |
 | 3   | CI-grade dry runs: structured report, SQL preview | 1    | M      | shipped        |
 | 4   | Databricks SQL warehouse adapter (no PySpark)     | 1    | L      | shipped        |
-| 5   | Delta-format / view guard in the reader           | 2    | S      | not tracked    |
+| 5   | Delta-format / view guard in the reader           | 2    | S      | shipped        |
 | 6   | Identity columns                                  | 2    | M      | not tracked    |
 | 7   | Adoption tooling: declaration codegen + names     | 2    | M–L    | partly tracked |
 | 8   | CHECK constraints                                 | 2    | M      | not tracked    |
@@ -29,11 +29,12 @@ this document supersedes their prioritisation but not their detail.
 | 18  | Plan artifacts (approve-then-apply)               | 4    | L      | not tracked    |
 | 19  | Existing gated items (UNIQUE, Char/Varchar, ...)  | 4    | —      | tracked        |
 
-Sequencing note: impact order is not build order. Items 3 and 4 shipped as the
-read-only `delta-engine plan MODULE:ATTRIBUTE` workflow; the remaining items
-are future work. Item 2 shipped without the over-broad interim heuristic; items
-5 and 9 are afternoon-sized and can ship independently;
-items 17 and 18 remain deliberately gated on evidence from real users.
+Sequencing note: impact order is not build order. Items 1–5 are shipped; items
+3 and 4 shipped as the read-only `delta-engine plan MODULE:ATTRIBUTE`
+workflow, and item 2 shipped without the over-broad interim heuristic. Identity
+columns are the highest-impact unfinished item, while item 9 remains a smaller
+independent change. Items 17 and 18 remain deliberately gated on evidence from
+real users.
 
 ---
 
@@ -139,19 +140,15 @@ the Python API remains the write/apply mechanism.
 
 ### 5. Delta-format and view guard in the reader
 
-**Why.** `tableExists` answers true for views and non-Delta tables, and
-nothing downstream checks the format. A view limps to a confusing raw
-`ReadError` at `DESCRIBE DETAIL`. A Parquet/Iceberg table is worse:
-`DESCRIBE DETAIL` succeeds, the engine diffs it as Delta, and can plan
-`delta.*` properties, `CLUSTER BY`, and constraint DDL against it, failing (or
-partially succeeding) at execution with errors pointing nowhere near the
-cause.
+**Status.** Shipped 2026-07-16 through the shared AS JSON reader.
 
-**Shape (S).** The `DESCRIBE DETAIL` row is already fetched for every present
-table and carries `format`. Check it and return a typed "exists but is not a
-Delta table" read failure; catch the view case earlier via the catalog table
-type for a clean message. Same protective class as
-`ColumnMappingRequiredForDrop`, at the read boundary.
+`DESCRIBE TABLE EXTENDED ... AS JSON` supplies the relation type and provider.
+The reader admits managed tables, external tables, and streaming tables only
+when their provider is Delta. Views, materialized views, foreign tables,
+non-Delta providers, missing metadata, and unknown future relation kinds fail
+the read before the engine can diff or plan changes against them. Focused
+reader tests cover every admitted kind and representative rejected kinds and
+providers.
 
 ### 6. Identity columns
 

--- a/docs/todo/todo.md
+++ b/docs/todo/todo.md
@@ -1,7 +1,12 @@
 # Open questions and decisions
 
 - [x] Resolve the [PR #280 table-feature enablement design review](2026-07-24-table-feature-enablement-ousterhout-review.md): the domain differ derives desired requirements from the column tree, observed support comes from the existing AS JSON `delta.feature.*` property projection, feature identities are typed, the report contract includes `features`, and properties remain semantically separate. Credentialed live verification remains required before merge.
-- [ ] Address the prioritized stale, inaccurate, and missing documentation in the [2026-07-24 documentation accuracy and coverage review](2026-07-24-documentation-accuracy-review.md). Immediate corrections are the walkthrough's Databricks Runtime floor, `Map` key validation, the full liquid-clustering key-type restriction, and the unpinned CI installation example; broader follow-up is publishing tested-runtime evidence once live Spark coverage exists.
+- [x] Correct the stale and inaccurate documentation identified during the
+      2026-07-24 documentation cleanup. The walkthrough states the Databricks
+      Runtime floor, `Map` key validation and the full liquid-clustering
+      key-type restriction are documented, and the CI installation example is
+      pinned. Tested-runtime evidence remains tracked separately with the
+      distribution and runtime-confidence work below.
 - [ ] Complete the remaining distribution and runtime-confidence work recorded in the [2026-07-23 distribution/versioning/runtime review](2026-07-23-distribution-versioning-runtime-review.md). Artifact validation, dependency bounds, installation-path guidance, base-only Databricks guidance, actionable optional-dependency errors, and the [runtime compatibility policy](../explanation-runtime-compatibility.md) are implemented. Remaining runtime work is live Spark-backend smoke coverage and publishing the environments it actually tests as evidence; the existing weekly SQL warehouse suite does not exercise numbered cluster runtimes.
       The focused [2026-07-29 Databricks runtime compatibility audit](2026-07-29-databricks-runtime-compatibility-audit.md) records the evidence gaps, proposed minimum live coverage, serverless and warehouse-channel scope, runtime diagnostics, metadata-evolution policy, and prioritized assurance backlog.
 - [ ] Add Spark-backend support for Dedicated access-mode compute (`data_security_mode` value `SINGLE_USER`). It does not currently work and should be treated as unsupported. Identify the incompatible boundary, implement the narrow fix, and add a live regression before documenting support. See the [runtime compatibility audit](2026-07-29-databricks-runtime-compatibility-audit.md).


### PR DESCRIPTION
## What changed

- remove the dead documentation-review link and mark its already-landed corrections complete
- mark type widening and the Delta relation guard as shipped in the feature roadmap
- replace the reader guard's obsolete `DESCRIBE DETAIL` proposal with the delivered AS JSON behavior
- identify identity columns as the highest-impact unfinished roadmap item

## Why

The backlog had drifted behind the implementation. It linked to a review file that does not exist, described completed documentation corrections as pending, and still presented the Delta-format/view guard as unimplemented even though the shared reader now rejects unsupported relation kinds and non-Delta providers before planning.

## Impact

Documentation only. No package behavior changes.

## Checks

- `git diff --check`
- `uv run --group docs myst-docutils-html --myst-all-links-external=true --halt=warning docs/todo/todo.md /tmp/delta-engine-backlog-cleanup-todo.html`
- `uv run --group docs myst-docutils-html --myst-all-links-external=true --halt=warning docs/todo/roadmap.md /tmp/delta-engine-backlog-cleanup-roadmap.html`