### PR TITLE
feat: let a rejected table say what drifted

### DIFF
--- a/docs/reference-run-report.md
+++ b/docs/reference-run-report.md
@@ -27,6 +27,10 @@ Version 2 renamed the planning-phase status from `VALIDATION_FAILED` to
 `PLANNING_FAILED` and the corresponding failure phase from `VALIDATION` to
 `PLANNING`.
 
+`rejected_changes` was added without a version bump: adding a field is
+backwards-compatible, and a reader that does not know the key sees exactly the
+payload it saw before.
+
 ## Run-level fields
 
 `SyncReport.to_dict()` returns:
@@ -52,6 +56,7 @@ Each entry in `tables`, and the whole of `TableRunReport.to_dict()`:
 | `has_changes`            | `bool`           | True if this table has a planned change                      |
 | `has_failures`           | `bool`           | True if this table failed a phase                            |
 | `changes`                | `list[dict]`     | Summaries of the planned changes, in plan order (see below)  |
+| `rejected_changes`       | `list[dict]`     | Differences found but refused, when the plan was rejected; empty otherwise |
 | `planned_sql_statements` | `list[str]`      | Full compiled DDL the plan lowers to, in order               |
 | `failures`               | `list[dict]`     | Failure records, in phase order (see below)                  |
 | `execution`              | `dict` \| `None` | Execution counts, or `None` on a dry run or a skipped table  |
@@ -70,6 +75,16 @@ description is `planned_sql_statements`:
 | `operation` | `str` | `add`, `remove`, or `change`                                                       |
 | `subject`   | `str` | What the change targets: a column, property, or tag name, or one of `table`, `primary key`, `clustering`, `partitioning` |
 | `detail`    | `str` | How it changed, e.g. `Integer → Long` or `= 'true' (was 'false')`; empty when there is none |
+
+### Rejected change records
+
+When a table's diff is rejected, no plan exists, so `changes` is empty. The
+differences the engine did find are projected into `rejected_changes` in the
+same record shape, so a reader can see *what* was refused alongside the
+`failures` list that says *why*. It includes both the actions the engine would
+have taken and the differences no action can close (a column spelled
+differently from the catalog, a property set but undeclared, a partitioning
+change). It is always empty for a table that planned successfully.
 
 ### Failure records
 

--- a/docs/reference-safe-change-rules.md
+++ b/docs/reference-safe-change-rules.md
@@ -73,7 +73,7 @@ regardless of the rule set. They are the `ELIGIBILITY_CHECKS` in
 | Law                              | What it blocks                                                                                          | How to resolve                                                                        |
 | -------------------------------- | ------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------- |
 | `ColumnSpellingMustMatchCatalog` | A declared column (or `renamed_from` reference) spelled differently from the catalog — case must match exactly | Update the declaration to the catalog's exact spelling (`DESCRIBE TABLE` shows it)     |
-| `UnmanagedAspectDrift`           | An unmanaged aspect (e.g. column structure) has drifted from the declaration in a restricted-scope sync  | Sync the table fully, or update the declaration to match the live schema              |
+| `UnmanagedAspectDrift`           | An unmanaged aspect (e.g. column structure) has drifted from the declaration in a restricted-scope sync — the failure names each difference | Update the declaration to match the live table, or widen its scope to manage this aspect |
 | `MissingTableUnmanaged`          | The table does not exist but this definition does not manage table existence                            | Create the table out-of-band first, or manage it fully                                |
 | `StreamingTableAnnotationsOnly`  | The observed table is a streaming table and the declaration manages more than comments and tags | Declare it with `scope="annotations"` or `scope="tags"`; the table's schema, properties, and keys belong to its owning pipeline |
 

--- a/src/delta_engine/application/diff_entries.py
+++ b/src/delta_engine/application/diff_entries.py
@@ -19,11 +19,15 @@ from delta_engine.domain.plan import (
     AddColumn,
     AlterClustering,
     AlterColumnType,
+    ColumnCaseDrift,
+    ColumnRenameConflict,
     CreateTable,
     DropColumn,
     DropForeignKey,
     DropPrimaryKey,
     EnableTableFeature,
+    PartitioningChanged,
+    PropertyUndeclared,
     RenameColumn,
     SetColumnComment,
     SetColumnNullability,
@@ -33,6 +37,7 @@ from delta_engine.domain.plan import (
     SetProperty,
     SetTableComment,
     SetTableTag,
+    Unresolvable,
     UnsetColumnTag,
     UnsetProperty,
     UnsetTableTag,
@@ -464,5 +469,71 @@ def _(action: AlterClustering) -> tuple[DiffEntry, ...]:
             DiffOperation.CHANGE,
             subject="clustering",
             detail=(*_columns_detail(action.desired_clustering), f"— {_OPTIMIZE_FULL_HINT}"),
+        ),
+    )
+
+
+@functools.singledispatch
+def unresolvable_entries(unresolvable: Unresolvable) -> tuple[DiffEntry, ...]:
+    """
+    Describe one unresolvable difference as category-tagged diff entries.
+
+    The sibling of :func:`action_entries` for differences no action can close.
+    Every entry is a ``CHANGE``: an unresolvable difference is neither an
+    addition nor a removal the engine could make, it is a disagreement between
+    the declaration and the catalog that something outside this sync must
+    settle.
+    """
+    raise NotImplementedError(f"No diff entries for unresolvable {type(unresolvable).__name__}")
+
+
+@unresolvable_entries.register
+def _(unresolvable: ColumnCaseDrift) -> tuple[DiffEntry, ...]:
+    return (
+        DiffEntry(
+            DiffCategory.COLUMNS,
+            DiffOperation.CHANGE,
+            subject=unresolvable.declared_name,
+            detail=(f"spelled '{unresolvable.observed_name}' in the catalog",),
+        ),
+    )
+
+
+@unresolvable_entries.register
+def _(unresolvable: ColumnRenameConflict) -> tuple[DiffEntry, ...]:
+    return (
+        DiffEntry(
+            DiffCategory.COLUMNS,
+            DiffOperation.CHANGE,
+            subject=unresolvable.old_name,
+            detail=(f"renamed → {unresolvable.new_name}, but both columns exist",),
+        ),
+    )
+
+
+@unresolvable_entries.register
+def _(unresolvable: PropertyUndeclared) -> tuple[DiffEntry, ...]:
+    # Same two-phrase shape as a property change, so the trailing clause aligns
+    # into its own column down a group of property lines.
+    return (
+        DiffEntry(
+            DiffCategory.PROPERTIES,
+            DiffOperation.CHANGE,
+            subject=unresolvable.name,
+            detail=(f"= '{unresolvable.observed_value}'", "(set on the table, undeclared)"),
+        ),
+    )
+
+
+@unresolvable_entries.register
+def _(unresolvable: PartitioningChanged) -> tuple[DiffEntry, ...]:
+    observed = ", ".join(unresolvable.observed_partitioning)
+    desired = ", ".join(unresolvable.desired_partitioning)
+    return (
+        DiffEntry(
+            DiffCategory.PARTITIONING,
+            DiffOperation.CHANGE,
+            subject="partitioning",
+            detail=(f"({observed}) → ({desired})",),
         ),
     )

--- a/src/delta_engine/application/diff_entries.py
+++ b/src/delta_engine/application/diff_entries.py
@@ -37,6 +37,7 @@ from delta_engine.domain.plan import (
     SetProperty,
     SetTableComment,
     SetTableTag,
+    TableDrift,
     Unresolvable,
     UnsetColumnTag,
     UnsetProperty,
@@ -200,6 +201,25 @@ def action_entries(action: Action) -> tuple[DiffEntry, ...]:
 def plan_entries(plan: ActionPlan) -> tuple[DiffEntry, ...]:
     """Every diff entry a plan lowers to, in plan order — one action may yield several."""
     return tuple(entry for action in plan for entry in action_entries(action))
+
+
+def drift_entries(drift: TableDrift) -> tuple[DiffEntry, ...]:
+    """
+    Every diff entry a drift lowers to, in diff order — actions, then the rest.
+
+    The sibling of :func:`plan_entries` for a diff that never became a plan.
+    Both of the drift's streams are included: an unresolvable difference is
+    frequently the very reason the diff was rejected, so showing only the
+    actions would omit the answer.
+    """
+    return (
+        *(entry for action in drift.actions for entry in action_entries(action)),
+        *(
+            entry
+            for unresolvable in drift.unresolvable
+            for entry in unresolvable_entries(unresolvable)
+        ),
+    )
 
 
 @action_entries.register

--- a/src/delta_engine/application/engine.py
+++ b/src/delta_engine/application/engine.py
@@ -175,6 +175,7 @@ class _TableRun:
             planned_sql_statements=self.planned_sql_statements,
             resolution=self.resolution,
             execution=self.execution,
+            diff=self.diff,
         )
 
 

--- a/src/delta_engine/application/failures.py
+++ b/src/delta_engine/application/failures.py
@@ -117,14 +117,24 @@ class ReadFailure(Failure):
 
 @dataclass(frozen=True, slots=True)
 class ValidationFailure(Failure):
-    """Description of a validation rule failure."""
+    """
+    Description of a validation rule failure.
+
+    ``details`` are the individual differences behind a summary judgment, for
+    a rule whose message names a whole aspect rather than one column. They are
+    separate lines rather than newlines inside ``message`` so the report
+    renderer owns their indentation, as it already does for the SQL line of an
+    execution failure; a rule that embeds its own layout composes wrongly
+    wherever the failure is nested.
+    """
 
     phase: ClassVar[FailurePhase] = FailurePhase.PLANNING
     rule_name: str
     message: str
+    details: tuple[str, ...] = ()
 
     def format_lines(self) -> tuple[str, ...]:
-        return (f"Validation failed: {self.rule_name} - {self.message}",)
+        return (f"Validation failed: {self.rule_name} - {self.message}", *self.details)
 
     def headline(self) -> str:
         return f"Validation failed: {self.rule_name}"

--- a/src/delta_engine/application/rendering.py
+++ b/src/delta_engine/application/rendering.py
@@ -16,11 +16,12 @@ from typing import Final
 from delta_engine.application.diff_entries import (
     DiffCategory,
     DiffEntry,
+    drift_entries,
     plan_entries,
 )
 from delta_engine.application.failures import ReadFailure
 from delta_engine.application.report import SyncReport, TableRunReport
-from delta_engine.domain.plan import ActionPlan
+from delta_engine.domain.plan import ActionPlan, TableDrift
 
 # Shown wherever a report has a readable state but no planned actions. One
 # spelling, two presentations: bare in the grid's DETAIL cell, parenthesised as
@@ -65,15 +66,28 @@ def _render_entry_groups(entries: Sequence[DiffEntry]) -> list[str]:
 
 
 def render_diff_block(report: TableRunReport) -> str:
-    """Render one table's change block: its name then its planned changes, grouped."""
+    """Render one table's change block: its name then its changes, grouped."""
     header = str(report.qualified_name)
     if isinstance(report.read, ReadFailure):
         return f"{header}\n  (could not read — no diff)"
+
     plan = report.plan
+    if plan is None:
+        # No plan means the diff was rejected, which is not the same as having
+        # found nothing. The failures section says which rule refused; this
+        # says what it refused.
+        refused = drift_entries(report.diff) if isinstance(report.diff, TableDrift) else ()
+        if refused:
+            return "\n".join(
+                [f"{header}  (REJECTED — no SQL planned)", *_render_entry_groups(refused)]
+            )
+        return f"{header}\n  ({_NO_CHANGES} — see failures)"
+
     if not plan:
         if report.has_failures:
             return f"{header}\n  ({_NO_CHANGES} — see failures)"
         return f"{header}\n  ({_NO_CHANGES})"
+
     if report.creates_table:
         header = f"{header}  (CREATE)"
     return "\n".join([header, *_render_entry_groups(plan_entries(plan))])

--- a/src/delta_engine/application/report.py
+++ b/src/delta_engine/application/report.py
@@ -5,14 +5,14 @@ Run reports: per-table and run-level outcome aggregates.
 engine run; `SyncReport` aggregates those table snapshots.
 """
 
-from collections.abc import Iterator, Mapping
+from collections.abc import Iterable, Iterator, Mapping
 from dataclasses import dataclass, replace
 from datetime import datetime
 from enum import StrEnum
 from types import MappingProxyType
 from typing import Any, Final, NamedTuple
 
-from delta_engine.application.diff_entries import plan_entries
+from delta_engine.application.diff_entries import DiffEntry, drift_entries, plan_entries
 from delta_engine.application.failures import (
     Failure,
     FailurePhase,
@@ -28,7 +28,7 @@ from delta_engine.application.planning import (
 from delta_engine.application.ports import ExecutionSummary, ReadResult
 from delta_engine.application.relationships import TableResolution
 from delta_engine.domain.model import DesiredTable, QualifiedName
-from delta_engine.domain.plan import ActionPlan, CreateTable, TableDiff
+from delta_engine.domain.plan import ActionPlan, CreateTable, TableDiff, TableDrift
 
 # ---------- Status enums ----------
 
@@ -84,6 +84,19 @@ _STATUS_FOR_PHASE: Final[Mapping[FailurePhase, TableRunStatus]] = MappingProxyTy
 )
 
 
+def _entry_records(entries: Iterable[DiffEntry]) -> list[dict[str, str]]:
+    """Project interpreted diff entries as flat records, in the order given."""
+    return [
+        {
+            "kind": entry.category.name.lower(),
+            "operation": entry.operation.value,
+            "subject": entry.subject,
+            "detail": " ".join(entry.detail),
+        }
+        for entry in entries
+    ]
+
+
 def _change_records(plan: ActionPlan | None) -> list[dict[str, str]]:
     """
     Summarise the plan as flat change records, in plan order.
@@ -95,15 +108,21 @@ def _change_records(plan: ActionPlan | None) -> list[dict[str, str]]:
     """
     if plan is None:
         return []
-    return [
-        {
-            "kind": entry.category.name.lower(),
-            "operation": entry.operation.value,
-            "subject": entry.subject,
-            "detail": " ".join(entry.detail),
-        }
-        for entry in plan_entries(plan)
-    ]
+    return _entry_records(plan_entries(plan))
+
+
+def _rejected_change_records(
+    diff: TableDiff | None, plan: ActionPlan | None
+) -> list[dict[str, str]]:
+    """
+    Summarise the differences a rejected diff found, in diff order.
+
+    Empty whenever a plan exists: an accepted diff's differences are its
+    changes, already projected by ``_change_records``.
+    """
+    if plan is not None or not isinstance(diff, TableDrift):
+        return []
+    return _entry_records(drift_entries(diff))
 
 
 def _failure_records(failures: tuple[Failure, ...]) -> list[dict[str, str]]:
@@ -265,6 +284,7 @@ class TableRunReport:
             "has_changes": self.has_changes,
             "has_failures": self.has_failures,
             "changes": _change_records(self.plan),
+            "rejected_changes": _rejected_change_records(self.diff, self.plan),
             "planned_sql_statements": list(self.planned_sql_statements),
             "failures": _failure_records(self.failures),
             "execution": execution_record,

--- a/src/delta_engine/application/report.py
+++ b/src/delta_engine/application/report.py
@@ -28,7 +28,7 @@ from delta_engine.application.planning import (
 from delta_engine.application.ports import ExecutionSummary, ReadResult
 from delta_engine.application.relationships import TableResolution
 from delta_engine.domain.model import DesiredTable, QualifiedName
-from delta_engine.domain.plan import ActionPlan, CreateTable
+from delta_engine.domain.plan import ActionPlan, CreateTable, TableDiff
 
 # ---------- Status enums ----------
 
@@ -132,6 +132,10 @@ class TableRunReport:
     ``blocked_failures`` is the derived consequence of other tables' fates,
     baked in at assembly — a blocked table records no execution outcome of its
     own.
+    ``diff`` is the complete set of differences the engine found — actions and
+    unresolvable differences alike — retained so a table whose plan was
+    rejected can still show what drifted. It is ``None`` when the read failed,
+    and may be ``None`` on a hand-constructed report.
     """
 
     read: ReadResult
@@ -140,6 +144,7 @@ class TableRunReport:
     resolution: TableResolution
     execution: ExecutionSummary | None
     blocked_failures: tuple[ForeignKeyFailure, ...] = ()
+    diff: TableDiff | None = None
 
     def __post_init__(self) -> None:
         read_failed = isinstance(self.read, ReadFailure)
@@ -150,6 +155,8 @@ class TableRunReport:
             raise ValueError("Planning cannot follow a failed read")
         if not read_failed and self.planning is None:
             raise ValueError("A successful read requires a planning outcome")
+        if read_failed and self.diff is not None:
+            raise ValueError("A failed read produces no diff")
 
         plan = self.plan
         if plan is not None and plan.target != self.qualified_name:

--- a/src/delta_engine/application/validation.py
+++ b/src/delta_engine/application/validation.py
@@ -5,6 +5,7 @@ from dataclasses import dataclass
 from types import MappingProxyType
 from typing import ClassVar, Final, Protocol, assert_never
 
+from delta_engine.application.diff_entries import action_entries, unresolvable_entries
 from delta_engine.application.failures import ValidationFailure
 from delta_engine.application.properties import (
     DELTA_PROPERTY_POLICY,
@@ -27,6 +28,7 @@ from delta_engine.domain.model import (
     TimestampNtz,
 )
 from delta_engine.domain.plan import (
+    Action,
     AddColumn,
     AlterColumnType,
     ColumnCaseDrift,
@@ -41,6 +43,7 @@ from delta_engine.domain.plan import (
     TableDiff,
     TableDrift,
     TableMissing,
+    Unresolvable,
     UnsetProperty,
 )
 
@@ -510,6 +513,23 @@ class ColumnSpellingMustMatchCatalog:
                 assert_never(unreachable)
 
 
+def _difference_lines(difference: Action | Unresolvable) -> tuple[str, ...]:
+    """
+    State one difference the way the diff view states it, one line each.
+
+    Reusing the diff interpretation is the point: a rejection message that
+    described drift in its own words would drift from the diff block a reader
+    is comparing it against. Layout is left to whoever renders the failure —
+    these lines carry no indentation of their own.
+    """
+    entries = (
+        action_entries(difference)
+        if isinstance(difference, Action)
+        else unresolvable_entries(difference)
+    )
+    return tuple(f"{entry.symbol} {' '.join(entry.cells)}" for entry in entries)
+
+
 class UnmanagedAspectDrift:
     """
     Fail once per unmanaged aspect that has drifted.
@@ -522,9 +542,9 @@ class UnmanagedAspectDrift:
     aspect the declaration does not manage.
 
     It reads the diff's raw actions and unresolvable differences — its subject
-    is exactly the out-of-scope differences it exists to reject. dict.fromkeys
-    deduplicates the aspects while preserving first-seen order, so failure
-    order follows diff order deterministically.
+    is exactly the out-of-scope differences it exists to reject. Grouping by
+    aspect preserves first-seen order, so failure order follows diff order
+    deterministically, and each failure names only its own differences.
 
     ``ColumnCaseDrift`` is the one difference it passes over: a column spelled
     differently from the catalog is a defect in the declaration rather than
@@ -543,23 +563,28 @@ class UnmanagedAspectDrift:
                 return ()
 
             case TableDrift() as drift:
-                unmanaged_aspects = dict.fromkeys(
-                    difference.aspect
-                    for difference in (*drift.actions, *drift.unresolvable)
-                    if not isinstance(difference, ColumnCaseDrift)
-                    and difference.aspect not in drift.desired.managed_aspects
-                )
+                lines_by_aspect: dict[TableAspect, list[str]] = {}
+                for difference in (*drift.actions, *drift.unresolvable):
+                    if isinstance(difference, ColumnCaseDrift):
+                        continue
+                    if difference.aspect in drift.desired.managed_aspects:
+                        continue
+                    lines_by_aspect.setdefault(difference.aspect, []).extend(
+                        _difference_lines(difference)
+                    )
 
                 return tuple(
                     ValidationFailure(
                         rule_name=self.name,
                         message=(
                             f"Operation not allowed: {aspect.label} has drifted"
-                            " but is not managed by this definition. Sync the table fully"
-                            " or update the declaration to match the live schema."
+                            " but is not managed by this definition. Update the declaration"
+                            " to match the live table, or widen its scope to manage"
+                            " this aspect."
                         ),
+                        details=tuple(lines),
                     )
-                    for aspect in unmanaged_aspects
+                    for aspect, lines in lines_by_aspect.items()
                 )
 
 

--- a/tests/application/test_engine.py
+++ b/tests/application/test_engine.py
@@ -31,6 +31,7 @@ from delta_engine.domain.model import ObservedColumn, ObservedTable, QualifiedNa
 from delta_engine.domain.model.constraints import PrimaryKeyConstraint
 from delta_engine.domain.plan import ActionPlan
 from delta_engine.domain.plan.actions import (
+    AddColumn,
     CreateTable,
     SetColumnComment,
     SetColumnTag,
@@ -1781,3 +1782,34 @@ def test_foreign_key_sql_uses_the_declared_names_from_both_registered_tables():
         "FOREIGN KEY (`orderref`) REFERENCES `c`.`s`.`parent` (`orderid`)" in statement
         for statement in child_report.planned_sql_statements
     )
+
+
+def test_a_rejected_table_still_reports_the_drift_that_was_found():
+    # Given a declaration whose only change is one the safety rules refuse
+    reader = _RecordingReader({"cat.sch.orders": _existing_id_table("cat.sch.orders")})
+    engine = Engine(reader=reader, executor=_RecordingExecutor())
+
+    # When the sync runs and planning rejects it
+    report = engine.sync(_spec_adding_not_null("cat.sch.orders"), dry_run=True)
+
+    # Then the table has no plan, but the diff that caused the rejection survives
+    (table_report,) = report.table_reports
+    assert table_report.plan is None
+    assert table_report.diff is not None
+    assert any(
+        isinstance(action, AddColumn) and action.column.name == "order_id"
+        for action in table_report.diff.actions
+    )
+
+
+def test_a_failed_read_leaves_no_diff_on_the_report():
+    # Given a table whose catalog read fails
+    reader = _RecordingReader({"cat.sch.orders": ReadError("IOError", "boom")})
+    engine = Engine(reader=reader, executor=_RecordingExecutor())
+
+    # When the sync runs
+    report = engine.sync(_spec("cat.sch.orders"), dry_run=True)
+
+    # Then there is nothing to have diffed
+    (table_report,) = report.table_reports
+    assert table_report.diff is None

--- a/tests/application/test_rendering.py
+++ b/tests/application/test_rendering.py
@@ -44,6 +44,7 @@ from delta_engine.domain.plan import (
     ColumnRenameConflict,
     PartitioningChanged,
     PropertyUndeclared,
+    diff_table,
 )
 from delta_engine.domain.plan.actions import (
     Action,
@@ -979,3 +980,83 @@ def test_enable_table_feature_renders_a_permanent_features_entry():
 )
 def test_unresolvable_differences_describe_themselves(unresolvable, expected):
     assert unresolvable_entries(unresolvable) == expected
+
+
+def test_a_rejected_table_shows_the_drift_that_was_refused():
+    # Given a table whose declaration adds a NOT NULL column and drops another,
+    # both refused by validation
+    qualified_name = QualifiedName("cat", "sch", "orders")
+    desired = DesiredTable(
+        qualified_name=qualified_name,
+        columns=(
+            DesiredColumn("id", Integer(), nullable=False),
+            DesiredColumn("email", String(), nullable=False),
+        ),
+    )
+    observed = ObservedTable(
+        qualified_name=qualified_name,
+        columns=(
+            ObservedColumn("id", Integer(), nullable=False),
+            ObservedColumn("obsolete", String()),
+        ),
+    )
+    report = TableRunReport(
+        read=TablePresent(table=observed),
+        planning=PlanningFailed(
+            (ValidationFailure(rule_name="NonNullableColumnAdd", message="nope"),)
+        ),
+        planned_sql_statements=(),
+        resolution=TableResolution(desired, (), ()),
+        execution=None,
+        diff=diff_table(desired, observed),
+    )
+
+    # When the block is rendered
+    block = render_diff_block(report)
+
+    # Then it names the refused changes rather than claiming there were none
+    assert "(no changes" not in block
+    assert "REJECTED" in block.splitlines()[0]
+    assert "+ email" in block
+    assert "- obsolete" in block
+
+
+def test_a_rejected_table_shows_the_differences_no_action_could_close():
+    # Given a table rejected over drift an action cannot express
+    qualified_name = QualifiedName("cat", "sch", "orders")
+    columns = (("id", Integer()), ("region", String()), ("country", String()))
+    desired = DesiredTable(
+        qualified_name=qualified_name,
+        columns=tuple(DesiredColumn(name, data_type) for name, data_type in columns),
+        partitioned_by=("region",),
+    )
+    observed = ObservedTable(
+        qualified_name=qualified_name,
+        columns=tuple(ObservedColumn(name, data_type) for name, data_type in columns),
+        partitioned_by=("country",),
+    )
+    report = TableRunReport(
+        read=TablePresent(table=observed),
+        planning=PlanningFailed(
+            (ValidationFailure(rule_name="PartitioningIsImmutable", message="nope"),)
+        ),
+        planned_sql_statements=(),
+        resolution=TableResolution(desired, (), ()),
+        execution=None,
+        diff=diff_table(desired, observed),
+    )
+
+    # When the block is rendered
+    block = render_diff_block(report)
+
+    # Then the unresolvable difference is shown alongside any refused actions
+    assert "~ partitioning  (country) → (region)" in block
+
+
+def test_a_table_with_no_diff_at_all_still_points_at_its_failures():
+    # Given a report that carries failures but no diff (a hand-built report,
+    # or a table that failed before the diff phase)
+    block = render_diff_block(_report_with_empty_plan_and_failure())
+
+    # Then the old wording stands — there is genuinely nothing to show
+    assert "(no changes — see failures)" in block

--- a/tests/application/test_rendering.py
+++ b/tests/application/test_rendering.py
@@ -7,6 +7,7 @@ from delta_engine.application.diff_entries import (
     DiffEntry,
     DiffOperation,
     action_entries,
+    unresolvable_entries,
 )
 from delta_engine.application.failures import ExecutionFailure, ReadFailure, ValidationFailure
 from delta_engine.application.planning import PlanningFailed, PlanningSucceeded
@@ -37,6 +38,12 @@ from delta_engine.domain.model import (
     QualifiedName,
     String,
     TableFeature,
+)
+from delta_engine.domain.plan import (
+    ColumnCaseDrift,
+    ColumnRenameConflict,
+    PartitioningChanged,
+    PropertyUndeclared,
 )
 from delta_engine.domain.plan.actions import (
     Action,
@@ -424,6 +431,20 @@ def test_every_action_type_has_registered_diff_entries():
     for action_type in concrete_action_types:
         assert action_entries.dispatch(action_type) is not fallback, (
             f"No diff entries registered for {action_type.__name__}"
+        )
+
+
+def test_every_unresolvable_type_has_registered_diff_entries():
+    # Given every member of the Unresolvable union
+    import typing
+
+    from delta_engine.domain.plan.unresolvable import Unresolvable
+
+    # Then each dispatches to a real arm, not the NotImplementedError fallback
+    fallback = unresolvable_entries.dispatch(object)
+    for unresolvable_type in typing.get_args(Unresolvable.__value__):
+        assert unresolvable_entries.dispatch(unresolvable_type) is not fallback, (
+            f"No diff entries registered for {unresolvable_type.__name__}"
         )
 
 
@@ -903,3 +924,58 @@ def test_enable_table_feature_renders_a_permanent_features_entry():
     assert entry.symbol == "+"
     assert entry.subject == "timestampNtz"
     assert "permanent" in entry.detail[0]
+
+
+@pytest.mark.parametrize(
+    ("unresolvable", "expected"),
+    [
+        (
+            ColumnCaseDrift(declared_name="SKU", observed_name="sku"),
+            (
+                DiffEntry(
+                    DiffCategory.COLUMNS,
+                    DiffOperation.CHANGE,
+                    "SKU",
+                    ("spelled 'sku' in the catalog",),
+                ),
+            ),
+        ),
+        (
+            ColumnRenameConflict(old_name="old_id", new_name="id"),
+            (
+                DiffEntry(
+                    DiffCategory.COLUMNS,
+                    DiffOperation.CHANGE,
+                    "old_id",
+                    ("renamed → id, but both columns exist",),
+                ),
+            ),
+        ),
+        (
+            PropertyUndeclared(name="delta.enableChangeDataFeed", observed_value="true"),
+            (
+                DiffEntry(
+                    DiffCategory.PROPERTIES,
+                    DiffOperation.CHANGE,
+                    "delta.enableChangeDataFeed",
+                    ("= 'true'", "(set on the table, undeclared)"),
+                ),
+            ),
+        ),
+        (
+            PartitioningChanged(
+                desired_partitioning=("region",), observed_partitioning=("country",)
+            ),
+            (
+                DiffEntry(
+                    DiffCategory.PARTITIONING,
+                    DiffOperation.CHANGE,
+                    "partitioning",
+                    ("(country) → (region)",),
+                ),
+            ),
+        ),
+    ],
+)
+def test_unresolvable_differences_describe_themselves(unresolvable, expected):
+    assert unresolvable_entries(unresolvable) == expected

--- a/tests/application/test_report.py
+++ b/tests/application/test_report.py
@@ -35,6 +35,7 @@ from delta_engine.domain.model import (
     QualifiedName,
     TableFeature,
 )
+from delta_engine.domain.plan import TableDiff, diff_table
 from delta_engine.domain.plan.actions import (
     ActionPlan,
     CreateTable,
@@ -110,6 +111,7 @@ def _report(
     dependencies: tuple[ForeignKeyConstraint, ...] = (),
     execution: ExecutionSummary | None = None,
     blocked_failures: tuple[ForeignKeyFailure, ...] = (),
+    diff: TableDiff | None = None,
 ) -> TableRunReport:
     """Construct a frozen report snapshot from concise test inputs."""
     if execution is not None and not planned_sql_statements:
@@ -152,6 +154,7 @@ def _report(
         resolution=resolution,
         execution=execution,
         blocked_failures=blocked_failures,
+        diff=diff,
     )
 
 
@@ -848,4 +851,18 @@ def test_blocked_failures_require_the_dependency_blocking_reason():
                     reason=ForeignKeyFailureReason.CYCLE,
                 ),
             ),
+        )
+
+
+def test_a_report_cannot_claim_a_diff_after_a_failed_read():
+    # Given a read that failed, there is nothing to have compared
+    desired = _a_desired_table()
+    observed = _an_observed_table()
+
+    # Then constructing a report that claims both is rejected
+    with pytest.raises(ValueError, match="failed read produces no diff"):
+        _report(
+            desired=desired,
+            read=ReadFailure(exception_type="IOError", message="boom"),
+            diff=diff_table(desired, observed),
         )

--- a/tests/application/test_report.py
+++ b/tests/application/test_report.py
@@ -33,6 +33,7 @@ from delta_engine.domain.model import (
     ObservedColumn,
     ObservedTable,
     QualifiedName,
+    String,
     TableFeature,
 )
 from delta_engine.domain.plan import TableDiff, diff_table
@@ -866,3 +867,52 @@ def test_a_report_cannot_claim_a_diff_after_a_failed_read():
             read=ReadFailure(exception_type="IOError", message="boom"),
             diff=diff_table(desired, observed),
         )
+
+
+def test_a_rejected_table_projects_the_changes_it_refused():
+    # Given a table whose diff was rejected
+    qualified_name = _name("orders")
+    desired = DesiredTable(
+        qualified_name=qualified_name,
+        columns=(
+            DesiredColumn("id", Integer(), nullable=False),
+            DesiredColumn("email", String(), nullable=False),
+        ),
+    )
+    observed = ObservedTable(
+        qualified_name=qualified_name,
+        columns=(ObservedColumn("id", Integer(), nullable=False),),
+    )
+    report = _report(
+        desired=desired,
+        read=TablePresent(table=observed),
+        failures=(ValidationFailure(rule_name="NonNullableColumnAdd", message="nope"),),
+        diff=diff_table(desired, observed),
+    )
+
+    # When it is projected
+    record = report.to_dict()
+
+    # Then `changes` stays empty — nothing was planned — and the refused
+    # differences are stated separately
+    assert record["changes"] == []
+    assert record["rejected_changes"] == [
+        {
+            "kind": "columns",
+            "operation": "add",
+            "subject": "email",
+            "detail": "String NOT NULL",
+        }
+    ]
+
+
+def test_a_successful_table_projects_no_rejected_changes():
+    # Given a table that planned cleanly
+    report = _report(
+        desired=_a_desired_table("tbl"),
+        read=TablePresent(table=_an_observed_table()),
+        plan=_plan("tbl", SetTableComment(desired_comment="hello", observed_comment="")),
+    )
+
+    # Then the rejected list is empty rather than absent
+    assert report.to_dict()["rejected_changes"] == []

--- a/tests/application/test_validation.py
+++ b/tests/application/test_validation.py
@@ -7,6 +7,7 @@ from delta_engine.application.scopes import ANNOTATION_ASPECTS, METADATA_ASPECTS
 from delta_engine.application.validation import (
     DEFAULT_SAFETY_RULES,
     ELIGIBILITY_CHECKS,
+    UnmanagedAspectDrift,
     validate_diff,
 )
 from delta_engine.domain.model import (
@@ -49,7 +50,11 @@ from delta_engine.domain.plan.diff import (
     TableDrift,
     diff_table,
 )
-from delta_engine.domain.plan.unresolvable import ColumnCaseDrift, ColumnRenameConflict
+from delta_engine.domain.plan.unresolvable import (
+    ColumnCaseDrift,
+    ColumnRenameConflict,
+    PartitioningChanged,
+)
 from tests.builders import as_observed_columns
 
 _QUALIFIED_NAME = QualifiedName("dev", "silver", "test")
@@ -1209,3 +1214,66 @@ def test_scope_failure_prevents_safety_evaluation():
     failures = validate_diff(diff, rules=(MustNotRun(),))
 
     assert failures[0].rule_name == "UnmanagedAspectDrift"
+
+
+def test_unmanaged_drift_names_the_differences_that_drifted():
+    # Given a metadata-scoped declaration against a table whose columns drifted
+    diff = _drift(
+        AddColumn(DesiredColumn("legacy_region", String())),
+        AlterColumnType(column_name="amount", desired_type=Long(), observed_type=Integer()),
+        managed_aspects=METADATA_ASPECTS,
+    )
+
+    # When the eligibility check judges it
+    (failure,) = UnmanagedAspectDrift().evaluate(diff)
+
+    # Then the message names the aspect, and each difference is stated in full
+    assert "column structure" in failure.message
+    assert failure.details == (
+        "+ legacy_region String",
+        "~ amount Integer → Long",
+    )
+
+
+def test_unmanaged_drift_names_differences_no_action_could_close():
+    # Given drift a plan action cannot express
+    diff = _drift(
+        PartitioningChanged(desired_partitioning=("region",), observed_partitioning=("country",)),
+        managed_aspects=METADATA_ASPECTS,
+    )
+
+    # When the check judges it
+    (failure,) = UnmanagedAspectDrift().evaluate(diff)
+
+    # Then it is named too — an unresolvable difference is often the whole reason
+    assert failure.details == ("~ partitioning (country) → (region)",)
+
+
+def test_unmanaged_drift_reports_one_failure_per_aspect():
+    # Given drift in two unmanaged aspects at once
+    diff = _drift(
+        AddColumn(DesiredColumn("legacy_region", String())),
+        PartitioningChanged(desired_partitioning=("region",), observed_partitioning=("country",)),
+        managed_aspects=METADATA_ASPECTS,
+    )
+
+    # When the check judges it
+    failures = UnmanagedAspectDrift().evaluate(diff)
+
+    # Then each aspect gets its own failure, each naming only its own differences
+    assert len(failures) == 2
+    assert [failure.details for failure in failures] == [
+        ("+ legacy_region String",),
+        ("~ partitioning (country) → (region)",),
+    ]
+
+
+def test_unmanaged_drift_still_passes_over_a_column_spelled_differently():
+    # Given case drift, which ColumnSpellingMustMatchCatalog owns at every scope
+    diff = _drift(
+        ColumnCaseDrift(declared_name="SKU", observed_name="sku"),
+        managed_aspects=METADATA_ASPECTS,
+    )
+
+    # Then this check says nothing about it
+    assert UnmanagedAspectDrift().evaluate(diff) == ()


### PR DESCRIPTION
PR 2 of the [sync report diagnostics plan](https://github.com/Tomoscorbin/delta-engine/pull/311) (tasks 8–12), branched off `main`.

The engine computed a complete `TableDiff` for every readable table and then discarded it at `to_report()`, so a table whose plan was rejected could only ever name the rule that refused it — never what it refused. A metadata-scoped declaration against a drifted table said this and nothing else:

```
main.sales.orders
  (no changes — see failures)

Failures
--------
  main.sales.orders
    Validation failed: UnmanagedAspectDrift - Operation not allowed: column structure
    has drifted but is not managed by this definition. Sync the table fully or update
    the declaration to match the live schema.
```

and now says this:

```
main.sales.orders  (REJECTED — no SQL planned)
  columns
    - legacy_region
    ~ customer_id    Integer → Long

Failures
--------
  main.sales.orders
    Validation failed: UnmanagedAspectDrift - Operation not allowed: column structure
    has drifted but is not managed by this definition. Update the declaration to match
    the live table, or widen its scope to manage this aspect.
        - legacy_region
        ~ customer_id Integer → Long
```

## What

- **`TableRunReport` carries the diff it was built from.** Optional with a `None` default — the report is public and hand-constructible, and demanding a domain `TableDiff` of every hand-built report would be hostile. The engine, its only production constructor, always supplies one. The direction that is genuinely impossible gets an invariant: a failed read produces no diff.
- **`unresolvable_entries`** joins `action_entries` as the interpretation of the four differences no action can close, so a rejected table's non-action drift can be shown at all. `drift_entries` sits beside `plan_entries` as the collection-level answer both consumers need.
- **`render_diff` shows a rejected table's differences** under a `(REJECTED — no SQL planned)` header. The old code tested `if not plan`, true for both `None` and an empty plan; those are different states, and only the first has a diff worth showing.
- **`to_dict()` gains `rejected_changes`** — additive, so `schema_version` stays `2`. `changes` stays empty for a rejected table rather than absorbing the refused differences: a reader acting on `changes` is acting on what will be applied, and nothing here will be.
- **`UnmanagedAspectDrift` enumerates the differences per aspect** instead of collapsing them to a bare label, and its remedy no longer tells a metadata-scoped author to sync the table fully — the one thing that scope exists to prevent.

## Two deviations from the plan

**The drift lines are `ValidationFailure.details`, not newlines inside `message`.** The plan had the rule build its own indented block. That composes wrongly: `render_failures_section` indents the first line of `format_lines()` and nests the rest a level deeper, so an embedded remedy line rendered at *less* indentation than the failure it belonged to, and the JSON `message` gained raw `\n    ` runs no other failure has. Details as separate lines lets the renderer own the layout, exactly as it already does for `ExecutionFailure`'s SQL line.

**No `ValidationFailure.subject`.** Task 12's tests used it, but it comes from PR 1's task 6, which has not landed (#313 covered task 1 only). Adding the field here and populating it for one rule out of fourteen would be a half-done version of a task that belongs elsewhere, so these tests assert on the message and details instead. Worth knowing: **PR 1 tasks 4, 5, 6 and 7 are still outstanding** — statement numbers still read from 0, and the run summary still says `1 tables`.

## Verified

Full suite (1149 passed, coverage 96.52%), mypy, ruff check + format, `lint-imports` (7 kept), `sphinx-build -W`, plus a manual run of the metadata-scope scenario above through the real engine.