### PR TITLE
refactor: a resolution carries the declaration it judged

### DIFF
--- a/docs/explanation-architecture.md
+++ b/docs/explanation-architecture.md
@@ -70,7 +70,7 @@ through a sync.
 | `ValidationResult` | Lower-level validation verdict used to test policy rules in isolation.                                                                                      |
 | `PlanningResult`   | The total application boundary: either `PlanningSucceeded(ActionPlan)` or `PlanningFailed(validation failures)`.                                            |
 | `ActionPlan`       | The qualified table target, relation kind, and ordered actions that should be executed if the table is allowed to run.                                      |
-| `ResolveResult`    | One explicit success or structural failure per table in dependency-first order; every resolution carries its planned foreign-key actions, and successful ones retain the resolved dependencies the execution gate applies.                   |
+| `TableResolution`  | One table's static relationship facts, in dependency-first order by tuple position: the declaration it was judged from, that table's dependency edges, and its structural foreign-key verdicts.                   |
 | `ExecutionSummary` | The result of running a plan's compiled statements. It records successful statements and the first failed statement, if execution failed.                   |
 | `TableRunReport`   | The immutable public snapshot of a completed table run: desired state, read result, accepted plan, compiled SQL, failures, and attempted statement results.                  |
 | `SyncReport`       | The aggregate result for the whole sync. It is returned on success and attached to `SyncFailedError` on real-run failure.                                   |

--- a/src/delta_engine/application/engine.py
+++ b/src/delta_engine/application/engine.py
@@ -125,15 +125,15 @@ class _TableRun:
     """
     Mutable scratch pad threaded through the sync phases.
 
-    Born in the resolve phase, in dependency order, carrying its static facts:
-    the declaration, its dependency edges, and its structural verdicts. Its
-    read, diff, planning outcome, compiled SQL, and execution outcome accrete
-    as the worldly phases run, each written once, then the run is frozen into
-    a public :class:`TableRunReport`. Kept private to the engine so the
-    published report stays immutable while the phases mutate in place.
+    Born in the resolve phase, in dependency order, carrying its resolution —
+    which holds its static facts: the declaration, its dependency edges, and
+    its structural verdicts. Its read, diff, planning outcome, compiled SQL,
+    and execution outcome accrete as the worldly phases run, each written
+    once, then the run is frozen into a public :class:`TableRunReport`. Kept
+    private to the engine so the published report stays immutable while the
+    phases mutate in place.
     """
 
-    desired: DesiredTable
     resolution: TableResolution
     read: ReadResult | None = None
     diff: TableDiff | None = None
@@ -142,8 +142,12 @@ class _TableRun:
     execution: ExecutionOutcome | None = None
 
     @property
+    def desired(self) -> DesiredTable:
+        return self.resolution.desired
+
+    @property
     def qualified_name(self) -> QualifiedName:
-        return self.desired.qualified_name
+        return self.resolution.qualified_name
 
     @property
     def plan(self) -> ActionPlan | None:
@@ -171,7 +175,6 @@ class _TableRun:
         if self.read is None:
             raise RuntimeError(f"Run was frozen before its read completed: {self.qualified_name}")
         return TableRunReport(
-            desired=self.desired,
             read=self.read,
             planning=self.planning,
             planned_sql_statements=self.planned_sql_statements,
@@ -364,15 +367,10 @@ class Engine:
         ``_gate``. Every run carries a resolution from birth, so no later
         phase has to consider a half-resolved table.
         """
-        ordered_resolutions = resolve(tables)
-
-        desired_by_name = {table.qualified_name: table for table in tables}
-
         runs: list[_TableRun] = []
 
-        for resolution in ordered_resolutions:
-            desired = desired_by_name[resolution.qualified_name]
-            runs.append(_TableRun(desired=desired, resolution=resolution))
+        for resolution in resolve(tables):
+            runs.append(_TableRun(resolution=resolution))
 
             if resolution.structural_failures:
                 logger.error("Foreign key resolution failed for %s", resolution.qualified_name)

--- a/src/delta_engine/application/relationships.py
+++ b/src/delta_engine/application/relationships.py
@@ -4,10 +4,11 @@ Cross-table relationship resolution: ordering, edges, and structural verdicts.
 The public entry point is `resolve`, which takes the registered desired tables
 and returns one `TableResolution` per table in dependency-first order. It is
 pure declaration analysis: no catalog state is consulted, and no work is
-planned — differences are the differ's. Each resolution carries the table's
-dependency edges (the declared constraints themselves) and its structural
-foreign-key verdicts, and states through `blocked_by` which of those edges
-block it once the caller knows which tables will not converge.
+planned — differences are the differ's. Each resolution carries the
+declaration it judged, that table's dependency edges (the declared
+constraints themselves), and its structural foreign-key verdicts, and states
+through `blocked_by` which of those edges block it once the caller knows which
+tables will not converge.
 
 For example, given these declared foreign keys (child ──► parent)::
 
@@ -59,14 +60,22 @@ class TableResolution:
     """
     One table's static relationship facts, in dependency order by tuple position.
 
-    ``dependencies`` are the retained dependency edges — the managed foreign
-    keys themselves, declared constraints verbatim. Empty
-    ``structural_failures`` means the table is structurally sound.
+    ``desired`` is the declaration these facts were judged from, so a
+    resolution is self-sufficient: callers read the table from it rather than
+    looking it back up by name. ``dependencies`` are the retained dependency
+    edges — the managed foreign keys themselves, declared constraints
+    verbatim. Empty ``structural_failures`` means the table is structurally
+    sound.
     """
 
-    qualified_name: QualifiedName
+    desired: DesiredTable
     dependencies: tuple[ForeignKeyConstraint, ...]
     structural_failures: tuple[ForeignKeyFailure, ...]
+
+    @property
+    def qualified_name(self) -> QualifiedName:
+        """The identity of the declaration these facts were judged from."""
+        return self.desired.qualified_name
 
     def blocked_by(self, unconverged: AbstractSet[QualifiedName]) -> tuple[ForeignKeyFailure, ...]:
         """
@@ -95,11 +104,11 @@ def resolve(tables: tuple[DesiredTable, ...]) -> tuple[TableResolution, ...]:
     Resolve cross-table relationships for one sync.
 
     Pure declaration analysis: orders every table dependency-first, judges
-    each managed foreign key structurally, and retains each table's
-    dependency edges as the declared constraints themselves. No catalog
-    state is consulted, and no work is planned — differences are the
-    differ's, and blocking is inherited at enactment along these edges via
-    :meth:`TableResolution.blocked_by`.
+    each managed foreign key structurally, and retains each declaration
+    alongside its dependency edges as the declared constraints themselves.
+    No catalog state is consulted, and no work is planned — differences are
+    the differ's, and blocking is inherited at enactment along these edges
+    via :meth:`TableResolution.blocked_by`.
     """
     registered_names = {table.qualified_name for table in tables}
     dependencies_by_table = _build_dependencies(tables, registered_names)
@@ -110,7 +119,7 @@ def resolve(tables: tuple[DesiredTable, ...]) -> tuple[TableResolution, ...]:
 
     return tuple(
         TableResolution(
-            qualified_name=table.qualified_name,
+            desired=table,
             dependencies=dependencies_by_table[table.qualified_name],
             structural_failures=failures_by_table.get(table.qualified_name, ()),
         )

--- a/src/delta_engine/application/report.py
+++ b/src/delta_engine/application/report.py
@@ -123,7 +123,6 @@ class TableRunReport:
     changes remain inspectable even when execution is skipped or blocked.
     """
 
-    desired: DesiredTable
     read: ReadResult
     planning: PlanningResult | None
     planned_sql_statements: tuple[str, ...]
@@ -135,8 +134,6 @@ class TableRunReport:
         planning_failed = isinstance(self.planning, PlanningFailed)
         resolution_failed = bool(self.resolution.structural_failures)
 
-        if self.resolution.qualified_name != self.qualified_name:
-            raise ValueError("Resolution outcome must belong to the reported table")
         if read_failed and self.planning is not None:
             raise ValueError("Planning cannot follow a failed read")
         if not read_failed and self.planning is None:
@@ -210,9 +207,14 @@ class TableRunReport:
         return tuple(failures)
 
     @property
+    def desired(self) -> DesiredTable:
+        """The declaration this run reconciled, as retained by its resolution."""
+        return self.resolution.desired
+
+    @property
     def qualified_name(self) -> QualifiedName:
         """The table identity from the declaration retained by this report."""
-        return self.desired.qualified_name
+        return self.resolution.qualified_name
 
     @property
     def status(self) -> TableRunStatus:

--- a/tests/application/test_errors.py
+++ b/tests/application/test_errors.py
@@ -76,13 +76,12 @@ def _table_report(
         else PlanningSucceeded(ActionPlan(target=desired.qualified_name))
     )
     resolution = TableResolution(
-        qualified_name=desired.qualified_name,
+        desired=desired,
         dependencies=(),
         structural_failures=resolution_failures,
     )
 
     return TableRunReport(
-        desired=desired,
         read=read,
         planning=planning,
         planned_sql_statements=statements,

--- a/tests/application/test_relationships.py
+++ b/tests/application/test_relationships.py
@@ -239,6 +239,19 @@ def test_resolve_with_empty_tables_returns_empty_result():
     assert result == ()
 
 
+def test_each_resolution_carries_the_declaration_it_was_judged_from():
+    # Given two tables whose dependency reverses their input order
+    parent = _table("cat.sch.customers")
+    child = _table_with_fk("cat.sch.orders", "cat.sch.customers")
+
+    # When resolving dependencies
+    result = resolve((child, parent))
+
+    # Then each resolution carries its own declaration, so callers need no lookup
+    assert [resolution.desired for resolution in result] == [parent, child]
+    assert _resolution_for(result, "cat.sch.orders").desired is child
+
+
 def test_resolve_with_no_fks_preserves_prepared_input_order():
     # Given three independent tables in prepared order
     tables = (

--- a/tests/application/test_rendering.py
+++ b/tests/application/test_rendering.py
@@ -350,13 +350,12 @@ def _report_with_empty_plan_and_failure() -> TableRunReport:
         qualified_name=qualified_name, columns=(ObservedColumn("id", Integer()),)
     )
     return TableRunReport(
-        desired=desired,
         read=TablePresent(table=observed),
         planning=PlanningFailed(
             (ValidationFailure(rule_name="UnsupportedColumnTypeChange", message="nope"),)
         ),
         planned_sql_statements=(),
-        resolution=TableResolution(qualified_name, (), ()),
+        resolution=TableResolution(desired, (), ()),
         execution_outcome=None,
     )
 
@@ -373,7 +372,6 @@ def test_diff_block_shows_plain_no_changes_when_nothing_failed():
     # Given a fully in-sync table
     report = _report_with_empty_plan_and_failure()
     healthy = TableRunReport(
-        desired=report.desired,
         read=report.read,
         planning=PlanningSucceeded(ActionPlan(target=report.desired.qualified_name)),
         planned_sql_statements=(),
@@ -430,13 +428,14 @@ def test_diff_block_reports_a_read_failure_instead_of_a_diff():
     qualified_name = QualifiedName("cat", "sch", "orders")
     failure = ReadFailure("IOError", "boom")
     report = TableRunReport(
-        desired=DesiredTable(
-            qualified_name=qualified_name, columns=(DesiredColumn("id", Integer()),)
-        ),
         read=failure,
         planning=None,
         planned_sql_statements=(),
-        resolution=TableResolution(qualified_name, (), ()),
+        resolution=TableResolution(
+            DesiredTable(qualified_name=qualified_name, columns=(DesiredColumn("id", Integer()),)),
+            (),
+            (),
+        ),
         execution_outcome=None,
     )
 
@@ -453,6 +452,7 @@ def test_diff_block_reports_a_read_failure_instead_of_a_diff():
 def _grid_report(name, *, plan=None, failures=(), execution=None):
     qualified_name = QualifiedName("cat", "sch", name)
     columns = (DesiredColumn("id", Integer()),)
+    desired = DesiredTable(qualified_name=qualified_name, columns=columns)
     if plan is None and not failures:
         plan = ActionPlan(target=qualified_name)
     planning_failures = tuple(
@@ -460,7 +460,6 @@ def _grid_report(name, *, plan=None, failures=(), execution=None):
     )
     planning = PlanningFailed(planning_failures) if planning_failures else PlanningSucceeded(plan)
     return TableRunReport(
-        desired=DesiredTable(qualified_name=qualified_name, columns=columns),
         read=TablePresent(
             table=ObservedTable(
                 qualified_name=qualified_name, columns=(ObservedColumn("id", Integer()),)
@@ -471,7 +470,7 @@ def _grid_report(name, *, plan=None, failures=(), execution=None):
         planned_sql_statements=tuple(
             f"SQL {index}" for index in range(len(plan) if plan is not None else 0)
         ),
-        resolution=TableResolution(qualified_name, (), ()),
+        resolution=TableResolution(desired, (), ()),
         execution_outcome=execution,
     )
 

--- a/tests/application/test_report.py
+++ b/tests/application/test_report.py
@@ -131,7 +131,7 @@ def _report(
         planning = PlanningSucceeded(report_plan)
 
     resolution = TableResolution(
-        qualified_name=desired.qualified_name,
+        desired=desired,
         dependencies=(),
         structural_failures=() if execution_blocked else resolution_failures,
     )
@@ -140,7 +140,6 @@ def _report(
     )
 
     return TableRunReport(
-        desired=desired,
         read=read,
         planning=planning,
         planned_sql_statements=planned_sql_statements,
@@ -436,11 +435,10 @@ def test_table_run_report_rejects_planning_after_a_failed_read():
 
     with pytest.raises(ValueError, match="Planning cannot follow a failed read"):
         TableRunReport(
-            desired=desired,
             read=ReadFailure("IOError", "boom"),
             planning=PlanningSucceeded(ActionPlan(target=desired.qualified_name)),
             planned_sql_statements=(),
-            resolution=TableResolution(desired.qualified_name, (), ()),
+            resolution=TableResolution(desired, (), ()),
             execution_outcome=None,
         )
 
@@ -456,11 +454,10 @@ def test_table_run_report_rejects_execution_after_failed_resolution():
 
     with pytest.raises(ValueError, match="Execution cannot follow a failed earlier phase"):
         TableRunReport(
-            desired=desired,
             read=TablePresent(table=_an_observed_table()),
             planning=PlanningSucceeded(ActionPlan(target=desired.qualified_name)),
             planned_sql_statements=("SQL",),
-            resolution=TableResolution(desired.qualified_name, (), (failure,)),
+            resolution=TableResolution(desired, (), (failure,)),
             execution_outcome=ExecutionSummary((_ok_exec(0, "SQL"),)),
         )
 
@@ -470,11 +467,10 @@ def test_table_run_report_rejects_execution_unrelated_to_planned_sql():
 
     with pytest.raises(ValueError, match="planned statement prefix"):
         TableRunReport(
-            desired=desired,
             read=TablePresent(table=_an_observed_table()),
             planning=PlanningSucceeded(ActionPlan(target=desired.qualified_name)),
             planned_sql_statements=("PLANNED SQL",),
-            resolution=TableResolution(desired.qualified_name, (), ()),
+            resolution=TableResolution(desired, (), ()),
             execution_outcome=ExecutionSummary((_ok_exec(0, "OTHER SQL"),)),
         )
 


### PR DESCRIPTION
> **Stacked on #290** (`refactor/relationship-resolver`), like #295 and #297 before it. Retarget to `main` when #290 merges.

## What

A resolution now carries the declaration it was judged from.

`resolve` returned one `TableResolution(qualified_name, dependencies, structural_failures)` per table — a *name tag* for a table the caller already held. So the engine rebuilt the index to look the declaration back up:

```python
ordered_resolutions = resolve(tables)
desired_by_name = {table.qualified_name: table for table in tables}

for resolution in ordered_resolutions:
    desired = desired_by_name[resolution.qualified_name]
    runs.append(_TableRun(desired=desired, resolution=resolution))
```

That is the same `{qualified_name: table}` index `_order_tables` had already built one function call earlier to produce the order it returned. The field becomes `desired: DesiredTable` and `qualified_name` derives from it, so the join disappears:

```python
for resolution in resolve(tables):
    runs.append(_TableRun(resolution=resolution))
```

Consequences:

- **`_TableRun` and `TableRunReport` each hold one field fewer.** Both had a `desired` alongside their `resolution`; both now read it through the resolution as a property. `TableRunReport.desired` and `.qualified_name` remain readable exactly as before — no public read API changes.
- **A runtime guard is deleted.** `TableRunReport.__post_init__` raised `"Resolution outcome must belong to the reported table"`, defending the one way the hand-join could go wrong. With a single field there is no pair to disagree, so the invariant is held by the type instead of checked on every construction. Nothing had ever built a mismatched pair and no test pinned the guard.

## Why

The lookup was not incidental — it was the cost of a return type that named its subject instead of carrying it. #297 is what made it fixable: before it, a resolution's subject was a `TableSnapshot` (declaration *and* read), so handing the caller "the thing this resolution is about" would have meant handing back worldly state from a phase that now runs before the read. With resolution reduced to pure declaration analysis, its subject is exactly a `DesiredTable` — the value the caller passed in.

Two smaller signals pointed the same way. `_classify_structural_failures` already reads columns, primary keys, types, and managed aspects straight off `DesiredTable`, so the table was fully in this module's vocabulary; only the return type pretended otherwise. And the guard in `report.py` is what a hand-maintained invariant looks like when the type won't hold it.

## Behaviour changes

None. Same order, same edges, same verdicts, same failures, same statuses, same SQL.

One API note for future work: `TableResolution` is no longer hashable, because `DesiredTable` holds mappings. This matches `TableDrift`, `TableMissing`, and `TableRunReport`, which already carry one and are already unhashable. Nothing hashes a resolution today; a future `set[TableResolution]` would not work.

## Verification

- Full suite **1097 passed** (1096 on the base, +1 new pin); coverage 96.65%. ruff, `ruff format --check`, mypy, `lint-imports` (7 contracts kept), and sphinx `-W` all green.
- New pin: `test_each_resolution_carries_the_declaration_it_was_judged_from` — resolutions come back carrying their own declarations, in dependency order, for input whose dependency reverses its input order. Only `qualified_name` was pinned before, so carrying the declaration was untested as the new public fact.
- The 9 test construction sites (`test_report.py`, `test_rendering.py`, `test_errors.py`) are mechanical. The two `_report`/`_table_report` factories already took `desired` and derived the resolution's name from it, so they now pass the table itself and stop passing it twice; `test_rendering.py`'s `_grid_report` hoists its inline `DesiredTable` to a local for the same reason.
- **`tests/live/` untouched** — `git diff` against the base is empty. No live-suite handoff: no SQL and no live-observable behaviour changes.
- Docs: corrected `explanation-architecture.md`'s vocabulary row, which still described the pre-#297 `ResolveResult` ("one explicit success or structural failure per table… carries its planned foreign-key actions") — a name and a shape that no longer exist. It now describes `TableResolution`, including the declaration it carries.
