### PR TITLE
refactor: harden sequence inputs in frozen models

### DIFF
--- a/src/delta_engine/adapters/databricks/read.py
+++ b/src/delta_engine/adapters/databricks/read.py
@@ -154,10 +154,10 @@ def _read_observed_table(
     """Read the information_schema metadata (tags, keys, inbound FKs) and assemble the table."""
     qualified_name = description.qualified_name
     column_tags = read_column_tags(run_query, qualified_name)
-    tagged_columns = tuple(
+    tagged_columns = [
         replace(column, tags=column_tags.get(column.name, MappingProxyType({})))
         for column in description.columns
-    )
+    ]
     return ObservedTable(
         qualified_name=qualified_name,
         columns=tagged_columns,

--- a/src/delta_engine/adapters/databricks/sql/compile.py
+++ b/src/delta_engine/adapters/databricks/sql/compile.py
@@ -5,7 +5,7 @@ Uses `functools.singledispatch` to render SQL per action type and returns the
 statements in plan order, ready to execute against a Spark session.
 """
 
-from collections.abc import Mapping
+from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
 from functools import singledispatch
 from types import MappingProxyType
@@ -91,9 +91,9 @@ def compile_plan(plan: ActionPlan) -> CompiledPlan:
     ON) use the same plan target but are unaffected by the relation kind.
     """
     target = _Target(qualified_name=plan.target, kind=plan.kind)
-    compiled_actions = tuple(
+    compiled_actions = [
         CompiledAction(action=action, statement=_compile_action(action, target)) for action in plan
-    )
+    ]
 
     return CompiledPlan(
         plan=plan,
@@ -336,7 +336,7 @@ def _properties_clause(props: Mapping[str, str | None]) -> str:
     return f"TBLPROPERTIES ({pairs})"
 
 
-def _partitioned_by_clause(partitioned_by: tuple[str, ...]) -> str:
+def _partitioned_by_clause(partitioned_by: Sequence[str]) -> str:
     """Return PARTITIONED BY (...) or '' if unpartitioned."""
     if not partitioned_by:
         return ""
@@ -344,7 +344,7 @@ def _partitioned_by_clause(partitioned_by: tuple[str, ...]) -> str:
     return f"PARTITIONED BY ({quoted_columns})"
 
 
-def _clustered_by_clause(clustered_by: tuple[str, ...]) -> str:
+def _clustered_by_clause(clustered_by: Sequence[str]) -> str:
     """Return CLUSTER BY (...) or '' when the table declares no clustering."""
     if not clustered_by:
         return ""

--- a/src/delta_engine/adapters/databricks/sql/describe.py
+++ b/src/delta_engine/adapters/databricks/sql/describe.py
@@ -12,7 +12,7 @@ document — they come from information_schema as structured rows (see
 string this document also carries is left unread.
 """
 
-from collections.abc import Mapping
+from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
 import json
 from types import MappingProxyType
@@ -20,6 +20,7 @@ from types import MappingProxyType
 from delta_engine.adapters.databricks.sql.rows import Rows
 from delta_engine.adapters.databricks.sql.types import data_type_from_json
 from delta_engine.domain.model import ObservedColumn, QualifiedName
+from delta_engine.domain.model.frozen import freeze_strings
 
 
 class MetadataParseError(Exception):
@@ -31,13 +32,27 @@ class TableDescription:
     """Backend-neutral relation facts, columns, and layout from one AS JSON document."""
 
     qualified_name: QualifiedName
-    columns: tuple[ObservedColumn, ...]
+    columns: Sequence[ObservedColumn]
     comment: str
-    partitioned_by: tuple[str, ...]
-    clustered_by: tuple[str, ...]
+    partitioned_by: Sequence[str]
+    clustered_by: Sequence[str]
     table_properties: Mapping[str, str]
     relation_type: str | None
     provider: str | None
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "columns", tuple(self.columns))
+        object.__setattr__(
+            self,
+            "partitioned_by",
+            freeze_strings(self.partitioned_by, field_name="partitioned_by"),
+        )
+        object.__setattr__(
+            self,
+            "clustered_by",
+            freeze_strings(self.clustered_by, field_name="clustered_by"),
+        )
+        object.__setattr__(self, "table_properties", MappingProxyType(dict(self.table_properties)))
 
 
 def table_description_from_rows(rows: Rows, qualified_name: QualifiedName) -> TableDescription:

--- a/src/delta_engine/adapters/databricks/sql/rows.py
+++ b/src/delta_engine/adapters/databricks/sql/rows.py
@@ -65,7 +65,7 @@ def read_primary_key(
     if not ordered:
         return None
     return PrimaryKeyConstraint(
-        columns=tuple(row.column_name for row in ordered),
+        columns=[row.column_name for row in ordered],
         constraint_name=ordered[0].constraint_name,
     )
 
@@ -86,13 +86,13 @@ def read_foreign_keys(
         grouped.setdefault(row.constraint_name, []).append(row)
     return tuple(
         ForeignKeyConstraint(
-            local_columns=tuple(row.local_column for row in group),
+            local_columns=[row.local_column for row in group],
             referenced_table=QualifiedName(
                 group[0].referenced_catalog,
                 group[0].referenced_schema,
                 group[0].referenced_table,
             ),
-            referenced_columns=tuple(row.referenced_column for row in group),
+            referenced_columns=[row.referenced_column for row in group],
             constraint_name=constraint_name,
         )
         for constraint_name, group in grouped.items()

--- a/src/delta_engine/adapters/databricks/sql/types.py
+++ b/src/delta_engine/adapters/databricks/sql/types.py
@@ -189,6 +189,6 @@ def _struct_from_json(type_obj: dict) -> DataType | None:
             return None
         fields.append(StructField(name=field_name, data_type=field_type))
     try:
-        return Struct(tuple(fields))
+        return Struct(fields)
     except ValueError:
         return None

--- a/src/delta_engine/api/delta_table.py
+++ b/src/delta_engine/api/delta_table.py
@@ -551,7 +551,7 @@ def _lower_declaration(declaration: _NormalizedDeclaration) -> DesiredTable:
     """Lower a valid public declaration into the domain model."""
     column_names = {column.name: column.name for column in declaration.columns}
     primary_key_columns = (
-        tuple(column_names.get(name, name) for name in declaration.primary_key)
+        [column_names.get(name, name) for name in declaration.primary_key]
         if declaration.primary_key is not None
         else None
     )
@@ -563,15 +563,17 @@ def _lower_declaration(declaration: _NormalizedDeclaration) -> DesiredTable:
         if primary_key_columns is not None
         else None
     )
-    owner_primary_key = primary_key_constraint.columns if primary_key_constraint is not None else ()
-    foreign_keys = tuple(
+    owner_primary_key = (
+        tuple(primary_key_constraint.columns) if primary_key_constraint is not None else ()
+    )
+    foreign_keys = [
         foreign_key._to_constraint(
             declaration.qualified_name,
             declaration.columns,
             owner_primary_key,
         )
         for foreign_key in declaration.foreign_key_declarations
-    )
+    ]
 
     # DesiredTable enforces domain invariants (non-empty and unique columns,
     # existing layout/key columns, and coherent constraints) at construction.
@@ -581,8 +583,8 @@ def _lower_declaration(declaration: _NormalizedDeclaration) -> DesiredTable:
         comment=declaration.comment,
         properties=declaration.properties,
         tags=declaration.tags,
-        partitioned_by=tuple(column_names.get(name, name) for name in declaration.partitioned_by),
-        clustered_by=tuple(column_names.get(name, name) for name in declaration.clustered_by),
+        partitioned_by=[column_names.get(name, name) for name in declaration.partitioned_by],
+        clustered_by=[column_names.get(name, name) for name in declaration.clustered_by],
         primary_key=primary_key_constraint,
         foreign_keys=foreign_keys,
         managed_aspects=declaration.managed_aspects,
@@ -693,7 +695,7 @@ class DeltaTable:
     @property
     def columns(self) -> tuple[Column, ...]:
         """Declared columns, in declaration order."""
-        return self._desired_table.columns
+        return tuple(self._desired_table.columns)
 
     @property
     def comment(self) -> str:
@@ -717,12 +719,12 @@ class DeltaTable:
     @property
     def partitioned_by(self) -> tuple[str, ...]:
         """Partition column names, in declaration order."""
-        return self._desired_table.partitioned_by
+        return tuple(self._desired_table.partitioned_by)
 
     @property
     def clustered_by(self) -> tuple[str, ...]:
         """Clustering key column names, in declaration order."""
-        return self._desired_table.clustered_by
+        return tuple(self._desired_table.clustered_by)
 
     @property
     def primary_key(self) -> tuple[str, ...]:

--- a/src/delta_engine/application/diff_entries.py
+++ b/src/delta_engine/application/diff_entries.py
@@ -7,12 +7,14 @@ what each action *means* (category, operation, subject, detail); presentation
 (grouping, grids, dict shapes) belongs to the consumers.
 """
 
+from collections.abc import Sequence
 from dataclasses import dataclass
 from enum import IntEnum, StrEnum
 import functools
 from typing import Final, assert_never
 
 from delta_engine.domain.model import DesiredColumn
+from delta_engine.domain.model.frozen import freeze_strings
 from delta_engine.domain.plan import (
     Action,
     ActionPlan,
@@ -143,7 +145,10 @@ class DiffEntry:
     category: DiffCategory
     operation: DiffOperation
     subject: str
-    detail: tuple[str, ...] = ()
+    detail: Sequence[str] = ()
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "detail", freeze_strings(self.detail, field_name="detail"))
 
     @property
     def symbol(self) -> str:
@@ -161,9 +166,7 @@ def _column_add_entry(column: DesiredColumn) -> DiffEntry:
     detail = [str(column.data_type)]
     if not column.nullable:
         detail.append("NOT NULL")
-    return DiffEntry(
-        DiffCategory.COLUMNS, DiffOperation.ADD, subject=column.name, detail=tuple(detail)
-    )
+    return DiffEntry(DiffCategory.COLUMNS, DiffOperation.ADD, subject=column.name, detail=detail)
 
 
 def _named_value_entry(
@@ -187,7 +190,7 @@ def _named_value_entry(
     )
 
 
-def _columns_detail(columns: tuple[str, ...]) -> tuple[str, ...]:
+def _columns_detail(columns: Sequence[str]) -> tuple[str, ...]:
     """Render a column list as the single parenthesised detail phrase it reads as."""
     return (f"({', '.join(columns)})",)
 

--- a/src/delta_engine/application/engine.py
+++ b/src/delta_engine/application/engine.py
@@ -253,7 +253,7 @@ class Engine:
         report = SyncReport.assemble(
             started_at=run_started,
             ended_at=datetime.now(UTC),
-            table_reports=tuple(run.to_report() for run in runs),
+            table_reports=[run.to_report() for run in runs],
             dry_run=dry_run,
         )
 
@@ -450,4 +450,4 @@ class Engine:
                 )
             )
 
-        return ExecutionSummary(compiled_plan=compiled, results=tuple(results))
+        return ExecutionSummary(compiled_plan=compiled, results=results)

--- a/src/delta_engine/application/failures.py
+++ b/src/delta_engine/application/failures.py
@@ -8,11 +8,13 @@ together rather than being scattered across its producers.
 """
 
 from abc import ABC, abstractmethod
+from collections.abc import Sequence
 from dataclasses import dataclass
 from enum import IntEnum, StrEnum
 from typing import ClassVar, Final, assert_never
 
 from delta_engine.domain.model import QualifiedName
+from delta_engine.domain.model.frozen import freeze_strings
 
 
 class FailurePhase(IntEnum):
@@ -131,7 +133,10 @@ class ValidationFailure(Failure):
     phase: ClassVar[FailurePhase] = FailurePhase.PLANNING
     rule_name: str
     message: str
-    details: tuple[str, ...] = ()
+    details: Sequence[str] = ()
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "details", freeze_strings(self.details, field_name="details"))
 
     def format_lines(self) -> tuple[str, ...]:
         return (f"Validation failed: {self.rule_name} - {self.message}", *self.details)
@@ -167,9 +172,16 @@ class ForeignKeyFailure(Failure):
 
     phase: ClassVar[FailurePhase] = FailurePhase.FOREIGN_KEY
     table: QualifiedName
-    local_columns: tuple[str, ...]
+    local_columns: Sequence[str]
     references: QualifiedName
     reason: ForeignKeyFailureReason
+
+    def __post_init__(self) -> None:
+        object.__setattr__(
+            self,
+            "local_columns",
+            freeze_strings(self.local_columns, field_name="local_columns"),
+        )
 
     @property
     def _constraint(self) -> str:

--- a/src/delta_engine/application/planning.py
+++ b/src/delta_engine/application/planning.py
@@ -1,5 +1,6 @@
 """Validated boundary from complete table diffs to executable action plans."""
 
+from collections.abc import Sequence
 from dataclasses import dataclass
 from typing import assert_never
 
@@ -24,7 +25,10 @@ class PlanningSucceeded:
 class PlanningFailed:
     """Rejected diff; no action plan exists for this result variant."""
 
-    failures: tuple[ValidationFailure, ...]
+    failures: Sequence[ValidationFailure]
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "failures", tuple(self.failures))
 
 
 type PlanningResult = PlanningSucceeded | PlanningFailed

--- a/src/delta_engine/application/ports.py
+++ b/src/delta_engine/application/ports.py
@@ -8,6 +8,7 @@ the whole contract. ``DesiredTableSource`` is the inbound counterpart: the
 contract a user-facing declaration satisfies to enter a sync.
 """
 
+from collections.abc import Sequence
 from dataclasses import dataclass
 from typing import Protocol
 
@@ -89,9 +90,7 @@ class CompiledAction:
 
     def __post_init__(self) -> None:
         if not self.statement.strip():
-            raise ValueError(
-                f"{type(self.action).__name__} compiled to an empty statement"
-            )
+            raise ValueError(f"{type(self.action).__name__} compiled to an empty statement")
 
 
 @dataclass(frozen=True, slots=True)
@@ -99,7 +98,7 @@ class CompiledPlan:
     """An accepted action plan paired exactly with its compiled statements."""
 
     plan: ActionPlan
-    compiled_actions: tuple[CompiledAction, ...]
+    compiled_actions: Sequence[CompiledAction]
 
     def __post_init__(self) -> None:
         compiled_actions = tuple(self.compiled_actions)
@@ -146,7 +145,7 @@ class ExecutionSummary:
     """
 
     compiled_plan: CompiledPlan
-    results: tuple[ExecutionResult, ...] = ()
+    results: Sequence[ExecutionResult] = ()
 
     def __post_init__(self) -> None:
         """Reject result histories that the engine's execution loop cannot produce."""

--- a/src/delta_engine/application/properties.py
+++ b/src/delta_engine/application/properties.py
@@ -25,7 +25,7 @@ DETAIL's properties: if the platform auto-writes the key, do not add it to
 the policy. Additions are called out in release notes.
 """
 
-from collections.abc import Callable, Mapping
+from collections.abc import Callable, Mapping, Sequence, Set
 from dataclasses import dataclass, field
 from enum import StrEnum
 import re
@@ -95,7 +95,10 @@ class PropertyDefinition:
     key: Property
     value_description: str
     is_valid_value: Callable[[str], bool]
-    permitted_transitions: frozenset[tuple[str, str | None]] = field(default_factory=frozenset)
+    permitted_transitions: Set[tuple[str, str | None]] = field(default_factory=frozenset)
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "permitted_transitions", frozenset(self.permitted_transitions))
 
     def reject_declared_value(self, value: str | None) -> str | None:
         """
@@ -129,12 +132,13 @@ class PropertyDefinition:
 class PropertyPolicy:
     """Validate declarations and transitions for the managed properties."""
 
-    definitions: tuple[PropertyDefinition, ...]
+    definitions: Sequence[PropertyDefinition]
     _definitions_by_name: Mapping[str, PropertyDefinition] = field(
         init=False, repr=False, compare=False
     )
 
     def __post_init__(self) -> None:
+        object.__setattr__(self, "definitions", tuple(self.definitions))
         definitions_by_name = {definition.key.value: definition for definition in self.definitions}
 
         if len(definitions_by_name) != len(self.definitions):

--- a/src/delta_engine/application/relationships.py
+++ b/src/delta_engine/application/relationships.py
@@ -34,7 +34,7 @@ All graph-traversal implementation details (adjacency map, Tarjan's
 strongly-connected-components algorithm) are hidden behind that interface.
 """
 
-from collections.abc import Mapping, Set as AbstractSet
+from collections.abc import Mapping, Sequence, Set
 from dataclasses import dataclass
 
 from delta_engine.application.failures import (
@@ -69,15 +69,19 @@ class TableResolution:
     """
 
     desired: DesiredTable
-    dependencies: tuple[ForeignKeyConstraint, ...]
-    structural_failures: tuple[ForeignKeyFailure, ...]
+    dependencies: Sequence[ForeignKeyConstraint]
+    structural_failures: Sequence[ForeignKeyFailure]
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "dependencies", tuple(self.dependencies))
+        object.__setattr__(self, "structural_failures", tuple(self.structural_failures))
 
     @property
     def qualified_name(self) -> QualifiedName:
         """The identity of the declaration these facts were judged from."""
         return self.desired.qualified_name
 
-    def blocked_by(self, unconverged: AbstractSet[QualifiedName]) -> tuple[ForeignKeyFailure, ...]:
+    def blocked_by(self, unconverged: Set[QualifiedName]) -> tuple[ForeignKeyFailure, ...]:
         """
         Return one failure per dependency edge that will not converge this sync.
 
@@ -127,7 +131,7 @@ def resolve(tables: tuple[DesiredTable, ...]) -> tuple[TableResolution, ...]:
     )
 
 
-def _managed_foreign_keys(table: DesiredTable) -> tuple[ForeignKeyConstraint, ...]:
+def _managed_foreign_keys(table: DesiredTable) -> Sequence[ForeignKeyConstraint]:
     """Return foreign keys this declaration is responsible for reconciling."""
     if TableAspect.FOREIGN_KEYS not in table.managed_aspects:
         return ()
@@ -165,7 +169,7 @@ def _foreign_key_types_match(
 
 def _build_dependencies(
     tables: tuple[DesiredTable, ...],
-    registered_names: AbstractSet[QualifiedName],
+    registered_names: Set[QualifiedName],
 ) -> dict[QualifiedName, tuple[ForeignKeyConstraint, ...]]:
     """
     Build the dependency edges for every table.
@@ -306,7 +310,7 @@ def _order_tables(
 
 def _classify_structural_failures(
     tables: tuple[DesiredTable, ...],
-    registered_names: AbstractSet[QualifiedName],
+    registered_names: Set[QualifiedName],
     cycle_partners_by_table: dict[QualifiedName, frozenset[QualifiedName]],
 ) -> dict[QualifiedName, tuple[ForeignKeyFailure, ...]]:
     """

--- a/src/delta_engine/application/rendering.py
+++ b/src/delta_engine/application/rendering.py
@@ -137,7 +137,7 @@ def _grid_row_cells(report: TableRunReport) -> tuple[str, str, str, str]:
     )
 
 
-def render_grid(reports: tuple[TableRunReport, ...]) -> str:
+def render_grid(reports: Sequence[TableRunReport]) -> str:
     """Render an aligned TABLE | STATUS | STATEMENTS | DETAIL grid for ``reports``."""
     rows = [_GRID_HEADERS, *(_grid_row_cells(report) for report in reports)]
     return "\n".join(_aligned_rows(rows))
@@ -162,7 +162,7 @@ def _dry_run_banner(report: SyncReport) -> str:
     return "PLAN — no planned SQL executed" if report.dry_run else ""
 
 
-def render_failures_section(reports: tuple[TableRunReport, ...]) -> str:
+def render_failures_section(reports: Sequence[TableRunReport]) -> str:
     """Render full per-table failure detail for every failed table; empty when none failed."""
     failed = [report for report in reports if report.has_failures]
     if not failed:

--- a/src/delta_engine/application/report.py
+++ b/src/delta_engine/application/report.py
@@ -5,7 +5,7 @@ Run reports: per-table and run-level outcome aggregates.
 engine run; `SyncReport` aggregates those table snapshots.
 """
 
-from collections.abc import Iterable, Iterator, Mapping
+from collections.abc import Iterable, Iterator, Mapping, Sequence
 from dataclasses import dataclass, replace
 from datetime import datetime
 from enum import StrEnum
@@ -162,10 +162,11 @@ class TableRunReport:
     compiled: CompiledPlan | None
     resolution: TableResolution
     execution: ExecutionSummary | None
-    blocked_failures: tuple[ForeignKeyFailure, ...] = ()
+    blocked_failures: Sequence[ForeignKeyFailure] = ()
     diff: TableDiff | None = None
 
     def __post_init__(self) -> None:
+        object.__setattr__(self, "blocked_failures", tuple(self.blocked_failures))
         read_failed = isinstance(self.read, ReadFailure)
         planning_failed = isinstance(self.planning, PlanningFailed)
         resolution_failed = bool(self.resolution.structural_failures)
@@ -301,8 +302,11 @@ class SyncReport:
 
     started_at: datetime
     ended_at: datetime
-    table_reports: tuple[TableRunReport, ...]
+    table_reports: Sequence[TableRunReport]
     dry_run: bool = False
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "table_reports", tuple(self.table_reports))
 
     @classmethod
     def assemble(
@@ -310,7 +314,7 @@ class SyncReport:
         *,
         started_at: datetime,
         ended_at: datetime,
-        table_reports: tuple[TableRunReport, ...],
+        table_reports: Sequence[TableRunReport],
         dry_run: bool,
     ) -> "SyncReport":
         """
@@ -337,7 +341,7 @@ class SyncReport:
         return cls(
             started_at=started_at,
             ended_at=ended_at,
-            table_reports=tuple(derived),
+            table_reports=derived,
             dry_run=dry_run,
         )
 

--- a/src/delta_engine/application/validation.py
+++ b/src/delta_engine/application/validation.py
@@ -582,7 +582,7 @@ class UnmanagedAspectDrift:
                             " to match the live table, or widen its scope to manage"
                             " this aspect."
                         ),
-                        details=tuple(lines),
+                        details=lines,
                     )
                     for aspect, lines in lines_by_aspect.items()
                 )

--- a/src/delta_engine/domain/model/constraints.py
+++ b/src/delta_engine/domain/model/constraints.py
@@ -1,8 +1,9 @@
 """Domain value objects representing key constraints (primary and foreign)."""
 
-from collections.abc import Iterable
+from collections.abc import Iterable, Sequence
 from dataclasses import dataclass
 
+from delta_engine.domain.model.frozen import freeze_strings
 from delta_engine.domain.model.identifier import Identifier
 from delta_engine.domain.model.qualified_name import QualifiedName
 
@@ -32,7 +33,7 @@ class PrimaryKeyConstraint:
 
     """
 
-    columns: tuple[str, ...]
+    columns: Sequence[str]
     constraint_name: str
 
     @property
@@ -41,9 +42,10 @@ class PrimaryKeyConstraint:
         return key_signature(self.columns)
 
     def __post_init__(self) -> None:
+        columns = freeze_strings(self.columns, field_name="columns")
+        object.__setattr__(self, "columns", tuple(Identifier(column) for column in columns))
         if not self.columns:
             raise ValueError("columns must not be empty")
-        object.__setattr__(self, "columns", tuple(Identifier(column) for column in self.columns))
 
         seen: set[str] = set()
         for column in self.columns:
@@ -81,12 +83,22 @@ class ForeignKeyConstraint:
 
     """
 
-    local_columns: tuple[str, ...]
+    local_columns: Sequence[str]
     referenced_table: QualifiedName
-    referenced_columns: tuple[str, ...]
+    referenced_columns: Sequence[str]
     constraint_name: str
 
     def __post_init__(self) -> None:
+        object.__setattr__(
+            self,
+            "local_columns",
+            freeze_strings(self.local_columns, field_name="local_columns"),
+        )
+        object.__setattr__(
+            self,
+            "referenced_columns",
+            freeze_strings(self.referenced_columns, field_name="referenced_columns"),
+        )
         if not self.local_columns:
             raise ValueError("local_columns must not be empty")
 
@@ -142,7 +154,7 @@ class ForeignKeyConstraint:
         ``constraint_name`` so generated and catalog names still match by
         content.
         """
-        return (self.local_columns, self.referenced_table, self.referenced_columns)
+        return (tuple(self.local_columns), self.referenced_table, tuple(self.referenced_columns))
 
     @property
     def referenced_key_signature(self) -> KeySignature:

--- a/src/delta_engine/domain/model/frozen.py
+++ b/src/delta_engine/domain/model/frozen.py
@@ -2,6 +2,9 @@
 
 from collections.abc import Sequence
 
+# TODO: Reconsider accepting only list[T] | tuple[T, ...] so bare strings are
+# excluded by the input type and this special-case helper is unnecessary.
+
 
 def freeze_strings(values: Sequence[str], *, field_name: str) -> tuple[str, ...]:
     """Copy an ordered string collection while rejecting an ambiguous bare string."""

--- a/src/delta_engine/domain/model/frozen.py
+++ b/src/delta_engine/domain/model/frozen.py
@@ -1,0 +1,10 @@
+"""Collection normalization for immutable model values."""
+
+from collections.abc import Sequence
+
+
+def freeze_strings(values: Sequence[str], *, field_name: str) -> tuple[str, ...]:
+    """Copy an ordered string collection while rejecting an ambiguous bare string."""
+    if isinstance(values, str):
+        raise TypeError(f"{field_name} must be a sequence of strings, not a string")
+    return tuple(values)

--- a/src/delta_engine/domain/model/table.py
+++ b/src/delta_engine/domain/model/table.py
@@ -1,6 +1,6 @@
 """Domain models for desired and observed table state."""
 
-from collections.abc import Mapping
+from collections.abc import Mapping, Sequence, Set
 from dataclasses import dataclass, field
 from enum import Enum, auto
 from types import MappingProxyType
@@ -12,12 +12,13 @@ from delta_engine.domain.model.constraints import (
     ForeignKeyReference,
     PrimaryKeyConstraint,
 )
+from delta_engine.domain.model.frozen import freeze_strings
 from delta_engine.domain.model.identifier import Identifier
 from delta_engine.domain.model.qualified_name import QualifiedName
 from delta_engine.domain.model.table_feature import TableFeature
 
 
-def _validate_key_column_list(kind: str, names: tuple[str, ...], column_names: set[str]) -> None:
+def _validate_key_column_list(kind: str, names: Sequence[str], column_names: set[str]) -> None:
     """Rules shared by partition and clustering key lists: existing and unique."""
     missing = [name for name in names if str(name) not in column_names]
     if missing:
@@ -31,12 +32,12 @@ def _validate_key_column_list(kind: str, names: tuple[str, ...], column_names: s
 
 
 def _validate_table_structure(
-    columns: tuple[DesiredColumn | ObservedColumn, ...],
+    columns: Sequence[DesiredColumn | ObservedColumn],
     tags: Mapping[str, str],
-    partitioned_by: tuple[str, ...],
-    clustered_by: tuple[str, ...],
+    partitioned_by: Sequence[str],
+    clustered_by: Sequence[str],
     primary_key: PrimaryKeyConstraint | None,
-    foreign_keys: tuple[ForeignKeyConstraint, ...],
+    foreign_keys: Sequence[ForeignKeyConstraint],
 ) -> None:
     """
     Validate the structural invariants shared by desired and observed tables.
@@ -144,20 +145,20 @@ class DesiredTable:
     """
 
     qualified_name: QualifiedName
-    columns: tuple[DesiredColumn, ...]
+    columns: Sequence[DesiredColumn]
     comment: str = ""
     tags: Mapping[str, str] = field(default_factory=dict)
-    partitioned_by: tuple[str, ...] = ()
-    clustered_by: tuple[str, ...] = ()
+    partitioned_by: Sequence[str] = ()
+    clustered_by: Sequence[str] = ()
     primary_key: PrimaryKeyConstraint | None = None
-    foreign_keys: tuple[ForeignKeyConstraint, ...] = ()
+    foreign_keys: Sequence[ForeignKeyConstraint] = ()
     properties: Mapping[str, str | None] = field(default_factory=dict)
-    managed_aspects: frozenset[TableAspect] = field(default_factory=lambda: ALL_ASPECTS)
+    managed_aspects: Set[TableAspect] = field(default_factory=lambda: ALL_ASPECTS)
 
     @property
     def primary_key_columns(self) -> tuple[str, ...]:
         """Primary key column names, or ``()`` when the table has no primary key."""
-        return self.primary_key.columns if self.primary_key is not None else ()
+        return tuple(self.primary_key.columns) if self.primary_key is not None else ()
 
     def __post_init__(self) -> None:
         """
@@ -184,12 +185,15 @@ class DesiredTable:
         representable.
 
         """
+        object.__setattr__(self, "columns", tuple(self.columns))
         object.__setattr__(self, "tags", MappingProxyType(dict(self.tags)))
-        object.__setattr__(
-            self, "partitioned_by", tuple(Identifier(n) for n in self.partitioned_by)
-        )
-        object.__setattr__(self, "clustered_by", tuple(Identifier(n) for n in self.clustered_by))
+        partitioned_by = freeze_strings(self.partitioned_by, field_name="partitioned_by")
+        clustered_by = freeze_strings(self.clustered_by, field_name="clustered_by")
+        object.__setattr__(self, "partitioned_by", tuple(Identifier(n) for n in partitioned_by))
+        object.__setattr__(self, "clustered_by", tuple(Identifier(n) for n in clustered_by))
+        object.__setattr__(self, "foreign_keys", tuple(self.foreign_keys))
         object.__setattr__(self, "properties", MappingProxyType(dict(self.properties)))
+        object.__setattr__(self, "managed_aspects", frozenset(self.managed_aspects))
 
         _validate_table_structure(
             columns=self.columns,
@@ -206,7 +210,7 @@ class DesiredTable:
                 " declares nothing for the engine to do"
             )
         seen: set[frozenset[str]] = set()
-        local_columns_by_constraint_name: dict[str, tuple[str, ...]] = {}
+        local_columns_by_constraint_name: dict[str, Sequence[str]] = {}
         for foreign_key in self.foreign_keys:
             local_column_set = frozenset(foreign_key.local_columns)
             if local_column_set in seen:
@@ -298,30 +302,34 @@ class ObservedTable:
     """
 
     qualified_name: QualifiedName
-    columns: tuple[ObservedColumn, ...]
+    columns: Sequence[ObservedColumn]
     comment: str = ""
     tags: Mapping[str, str] = field(default_factory=dict)
-    partitioned_by: tuple[str, ...] = ()
-    clustered_by: tuple[str, ...] = ()
+    partitioned_by: Sequence[str] = ()
+    clustered_by: Sequence[str] = ()
     primary_key: PrimaryKeyConstraint | None = None
-    foreign_keys: tuple[ForeignKeyConstraint, ...] = ()
+    foreign_keys: Sequence[ForeignKeyConstraint] = ()
     properties: Mapping[str, str] = field(default_factory=dict)
-    supported_features: frozenset[TableFeature] = frozenset()
-    referencing_foreign_keys: tuple[ForeignKeyReference, ...] = ()
+    supported_features: Set[TableFeature] = frozenset()
+    referencing_foreign_keys: Sequence[ForeignKeyReference] = ()
     kind: TableKind = TableKind.TABLE
 
     @property
     def primary_key_columns(self) -> tuple[str, ...]:
         """Primary key column names, or ``()`` when the table has no primary key."""
-        return self.primary_key.columns if self.primary_key is not None else ()
+        return tuple(self.primary_key.columns) if self.primary_key is not None else ()
 
     def __post_init__(self) -> None:
+        object.__setattr__(self, "columns", tuple(self.columns))
         object.__setattr__(self, "tags", MappingProxyType(dict(self.tags)))
-        object.__setattr__(
-            self, "partitioned_by", tuple(Identifier(n) for n in self.partitioned_by)
-        )
-        object.__setattr__(self, "clustered_by", tuple(Identifier(n) for n in self.clustered_by))
+        partitioned_by = freeze_strings(self.partitioned_by, field_name="partitioned_by")
+        clustered_by = freeze_strings(self.clustered_by, field_name="clustered_by")
+        object.__setattr__(self, "partitioned_by", tuple(Identifier(n) for n in partitioned_by))
+        object.__setattr__(self, "clustered_by", tuple(Identifier(n) for n in clustered_by))
+        object.__setattr__(self, "foreign_keys", tuple(self.foreign_keys))
         object.__setattr__(self, "properties", MappingProxyType(dict(self.properties)))
+        object.__setattr__(self, "supported_features", frozenset(self.supported_features))
+        object.__setattr__(self, "referencing_foreign_keys", tuple(self.referencing_foreign_keys))
 
         _validate_table_structure(
             columns=self.columns,

--- a/src/delta_engine/domain/plan/actions.py
+++ b/src/delta_engine/domain/plan/actions.py
@@ -1,7 +1,7 @@
 """Canonical domain vocabulary for executable table actions."""
 
 from abc import ABC, abstractmethod
-from collections.abc import Iterator
+from collections.abc import Iterator, Sequence
 from dataclasses import dataclass
 from enum import IntEnum, auto
 from typing import ClassVar
@@ -19,6 +19,7 @@ from delta_engine.domain.model import (
     TableFeature,
     TableKind,
 )
+from delta_engine.domain.model.frozen import freeze_strings
 
 
 class ActionPhase(IntEnum):
@@ -73,6 +74,7 @@ class Action(ABC):
     def subject(self) -> str:
         """Identifier targeted within the phase; subclasses must override."""
         ...
+
 
 @dataclass(frozen=True, slots=True)
 class CreateTable(Action):
@@ -392,18 +394,24 @@ class SetForeignKey(Action):
 class AlterClustering(Action):
     """Set or clear liquid-clustering keys, preserving desired and observed state."""
 
-    desired_clustering: tuple[str, ...]
-    observed_clustering: tuple[str, ...]
+    desired_clustering: Sequence[str]
+    observed_clustering: Sequence[str]
 
     aspect: ClassVar[TableAspect] = TableAspect.CLUSTERING
     phase: ClassVar[ActionPhase] = ActionPhase.SET_CLUSTERING
 
     def __post_init__(self) -> None:
-        object.__setattr__(
-            self, "desired_clustering", tuple(Identifier(n) for n in self.desired_clustering)
+        desired_clustering = freeze_strings(
+            self.desired_clustering, field_name="desired_clustering"
+        )
+        observed_clustering = freeze_strings(
+            self.observed_clustering, field_name="observed_clustering"
         )
         object.__setattr__(
-            self, "observed_clustering", tuple(Identifier(n) for n in self.observed_clustering)
+            self, "desired_clustering", tuple(Identifier(n) for n in desired_clustering)
+        )
+        object.__setattr__(
+            self, "observed_clustering", tuple(Identifier(n) for n in observed_clustering)
         )
         if set(self.desired_clustering) == set(self.observed_clustering):
             raise ValueError(f"AlterClustering carries no difference: {self.desired_clustering!r}")
@@ -455,7 +463,7 @@ class ActionPlan:
     """
 
     target: QualifiedName
-    actions: tuple[Action, ...] = ()
+    actions: Sequence[Action] = ()
     kind: TableKind = TableKind.TABLE
 
     def __post_init__(self) -> None:

--- a/src/delta_engine/domain/plan/diff.py
+++ b/src/delta_engine/domain/plan/diff.py
@@ -8,7 +8,7 @@ lives in ``application/relationships.py``; validation, safety policy,
 execution ordering, and backend compilation live elsewhere.
 """
 
-from collections.abc import Iterable, Mapping
+from collections.abc import Iterable, Mapping, Sequence, Set
 from dataclasses import dataclass, replace
 from typing import Final
 
@@ -27,6 +27,7 @@ from delta_engine.domain.model import (
     TimestampNtz,
     Variant,
 )
+from delta_engine.domain.model.frozen import freeze_strings
 from delta_engine.domain.plan.actions import (
     Action,
     AddColumn,
@@ -99,10 +100,12 @@ class TableDrift:
 
     desired: DesiredTable
     observed: ObservedTable
-    actions: tuple[Action, ...] = ()
-    unresolvable: tuple[Unresolvable, ...] = ()
+    actions: Sequence[Action] = ()
+    unresolvable: Sequence[Unresolvable] = ()
 
     def __post_init__(self) -> None:
+        object.__setattr__(self, "actions", tuple(self.actions))
+        object.__setattr__(self, "unresolvable", tuple(self.unresolvable))
         _require_same_table(self.desired, self.observed)
 
     @property
@@ -171,7 +174,7 @@ def _diff_existing_table(desired: DesiredTable, observed: ObservedTable) -> Tabl
 
 def _diff_required_features(
     columns: Iterable[DesiredColumn],
-    supported_features: frozenset[TableFeature],
+    supported_features: Set[TableFeature],
 ) -> tuple[EnableTableFeature, ...]:
     """Return upgrades required by the desired column type trees."""
     required_features = {
@@ -240,11 +243,26 @@ class _RenameResolution:
     drops them.
     """
 
-    columns: tuple[ObservedColumn, ...]
-    partitioned_by: tuple[str, ...]
-    clustered_by: tuple[str, ...]
-    actions: tuple[RenameColumn, ...]
-    conflicts: tuple[ColumnRenameConflict, ...]
+    columns: Sequence[ObservedColumn]
+    partitioned_by: Sequence[str]
+    clustered_by: Sequence[str]
+    actions: Sequence[RenameColumn]
+    conflicts: Sequence[ColumnRenameConflict]
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "columns", tuple(self.columns))
+        object.__setattr__(
+            self,
+            "partitioned_by",
+            freeze_strings(self.partitioned_by, field_name="partitioned_by"),
+        )
+        object.__setattr__(
+            self,
+            "clustered_by",
+            freeze_strings(self.clustered_by, field_name="clustered_by"),
+        )
+        object.__setattr__(self, "actions", tuple(self.actions))
+        object.__setattr__(self, "conflicts", tuple(self.conflicts))
 
 
 def _resolve_column_renames(desired: DesiredTable, observed: ObservedTable) -> _RenameResolution:
@@ -273,23 +291,23 @@ def _resolve_column_renames(desired: DesiredTable, observed: ObservedTable) -> _
         new_names_by_old[old_name] = target.name
         actions.append(RenameColumn(old_name=observed_column.name, new_name=target.name))
 
-    projected_columns = tuple(
+    projected_columns = [
         replace(column, name=new_names_by_old[column.name])
         if column.name in new_names_by_old
         else column
         for column in observed.columns
         if column.name not in conflicted_sources
-    )
+    ]
     return _RenameResolution(
         columns=projected_columns,
         partitioned_by=_project_names(observed.partitioned_by, new_names_by_old),
         clustered_by=_project_names(observed.clustered_by, new_names_by_old),
-        actions=tuple(actions),
-        conflicts=tuple(conflicts),
+        actions=actions,
+        conflicts=conflicts,
     )
 
 
-def _project_names(names: tuple[str, ...], renames: Mapping[str, str]) -> tuple[str, ...]:
+def _project_names(names: Sequence[str], renames: Mapping[str, str]) -> tuple[str, ...]:
     """Project column names through the applied rename mapping."""
     return tuple(renames.get(name, name) for name in names)
 
@@ -298,14 +316,19 @@ def _project_names(names: tuple[str, ...], renames: Mapping[str, str]) -> tuple[
 class _ColumnAlignment:
     """Desired and rename-projected observed columns classified by name."""
 
-    added: tuple[DesiredColumn, ...]
-    removed: tuple[ObservedColumn, ...]
-    matched: tuple[tuple[DesiredColumn, ObservedColumn], ...]
+    added: Sequence[DesiredColumn]
+    removed: Sequence[ObservedColumn]
+    matched: Sequence[tuple[DesiredColumn, ObservedColumn]]
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "added", tuple(self.added))
+        object.__setattr__(self, "removed", tuple(self.removed))
+        object.__setattr__(self, "matched", tuple(self.matched))
 
 
 def _diff_columns(
-    desired_columns: tuple[DesiredColumn, ...],
-    observed_columns: tuple[ObservedColumn, ...],
+    desired_columns: Sequence[DesiredColumn],
+    observed_columns: Sequence[ObservedColumn],
 ) -> tuple[Action, ...]:
     """Return every action required to converge the table's columns."""
     alignment = _align_columns(desired_columns, observed_columns)
@@ -324,20 +347,20 @@ def _diff_columns(
 
 
 def _align_columns(
-    desired_columns: tuple[DesiredColumn, ...],
-    observed_columns: tuple[ObservedColumn, ...],
+    desired_columns: Sequence[DesiredColumn],
+    observed_columns: Sequence[ObservedColumn],
 ) -> _ColumnAlignment:
     """Classify columns in stable desired and observed order."""
     desired_by_name = {column.name: column for column in desired_columns}
     observed_by_name = {column.name: column for column in observed_columns}
 
-    added = tuple(column for column in desired_columns if column.name not in observed_by_name)
-    removed = tuple(column for column in observed_columns if column.name not in desired_by_name)
-    matched = tuple(
+    added = [column for column in desired_columns if column.name not in observed_by_name]
+    removed = [column for column in observed_columns if column.name not in desired_by_name]
+    matched = [
         (column, observed_by_name[column.name])
         for column in desired_columns
         if column.name in observed_by_name
-    )
+    ]
 
     return _ColumnAlignment(
         added=added,

--- a/src/delta_engine/domain/plan/unresolvable.py
+++ b/src/delta_engine/domain/plan/unresolvable.py
@@ -1,9 +1,11 @@
 """Canonical domain vocabulary for differences no action can close."""
 
+from collections.abc import Sequence
 from dataclasses import dataclass
 from typing import ClassVar
 
 from delta_engine.domain.model import Identifier, TableAspect
+from delta_engine.domain.model.frozen import freeze_strings
 
 
 @dataclass(frozen=True, slots=True)
@@ -58,12 +60,22 @@ class PropertyUndeclared:
 class PartitioningChanged:
     """Partitioning drift, which has no supported in-place action."""
 
-    desired_partitioning: tuple[str, ...]
-    observed_partitioning: tuple[str, ...]
+    desired_partitioning: Sequence[str]
+    observed_partitioning: Sequence[str]
 
     aspect: ClassVar[TableAspect] = TableAspect.PARTITIONING
 
     def __post_init__(self) -> None:
+        object.__setattr__(
+            self,
+            "desired_partitioning",
+            freeze_strings(self.desired_partitioning, field_name="desired_partitioning"),
+        )
+        object.__setattr__(
+            self,
+            "observed_partitioning",
+            freeze_strings(self.observed_partitioning, field_name="observed_partitioning"),
+        )
         if self.desired_partitioning == self.observed_partitioning:
             raise ValueError(
                 f"PartitioningChanged carries no difference: {self.desired_partitioning!r}"


### PR DESCRIPTION
## Summary

- accept `collections.abc.Sequence` and `collections.abc.Set` at frozen dataclass boundaries
- copy ordered inputs to tuples and set-like inputs to frozensets before validation
- reject bare strings where a sequence of strings is required
- remove redundant caller-side tuple coercions while retaining the explicit normalized declaration boundary

## Why

Callers were repeatedly responsible for writing `SomeClass(tuple(values))`, even when the receiving frozen dataclass already owned ordering or validation invariants. Some frozen records also retained mutable lists or sets when called from untyped code.

Moving normalization into constructors gives callers a natural sequence-based API while preserving immutable runtime state.

## Impact

Existing tuple inputs and stored equality/order semantics are unchanged. Lists and other valid sequences are now accepted consistently, copied on construction, and never retained by alias. Public tuple-returning properties continue to return tuples.

No test files were changed.

## Validation

- `uv run pytest` — 1,156 passed, 73 deselected
- `uv run ruff check .`
- `uv run mypy .`
- `uv run lint-imports`
- `git diff --check`
