### PR TITLE
fix: decimal rejects non integer precision and scale

### DIFF
--- a/src/delta_engine/domain/model/data_type.py
+++ b/src/delta_engine/domain/model/data_type.py
@@ -70,7 +70,7 @@ class Decimal(DataType):
     scale: int = 0
 
     def __post_init__(self) -> None:
-        if type(self.precision) is not int and type(self.scale) is not int:
+        if type(self.precision) is not int or type(self.scale) is not int:
             raise ValueError(
                 "precision and scale must by type int;"
                 f" got precision: {type(self.precision)}, scale: {type(self.scale)}"

--- a/tests/domain/model/test_data_type.py
+++ b/tests/domain/model/test_data_type.py
@@ -41,10 +41,13 @@ def test_decimal_accepts_maximum_precision_and_scale() -> None:
     assert Decimal(38, 38).precision == 38
 
 
-@pytest.mark.parametrize("value", ["1", 1.0, True])
-def test_decimal_rejects_non_integer_precision_and_scale(value) -> None:
+@given(
+    precision=st.sampled_from(["1", 1.0, True, False]),
+    scale=st.sampled_from(["1", 1.0, True, False]),
+)
+def test_decimal_rejects_non_integer_precision_and_scale(precision, scale) -> None:
     with pytest.raises(ValueError):
-        Decimal(value, value)
+        Decimal(precision, scale)
 
 
 def test_struct_field_requires_non_blank_name_and_preserves_case() -> None:


### PR DESCRIPTION
<!--
The PR TITLE becomes the squash-commit message on main and drives the
automatic version bump and changelog. It MUST be a Conventional Commit:

  feat: ...      -> minor release
  fix: ...       -> patch release
  feat!: ... / BREAKING CHANGE -> handled as a 0.x minor while pre-1.0
  docs/chore/refactor/test/ci/build/style: ... -> no release

Scope is optional, e.g. `feat(api): ...`.
-->

## What

Fixed a bug where Decimal type did not reject non-integer types for precision and scale
