### PR TITLE
feat: render table change outcomes

### DIFF
--- a/docs/reference-run-report.md
+++ b/docs/reference-run-report.md
@@ -51,14 +51,14 @@ For Python callers, `SyncReport.table_change_states` returns one
 between a planned dry-run change and an unapplied real-run change depends on
 the run's `dry_run` mode, not on the table report alone.
 
-| Value               | Meaning                                                        |
-| ------------------- | -------------------------------------------------------------- |
-| `NOT_PLANNED`       | Reading or planning failed before a plan was accepted          |
-| `UNCHANGED`         | The accepted plan contained no catalog changes                 |
-| `PLANNED`           | A dry run compiled a non-empty plan without executing it       |
-| `NOT_APPLIED`       | A real-run change was blocked, or its first statement failed   |
-| `PARTIALLY_APPLIED` | Some statements succeeded before a later statement failed      |
-| `APPLIED`           | Every statement in a non-empty real-run plan succeeded         |
+| Member              | Value               | Meaning                                                        |
+| ------------------- | ------------------- | -------------------------------------------------------------- |
+| `NOT_PLANNED`       | `not planned`       | Reading or planning failed before a plan was accepted          |
+| `UNCHANGED`         | `unchanged`         | The accepted plan contained no catalog changes                 |
+| `PLANNED`           | `planned`           | A dry run compiled a non-empty plan without executing it       |
+| `NOT_APPLIED`       | `not applied`       | A real-run change was blocked, or its first statement failed   |
+| `PARTIALLY_APPLIED` | `partially applied` | Some statements succeeded before a later statement failed      |
+| `APPLIED`           | `applied`           | Every statement in a non-empty real-run plan succeeded         |
 
 Change state is deliberately separate from `TableRunStatus`: status explains
 which phase failed, while change state describes the effect on the catalog. A

--- a/docs/reference-run-report.md
+++ b/docs/reference-run-report.md
@@ -66,6 +66,12 @@ table can therefore be `EXECUTION_FAILED` with either `NOT_APPLIED` or
 `PARTIALLY_APPLIED`, and an unchanged table can still carry a foreign-key
 failure. Import the enum with `from delta_engine import TableChangeState`.
 
+The human-readable renderers use these states on real runs. `render_diff`
+marks non-empty plans that were not applied or only partially applied, while
+the `render_report` footer counts catalog outcomes. A compiled plan blocked
+before execution shows statement progress as `0/n`. Dry-run diff blocks and
+their changed/unchanged/failed footer keep describing planned work instead.
+
 This Python-level derived view does not add fields to `SyncReport.to_dict()` or
 `TableRunReport.to_dict()`; the structured schema below remains version 2.
 

--- a/src/delta_engine/application/rendering.py
+++ b/src/delta_engine/application/rendering.py
@@ -32,12 +32,12 @@ _DETAIL_MAX_CHARS: Final[int] = 60
 
 _GRID_HEADERS: Final[tuple[str, str, str, str]] = ("TABLE", "STATUS", "STATEMENTS", "DETAIL")
 
-_REAL_RUN_OUTCOMES: Final[tuple[tuple[TableChangeState, str], ...]] = (
-    (TableChangeState.APPLIED, "applied"),
-    (TableChangeState.PARTIALLY_APPLIED, "partially applied"),
-    (TableChangeState.NOT_APPLIED, "not applied"),
-    (TableChangeState.UNCHANGED, "unchanged"),
-    (TableChangeState.NOT_PLANNED, "not planned"),
+_REAL_RUN_OUTCOME_ORDER: Final[tuple[TableChangeState, ...]] = (
+    TableChangeState.APPLIED,
+    TableChangeState.PARTIALLY_APPLIED,
+    TableChangeState.NOT_APPLIED,
+    TableChangeState.UNCHANGED,
+    TableChangeState.NOT_PLANNED,
 )
 
 
@@ -78,12 +78,12 @@ def _change_outcome_marker(
 ) -> str | None:
     """Describe an incomplete real-run outcome; omit previews and complete outcomes."""
     if change_state is TableChangeState.NOT_APPLIED:
-        return "not applied"
+        return change_state.value
     if change_state is TableChangeState.PARTIALLY_APPLIED:
         progress = report.statement_progress
         if progress is None:
             raise ValueError("A partially applied change requires execution progress")
-        return f"partially applied, {progress.applied}/{progress.planned}"
+        return f"{change_state.value}, {progress.applied}/{progress.planned}"
     return None
 
 
@@ -215,7 +215,7 @@ def _real_run_summary(report: SyncReport) -> str:
     """Count each table by the catalog change state derived by the aggregate."""
     counts = Counter(report.table_change_states)
     return ", ".join(
-        f"{counts[state]} {label}" for state, label in _REAL_RUN_OUTCOMES if counts[state]
+        f"{counts[state]} {state.value}" for state in _REAL_RUN_OUTCOME_ORDER if counts[state]
     )
 
 

--- a/src/delta_engine/application/rendering.py
+++ b/src/delta_engine/application/rendering.py
@@ -20,7 +20,7 @@ from delta_engine.application.diff_entries import (
     plan_entries,
 )
 from delta_engine.application.failures import ReadFailure
-from delta_engine.application.report import SyncReport, TableRunReport
+from delta_engine.application.report import SyncReport, TableChangeState, TableRunReport
 from delta_engine.domain.plan import ActionPlan, TableDrift
 
 # Shown wherever a report has a readable state but no planned actions. One
@@ -31,6 +31,14 @@ _NO_CHANGES: Final[str] = "no changes"
 _DETAIL_MAX_CHARS: Final[int] = 60
 
 _GRID_HEADERS: Final[tuple[str, str, str, str]] = ("TABLE", "STATUS", "STATEMENTS", "DETAIL")
+
+_REAL_RUN_OUTCOMES: Final[tuple[tuple[TableChangeState, str], ...]] = (
+    (TableChangeState.APPLIED, "applied"),
+    (TableChangeState.PARTIALLY_APPLIED, "partially applied"),
+    (TableChangeState.NOT_APPLIED, "not applied"),
+    (TableChangeState.UNCHANGED, "unchanged"),
+    (TableChangeState.NOT_PLANNED, "not planned"),
+)
 
 
 def _aligned_rows(rows: Sequence[Sequence[str]]) -> list[str]:
@@ -65,8 +73,22 @@ def _render_entry_groups(entries: Sequence[DiffEntry]) -> list[str]:
     return lines
 
 
-def render_diff_block(report: TableRunReport) -> str:
-    """Render one table's change block: its name then its changes, grouped."""
+def _change_outcome_marker(
+    report: TableRunReport, change_state: TableChangeState | None
+) -> str | None:
+    """Describe an incomplete real-run outcome; omit previews and complete outcomes."""
+    if change_state is TableChangeState.NOT_APPLIED:
+        return "not applied"
+    if change_state is TableChangeState.PARTIALLY_APPLIED:
+        progress = report.statement_progress
+        if progress is None:
+            raise ValueError("A partially applied change requires execution progress")
+        return f"partially applied, {progress.applied}/{progress.planned}"
+    return None
+
+
+def _render_diff_block(report: TableRunReport, *, change_state: TableChangeState | None) -> str:
+    """Render one table's change block, optionally marking its aggregate outcome."""
     header = str(report.qualified_name)
     if isinstance(report.read, ReadFailure):
         return f"{header}\n  (could not read — no diff)"
@@ -88,19 +110,30 @@ def render_diff_block(report: TableRunReport) -> str:
             return f"{header}\n  ({_NO_CHANGES} — see failures)"
         return f"{header}\n  ({_NO_CHANGES})"
 
-    if report.creates_table:
-        header = f"{header}  (CREATE)"
+    notes = ["CREATE"] if report.creates_table else []
+    if marker := _change_outcome_marker(report, change_state):
+        notes.append(marker)
+    if notes:
+        header = f"{header}  ({' — '.join(notes)})"
     return "\n".join([header, *_render_entry_groups(plan_entries(plan))])
 
 
-def _grid_statements_cell(report: TableRunReport) -> str:
-    """STATEMENTS cell: applied/planned when execution ran, — on a failure, else planned count."""
+def render_diff_block(report: TableRunReport) -> str:
+    """Render one table's planned change block without claiming a run outcome."""
+    return _render_diff_block(report, change_state=None)
+
+
+def _grid_statements_cell(
+    report: TableRunReport, change_state: TableChangeState | None = None
+) -> str:
+    """STATEMENTS cell: execution progress, compiled count, or — when none compiled."""
     progress = report.statement_progress
     if progress is not None:
         return f"{progress.applied}/{progress.planned}"
+    planned = len(report.compiled.statements) if report.compiled is not None else 0
     if report.has_failures:
-        return "—"
-    return str(len(report.compiled.statements)) if report.compiled is not None else "0"
+        return f"0/{planned}" if change_state is TableChangeState.NOT_APPLIED and planned else "—"
+    return str(planned)
 
 
 def _humanized_action_summary(plan: ActionPlan | None) -> str:
@@ -127,12 +160,14 @@ def _truncate(text: str, limit: int = _DETAIL_MAX_CHARS) -> str:
     return text if len(text) <= limit else text[: limit - 1] + "…"
 
 
-def _grid_row_cells(report: TableRunReport) -> tuple[str, str, str, str]:
+def _grid_row_cells(
+    report: TableRunReport, change_state: TableChangeState | None = None
+) -> tuple[str, str, str, str]:
     """Return the four grid cells for one report (DETAIL already truncated)."""
     return (
         str(report.qualified_name),
         report.status.value,
-        _grid_statements_cell(report),
+        _grid_statements_cell(report, change_state),
         _truncate(_grid_detail(report)),
     )
 
@@ -143,18 +178,44 @@ def render_grid(reports: Sequence[TableRunReport]) -> str:
     return "\n".join(_aligned_rows(rows))
 
 
+def _render_run_grid(report: SyncReport) -> str:
+    """Render the grid with catalog outcomes supplied by the validated aggregate."""
+    rows = [
+        _GRID_HEADERS,
+        *(
+            _grid_row_cells(table_report, change_state)
+            for table_report, change_state in zip(
+                report.table_reports, report.table_change_states, strict=True
+            )
+        ),
+    ]
+    return "\n".join(_aligned_rows(rows))
+
+
 def _count_phrase(count: int, singular: str, plural: str) -> str:
     """Render a count with the noun that agrees with it."""
     return f"{count} {singular if count == 1 else plural}"
 
 
 def run_summary_footer(report: SyncReport) -> str:
-    """One-line summary: table total, changed/unchanged/failed counts, duration."""
+    """Summarise planned work for a preview or catalog outcomes for a real run."""
+    total = _count_phrase(len(report.table_reports), "table", "tables")
+    summary = _planned_summary(report) if report.dry_run else _real_run_summary(report)
+    prefix = f"{total}: {summary}" if summary else total
+    return f"{prefix} ({report.duration_seconds:.1f}s)"
+
+
+def _planned_summary(report: SyncReport) -> str:
+    """Count changed, unchanged, and failed tables without claiming an outcome."""
     counts = report.counts
-    return (
-        f"{_count_phrase(counts.total, 'table', 'tables')}: "
-        f"{counts.changed} changed, {counts.unchanged} unchanged, "
-        f"{counts.failed} failed ({report.duration_seconds:.1f}s)"
+    return f"{counts.changed} changed, {counts.unchanged} unchanged, {counts.failed} failed"
+
+
+def _real_run_summary(report: SyncReport) -> str:
+    """Count each table by the catalog change state derived by the aggregate."""
+    counts = Counter(report.table_change_states)
+    return ", ".join(
+        f"{counts[state]} {label}" for state, label in _REAL_RUN_OUTCOMES if counts[state]
     )
 
 
@@ -191,7 +252,7 @@ def render_report(report: SyncReport) -> str:
     parts = (
         _heading("SYNC REPORT"),
         _dry_run_banner(report),
-        render_grid(report.table_reports),
+        _render_run_grid(report),
         render_failures_section(report.table_reports),
         run_summary_footer(report),
     )
@@ -200,5 +261,10 @@ def render_report(report: SyncReport) -> str:
 
 def render_diff(report: SyncReport) -> str:
     """Render every table's planned changes as +/-/~ blocks, under a DIFF title."""
-    blocks = [render_diff_block(table_report) for table_report in report.table_reports]
+    blocks = [
+        _render_diff_block(table_report, change_state=change_state)
+        for table_report, change_state in zip(
+            report.table_reports, report.table_change_states, strict=True
+        )
+    ]
     return "\n\n".join([_heading("DIFF"), *blocks])

--- a/src/delta_engine/application/report.py
+++ b/src/delta_engine/application/report.py
@@ -47,12 +47,12 @@ class TableRunStatus(StrEnum):
 class TableChangeState(StrEnum):
     """What happened to one table's intended catalog change within a run."""
 
-    NOT_PLANNED = "NOT_PLANNED"
-    UNCHANGED = "UNCHANGED"
-    PLANNED = "PLANNED"
-    NOT_APPLIED = "NOT_APPLIED"
-    PARTIALLY_APPLIED = "PARTIALLY_APPLIED"
-    APPLIED = "APPLIED"
+    NOT_PLANNED = "not planned"
+    UNCHANGED = "unchanged"
+    PLANNED = "planned"
+    NOT_APPLIED = "not applied"
+    PARTIALLY_APPLIED = "partially applied"
+    APPLIED = "applied"
 
 
 # ---------- Derived run facts ----------

--- a/tests/application/test_rendering.py
+++ b/tests/application/test_rendering.py
@@ -9,7 +9,13 @@ from delta_engine.application.diff_entries import (
     action_entries,
     unresolvable_entries,
 )
-from delta_engine.application.failures import ExecutionFailure, ReadFailure, ValidationFailure
+from delta_engine.application.failures import (
+    ExecutionFailure,
+    ForeignKeyFailure,
+    ForeignKeyFailureReason,
+    ReadFailure,
+    ValidationFailure,
+)
 from delta_engine.application.planning import PlanningFailed, PlanningSucceeded
 from delta_engine.application.ports import (
     ExecutionSucceeded,
@@ -588,7 +594,7 @@ def test_diff_block_reports_a_read_failure_instead_of_a_diff():
 # ---------- grid rendering ----------
 
 
-def _grid_report(name, *, plan=None, failures=(), execution=None):
+def _grid_report(name, *, plan=None, failures=(), execution=None, blocked_failures=()):
     qualified_name = QualifiedName("cat", "sch", name)
     columns = (DesiredColumn("id", Integer()),)
     desired = DesiredTable(qualified_name=qualified_name, columns=columns)
@@ -616,6 +622,7 @@ def _grid_report(name, *, plan=None, failures=(), execution=None):
         compiled=compiled,
         resolution=TableResolution(desired, (), ()),
         execution=execution,
+        blocked_failures=blocked_failures,
     )
 
 
@@ -645,6 +652,15 @@ def _successful_execution(plan: ActionPlan) -> ExecutionSummary:
             ExecutionSucceeded(statement_index=index, statement=statement)
             for index, statement in enumerate(statements)
         ),
+    )
+
+
+def _blocked_failure(name: str) -> ForeignKeyFailure:
+    return ForeignKeyFailure(
+        table=QualifiedName("cat", "sch", name),
+        local_columns=("parent_id",),
+        references=QualifiedName("cat", "sch", "parent"),
+        reason=ForeignKeyFailureReason.BLOCKED_BY_FAILED_DEPENDENCY,
     )
 
 
@@ -687,6 +703,48 @@ def test_grid_statements_cell_shows_applied_over_planned_on_partial_failure():
 
     # Then the STATEMENTS cell reads applied/planned
     assert "2/3" in data_row
+
+
+def test_grid_statement_counts_distinguish_blocking_from_pre_compilation_failure():
+    # Given a compiled two-statement plan blocked in real and dry runs, plus a rejected plan
+    blocked = _grid_report(
+        "blocked",
+        plan=_plan(
+            "blocked",
+            AddColumn(DesiredColumn("a", Integer())),
+            AddColumn(DesiredColumn("b", Integer())),
+        ),
+        blocked_failures=(_blocked_failure("blocked"),),
+    )
+    rejected = _grid_report(
+        "rejected",
+        failures=(ValidationFailure(rule_name="R", message="m"),),
+    )
+    started_at = datetime(2025, 1, 1, 0, 0, 0)
+    ended_at = datetime(2025, 1, 1, 0, 0, 3)
+    real_run = SyncReport(
+        started_at=started_at,
+        ended_at=ended_at,
+        table_reports=(blocked, rejected),
+    )
+    dry_run = SyncReport(
+        started_at=started_at,
+        ended_at=ended_at,
+        table_reports=(blocked,),
+        dry_run=True,
+    )
+
+    # When rendering both reports
+    real_lines = render_report(real_run).splitlines()
+    dry_lines = render_report(dry_run).splitlines()
+    blocked_row = next(line for line in real_lines if line.startswith("cat.sch.blocked"))
+    rejected_row = next(line for line in real_lines if line.startswith("cat.sch.rejected"))
+    dry_blocked_row = next(line for line in dry_lines if line.startswith("cat.sch.blocked"))
+
+    # Then only the real blocked work is counted; rejected and previewed work stay unknown
+    assert "0/2" in blocked_row
+    assert "—" in rejected_row
+    assert "—" in dry_blocked_row
 
 
 def test_grid_detail_shows_first_failure_and_extra_count_when_multiple():
@@ -782,6 +840,49 @@ def test_run_summary_footer_counts_changed_unchanged_and_failed():
     assert footer == "3 tables: 1 changed, 1 unchanged, 1 failed (3.0s)"
 
 
+def test_real_run_footer_counts_each_catalog_change_outcome():
+    # Given a real run containing every possible non-preview catalog outcome
+    applied_plan = _plan("applied", AddColumn(DesiredColumn("a", Integer())))
+    applied = _grid_report(
+        "applied",
+        plan=applied_plan,
+        execution=_successful_execution(applied_plan),
+    )
+    partial_plan = _plan(
+        "partial",
+        AddColumn(DesiredColumn("a", Integer())),
+        AddColumn(DesiredColumn("b", Integer())),
+    )
+    partial = _grid_report(
+        "partial",
+        plan=partial_plan,
+        execution=_failed_execution(partial_plan, applied=1),
+    )
+    blocked = _grid_report(
+        "blocked",
+        plan=_plan("blocked", AddColumn(DesiredColumn("a", Integer()))),
+        blocked_failures=(_blocked_failure("blocked"),),
+    )
+    unchanged = _grid_report("unchanged")
+    not_planned = _grid_report(
+        "not_planned",
+        failures=(ValidationFailure(rule_name="R", message="m"),),
+    )
+    sync = SyncReport(
+        started_at=datetime(2025, 1, 1, 0, 0, 0),
+        ended_at=datetime(2025, 1, 1, 0, 0, 3),
+        table_reports=(applied, partial, blocked, unchanged, not_planned),
+    )
+
+    # When rendering the real-run footer
+    footer = run_summary_footer(sync)
+
+    # Then it reports catalog outcomes rather than planned-change and failure counts
+    assert footer == (
+        "5 tables: 1 applied, 1 partially applied, 1 not applied, 1 unchanged, 1 not planned (3.0s)"
+    )
+
+
 def test_a_single_table_run_uses_the_singular_noun():
     sync = SyncReport(
         started_at=datetime(2025, 1, 1, 0, 0, 0),
@@ -830,12 +931,12 @@ def test_render_report_of_an_empty_run_is_a_header_and_zero_footer():
     # When rendering the whole report
     rendered = render_report(sync)
 
-    # Then the title, grid header, and a zero-count footer are shown -- no empty-run sentinel
+    # Then the title, grid header, and an outcome-free footer are shown -- no empty-run sentinel
     lines = rendered.splitlines()
     assert lines[0] == "SYNC REPORT"
     grid_header = next(line for line in lines if line.startswith("TABLE"))
     assert grid_header.split() == ["TABLE", "STATUS", "STATEMENTS", "DETAIL"]
-    assert rendered.endswith("0 tables: 0 changed, 0 unchanged, 0 failed (3.0s)")
+    assert rendered.endswith("0 tables (3.0s)")
 
 
 def test_render_report_shows_a_full_failures_section_for_failed_tables():
@@ -995,8 +1096,48 @@ def test_render_diff_joins_each_tables_change_block_in_report_order():
 
     # Then each table's change block appears, in report order
     assert rendered.index("cat.sch.a") < rendered.index("cat.sch.b")
+    assert "cat.sch.a" in rendered.splitlines()
+    assert "cat.sch.b" in rendered.splitlines()
     assert "~ table  'c'" in rendered
     assert "+ age  Integer" in rendered
+
+
+def test_render_diff_marks_unapplied_real_run_changes_in_their_headers():
+    # Given a real run with applied, blocked, and partially applied plans
+    applied_plan = _plan("applied", AddColumn(DesiredColumn("a", Integer())))
+    applied = _grid_report(
+        "applied",
+        plan=applied_plan,
+        execution=_successful_execution(applied_plan),
+    )
+    blocked = _grid_report(
+        "blocked",
+        plan=_plan("blocked", AddColumn(DesiredColumn("a", Integer()))),
+        blocked_failures=(_blocked_failure("blocked"),),
+    )
+    partial_plan = _plan(
+        "partial",
+        AddColumn(DesiredColumn("a", Integer())),
+        AddColumn(DesiredColumn("b", Integer())),
+    )
+    partial = _grid_report(
+        "partial",
+        plan=partial_plan,
+        execution=_failed_execution(partial_plan, applied=1),
+    )
+    sync = SyncReport(
+        started_at=datetime(2025, 1, 1, 0, 0, 0),
+        ended_at=datetime(2025, 1, 1, 0, 0, 3),
+        table_reports=(applied, blocked, partial),
+    )
+
+    # When rendering the real run's diff
+    lines = render_diff(sync).splitlines()
+
+    # Then only incomplete outcomes are marked with how much reached the catalog
+    assert "cat.sch.applied" in lines
+    assert "cat.sch.blocked  (not applied)" in lines
+    assert "cat.sch.partial  (partially applied, 1/2)" in lines
 
 
 def test_enable_table_feature_renders_a_permanent_features_entry():
@@ -1097,12 +1238,18 @@ def test_a_rejected_table_shows_the_drift_that_was_refused():
         diff=diff_table(desired, observed),
     )
 
-    # When the block is rendered
-    block = render_diff_block(report)
+    # When the rejected report is rendered as part of a real run
+    block = render_diff(
+        SyncReport(
+            started_at=datetime(2025, 1, 1, 0, 0, 0),
+            ended_at=datetime(2025, 1, 1, 0, 0, 3),
+            table_reports=(report,),
+        )
+    )
 
     # Then it names the refused changes rather than claiming there were none
     assert "(no changes" not in block
-    assert "REJECTED" in block.splitlines()[0]
+    assert "cat.sch.orders  (REJECTED — no SQL planned)" in block.splitlines()
     assert "+ email" in block
     assert "- obsolete" in block
 

--- a/tests/application/test_report.py
+++ b/tests/application/test_report.py
@@ -696,24 +696,6 @@ def test_statement_progress_counts_applied_against_planned():
 # ---------- Catalog change state
 
 
-def test_change_state_values_are_human_readable():
-    # Given the complete catalog change-state vocabulary
-    states = tuple(TableChangeState)
-
-    # When reading the public string values
-    values = tuple(state.value for state in states)
-
-    # Then each value is suitable for direct human-readable rendering
-    assert values == (
-        "not planned",
-        "unchanged",
-        "planned",
-        "not applied",
-        "partially applied",
-        "applied",
-    )
-
-
 def test_change_state_is_not_planned_when_no_plan_was_accepted():
     # Given a table whose catalog read failed before planning
     report = _report(

--- a/tests/application/test_report.py
+++ b/tests/application/test_report.py
@@ -696,6 +696,24 @@ def test_statement_progress_counts_applied_against_planned():
 # ---------- Catalog change state
 
 
+def test_change_state_values_are_human_readable():
+    # Given the complete catalog change-state vocabulary
+    states = tuple(TableChangeState)
+
+    # When reading the public string values
+    values = tuple(state.value for state in states)
+
+    # Then each value is suitable for direct human-readable rendering
+    assert values == (
+        "not planned",
+        "unchanged",
+        "planned",
+        "not applied",
+        "partially applied",
+        "applied",
+    )
+
+
 def test_change_state_is_not_planned_when_no_plan_was_accepted():
     # Given a table whose catalog read failed before planning
     report = _report(


### PR DESCRIPTION
## Summary

- mark not-applied and partially applied real-run diff blocks using `SyncReport.table_change_states`
- show `0/n` for compiled real-run plans blocked before execution while preserving dry-run output
- summarise real runs by catalog outcomes: applied, partially applied, not applied, unchanged, and not planned
- preserve dry-run and rejected-plan wording and document the human-readable behaviour

## Design

Outcome-sensitive rendering consumes the validated `SyncReport` aggregate. Standalone `render_diff_block` and `render_grid` continue to render table-local facts without accepting a separately supplied run mode or change state, so callers cannot create contradictory public pairings.

## Validation

- `uv run pytest` — 1,180 passed, 74 deselected; 96.81% coverage
- `uv run mypy .` — 155 source files clean
- `uv run ruff check .`
- `uv run lint-imports` — 7 contracts kept
- `uv run --group docs sphinx-build -W -b html docs docs/_build/html`
- `uv run ruff format --check src/delta_engine/application/rendering.py tests/application/test_rendering.py`

The repository-wide format check still identifies two pre-existing files unchanged by this PR.