### PR TITLE
refactor: an execution summary answers with its failures

### DIFF
--- a/src/delta_engine/application/engine.py
+++ b/src/delta_engine/application/engine.py
@@ -167,7 +167,7 @@ class _TableRun:
             or isinstance(self.planning, PlanningFailed)
             or bool(self.resolution.structural_failures)
             or isinstance(self.execution, ExecutionBlockedByDependency)
-            or (isinstance(self.execution, ExecutionSummary) and self.execution.failed)
+            or (isinstance(self.execution, ExecutionSummary) and bool(self.execution.failures))
         )
 
     def to_report(self) -> TableRunReport:
@@ -445,14 +445,14 @@ class Engine:
             summary = self._execute_statements(run.planned_sql_statements)
             run.execution = summary
 
-            if summary.failed:
+            if summary.failures:
                 failed_during_execution.add(run.qualified_name)
 
             logger.info(
                 "Executed %d statement(s) for %s (%d failed)",
                 len(summary.results),
                 run.qualified_name,
-                summary.failed_count,
+                len(summary.failures),
             )
 
     def _execute_statements(self, statements: tuple[str, ...]) -> ExecutionSummary:

--- a/src/delta_engine/application/ports.py
+++ b/src/delta_engine/application/ports.py
@@ -104,10 +104,10 @@ class ExecutionSummary:
     """
     The outcome of running a plan's compiled statements.
 
-    A frozen container over the phase's raw results that answers ``failed``
-    and exposes its ``failures``. It owns the single pass that separates
-    failed statements from successful ones, so callers read a property
-    instead of re-deriving the split with ``isinstance``.
+    A frozen container over the phase's raw results that owns the single pass
+    separating failed statements from successful ones, so callers read
+    ``failures`` instead of re-deriving the split with ``isinstance``. The
+    executor stops at the first failure, so ``failures`` holds at most one.
     """
 
     results: tuple[ExecutionResult, ...] = ()
@@ -121,24 +121,14 @@ class ExecutionSummary:
                 raise ValueError("Execution cannot continue after a failure")
 
     @property
-    def failed(self) -> bool:
-        """True when any statement failed."""
-        return any(isinstance(result, ExecutionFailure) for result in self.results)
-
-    @property
     def failures(self) -> tuple[ExecutionFailure, ...]:
         """The failure detail from each failed statement, in execution order."""
         return tuple(result for result in self.results if isinstance(result, ExecutionFailure))
 
     @property
-    def failed_count(self) -> int:
-        """How many statements failed."""
-        return len(self.failures)
-
-    @property
     def applied_count(self) -> int:
         """How many statements ran successfully."""
-        return len(self.results) - self.failed_count
+        return len(self.results) - len(self.failures)
 
 
 class PlanExecutor(Protocol):

--- a/tests/application/test_ports.py
+++ b/tests/application/test_ports.py
@@ -25,9 +25,7 @@ def test_execution_summary_reports_no_failure_when_every_statement_succeeds():
     summary = ExecutionSummary((_ok_exec(0), _ok_exec(1)))
 
     # Then the summary reports success with no failures
-    assert summary.failed is False
-    assert summary.failures == ()
-    assert summary.failed_count == 0
+    assert not summary.failures
     assert summary.applied_count == 2
 
 
@@ -36,10 +34,8 @@ def test_execution_summary_exposes_the_failures_among_mixed_results():
     summary = ExecutionSummary((_ok_exec(0), _failed_exec(1, msg="bang")))
 
     # Then the summary surfaces the single failure and the applied count
-    assert summary.failed is True
-    assert summary.failed_count == 1
-    assert summary.applied_count == 1
     assert tuple(f.message for f in summary.failures) == ("bang",)
+    assert summary.applied_count == 1
 
 
 def test_execution_summary_defaults_to_an_empty_unattempted_run():
@@ -48,8 +44,7 @@ def test_execution_summary_defaults_to_an_empty_unattempted_run():
 
     # Then it is an empty, non-failing summary
     assert summary.results == ()
-    assert summary.failed is False
-    assert summary.failed_count == 0
+    assert not summary.failures
     assert summary.applied_count == 0
 
 


### PR DESCRIPTION
> **Stacked on #290** (`refactor/relationship-resolver`), like #295, #297, #299 and #300 before it. Retarget to `main` when #290 merges.

## What

`ExecutionSummary` loses two derived accessors.

```python
@property
def failed(self) -> bool:
    return any(isinstance(result, ExecutionFailure) for result in self.results)

@property
def failed_count(self) -> int:
    return len(self.failures)
```

`failed` is `bool(self.failures)` written as a second `isinstance` walk over the same tuple. `failed_count` is `len(self.failures)` — and can only ever be `0` or `1`, because `__post_init__` rejects any result following a failure, so a failure is always the last element. The architecture doc already states this: the summary "records successful statements and the first failed statement, if execution failed".

Their three readers all live in the engine and now read `failures` directly:

```python
or (isinstance(self.execution, ExecutionSummary) and bool(self.execution.failures))
...
if summary.failures:
...
    len(summary.failures),
```

The first is the idiom the same expression already used one line above for `structural_failures`.

## Why

This is #300's argument applied to the sibling type in the same file. A derived boolean over one tuple names nothing the tuple does not already answer, and a count whose range the invariant pins to `{0, 1}` promises more shape than the type can hold. Validation stopped exposing `failed` in #300; execution still did.

Unlike `ValidationResult`, the type itself stays — everything left on it hides something:

- `__post_init__` rejects statement histories the stop-at-first-failure executor cannot produce (non-contiguous indexes, results after a failure).
- `failures` owns the single `isinstance` pass that splits a *mixed* success/failure tuple, so callers do not re-derive it.
- `applied_count` (`len(results) - len(failures)`) is read by `TableRunReport.to_dict` and the report grid, and is not a restatement of either field.

## Behaviour changes

None. Same blocking decisions, same log output, same report projection.

## Verification

- Full suite **1096 passed**, coverage **96.64%** — unchanged from the base. No test was deleted; three tests lost the assertions that pinned the two removed properties.
- ruff, `ruff format --check`, mypy (`src`), `lint-imports` (7 contracts kept), and sphinx `-W` all green.
- Test coupling was entirely in `tests/application/test_ports.py`. In the passing cases, `failed is False` + `failures == ()` + `failed_count == 0` were three views of one fact and collapse to `assert not summary.failures`. In the mixed case, `failed is True` and `failed_count == 1` were both implied by the `("bang",)` failure-message compare that followed them, so they go rather than restate their successor — the same call made in #300.
- No doc changes needed: nothing under `docs/` referenced either property. `reference-run-report.md` documents `TableRunReport.has_failures`, which is a different (and public, JSON-contract) predicate and is untouched.
- **`tests/live/`** untouched — `git diff` against the base is empty. No SQL and no live-observable behaviour changes.
