### PR TITLE
feat: report assembly derives dependency blocking into baked projections

### DIFF
--- a/src/delta_engine/application/report.py
+++ b/src/delta_engine/application/report.py
@@ -6,7 +6,7 @@ engine run; `SyncReport` aggregates those table snapshots.
 """
 
 from collections.abc import Iterator, Mapping
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from datetime import datetime
 from enum import StrEnum
 from types import MappingProxyType
@@ -121,6 +121,9 @@ class TableRunReport:
     planned no-op retains an empty, target-bearing plan.
     ``planned_sql_statements`` is populated on dry and real runs so planned
     changes remain inspectable even when execution is skipped or blocked.
+    ``blocked_failures`` is the derived consequence of other tables' fates,
+    baked in at assembly — a blocked table records no execution outcome of its
+    own.
     """
 
     read: ReadResult
@@ -128,6 +131,7 @@ class TableRunReport:
     planned_sql_statements: tuple[str, ...]
     resolution: TableResolution
     execution_outcome: ExecutionOutcome | None
+    blocked_failures: tuple[ForeignKeyFailure, ...] = ()
 
     def __post_init__(self) -> None:
         read_failed = isinstance(self.read, ReadFailure)
@@ -150,6 +154,14 @@ class TableRunReport:
             raise ValueError("Execution cannot follow a failed earlier phase")
         if isinstance(self.execution_outcome, ExecutionBlockedByDependency) and resolution_failed:
             raise ValueError("Execution blocking requires a structurally sound resolution")
+        if self.blocked_failures:
+            if self.execution_outcome is not None:
+                raise ValueError("A blocked table records no execution outcome")
+            if any(
+                failure.reason is not ForeignKeyFailureReason.BLOCKED_BY_FAILED_DEPENDENCY
+                for failure in self.blocked_failures
+            ):
+                raise ValueError("Blocked failures must carry the dependency-blocking reason")
 
         execution = self.execution
         if execution is not None:
@@ -184,7 +196,9 @@ class TableRunReport:
         """
         Flatten canonical phase outcomes for callers.
 
-        Lifecycle order: structural, read, planning, execution.
+        Lifecycle order: structural, read, planning, execution — derived
+        blocking sits at the execution position, where the run it replaced
+        would have been.
         """
         failures: list[Failure] = []
 
@@ -203,6 +217,7 @@ class TableRunReport:
                 pass
             case _ as unreachable:
                 assert_never(unreachable)
+        failures.extend(self.blocked_failures)
 
         return tuple(failures)
 
@@ -267,6 +282,43 @@ class SyncReport:
     ended_at: datetime
     table_reports: tuple[TableRunReport, ...]
     dry_run: bool = False
+
+    @classmethod
+    def assemble(
+        cls,
+        *,
+        started_at: datetime,
+        ended_at: datetime,
+        table_reports: tuple[TableRunReport, ...],
+        dry_run: bool,
+    ) -> "SyncReport":
+        """
+        Assemble the run report, deriving dependency blocking from the graph.
+
+        Folds the blocking rule over the reports in dependency order: a table
+        that did not converge — own failures, or a dependency that did not —
+        marks its name, and a sound table its resolution reports as blocked is
+        replaced by a copy carrying those failures. The run recorded nothing
+        about blocking; this projection is where the consequence becomes
+        visible, dry and real runs alike.
+        """
+        not_converged: set[QualifiedName] = set()
+        derived: list[TableRunReport] = []
+        for report in table_reports:
+            if report.has_failures:
+                not_converged.add(report.qualified_name)
+                derived.append(report)
+                continue
+            blocking = report.resolution.blocked_by(not_converged)
+            if blocking:
+                not_converged.add(report.qualified_name)
+            derived.append(replace(report, blocked_failures=blocking) if blocking else report)
+        return cls(
+            started_at=started_at,
+            ended_at=ended_at,
+            table_reports=tuple(derived),
+            dry_run=dry_run,
+        )
 
     @property
     def has_failures(self) -> bool:

--- a/tests/application/test_report.py
+++ b/tests/application/test_report.py
@@ -29,6 +29,7 @@ from delta_engine.application.report import (
 from delta_engine.domain.model import (
     DesiredColumn,
     DesiredTable,
+    ForeignKeyConstraint,
     Integer,
     ObservedColumn,
     ObservedTable,
@@ -44,10 +45,15 @@ from delta_engine.domain.plan.actions import (
 # ---------- test builders
 
 
+def _name(table="observed"):
+    """Build the qualified name every builder in this file works in."""
+    return QualifiedName("cat", "schema", table)
+
+
 def _an_observed_table(partitioned_by=()):
     """Build a real ObservedTable, so reports are exercised against the domain type."""
     return ObservedTable(
-        qualified_name=QualifiedName("cat", "schema", "observed"),
+        qualified_name=_name(),
         columns=(ObservedColumn("id", Integer()),),
         partitioned_by=partitioned_by,
     )
@@ -56,7 +62,7 @@ def _an_observed_table(partitioned_by=()):
 def _a_desired_table(name="observed"):
     """Build a minimal real DesiredTable for pipeline-record construction."""
     return DesiredTable(
-        qualified_name=QualifiedName("cat", "schema", name),
+        qualified_name=_name(name),
         columns=(DesiredColumn("id", Integer()),),
     )
 
@@ -99,8 +105,10 @@ def _report(
     plan: ActionPlan | None | object = _PLAN_UNSET,
     planned_sql_statements: tuple[str, ...] = (),
     failures: tuple[Failure, ...] = (),
+    dependencies: tuple[ForeignKeyConstraint, ...] = (),
     execution: ExecutionSummary | None = None,
     execution_blocked: bool = False,
+    blocked_failures: tuple[ForeignKeyFailure, ...] = (),
 ) -> TableRunReport:
     """Construct a frozen report snapshot from concise test inputs."""
     if execution is not None and not planned_sql_statements:
@@ -132,7 +140,7 @@ def _report(
 
     resolution = TableResolution(
         desired=desired,
-        dependencies=(),
+        dependencies=dependencies,
         structural_failures=() if execution_blocked else resolution_failures,
     )
     execution_outcome = (
@@ -145,6 +153,7 @@ def _report(
         planned_sql_statements=planned_sql_statements,
         resolution=resolution,
         execution_outcome=execution_outcome,
+        blocked_failures=blocked_failures,
     )
 
 
@@ -582,3 +591,150 @@ def test_to_dict_is_deterministic():
         started_at=_t0(), ended_at=_t1(), table_reports=(_a_changed_table_report(),)
     )
     assert report.to_dict() == report.to_dict()
+
+
+# ---------- Derived dependency blocking
+
+
+def _fk_edge(parent: QualifiedName, constraint_name: str = "blocked_edge_fk"):
+    """Build a dependency edge onto ``parent``; blocking reads its columns and target."""
+    return ForeignKeyConstraint(
+        local_columns=("parent_id",),
+        referenced_table=parent,
+        referenced_columns=("id",),
+        constraint_name=constraint_name,
+    )
+
+
+def _blocked_failure():
+    """Build the failure ``b`` earns for its edge onto a parent ``a`` that did not converge."""
+    return ForeignKeyFailure(
+        table=_name("b"),
+        local_columns=("parent_id",),
+        references=_name("a"),
+        reason=ForeignKeyFailureReason.BLOCKED_BY_FAILED_DEPENDENCY,
+    )
+
+
+def _sound_report(name: str, dependencies: tuple[ForeignKeyConstraint, ...] = ()):
+    """Build a table that read, planned, and validated cleanly, with ``dependencies``."""
+    return _report(
+        desired=_a_desired_table(name),
+        read=TablePresent(table=_an_observed_table()),
+        dependencies=dependencies,
+    )
+
+
+def _assemble(*table_reports: TableRunReport) -> SyncReport:
+    return SyncReport.assemble(
+        started_at=_t0(),
+        ended_at=_t1(),
+        table_reports=table_reports,
+        dry_run=True,
+    )
+
+
+def test_assemble_bakes_blocked_failures_onto_a_sound_dependent_of_a_failed_parent():
+    # Given a parent that failed its read and a sound child depending on it
+    parent = _report(desired=_a_desired_table("a"), read=ReadFailure("IOError", "boom"))
+    child = _sound_report("b", dependencies=(_fk_edge(_name("a")),))
+
+    # When the run report is assembled
+    report = _assemble(parent, child)
+
+    # Then the child's blocking is derived into its frozen projection
+    _, derived_child = report.table_reports
+    (failure,) = derived_child.blocked_failures
+    assert failure.table == _name("b")
+    assert failure.references == _name("a")
+    assert failure.reason is ForeignKeyFailureReason.BLOCKED_BY_FAILED_DEPENDENCY
+    assert derived_child.execution_outcome is None
+    assert derived_child.status is TableRunStatus.FOREIGN_KEY_FAILED
+
+
+def test_assemble_propagates_blocking_along_chains():
+    # Given a -> b -> c where a failed its read: b is blocked, and c through b
+    reports = (
+        _report(desired=_a_desired_table("a"), read=ReadFailure("IOError", "boom")),
+        _sound_report("b", dependencies=(_fk_edge(_name("a")),)),
+        _sound_report("c", dependencies=(_fk_edge(_name("b"), constraint_name="c_b_fk"),)),
+    )
+
+    # When the run report is assembled
+    report = _assemble(*reports)
+
+    # Then each blocked table names the parent that blocked it
+    _, derived_b, derived_c = report.table_reports
+    assert [failure.references for failure in derived_b.blocked_failures] == [_name("a")]
+    assert [failure.references for failure in derived_c.blocked_failures] == [_name("b")]
+
+
+def test_assemble_does_not_bake_onto_a_table_with_its_own_failures():
+    # Given a parent that failed its read and a child that failed planning on its own
+    parent = _report(desired=_a_desired_table("a"), read=ReadFailure("IOError", "boom"))
+    child = _report(
+        desired=_a_desired_table("b"),
+        read=TablePresent(table=_an_observed_table()),
+        failures=(ValidationFailure(rule_name="SomeRule", message="unsafe"),),
+        dependencies=(_fk_edge(_name("a")),),
+    )
+
+    # When the run report is assembled
+    report = _assemble(parent, child)
+
+    # Then the child keeps exactly its own failures — blocking is not stacked on
+    # top of a table that already failed (it still counts as not converged for
+    # its own dependents, which the chain test covers)
+    _, derived_child = report.table_reports
+    assert derived_child.blocked_failures == ()
+    assert derived_child.status is TableRunStatus.PLANNING_FAILED
+
+
+def test_assemble_with_no_failures_returns_the_reports_unchanged():
+    # Given a sound dependency edge in a run where nothing failed
+    reports = (_sound_report("a"), _sound_report("b", dependencies=(_fk_edge(_name("a")),)))
+
+    report = _assemble(*reports)
+
+    assert report.table_reports == reports
+    assert report.has_failures is False
+
+
+def test_baked_blocked_failures_flatten_into_the_report_failures():
+    # Given a report whose blocking was baked in at assembly
+    child = _report(
+        desired=_a_desired_table("b"),
+        read=TablePresent(table=_an_observed_table()),
+        blocked_failures=(_blocked_failure(),),
+    )
+
+    # Then it reaches callers through the ordinary failure flattening
+    assert child.has_failures is True
+    assert child.failures == child.blocked_failures
+    assert child.status is TableRunStatus.FOREIGN_KEY_FAILED
+
+
+def test_blocked_failures_reject_a_recorded_execution_outcome():
+    with pytest.raises(ValueError, match="records no execution outcome"):
+        _report(
+            desired=_a_desired_table("b"),
+            read=TablePresent(table=_an_observed_table()),
+            execution=ExecutionSummary(),
+            blocked_failures=(_blocked_failure(),),
+        )
+
+
+def test_blocked_failures_require_the_dependency_blocking_reason():
+    with pytest.raises(ValueError, match="dependency-blocking reason"):
+        _report(
+            desired=_a_desired_table("b"),
+            read=TablePresent(table=_an_observed_table()),
+            blocked_failures=(
+                ForeignKeyFailure(
+                    table=_name("b"),
+                    local_columns=("parent_id",),
+                    references=_name("a"),
+                    reason=ForeignKeyFailureReason.CYCLE,
+                ),
+            ),
+        )


### PR DESCRIPTION
Task 1 of the derived-blocking work (pipeline-laws PR 3): teach the report layer to *derive* dependency blocking, so a later PR can stop *recording* it.

## What changes

`SyncReport.assemble` is the new door for building a run report. It folds the blocking rule — *a table did not converge iff it has own failures or any dependency did not* — over the table reports in dependency order, asking each `TableResolution.blocked_by` which of its edges point into the set of tables that will not converge. A sound table that comes back blocked is replaced by a copy carrying those failures.

`TableRunReport` gains `blocked_failures: tuple[ForeignKeyFailure, ...] = ()`:

- it flattens into `failures` at the execution position, where the run it replaced would have been, so `status`, `has_failures`, `failures_by_table`, `to_dict`, and rendering all pick it up with no changes of their own;
- `__post_init__` rejects a blocked table that also records an execution outcome, and rejects failures carrying any reason other than `BLOCKED_BY_FAILED_DEPENDENCY`.

No synthesiser lives in `report.py`: `blocked_by` already returns finished `ForeignKeyFailure`s, so assembly only decides *which* reports get them.

## Why it is safe to land alone

This is a pure addition. The engine still gates and still records `ExecutionBlockedByDependency`, and nothing calls `assemble` yet — so nothing is represented twice. The new invariant cannot collide with a recorded block either: a recorded block has a non-`None` outcome and empty `blocked_failures`, and its report already reports `has_failures`, so `assemble` would leave it untouched rather than try to decorate it.

Behaviour for every existing caller is unchanged: existing reports default to `blocked_failures=()`.

## Tests

Seven new tests in `tests/application/test_report.py`, all through the public API:

- blocking is baked onto a sound dependent of a failed parent (right failure fields, `FOREIGN_KEY_FAILED`, no execution outcome);
- blocking propagates along an `a → b → c` chain, each table naming the parent that blocked it;
- a table with its own failures is **not** decorated on top — it still counts as not-converged for its own dependents (the chain test covers that);
- a run with no failures returns its reports unchanged;
- baked failures reach callers through the ordinary flattening;
- both new invariants raise.

The file's `_report` builder gained `dependencies=` and `blocked_failures=` pass-throughs, and its qualified-name construction moved into one `_name` helper.

## Verification

`uv run pytest` (1103 passed, 96.67% coverage) · `ruff check` · `ruff format --check` · `mypy` (154 files) · `lint-imports` (7 contracts kept) · `sphinx-build -W`.

No file under `tests/live/` is touched. `rendering.py` is untouched and `to_dict` keys are unchanged (`schema_version` stays 2).

## Next

Task 2 deletes `_gate` and `ExecutionBlockedByDependency`, turns enactment into one walk, and points `sync` at `assemble`. Task 3 is docs.
