### PR TITLE
fix: a nested data type closes its own delimiters

### DIFF
--- a/docs/reference-run-report.md
+++ b/docs/reference-run-report.md
@@ -68,7 +68,7 @@ description is `planned_sql_statements`:
 | ----------- | ----- | ---------------------------------------------------------------------------------- |
 | `kind`      | `str` | Change category: `columns`, `keys`, `clustering`, `partitioning`, `features`, `properties`, `tags`, `comments` |
 | `operation` | `str` | `add`, `remove`, or `change`                                                       |
-| `subject`   | `str` | What the change targets: a column, property, or tag name, or one of `table`, `primary key`, `clustering`, `partitioning` |
+| `subject`   | `str` | What the change targets: the name of a column, property, tag, or table feature; `column <name>` or `column <name>.<tag>` when the target is scoped to a column; or one of `table`, `primary key`, `foreign key ...`, `clustering`, `partitioning` |
 | `detail`    | `str` | How it changed, e.g. `Integer → Long` or `= 'true' (was 'false')`; empty when there is none |
 
 ### Failure records

--- a/src/delta_engine/domain/model/data_type.py
+++ b/src/delta_engine/domain/model/data_type.py
@@ -155,7 +155,7 @@ class Struct(DataType):
             seen.add(field.name)
 
     def __str__(self) -> str:
-        return f"Struct<{', '.join(str(f) for f in self.fields)}"
+        return f"Struct<{', '.join(str(field) for field in self.fields)}>"
 
 
 @dataclass(frozen=True, slots=True)
@@ -181,4 +181,4 @@ class Map(DataType):
             raise ValueError("Map key type must not be a Map")
 
     def __str__(self) -> str:
-        return f"Map>{self.key}, {self.value}"
+        return f"Map<{self.key}, {self.value}>"

--- a/tests/application/test_rendering.py
+++ b/tests/application/test_rendering.py
@@ -25,17 +25,21 @@ from delta_engine.application.rendering import (
 )
 from delta_engine.application.report import SyncReport, TableRunReport
 from delta_engine.domain.model import (
+    Array,
     Decimal,
     DesiredColumn,
     DesiredTable,
     ForeignKeyConstraint,
     Integer,
     Long,
+    Map,
     ObservedColumn,
     ObservedTable,
     PrimaryKeyConstraint,
     QualifiedName,
     String,
+    Struct,
+    StructField,
     TableFeature,
 )
 from delta_engine.domain.plan.actions import (
@@ -144,6 +148,30 @@ def _plan(name: str, *actions: Action) -> ActionPlan:
                     DiffOperation.CHANGE,
                     "amount",
                     ("Decimal(10,2) → Decimal(12,2)",),
+                ),
+            ),
+        ),
+        # A nested type spells its own structure, so its delimiters have to
+        # nest too — unbalanced ones leave a reader unable to tell where an
+        # inner type ends.
+        (
+            AddColumn(
+                DesiredColumn(
+                    "payload",
+                    Struct(
+                        (
+                            StructField("id", Integer()),
+                            StructField("labels", Map(String(), Array(String()))),
+                        )
+                    ),
+                )
+            ),
+            (
+                DiffEntry(
+                    DiffCategory.COLUMNS,
+                    DiffOperation.ADD,
+                    "payload",
+                    ("Struct<id: Integer, labels: Map<String, Array<String>>>",),
                 ),
             ),
         ),


### PR DESCRIPTION
## What

`Struct.__str__` dropped its closing `>` and `Map.__str__` opened with `>` instead of `<`, so a struct or map column rendered as an unreadable fragment in both the text diff and the JSON report:

```
+ payload  Struct<id: Integer, labels: Map>String, String
```

Both were introduced in #313 and shipped to `main`.

## Why

The four composite `__str__` methods had no test between them — `data_type.py` sat at 96% with exactly those lines uncovered — which is how this passed mypy, ruff and the suite.

Rather than assert the spelling of each type in isolation, which only pins cosmetics, one row joins the existing `test_action_entries_render_expected` table with a type nesting all three composites (`Struct` → `Map` → `Array`), where the delimiters have to balance for the line to read at all. That row fails on both bugs. `data_type.py` goes to 100%.

Also names the foreign key and table feature subjects the run report reference omitted.

## Verified

Full suite, mypy, ruff, import-linter, `sphinx-build -W`. Confirmed the new row catches both bugs by reverting the fix and watching it fail.