### PR TITLE
fix: make sync failure messages actionable

### DIFF
--- a/src/delta_engine/application/failures.py
+++ b/src/delta_engine/application/failures.py
@@ -8,7 +8,7 @@ together rather than being scattered across its producers.
 """
 
 from abc import ABC, abstractmethod
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from enum import IntEnum, StrEnum
 from typing import ClassVar, Final, assert_never
 
@@ -121,6 +121,9 @@ class ValidationFailure(Failure):
     """
     Description of a validation rule failure.
 
+    ``subject`` is what the failure is about — a column, property key, or
+    aspect — used by the compact headline in the report grid. Rules that judge
+    the table as a whole leave it empty.
     ``details`` are the individual differences behind a summary judgment, for
     a rule whose message names a whole aspect rather than one column. They are
     separate lines rather than newlines inside ``message`` so the report
@@ -132,6 +135,7 @@ class ValidationFailure(Failure):
     phase: ClassVar[FailurePhase] = FailurePhase.PLANNING
     rule_name: str
     message: str
+    subject: str = field(default="", kw_only=True)
     details: ListOrTuple[str] = ()
 
     def __post_init__(self) -> None:
@@ -141,7 +145,8 @@ class ValidationFailure(Failure):
         return (f"Validation failed: {self.rule_name} - {self.message}", *self.details)
 
     def headline(self) -> str:
-        return f"Validation failed: {self.rule_name}"
+        subject = f" ({self.subject})" if self.subject else ""
+        return f"Validation failed: {self.rule_name}{subject}"
 
 
 @dataclass(frozen=True, slots=True)
@@ -156,13 +161,24 @@ class ExecutionFailure(Failure):
 
     def format_lines(self) -> tuple[str, ...]:
         return (
-            f"Execution failed at statement {self.statement_index}: "
+            f"Execution failed at statement {self.statement_number}: "
             f"{self.exception_type} - {_message_head(self.message)}",
             f"SQL: {self.statement}",
         )
 
     def headline(self) -> str:
-        return f"Execution failed at statement {self.statement_index}: {self.exception_type}"
+        return f"Execution failed at statement {self.statement_number}: {self.exception_type}"
+
+    @property
+    def statement_number(self) -> int:
+        """
+        The failing statement's one-based display position.
+
+        ``statement_index`` remains zero-based so it indexes the compiled
+        statements. Only the reader-facing number shifts, making "statement
+        3" agree with a report-grid progress count of "2/3".
+        """
+        return self.statement_index + 1
 
 
 @dataclass(frozen=True, slots=True)

--- a/src/delta_engine/application/rendering.py
+++ b/src/delta_engine/application/rendering.py
@@ -143,11 +143,17 @@ def render_grid(reports: Sequence[TableRunReport]) -> str:
     return "\n".join(_aligned_rows(rows))
 
 
+def _count_phrase(count: int, singular: str, plural: str) -> str:
+    """Render a count with the noun that agrees with it."""
+    return f"{count} {singular if count == 1 else plural}"
+
+
 def run_summary_footer(report: SyncReport) -> str:
     """One-line summary: table total, changed/unchanged/failed counts, duration."""
     counts = report.counts
     return (
-        f"{counts.total} tables: {counts.changed} changed, {counts.unchanged} unchanged, "
+        f"{_count_phrase(counts.total, 'table', 'tables')}: "
+        f"{counts.changed} changed, {counts.unchanged} unchanged, "
         f"{counts.failed} failed ({report.duration_seconds:.1f}s)"
     )
 

--- a/src/delta_engine/application/validation.py
+++ b/src/delta_engine/application/validation.py
@@ -129,8 +129,14 @@ class NonNullableColumnAdd:
             ValidationFailure(
                 rule_name=self.name,
                 message=(
-                    f"Operation not allowed: cannot add non-nullable column '{change.column.name}'"
+                    f"Operation not allowed: cannot add non-nullable column"
+                    f" '{change.column.name}'. Delta cannot safely add a NOT NULL column"
+                    " directly to an existing table. Add it nullable, backfill any NULLs,"
+                    " set NOT NULL outside the engine"
+                    " (ALTER TABLE ... ALTER COLUMN ... SET NOT NULL), then declare"
+                    " nullable=False — the next sync sees no drift."
                 ),
+                subject=str(change.column.name),
             )
             for change in drift.actions
             if isinstance(change, AddColumn) and not change.column.nullable
@@ -154,6 +160,7 @@ class NullabilityTighteningOnExistingColumn:
                     " (ALTER TABLE ... SET NOT NULL), then declare"
                     " nullable=False — the next sync sees no drift."
                 ),
+                subject=str(change.column_name),
             )
             for change in drift.actions
             if isinstance(change, SetColumnNullability) and not change.desired_nullable
@@ -200,6 +207,7 @@ class NonWideningColumnTypeChange:
                     " wide Decimal, Float to Double, Decimal digit growth, Date to"
                     " TimestampNtz); recreate the table to make any other type change."
                 ),
+                subject=str(change.column_name),
             )
             for change in drift.actions
             if isinstance(change, AlterColumnType)
@@ -232,6 +240,7 @@ class TypeWideningRequiredForTypeChange:
                     f" {Property.TYPE_WIDENING}='true'. Declare"
                     f" properties={{'{Property.TYPE_WIDENING}': 'true'}} on this table."
                 ),
+                subject=str(change.column_name),
             )
             for change in drift.actions
             if isinstance(change, AlterColumnType)
@@ -292,6 +301,7 @@ class PropertyTransitionNotSupported:
                                 f" from '{observed_value}' to '{desired_value}'."
                                 " Update the declaration to match the catalog value."
                             ),
+                            subject=name,
                         )
                     )
                 case UnsetProperty(name=name, observed_value=observed_value) if self._is_blocked(
@@ -305,6 +315,7 @@ class PropertyTransitionNotSupported:
                                 " the change is permanent on the table. Declare its"
                                 " current value."
                             ),
+                            subject=name,
                         )
                     )
                 case _:
@@ -330,7 +341,11 @@ class PropertyMustBeDeclared:
     def evaluate(self, drift: TableDrift) -> tuple[ValidationFailure, ...]:
         """Flag every managed key set on the table but absent from the declaration."""
         return tuple(
-            ValidationFailure(rule_name=self.name, message=self._message(unresolvable))
+            ValidationFailure(
+                rule_name=self.name,
+                message=self._message(unresolvable),
+                subject=unresolvable.name,
+            )
             for unresolvable in drift.unresolvable
             if isinstance(unresolvable, PropertyUndeclared)
         )
@@ -401,6 +416,7 @@ class AmbiguousColumnRename:
                     " on the table. If the old column should be dropped, remove the"
                     " renamed_from hint and drop it in its own sync."
                 ),
+                subject=str(unresolvable.old_name),
             )
             for unresolvable in drift.unresolvable
             if isinstance(unresolvable, ColumnRenameConflict)
@@ -504,6 +520,7 @@ class ColumnSpellingMustMatchCatalog:
                             f" '{unresolvable.observed_name}' in the catalog. Update the"
                             " declaration to match the catalog's spelling exactly."
                         ),
+                        subject=str(unresolvable.declared_name),
                     )
                     for unresolvable in drift.unresolvable
                     if isinstance(unresolvable, ColumnCaseDrift)
@@ -582,6 +599,7 @@ class UnmanagedAspectDrift:
                             " to match the live table, or widen its scope to manage"
                             " this aspect."
                         ),
+                        subject=aspect.label,
                         details=lines,
                     )
                     for aspect, lines in lines_by_aspect.items()

--- a/tests/application/test_errors.py
+++ b/tests/application/test_errors.py
@@ -200,7 +200,7 @@ def test_message_renders_execution_failure_detail_with_sql():
 
     # Then both the failure line and the SQL statement is present
     assert "cat.sch.tbl [EXECUTION_FAILED]" in message
-    assert "Execution failed at statement 2: SparkException - boom" in message
+    assert "Execution failed at statement 3: SparkException - boom" in message
     assert "ALTER TABLE cat.sch.tbl ADD COLUMN x INT" in message
 
 

--- a/tests/application/test_failures.py
+++ b/tests/application/test_failures.py
@@ -40,8 +40,32 @@ def test_execution_failure_formats_itself_as_two_lines_including_the_sql():
 
     # Then it renders the error line and the SQL together
     lines = failure.format_lines()
-    assert lines[0] == "Execution failed at statement 2: SparkException - boom"
+    # The stored index is zero-based; readers see a one-based statement number.
+    assert lines[0] == "Execution failed at statement 3: SparkException - boom"
     assert "ALTER TABLE t ADD COLUMN x INT" in lines[1]
+
+
+def test_a_validation_headline_names_its_subject_when_it_has_one():
+    failure = ValidationFailure(
+        rule_name="NonNullableColumnAdd",
+        message="Operation not allowed: cannot add non-nullable column 'email'.",
+        subject="email",
+    )
+
+    assert failure.headline() == "Validation failed: NonNullableColumnAdd (email)"
+
+
+def test_a_validation_headline_omits_an_absent_subject():
+    failure = ValidationFailure(rule_name="ColumnMappingRequiredForDrop", message="nope")
+
+    assert failure.headline() == "Validation failed: ColumnMappingRequiredForDrop"
+
+
+def test_adding_a_subject_preserves_positional_details_compatibility():
+    failure = ValidationFailure("UnmanagedAspectDrift", "nope", ("+ email String",))
+
+    assert failure.subject == ""
+    assert failure.details == ("+ email String",)
 
 
 def test_failure_display_shows_only_the_head_of_a_long_message():
@@ -118,7 +142,7 @@ def test_failure_headlines_summarize_without_the_detail_message():
             message="boom",
             statement="SQL",
         ).headline()
-        == "Execution failed at statement 2: SparkException"
+        == "Execution failed at statement 3: SparkException"
     )
     assert (
         ForeignKeyFailure(

--- a/tests/application/test_rendering.py
+++ b/tests/application/test_rendering.py
@@ -697,6 +697,23 @@ def test_grid_detail_shows_first_failure_and_extra_count_when_multiple():
     assert data_row.endswith("(+1 more)")
 
 
+def test_grid_detail_names_the_subject_a_rule_rejected():
+    report = _grid_report(
+        "orders",
+        failures=(
+            ValidationFailure(
+                rule_name="NonNullableColumnAdd",
+                message="Operation not allowed: cannot add non-nullable column 'email'.",
+                subject="email",
+            ),
+        ),
+    )
+
+    data_row = render_grid((report,)).splitlines()[1]
+
+    assert "NonNullableColumnAdd (email)" in data_row
+
+
 def test_grid_detail_truncates_an_overlong_detail_with_an_ellipsis():
     # Given a failure whose headline exceeds the detail width
     report = _grid_report(
@@ -751,6 +768,16 @@ def test_run_summary_footer_counts_changed_unchanged_and_failed():
 
     # Then each table is classified by its outcome
     assert footer == "3 tables: 1 changed, 1 unchanged, 1 failed (3.0s)"
+
+
+def test_a_single_table_run_uses_the_singular_noun():
+    sync = SyncReport(
+        started_at=datetime(2025, 1, 1, 0, 0, 0),
+        ended_at=datetime(2025, 1, 1, 0, 0, 3),
+        table_reports=(_grid_report("orders"),),
+    )
+
+    assert run_summary_footer(sync).startswith("1 table:")
 
 
 # ---------- whole-report rendering ----------
@@ -839,7 +866,7 @@ def test_failures_section_nests_supporting_detail_under_its_error_line():
 
     # Then the error line sits under its table, and the SQL nests below it —
     # depth is the renderer's decision, so the failure itself carries none
-    assert "    Execution failed at statement 0: AnalysisException - boom" in lines
+    assert "    Execution failed at statement 1: AnalysisException - boom" in lines
     assert "        SQL: SQL 0" in lines
 
 

--- a/tests/application/test_validation.py
+++ b/tests/application/test_validation.py
@@ -334,6 +334,9 @@ def test_rejects_adding_non_nullable_columns_to_existing_table():
     ]
     assert "a" in failures[0].message
     assert "b" in failures[1].message
+    assert [failure.subject for failure in failures] == ["a", "b"]
+    assert "backfill" in failures[0].message
+    assert "nullable=False" in failures[0].message
 
 
 def test_allows_adding_nullable_column_to_existing_table():
@@ -378,6 +381,7 @@ def test_rejects_tightening_existing_columns_to_not_null():
     ]
     assert "id" in failures[0].message
     assert "email" in failures[1].message
+    assert [failure.subject for failure in failures] == ["id", "email"]
 
 
 def test_allows_loosening_existing_column_to_nullable():
@@ -405,6 +409,7 @@ def test_rejects_widening_type_change_without_type_widening_declared():
     assert failures[0].rule_name == "TypeWideningRequiredForTypeChange"
     assert "id" in failures[0].message
     assert "delta.enableTypeWidening" in failures[0].message
+    assert failures[0].subject == "id"
 
 
 def test_widening_type_change_passes_with_type_widening_declared():
@@ -434,6 +439,7 @@ def test_rejects_non_widening_type_change_even_with_type_widening_declared():
 
     assert failures[0].rule_name == "NonWideningColumnTypeChange"
     assert "recreate the table" in failures[0].message
+    assert failures[0].subject == "id"
 
 
 def test_rejects_narrowing_type_change():
@@ -780,6 +786,7 @@ def test_blocks_column_mapping_downgrade():
     # Then validation rejects the transition
     assert failures[0].rule_name == "PropertyTransitionNotSupported"
     assert "delta.columnMapping.mode" in failures[0].message
+    assert failures[0].subject == "delta.columnMapping.mode"
 
 
 def test_allows_column_mapping_upgrade():
@@ -825,6 +832,7 @@ def test_blocks_none_declaration_on_removal_forbidden_key():
     # Then validation rejects the removal
     assert failures[0].rule_name == "PropertyTransitionNotSupported"
     assert "cannot be removed" in failures[0].message
+    assert failures[0].subject == "delta.columnMapping.mode"
 
 
 def test_allows_none_declaration_on_unrestricted_key():
@@ -851,6 +859,7 @@ def test_fails_undeclared_unrestricted_property_and_suggests_none():
     # Then validation tells the user to declare it or declare None
     assert failures[0].rule_name == "PropertyMustBeDeclared"
     assert "None" in failures[0].message
+    assert failures[0].subject == "delta.enableChangeDataFeed"
 
 
 def test_fails_undeclared_removal_forbidden_property_without_suggesting_none():
@@ -980,6 +989,7 @@ def test_ambiguous_rename_fails_when_source_and_target_both_exist():
     assert len(rename_failures) == 1
     message = rename_failures[0].message
     assert "customer_nm" in message and "customer_name" in message
+    assert rename_failures[0].subject == "customer_nm"
 
 
 def test_removed_column_that_is_not_a_rename_source_is_not_ambiguous():
@@ -1017,6 +1027,7 @@ def test_column_case_drift_fails_validation_naming_both_spellings():
     assert len(spelling_failures) == 1
     assert "'OrderId'" in spelling_failures[0].message
     assert "'orderid'" in spelling_failures[0].message
+    assert spelling_failures[0].subject == "OrderId"
 
 
 def test_agreeing_spelling_passes_the_case_rule():
@@ -1262,6 +1273,7 @@ def test_unmanaged_drift_reports_one_failure_per_aspect():
 
     # Then each aspect gets its own failure, each naming only its own differences
     assert len(failures) == 2
+    assert [failure.subject for failure in failures] == ["column structure", "partitioning"]
     assert [failure.details for failure in failures] == [
         ("+ legacy_region String",),
         ("~ partitioning (country) → (region)",),


### PR DESCRIPTION
## What

Completes PR 1 Tasks 4–7 from #311:

- display execution statement positions from 1 while retaining the internal zero-based `statement_index`
- give `NonNullableColumnAdd` an actionable nullable → backfill → `NOT NULL` remedy
- add a keyword-only `ValidationFailure.subject`, populate it for single-subject rules, and show it in the report grid
- render `1 table` instead of `1 tables` in run summaries

## Why

The existing output mixed zero-based statement indexes with one-based progress counts, omitted the remedy for one safety rule, hid the affected column or property in compact grid rows, and produced an ungrammatical single-table footer. Together these made failure reports harder to interpret and act on.

## Impact

Human-readable failure and summary text becomes clearer. The stored `statement_index` and the versioned `to_dict()` payload are unchanged. `ValidationFailure.subject` is keyword-only so existing positional use of the previously added `details` field remains compatible.

## Validation

- `uv run pytest -q` — 1,166 passed, 74 deselected; 96.68% coverage
- `uv run mypy src/delta_engine/`
- `uv run ruff check src/ tests/`
- `uv run lint-imports`
- `uv run --group docs sphinx-build -W -b html docs docs/_build/html`
- `git diff --check`
- all seven changed files pass `ruff format --check`

The repository-wide format check still identifies two unchanged pre-existing test files: `tests/e2e/test_engine_e2e.py` and `tests/live/test_sql_warehouse_live_types_and_layout.py`. They are intentionally outside this PR's scope.