### PR TITLE
fix: Decimal rejects non integer precision and scale

### DIFF
--- a/src/delta_engine/domain/model/data_type.py
+++ b/src/delta_engine/domain/model/data_type.py
@@ -67,7 +67,11 @@ class Decimal(DataType):
     scale: int = 0
 
     def __post_init__(self) -> None:
-        """Validate that 0 < precision <= 38 and 0 <= scale <= precision."""
+        if type(self.precision) is not int and type(self.scale) is not int:
+            raise ValueError(
+                "precision and scale must by type int;"
+                f" got precision: {type(self.precision)}, scale: {type(self.scale)}"
+            )
         # The cap is checked first so an over-limit precision always gets the
         # message naming the limit, even when the scale is also out of range.
         if self.precision > _MAX_DECIMAL_PRECISION:

--- a/tests/domain/model/test_data_type.py
+++ b/tests/domain/model/test_data_type.py
@@ -41,6 +41,12 @@ def test_decimal_accepts_maximum_precision_and_scale() -> None:
     assert Decimal(38, 38).precision == 38
 
 
+@pytest.mark.parametrize("value", ["1", 1.0, True])
+def test_decimal_rejects_non_integer_precision_and_scale(value) -> None:
+    with pytest.raises(ValueError):
+        Decimal(value, value)
+
+
 def test_struct_field_requires_non_blank_name_and_preserves_case() -> None:
     with pytest.raises(ValueError):
         StructField("", Integer())


### PR DESCRIPTION
<!--
The PR TITLE becomes the squash-commit message on main and drives the
automatic version bump and changelog. It MUST be a Conventional Commit:

  feat: ...      -> minor release
  fix: ...       -> patch release
  feat!: ... / BREAKING CHANGE -> handled as a 0.x minor while pre-1.0
  docs/chore/refactor/test/ci/build/style: ... -> no release

Scope is optional, e.g. `feat(api): ...`.
-->

## What

Decimal data type rejects non-integer precision and scale
