### PR TITLE
docs: fix stale guidance and record resolved review findings

### DIFF
--- a/docs/explanation-architecture.md
+++ b/docs/explanation-architecture.md
@@ -65,7 +65,7 @@ through a sync.
 | `CatalogState`     | A known catalog answer: `TablePresent` or `TableAbsent`. An unreadable state crosses the port as `ReadError`.                                               |
 | `ReadResult`       | The persistent read outcome retained by a table run: a `CatalogState` or the engine-created `ReadFailure`.                                                  |
 | `TableDiff`        | Typed desired/observed drift. It is either `TableMissing` or `TableDrift`; both state their remedies as `actions`, and a drift also carries `unresolvable`. |
-| `Unresolvable`     | A `TableDrift` difference no action can close: `ColumnRenameConflict`, `PropertyUndeclared`, or `PartitioningChanged`.                                      |
+| `Unresolvable`     | A `TableDrift` difference no action can close: `ColumnCaseDrift`, `ColumnRenameConflict`, `PropertyUndeclared`, or `PartitioningChanged`.                  |
 | `TableAspect`      | One managed aspect of a table: existence, columns, comments, properties, tags, partitioning, clustering, primary key, or foreign keys. Internal enum.       |
 | `ValidationFailure` | One policy rejection: the rule that raised it and the message the user reads. `validate_diff` returns them in evaluation order, empty when the diff is valid. |
 | `PlanningResult`   | The total application boundary: either `PlanningSucceeded(ActionPlan)` or `PlanningFailed(validation failures)`.                                            |
@@ -464,9 +464,10 @@ would drop those constraints implicitly as part of `RENAME COLUMN`; the
 engine states the drops instead of relying on that, so the plan is a
 complete transcript of what executes.
 
-Only three unresolvable differences exist: `ColumnRenameConflict`,
-`PropertyUndeclared`, and `PartitioningChanged`. Each states an ambiguity or
-unsupported transition without deciding its policy outcome. The
+Only four unresolvable differences exist: `ColumnCaseDrift`,
+`ColumnRenameConflict`, `PropertyUndeclared`, and `PartitioningChanged`. Each
+states an ambiguity or unsupported transition without deciding its policy
+outcome. The
 `Unresolvable` union names them, they live structurally apart from the
 actions, and the application default rules decide to reject each one.
 

--- a/docs/how-to-add-action-type.md
+++ b/docs/how-to-add-action-type.md
@@ -47,6 +47,7 @@ If the action belongs to a new execution phase, add it to the `ActionPhase` enum
 ```python
 class ActionPhase(IntEnum):
     CREATE_TABLE = auto()
+    ENABLE_TABLE_FEATURE = auto()
     SET_PROPERTY = auto()
     UNSET_PROPERTY = auto()
     SET_TABLE_TAG = auto()
@@ -57,9 +58,9 @@ class ActionPhase(IntEnum):
     ADD_COLUMN = auto()
     ALTER_COLUMN_TYPE = auto()
     SET_CLUSTERING = auto()
-    DROP_COLUMN = auto()
     SET_COLUMN_TAG = auto()
     UNSET_COLUMN_TAG = auto()
+    DROP_COLUMN = auto()
     SET_COLUMN_COMMENT = auto()
     SET_TABLE_COMMENT = auto()
     SET_COLUMN_NULLABILITY = auto()
@@ -96,7 +97,7 @@ Actions join the diff's `actions` tuple, so no union edit is needed. If the
 comparison cannot be represented as an action, add a frozen difference type in
 `unresolvable.py`, name it in `Unresolvable`, and emit it into the diff's
 `unresolvable` tuple from `diff.py`. Decide whether it is accepted or
-rejected in application validation; the current three unresolvable
+rejected in application validation; all four current unresolvable
 differences are rejected by the default policy. Successful `plan_diff`
 results must contain actions only.
 
@@ -121,14 +122,22 @@ Use `backtick` for identifiers and `quote_literal` for string literals (both in 
 In `src/delta_engine/application/diff_entries.py`, register a `singledispatch`
 arm on `action_entries` so the action shows up in reports. Return one or more
 `DiffEntry` values — each tags the line with a `DiffCategory` (columns, keys,
-clustering, partitioning, features, properties, tags, comments), a
-`+`/`-`/`~` symbol, and its aligned cells:
+clustering, partitioning, features, properties, tags, comments) and a
+`DiffOperation` (rendered `+`/`-`/`~`), names the target in `subject`, and
+carries each descriptive phrase as a separate `detail` element so the text
+renderer can align them into columns:
 
 ```python
 @action_entries.register
 def _(action: UpdateComment) -> tuple[DiffEntry, ...]:
-    text = f"column {action.column_name}: '{action.desired_comment}'"
-    return (DiffEntry(DiffCategory.COMMENTS, "~", (text,)),)
+    return (
+        DiffEntry(
+            DiffCategory.COMMENTS,
+            DiffOperation.CHANGE,
+            subject=f"column {action.column_name}",
+            detail=(f"'{action.desired_comment}'",),
+        ),
+    )
 ```
 
 An action may emit several entries across categories (`CreateTable` lists its columns and its primary key), and category grouping in the diff is display-only — it never changes execution order. `test_every_action_type_has_registered_diff_entries` fails if an action has no arm.

--- a/docs/how-to-configure-table.md
+++ b/docs/how-to-configure-table.md
@@ -599,9 +599,10 @@ type. A mismatch raises `ValueError` when the `DeltaTable` is constructed,
 before any sync runs. That check uses the exact parent object passed to
 `ForeignKey(references=...)`. If the same sync registers a different
 `DeltaTable` instance with the same qualified name but different key types, the
-resolver does not currently repeat the type check against that registered
-instance; Databricks can reject the resulting DDL at execution. Register the
-same parent object used by the foreign-key declaration.
+resolver repeats the type check against that registered instance and fails the
+table with `REFERENCED_COLUMN_TYPE_MISMATCH`, blocking its dependents.
+Register the same parent object used by the foreign-key declaration so the
+mismatch surfaces at construction rather than at resolution.
 
 ### Self-referential foreign keys
 

--- a/docs/reference-cli.md
+++ b/docs/reference-cli.md
@@ -136,9 +136,10 @@ Imported-code output, SDK or connector output, engine logs, configuration
 errors, and tracebacks go to stderr. This keeps the complete human-readable
 plan together on stdout while preserving diagnostics separately.
 
-SQL is compiled before cross-table dependency resolution. A table later
-blocked by a failed dependency can therefore carry table-local planned SQL;
-the report explains why those statements were not eligible to run.
+Cross-table dependency resolution orders the tables first; SQL is then
+compiled per table before anything would execute. A table later blocked by a
+failed dependency can therefore carry table-local planned SQL; the report
+explains why those statements were not eligible to run.
 
 ## Exit codes
 

--- a/docs/todo/business-logic-delta-databricks-correctness-review.md
+++ b/docs/todo/business-logic-delta-databricks-correctness-review.md
@@ -1,16 +1,17 @@
 # Business logic, Delta, and Databricks correctness review
 
-**Status:** Fresh sweep complete; original item 3 and fresh findings 9–15
-await agreement and implementation
+**Status:** 12 of 15 findings resolved (rechecked against `main`, 2026-08-05);
+items 11, 13, and 14 remain open
 
 **Original review:** 2026-07-14
 
 **Fresh sweep:** 2026-07-20
 
-**Fresh-sweep implementation PR:** Not opened
+**Fresh-sweep implementation:** landed piecemeal — see each finding's
+resolution note; items 11, 13, and 14 have no implementation PR yet
 
-This began as the second phase of the codebase review. Seven of the original
-eight findings have since been implemented, as recorded in their resolution
+This began as the second phase of the codebase review. All eight original
+findings have since been implemented, as recorded in their resolution
 notes below. On 2026-07-20 the current `main` branch was swept again from the
 public API through domain validation, dependency resolution, diffing,
 observation, SQL compilation, and execution reporting. The fresh findings were
@@ -47,10 +48,10 @@ path currently produces an incorrect result.
 | 9 ✅ | High | Non-default `STRING` collations are erased on observation | Collation drift can be reported as synchronized |
 | 10 ✅ | Medium | Column tags are not removed before dropping a column | Governed-tagged column drops fail during execution |
 | 11 | Medium | Tag declarations omit Databricks tag constraints | Invalid tag declarations reach execution |
-| 12 | Medium | Some validation runs before identifier normalization | Invalid layouts pass and valid foreign keys can be rejected |
+| 12 ✅ | Medium | Some validation runs before identifier normalization | Invalid layouts pass and valid foreign keys can be rejected |
 | 13 | Medium | Generated constraint names can be invalid or collide | Constraint creation fails on Unity Catalog |
 | 14 | Medium | Dependency traversal is recursive | A valid deep graph can abort synchronization with `RecursionError` |
-| 15 | Low | `Decimal` accepts non-integer precision and scale | The model can compile invalid `DECIMAL` SQL |
+| 15 ✅ | Low | `Decimal` accepts non-integer precision and scale | The model can compile invalid `DECIMAL` SQL |
 
 ## 1. Reject views and non-Delta tables at the read boundary
 
@@ -216,6 +217,18 @@ or [VARIANT](https://docs.databricks.com/aws/en/tables/features/variant).
 Feature activation is a permanent protocol change, so it must be visible in
 the plan. Rejecting the declaration and requiring an out-of-band command would
 also be safe, but would not provide declarative convergence.
+
+### Resolved (2026-07-24)
+
+Shipped in [PR #280](https://github.com/Tomoscorbin/delta-engine/pull/280)
+with follow-up refinements, in the shape settled by the
+[table-feature enablement design review](2026-07-24-table-feature-enablement-ousterhout-review.md):
+the domain differ derives required features from the desired column type tree,
+observed enablement is projected from the AS JSON `delta.feature.*` entries,
+feature identities are typed, and an explicit `EnableTableFeature` action —
+its own `ActionPhase`, ordered before the dependent column work — compiles to
+the documented `delta.feature.*` property assignment and appears in dry-run
+output and the report contract.
 
 ## 4. Validate foreign keys against the registered parent definition
 
@@ -709,6 +722,16 @@ Databricks requires integer precision and scale in the
    and other non-integer values.
 3. Add a type/value matrix while retaining the current precision and scale
    boundary tests.
+
+### Resolved (2026-08-01)
+
+Fixed in [PR #314](https://github.com/Tomoscorbin/delta-engine/pull/314) and
+corrected in [PR #317](https://github.com/Tomoscorbin/delta-engine/pull/317):
+`Decimal.__post_init__` requires `type(precision) is int` and
+`type(scale) is int` (rejecting `bool` with the rest) before the range
+checks. The initial guard joined the two conditions with `and`, so it only
+fired when both parameters were non-integers; #317 changed it to `or` and
+extended the test matrix accordingly.
 
 ## Residual concurrency limitation
 


### PR DESCRIPTION
## Summary

- fix the five documentation defects recorded in the Ousterhoutian complexity
  review (PR #312): the registered-parent type-check denial in
  `how-to-configure-table.md`, the reversed resolve/compile order in
  `reference-cli.md`, the `ActionPhase` example missing
  `ENABLE_TABLE_FEATURE` (and misordering the tag-unset/drop phases), the
  pre-`DiffOperation` `DiffEntry` example, and the three-vs-four
  unresolvable-difference counts in both guides
- refresh the correctness review's status: items 3, 12, and 15 are resolved
  on main (PRs #280, the 2026-07-25 identifier work, #314/#317); only items
  11, 13, and 14 remain open

## Impact

Documentation only.

## Validation

- `uv run sphinx-build -W -b html docs docs/_build/html` — build succeeded
- every corrected claim was verified against current `main` (`50193acc`):
  `REFERENCED_COLUMN_TYPE_MISMATCH` in `application/relationships.py`,
  the `Engine.sync` docstring's phase order, `ActionPhase` in
  `domain/plan/actions.py`, the `DiffEntry` fields and the
  `SetColumnComment` arm in `application/diff_entries.py`, and the
  four-member `Unresolvable` union