### PR TITLE
refactor: blocking is derived at the account, never recorded

### DIFF
--- a/docs/explanation-architecture.md
+++ b/docs/explanation-architecture.md
@@ -319,19 +319,19 @@ The full run, with reporting last:
    carries the privately constructed `ActionPlan` into the next phase.
 6. **Compile**: lower every accepted plan through the executor port and record
    the exact statements used for both dry-run preview and real execution.
-7. **Gate**: walk the dependency-ordered runs, blocking every run whose
-   dependency will not reach desired state this sync. Dry runs walk the same
-   gate, so blocking stays visible in previews.
-8. **Execute**: run the compiled statements of tables with a non-empty plan and
-   no failures (real runs only).
-9. **Report** (after the chain): return `SyncReport`, or raise
-   `SyncFailedError` with the report on real runs that failed.
+7. **Execute**: run the compiled statements of tables with a non-empty plan,
+   no failures of their own, and no dependency that will not converge (real
+   runs only).
+8. **Account**: freeze the runs into `SyncReport` through `SyncReport.assemble`,
+   which derives dependency blocking from the retained edges; or raise
+   `SyncFailedError` with that report on real runs that failed.
 
-Execution is gated by failures derived from the retained phase outcomes. A
-table that failed read, validation, or structural foreign-key resolution is
-skipped during execution, and its FK dependents are blocked with
-`ExecutionBlockedByDependency` on their execution slot. The engine still
-processes other tables.
+A table that failed read, validation, or structural foreign-key resolution is
+skipped during execution, and so is any table depending on one that will not
+converge. The engine still processes other tables. Nothing records the block:
+it is derived at accounting, so a blocked table carries no execution outcome
+and its `blocked_failures` name every dependency that let it down, whichever
+phase each one failed in.
 
 | Shape              | Produced by            | Consumed by                      | Purpose                                     |
 | ------------------ | ---------------------- | -------------------------------- | ------------------------------------------- |
@@ -629,24 +629,26 @@ declared foreign key structurally and reports:
 - `CYCLE` for true multi-table FK cycles.
 
 Whether a table is *blocked* by another table's failure is not a resolution
-outcome: the engine's execution gate emits `BLOCKED_BY_FAILED_DEPENDENCY` when
-a table depends on another table that will not reach desired state this sync,
-whatever phase failed it — a read failure, validation failure, structural FK
-failure, or an execution failure in the same run.
+outcome, and nor is it anybody's recorded outcome: it is derived from the
+retained dependency edges once the run's other fates are known.
+`TableResolution.blocked_by` states the rule — given the set of tables that
+will not converge, return one `BLOCKED_BY_FAILED_DEPENDENCY` failure per edge
+pointing into it — whatever phase failed each of those tables, be it a read
+failure, validation failure, structural FK failure, or an execution failure in
+the same run.
 
 Each mandatory gate implements the `ScopeGate` protocol over `TableDiff`; a gate returns no failures when its check does not apply to that diff arm. Each safety rule implements the `SafetyRule` protocol: a `name` `ClassVar[str]` and an `evaluate(drift: TableDrift) -> tuple[ValidationFailure, ...]` method. Safety rules usually scan `drift.actions` or `drift.unresolvable` directly — typically matching a specific type with `isinstance` — and return all violations at once, avoiding a fix-and-rerun cycle per failure. The scope gates run before any safety rule and short-circuit the safety stage on failure, so a safety rule only ever sees differences the declaration manages and does no scope filtering of its own.
 
 `validate_diff` evaluates every gate in `MANDATORY_SCOPE_GATES` and aggregates their failures in declaration order. A `TableMissing` clears the gates when table existence is managed — creating it from its full declaration is always safe — and fails with `MissingTableUnmanaged` when it is not, so no safety rule ever sees a missing table; a `TableDrift` clears the gates when its claimed scope and observed relation kind are valid and no unmanaged aspect has drifted. Only then does `validate_diff` call every rule in `DEFAULT_SAFETY_RULES` with the drift and aggregate their failures into one tuple, returned empty when the diff is valid. `plan_diff` fixes that default composition in place and turns those failures into the accepted/rejected planning sum.
 
-Execution walks the dependency-first order produced by the resolver and keeps a
-set of every table that will not converge — seeded with the tables that failed
-an earlier phase, then grown as tables fail or are blocked during the walk.
-Before each table executes, the engine walks the dependency edges its
-resolution retained and blocks on any that will not converge. An
-execution failure in a parent therefore gives every later dependent a
-`BLOCKED_BY_FAILED_DEPENDENCY` failure in the same run, including a dependent
-whose own plan is empty. One pass suffices because the resolver already placed
-parents before their dependents, and dry runs walk the same gate without
+Two walks fold that one rule over the dependency-first order the resolver
+produced, each accumulating its own not-converged set as it goes: `_execute`
+folds it to decide what not to attempt, and `SyncReport.assemble` folds it to
+say why a table was skipped. One pass suffices for each because the resolver
+already placed parents before their dependents. An execution failure in a
+parent therefore gives every later dependent a `BLOCKED_BY_FAILED_DEPENDENCY`
+failure in the same run, including a dependent whose own plan is empty; a dry
+run runs only the second walk, so the preview reports the same blocking without
 executing.
 
 ## Public declarations and lowering
@@ -769,9 +771,10 @@ failures: callers receive the complete failure tuple without another mutable
 source of run truth. For execution, the engine stops at the first failed
 statement because it is not transactional and later statements may depend on
 earlier ones. The `ExecutionSummary` records all attempted statements up to
-that point. Runtime dependency blocking is retained as an execution outcome;
-the report exposes its foreign-key failures and keeps `execution` as `None`
-because no statement was attempted.
+that point. Dependency blocking is retained as no outcome at all: it is derived
+at accounting into `blocked_failures`, which the report flattens at the
+execution position while `execution` stays `None` because no statement was
+attempted.
 
 Reports also keep the plan even when execution does not happen. That makes dry
 runs useful and makes failed runs explainable: a user can inspect what would
@@ -812,7 +815,7 @@ dependency cost.
 | Add a safety rule                 | `delta_engine.application.validation`                                      | Rules inspect the drift's managed actions and unresolvable differences and return `ValidationFailure` values.                                                                                                                               |
 | Add a data type                   | `delta_engine.domain.model.data_type` and adapter type mapping             | The domain type is backend-free; SQL names and Spark parsing live in the Databricks adapter.                                                                                                                                                |
 | Change public declarations        | `delta_engine.api`, surfaced only through `delta_engine.schema`            | Keep public ergonomics in `delta_engine.schema` and lower choices into domain snapshots before the engine phases begin.                                                                                                                     |
-| Change FK ordering, verdicts, or blocking | `delta_engine.application.relationships` (blocking gate: `Engine._gate`) | Cross-table relationship judgment — dependency ordering and structural validation (exact referenced spelling included) — lives in the application layer; FK *existence* is a difference like any other and lives in the differ.       |
+| Change FK ordering, verdicts, or blocking | `delta_engine.application.relationships` (the blocking rule is `TableResolution.blocked_by`, folded by `Engine._execute` and `SyncReport.assemble`) | Cross-table relationship judgment — dependency ordering and structural validation (exact referenced spelling included) — lives in the application layer; FK *existence* is a difference like any other and lives in the differ.       |
 | Change report output              | `delta_engine.application.report` and `delta_engine.application.rendering` | Keep display formatting out of domain objects.                                                                                                                                                                                              |
 | Change Databricks SQL             | `delta_engine.adapters.databricks.sql`                                     | Compile domain actions to backend statements at the adapter boundary.                                                                                                                                                                       |
 | Change CLI commands or output     | `delta_engine.cli`                                                         | Thin orchestration over `declarations.py`, `connection.py`, and the application ports; keep policy in the layers below.                                                                                                                     |

--- a/docs/explanation-sync-lifecycle.md
+++ b/docs/explanation-sync-lifecycle.md
@@ -28,7 +28,7 @@ lower → resolve → read → diff → plan → compile → execute → report
 | **Diff**    | How does observed state differ from desired? | Direct actions and non-action differences — foreign-key existence included — or no drift |
 | **Plan**    | Is the complete diff accepted?               | A validated action plan, or named validation failures with no plan |
 | **Compile** | What exact backend statements apply it?     | The SQL exposed on the report and passed unchanged to execution    |
-| **Execute** | Apply the compiled statements                | Attempted results, a dependency block, or skipped on a dry run     |
+| **Execute** | Apply the compiled statements                | Attempted results — or nothing, for tables skipped as no-ops, blocked, or on a dry run |
 
 Resolution comes before read because it needs nothing from the catalog: it
 judges the declarations against each other, so every table starts its worldly
@@ -88,21 +88,30 @@ foreign keys a table needs set or dropped are a difference like any other, so
 the diff states them; resolve judges only what one table's declaration means
 for another's.
 
-The same dependency logic propagates failure: if a table fails — at any phase,
+The same dependency edges propagate failure: if a table fails — at any phase,
 including mid-execution — every table whose foreign keys depend on it is
 blocked rather than executed, reporting `FOREIGN_KEY_FAILED`. The rule is
 uniform: if a dependency won't reach its desired state this sync, its
-dependents don't run either. Fix the upstream table and re-sync.
+dependents don't run either.
+
+Blocking is not something the engine records as it goes; it is worked out from
+the dependency edges once the run's other outcomes are known. So a blocked
+table carries no execution outcome at all, and it names *every* dependency that
+let it down, whichever phase each one failed in. The upshot for you is that a
+blocked table's report tells you the whole story of why it was skipped. Fix the
+upstream tables and re-sync.
 [Foreign keys](how-to-configure-table.md#foreign-keys) covers the
 declaration side.
 
 ## Dry runs execute nothing
 
 `sync(..., dry_run=True)` runs every phase but attempts no statements: resolve,
-read, diff, accepted/rejected planning, and compilation all happen, and the
-execution gate still records which tables a failure would block. You get every
-action and SQL statement planned from the catalog snapshot it read, plus any
-read, validation, foreign-key, or dependency-blocking failure the run found.
+read, diff, accepted/rejected planning, and compilation all happen, then the
+run stops. Because blocking is derived from the dependency edges rather than
+recorded while executing, the preview still shows which tables a failure would
+block. You get every action and SQL statement planned from the catalog snapshot
+it read, plus any read, validation, foreign-key, or dependency-blocking failure
+the run found.
 It cannot predict execution-time Databricks errors. The run makes zero catalog
 mutations and raises no exception.
 See [how to preview changes](how-to-preview-changes.md).

--- a/src/delta_engine/application/engine.py
+++ b/src/delta_engine/application/engine.py
@@ -16,24 +16,22 @@ The phases are:
   5. Plan     — retain an accepted plan of the complete diff, or the
                 rejected planning outcome
   6. Compile  — retain the exact backend statements for every accepted plan
-  7. Gate     — block dependents of failed tables (dry and real runs)
-  8. Execute  — retain attempted statement results (real runs only)
+  7. Execute  — retain attempted statement results (real runs only)
+  8. Account  — freeze the runs into a report that derives dependency blocking
 
 The declaration set is judged before the world is consulted: resolution reads
 only declarations, so a run is born knowing its position, its edges, and its
 structural verdicts, and no later phase has to narrow a union to reach them.
 
 Resolution is a pure structural judgment of the declarations against each
-other (CYCLE, UNRESOLVABLE_REFERENCE, ...). Whether a table is *blocked*
-by another table's failure is decided later, at the execution gate: walking
-the dependency-ordered runs, a run whose resolved dependency will not reach
-desired state this sync — a failed read, a rejected plan, a failed
-resolution, an execution failure, or a block of its own — is blocked with
-BLOCKED_BY_FAILED_DEPENDENCY rather than executed, so the block propagates
-along FK chains. The rule is uniform: if a dependency won't reach desired
-state this sync, its dependents don't execute either. A dry run applies the
-same gate without attempting statements, so blocking stays visible in
-previews.
+other (CYCLE, UNRESOLVABLE_REFERENCE, ...). Whether a table is *blocked* by
+another table's failure is nobody's outcome to record: it is the derived
+consequence of the dependency edges and the run's other fates, worked out once
+at accounting. One rule states it — a table did not converge if it has
+failures of its own or a dependency did not — and execution and accounting
+each fold that same rule over the dependency-ordered runs: execution to decide
+what not to attempt, accounting to say why. Because it is derived rather than
+recorded, blocking is equally visible in a dry run, which attempts nothing.
 
 A table that fails an early phase carries that failure forward on its run and
 is skipped by execution, so all tables are attempted and the report is always
@@ -74,8 +72,6 @@ from delta_engine.application.ports import (
 )
 from delta_engine.application.relationships import TableResolution, resolve
 from delta_engine.application.report import (
-    ExecutionBlockedByDependency,
-    ExecutionOutcome,
     SyncReport,
     TableRunReport,
 )
@@ -139,7 +135,7 @@ class _TableRun:
     diff: TableDiff | None = None
     planning: PlanningResult | None = None
     planned_sql_statements: tuple[str, ...] = ()
-    execution: ExecutionOutcome | None = None
+    execution: ExecutionSummary | None = None
 
     @property
     def desired(self) -> DesiredTable:
@@ -161,13 +157,17 @@ class _TableRun:
 
     @property
     def has_failures(self) -> bool:
-        """True when any completed phase has failed for this table."""
+        """
+        True when a completed phase failed this table on its own account.
+
+        Own faults only: being blocked by another table is not a fault of this
+        run, and is derived at accounting rather than recorded here.
+        """
         return (
             isinstance(self.read, ReadFailure)
             or isinstance(self.planning, PlanningFailed)
             or bool(self.resolution.structural_failures)
-            or isinstance(self.execution, ExecutionBlockedByDependency)
-            or (isinstance(self.execution, ExecutionSummary) and bool(self.execution.failures))
+            or (self.execution is not None and bool(self.execution.failures))
         )
 
     def to_report(self) -> TableRunReport:
@@ -205,11 +205,12 @@ class Engine:
         """
         Synchronize all registered tables to their desired state.
 
-        Runs lower → resolve → read → diff → plan → compile → gate → execute.
-        Resolution births one private run per table in dependency-first order
-        carrying its static facts, the worldly phases enrich the runs in
-        place, the gate blocks dependents of failed tables, and the completed
-        outcomes are finally frozen into ``TableRunReport`` values.
+        Runs lower → resolve → read → diff → plan → compile → execute →
+        account. Resolution births one private run per table in
+        dependency-first order carrying its static facts, the worldly phases
+        enrich the runs in place, and assembly freezes the completed outcomes
+        into ``TableRunReport`` values, deriving dependency blocking from the
+        edges as it goes.
 
         A table that fails an early phase carries that failure forward and is
         skipped by execution; its partial run is still included in the report.
@@ -218,12 +219,12 @@ class Engine:
             *tables: The table specifications to synchronize. Duplicate
                 qualified names raise ``DuplicateTableDefinitionError`` before
                 any phase runs.
-            dry_run: When True, run every phase but attempt no statements
-                (zero catalog mutations). The execution gate still records
-                dependency blocking, so a dependent of a failed table reports
-                BLOCKED_BY_FAILED_DEPENDENCY in the preview; no run retains
-                attempted statement results, while its ``plan`` still records
-                the actions compiled from the observed snapshot. The report is
+            dry_run: When True, stop after compile and attempt no statements
+                (zero catalog mutations). No run retains attempted statement
+                results, while its ``plan`` still records the actions compiled
+                from the observed snapshot. Blocking is derived rather than
+                executed, so a dependent of a failed table still reports
+                BLOCKED_BY_FAILED_DEPENDENCY in the preview. The report is
                 returned instead of raising ``SyncFailedError`` when a table
                 fails.
 
@@ -248,11 +249,10 @@ class Engine:
         self._diff(runs)
         self._plan(runs)
         self._compile(runs)
-        self._gate(runs)
         if not dry_run:
             self._execute(runs)
 
-        report = SyncReport(
+        report = SyncReport.assemble(
             started_at=run_started,
             ended_at=datetime.now(UTC),
             table_reports=tuple(run.to_report() for run in runs),
@@ -363,9 +363,10 @@ class Engine:
 
         Resolution is structural: it judges the declarations against each
         other, before any catalog state is fetched. Whether a table is
-        *blocked* by another's failure is decided later, by the gating walk in
-        ``_gate``. Every run carries a resolution from birth, so no later
-        phase has to consider a half-resolved table.
+        *blocked* by another's failure is not decided here but derived from
+        these edges once the run's other fates are known. Every run carries a
+        resolution from birth, so no later phase has to consider a
+        half-resolved table.
         """
         runs: list[_TableRun] = []
 
@@ -377,57 +378,29 @@ class Engine:
 
         return tuple(runs)
 
-    def _gate(self, runs: tuple[_TableRun, ...]) -> None:
-        """
-        Block every run whose dependency already failed an earlier phase.
-
-        Walks the resolved runs in dependency-first order, seeding the
-        will-not-converge set with every run that failed to read, resolve, or
-        plan, and recording ExecutionBlockedByDependency on each of their
-        dependents — which then blocks its own dependents, so the block
-        propagates along FK chains in one pass. The gate runs on dry and real
-        runs alike: blocking is part of the preview, and execution afterwards
-        only has to react to failures that arise while statements run.
-        """
-        failed: set[QualifiedName] = {run.qualified_name for run in runs if run.has_failures}
-
-        for run in runs:
-            if run.has_failures:
-                continue
-
-            blocking_failures = run.resolution.blocked_by(failed)
-            if blocking_failures:
-                run.execution = ExecutionBlockedByDependency(blocking_failures)
-                failed.add(run.qualified_name)
-                logger.error(
-                    "Execution blocked for %s (%d foreign key failure(s))",
-                    run.qualified_name,
-                    len(blocking_failures),
-                )
-
     def _execute(self, runs: tuple[_TableRun, ...]) -> None:
         """
-        Execute the plan of every gated run with no failures and a non-empty plan.
+        Execute every convergent run's plan, skipping dependents of failure.
 
-        The gate has already blocked dependents of tables that failed an
-        earlier phase, so this walk reacts only to failures that arise while
-        statements run: a run whose resolved dependency fails mid-execution is
-        blocked with BLOCKED_BY_FAILED_DEPENDENCY instead of executed — even a
-        dependent with no work of its own. A run with an empty plan and no
-        blocking failures is skipped and counts as a healthy parent. The
-        execution outcome remains the sole source of execution or runtime
-        dependency failures.
+        One walk in dependency order applies the single blocking rule: a run
+        with failures of its own, or with a dependency that will not converge,
+        joins the not-converged set and is skipped. Nothing is recorded on the
+        run either way — the account derives blocking from the same edges — so
+        the two arms differ only in what they can say about the skip. Plan
+        emptiness gates only statement execution: a no-op run still joins the
+        set through the same rule when its dependency failed, so blocking
+        propagates through tables with no work of their own.
         """
-        failed_during_execution: set[QualifiedName] = set()
+        not_converged: set[QualifiedName] = set()
 
         for run in runs:
             if run.has_failures:
+                not_converged.add(run.qualified_name)
                 continue
 
-            blocking_failures = run.resolution.blocked_by(failed_during_execution)
+            blocking_failures = run.resolution.blocked_by(not_converged)
             if blocking_failures:
-                run.execution = ExecutionBlockedByDependency(blocking_failures)
-                failed_during_execution.add(run.qualified_name)
+                not_converged.add(run.qualified_name)
                 logger.error(
                     "Execution blocked for %s (%d foreign key failure(s))",
                     run.qualified_name,
@@ -435,7 +408,6 @@ class Engine:
                 )
                 continue
 
-            # A no-op table must still be blocked when its dependency failed.
             plan = run.plan
             if plan is None:
                 raise RuntimeError(f"Executable table was not planned: {run.qualified_name}")
@@ -446,7 +418,7 @@ class Engine:
             run.execution = summary
 
             if summary.failures:
-                failed_during_execution.add(run.qualified_name)
+                not_converged.add(run.qualified_name)
 
             logger.info(
                 "Executed %d statement(s) for %s (%d failed)",

--- a/src/delta_engine/application/report.py
+++ b/src/delta_engine/application/report.py
@@ -92,25 +92,6 @@ def _failure_records(failures: tuple[Failure, ...]) -> list[dict[str, str]]:
 
 
 @dataclass(frozen=True, slots=True)
-class ExecutionBlockedByDependency:
-    """Execution was skipped because a referenced table failed while executing."""
-
-    failures: tuple[ForeignKeyFailure, ...]
-
-    def __post_init__(self) -> None:
-        if not self.failures:
-            raise ValueError("Dependency blocking requires at least one failure")
-        if any(
-            failure.reason is not ForeignKeyFailureReason.BLOCKED_BY_FAILED_DEPENDENCY
-            for failure in self.failures
-        ):
-            raise ValueError("Execution blocking requires dependency-blocking failures")
-
-
-type ExecutionOutcome = ExecutionSummary | ExecutionBlockedByDependency
-
-
-@dataclass(frozen=True, slots=True)
 class TableRunReport:
     """
     Frozen public projection of one completed table run.
@@ -130,7 +111,7 @@ class TableRunReport:
     planning: PlanningResult | None
     planned_sql_statements: tuple[str, ...]
     resolution: TableResolution
-    execution_outcome: ExecutionOutcome | None
+    execution_outcome: ExecutionSummary | None
     blocked_failures: tuple[ForeignKeyFailure, ...] = ()
 
     def __post_init__(self) -> None:
@@ -152,8 +133,6 @@ class TableRunReport:
             read_failed or planning_failed or resolution_failed
         ):
             raise ValueError("Execution cannot follow a failed earlier phase")
-        if isinstance(self.execution_outcome, ExecutionBlockedByDependency) and resolution_failed:
-            raise ValueError("Execution blocking requires a structurally sound resolution")
         if self.blocked_failures:
             if self.execution_outcome is not None:
                 raise ValueError("A blocked table records no execution outcome")
@@ -182,14 +161,8 @@ class TableRunReport:
 
     @property
     def execution(self) -> ExecutionSummary | None:
-        """The attempted statements, excluding dependency-blocked execution."""
-        match self.execution_outcome:
-            case ExecutionSummary() as summary:
-                return summary
-            case ExecutionBlockedByDependency() | None:
-                return None
-            case _ as unreachable:
-                assert_never(unreachable)
+        """The attempted statements; ``None`` when nothing was executed."""
+        return self.execution_outcome
 
     @property
     def failures(self) -> tuple[Failure, ...]:
@@ -208,15 +181,8 @@ class TableRunReport:
         if isinstance(self.planning, PlanningFailed):
             failures.extend(self.planning.failures)
 
-        match self.execution_outcome:
-            case ExecutionSummary() as summary:
-                failures.extend(summary.failures)
-            case ExecutionBlockedByDependency(failures=blocked):
-                failures.extend(blocked)
-            case None:
-                pass
-            case _ as unreachable:
-                assert_never(unreachable)
+        if self.execution_outcome is not None:
+            failures.extend(self.execution_outcome.failures)
         failures.extend(self.blocked_failures)
 
         return tuple(failures)

--- a/tests/application/test_engine.py
+++ b/tests/application/test_engine.py
@@ -23,7 +23,6 @@ from delta_engine.application.ports import (
     TablePresent,
 )
 from delta_engine.application.report import (
-    ExecutionBlockedByDependency,
     SyncReport,
     TableRunReport,
     TableRunStatus,
@@ -831,13 +830,13 @@ def test_read_failure_in_upstream_blocks_fk_dependent():
             _spec_with_fk("cat.sch.b", "cat.sch.a"),
         )
 
-    # Then b is blocked at the execution gate and neither table executes
+    # Then b is blocked by a and neither table executes
     report = exc_info.value.report
     table_a = _assert_status(report, "cat.sch.a", TableRunStatus.READ_FAILED)
     table_b = _assert_status(report, "cat.sch.b", TableRunStatus.FOREIGN_KEY_FAILED)
 
     assert table_b.resolution.structural_failures == ()
-    assert isinstance(table_b.execution_outcome, ExecutionBlockedByDependency)
+    assert table_b.blocked_failures != ()
     _assert_has_fk_failure(
         table_b,
         reason=ForeignKeyFailureReason.BLOCKED_BY_FAILED_DEPENDENCY,
@@ -867,7 +866,7 @@ def test_validation_failure_in_upstream_blocks_fk_dependent():
             _spec_with_fk("cat.sch.orders", "cat.sch.customers"),
         )
 
-    # Then orders is blocked at the execution gate, before any statement runs
+    # Then orders is blocked by customers, before any statement runs
     report = exc_info.value.report
     customers = _assert_status(
         report,
@@ -881,7 +880,7 @@ def test_validation_failure_in_upstream_blocks_fk_dependent():
     )
 
     assert orders.resolution.structural_failures == ()
-    assert isinstance(orders.execution_outcome, ExecutionBlockedByDependency)
+    assert orders.blocked_failures != ()
     _assert_has_fk_failure(
         orders,
         reason=ForeignKeyFailureReason.BLOCKED_BY_FAILED_DEPENDENCY,
@@ -906,14 +905,14 @@ def test_structural_fk_failure_in_upstream_blocks_fk_dependent():
             _spec_with_fk("cat.sch.b", "cat.sch.a"),
         )
 
-    # Then a fails resolution structurally and b is blocked at the execution gate
+    # Then a fails resolution structurally and b is blocked by a
     report = exc_info.value.report
     table_a = _assert_status(report, "cat.sch.a", TableRunStatus.FOREIGN_KEY_FAILED)
     table_b = _assert_status(report, "cat.sch.b", TableRunStatus.FOREIGN_KEY_FAILED)
 
     assert table_a.resolution.structural_failures != ()
     assert table_b.resolution.structural_failures == ()
-    assert isinstance(table_b.execution_outcome, ExecutionBlockedByDependency)
+    assert table_b.blocked_failures != ()
     _assert_has_fk_failure(
         table_b,
         reason=ForeignKeyFailureReason.BLOCKED_BY_FAILED_DEPENDENCY,
@@ -1194,6 +1193,54 @@ def test_execution_failure_blocks_diamond_dependent_with_one_failure_per_fk():
     assert executor.executed_names == ["cat.sch.a"]
 
 
+def test_blocked_table_lists_blockers_from_both_eras():
+    # Given suppliers fails structurally (FK to an unregistered table),
+    # employees fails while executing, and deliveries depends on both
+    deliveries = DeltaTable(
+        "cat",
+        "sch",
+        "deliveries",
+        columns=(
+            Column("id", String(), nullable=False),
+            Column("supplier_id", String()),
+            Column("employee_id", String()),
+        ),
+        primary_key=["id"],
+        foreign_keys=[
+            ForeignKey(
+                columns={"supplier_id": "id"},
+                references=_referenced_spec("cat.sch.suppliers"),
+            ),
+            ForeignKey(
+                columns={"employee_id": "id"},
+                references=_referenced_spec("cat.sch.employees"),
+            ),
+        ],
+    )
+    reader = _RecordingReader()  # every table absent — plans are creations
+    executor = _RecordingExecutor([_execution_error()])  # employees, the only table that runs
+    engine = Engine(reader=reader, executor=executor)
+
+    # When syncing for real
+    with pytest.raises(SyncFailedError) as exc_info:
+        engine.sync(
+            _spec_with_fk("cat.sch.suppliers", "cat.sch.ghost"),
+            _spec("cat.sch.employees"),
+            deliveries,
+        )
+
+    # Then deliveries names both blockers — the structural-era parent and the
+    # execution-era parent — not just the first era's
+    report = exc_info.value.report
+    table = _assert_status(report, "cat.sch.deliveries", TableRunStatus.FOREIGN_KEY_FAILED)
+    assert {str(failure.references) for failure in table.blocked_failures} == {
+        "cat.sch.employees",
+        "cat.sch.suppliers",
+    }
+    assert table.execution_outcome is None
+    assert executor.executed_names == ["cat.sch.employees"]
+
+
 def test_synced_fk_parent_with_no_work_does_not_block_dependent():
     # Given customers already matches its declaration and orders is absent
     reader = _RecordingReader({"cat.sch.customers": _existing_id_table_synced("cat.sch.customers")})
@@ -1392,7 +1439,7 @@ def test_dry_run_returns_fk_failures_without_raising_or_executing():
     )
 
 
-def test_dry_run_records_dependency_blocking_for_dependents_of_failed_tables():
+def test_dry_run_derives_dependency_blocking_for_dependents_of_failed_tables():
     # Given a parent that fails validation and a child declaring an FK to it
     reader = _RecordingReader(
         {
@@ -1413,7 +1460,7 @@ def test_dry_run_records_dependency_blocking_for_dependents_of_failed_tables():
     # Then the dry run keeps blocking visible without executing anything
     _assert_status(report, "cat.sch.customers", TableRunStatus.PLANNING_FAILED)
     orders = _assert_status(report, "cat.sch.orders", TableRunStatus.FOREIGN_KEY_FAILED)
-    assert isinstance(orders.execution_outcome, ExecutionBlockedByDependency)
+    assert orders.blocked_failures != ()
     _assert_has_fk_failure(
         orders,
         reason=ForeignKeyFailureReason.BLOCKED_BY_FAILED_DEPENDENCY,

--- a/tests/application/test_report.py
+++ b/tests/application/test_report.py
@@ -21,7 +21,6 @@ from delta_engine.application.ports import (
 )
 from delta_engine.application.relationships import TableResolution
 from delta_engine.application.report import (
-    ExecutionBlockedByDependency,
     SyncReport,
     TableRunReport,
     TableRunStatus,
@@ -107,7 +106,6 @@ def _report(
     failures: tuple[Failure, ...] = (),
     dependencies: tuple[ForeignKeyConstraint, ...] = (),
     execution: ExecutionSummary | None = None,
-    execution_blocked: bool = False,
     blocked_failures: tuple[ForeignKeyFailure, ...] = (),
 ) -> TableRunReport:
     """Construct a frozen report snapshot from concise test inputs."""
@@ -141,10 +139,7 @@ def _report(
     resolution = TableResolution(
         desired=desired,
         dependencies=dependencies,
-        structural_failures=() if execution_blocked else resolution_failures,
-    )
-    execution_outcome = (
-        ExecutionBlockedByDependency(resolution_failures) if execution_blocked else execution
+        structural_failures=resolution_failures,
     )
 
     return TableRunReport(
@@ -152,7 +147,7 @@ def _report(
         planning=planning,
         planned_sql_statements=planned_sql_statements,
         resolution=resolution,
-        execution_outcome=execution_outcome,
+        execution_outcome=execution,
         blocked_failures=blocked_failures,
     )
 
@@ -402,26 +397,6 @@ def test_status_reflects_the_earliest_failing_phase():
     )
     # Then its canonical read outcome determines the status
     assert read_failed.status is TableRunStatus.READ_FAILED
-
-
-def test_runtime_dependency_block_is_failure_but_not_statement_execution():
-    desired = _a_desired_table("orders")
-    failure = ForeignKeyFailure(
-        table=desired.qualified_name,
-        local_columns=("customer_id",),
-        references=QualifiedName("cat", "schema", "customers"),
-        reason=ForeignKeyFailureReason.BLOCKED_BY_FAILED_DEPENDENCY,
-    )
-    report = _report(
-        desired=desired,
-        read=TablePresent(table=_an_observed_table()),
-        failures=(failure,),
-        execution_blocked=True,
-    )
-
-    assert report.status is TableRunStatus.FOREIGN_KEY_FAILED
-    assert report.failures == (failure,)
-    assert report.execution is None
 
 
 def test_table_run_report_carries_its_desired_definition():


### PR DESCRIPTION
Tasks 2 and 3 of the derived-blocking work (pipeline-laws PR 3), completing what #302 set up: the engine stops *recording* dependency blocking, and the machinery for recording it is deleted.

## What changes

`Engine._gate` is gone. `_execute` is now the single dependency walk, folding the one blocking rule — *a table did not converge iff it has own failures or a dependency did not* — over the runs, and `sync` builds its report through `SyncReport.assemble`, which folds the same rule again to say *why* a table was skipped. Dry runs stop after compile; blocking still shows in the preview because it is derived, not enacted.

With nothing left to record, the recording vocabulary goes with it:

- `ExecutionBlockedByDependency` and the `ExecutionOutcome` alias are deleted; `TableRunReport.execution_outcome` narrows to `ExecutionSummary | None`.
- That collapses one `__post_init__` rule, the `execution` property's three-arm match, and the `failures` property's match into a single `if`.
- `_TableRun.has_failures` becomes own-faults-only: failed read, structural failures, rejected planning, failed summary. Being blocked is not a fault of the run.

Net −51 lines of source.

## Behaviour delta: a blocked table now names every blocker

Recording blocking took two passes — the gate before execution, then `_execute` for failures that arose mid-run — and the second could not add to what the first had already written. A table blocked by two parents that failed in *different eras* therefore listed only the first era's.

One derived walk lists both. `test_blocked_table_lists_blockers_from_both_eras` pins it: `suppliers` fails structurally, `employees` fails while executing, and `deliveries` depends on both.

Everything else is unchanged — statuses, `to_dict` keys (`schema_version` stays 2), rendering, and the FK failure values themselves. Only their location moved, from the execution slot to `blocked_failures`.

### Deviation from the plan, deliberate

The plan's `_execute` sketch dropped the `logger.error("Execution blocked for %s …")` line entirely, but its own behaviour-delta analysis scoped that loss to dry runs ("if one is added later it belongs on the real-run path"). I kept it on the real-run path: silently skipping tables during a long sync is a real observability regression, and the log is what tells you live which tables got dropped and why. The cost is that the walk names its two skip reasons in separate arms rather than one condition — both feed the same not-converged set, so the rule is still stated once.

## Tests

- New: `test_blocked_table_lists_blockers_from_both_eras` (the delta above).
- Re-pinned: the four gate assertions move from `isinstance(x.execution_outcome, ExecutionBlockedByDependency)` to `x.blocked_failures != ()`, with the same `_assert_has_fk_failure` reason/target checks alongside. `test_dry_run_records_…` → `test_dry_run_derives_…`; its meaning is unchanged.
- Deleted: `test_runtime_dependency_block_is_failure_but_not_statement_execution`, whose subject was the deleted type. #302's `test_baked_blocked_failures_flatten_into_the_report_failures` covers the derived form, and the new invariant makes its third assertion unviolatable.
- The `_report` builder's `execution_blocked` parameter is gone.

## Docs

`explanation-sync-lifecycle.md` (Execute row; the FK propagation section; dry runs) and `explanation-architecture.md` (phase list, the resolution/blocking passage, the execution walk, the run-truth passage, the where-to-make-changes pointer). `reference-run-report.md` needed no change — it never claimed blocking was recorded, and the statuses and `to_dict` fields are unchanged.

## Verification

`uv run pytest` (1103 passed, 96.92% coverage) · `ruff check` · `ruff format --check` · `mypy` (154 files) · `lint-imports` (7 contracts kept) · `sphinx-build -W`.

All four of the plan's end-state greps return nothing: no `ExecutionBlockedByDependency`/`ExecutionOutcome`, no `_gate`, and PR 1–2's end states still hold. No file under `tests/live/` is touched and `rendering.py` shows no diff.

## Follow-up, not in this PR

`TableRunReport.execution` is now a pure alias for `execution_outcome` — two names for one piece of state, vestigial once the union collapsed. Resolving it means renaming the field to `execution` and dropping the property, which keeps all ~45 reader sites (including the live suite) working and touches only the ~10 construction sites. Left out as a separate change.
