### PR TITLE
feat: retain lossless failure diagnostics in the machine report

### DIFF
--- a/docs/reference-run-report.md
+++ b/docs/reference-run-report.md
@@ -31,6 +31,10 @@ Version 2 renamed the planning-phase status from `VALIDATION_FAILED` to
 backwards-compatible, and a reader that does not know the key sees exactly the
 payload it saw before.
 
+The per-type failure fields (2026-08-05) were likewise added without a bump:
+every failure record still carries `phase`, `type`, and `message` with
+unchanged meaning, and the additional keys sit beside them.
+
 ## Consistency
 
 `SyncReport` rejects combinations that a completed engine run cannot produce.
@@ -139,6 +143,43 @@ Each entry in `failures`:
 | `phase`   | `str` | The phase that produced it: `READ`, `PLANNING`, `FOREIGN_KEY`, `EXECUTION` |
 | `type`    | `str` | The concrete failure class name, e.g. `ValidationFailure`                    |
 | `message` | `str` | The rendered failure message                                                 |
+
+Records are not all-string: the per-type fields below include an integer
+(`statement_index`) and lists (`details`, `columns`).
+
+#### Additional keys by type
+
+`ReadFailure`:
+
+| Field            | Type  | Meaning                                                        |
+| ---------------- | ----- | -------------------------------------------------------------- |
+| `exception_type` | `str` | The backend exception class name                               |
+| `diagnostic`     | `str` | The complete backend message; `message` may truncate long text |
+
+`ValidationFailure`:
+
+| Field     | Type        | Meaning                                                             |
+| --------- | ----------- | ------------------------------------------------------------------- |
+| `rule`    | `str`       | The rule that rejected the diff, e.g. `NonWideningColumnTypeChange` |
+| `subject` | `str`       | The column, property, or aspect judged; empty for whole-table rules |
+| `details` | `list[str]` | One line per difference behind a summary judgment                   |
+
+`ExecutionFailure`:
+
+| Field             | Type  | Meaning                                                        |
+| ----------------- | ----- | -------------------------------------------------------------- |
+| `exception_type`  | `str` | The backend exception class name                               |
+| `diagnostic`      | `str` | The complete backend message; `message` may truncate long text |
+| `statement_index` | `int` | 0-based index into the table's `planned_sql_statements`        |
+| `sql`             | `str` | The statement that failed                                      |
+
+`ForeignKeyFailure`:
+
+| Field        | Type        | Meaning                                                   |
+| ------------ | ----------- | --------------------------------------------------------- |
+| `reason`     | `str`       | Machine code for why, e.g. `BLOCKED_BY_FAILED_DEPENDENCY` |
+| `columns`    | `list[str]` | The declaring table's foreign-key columns                 |
+| `references` | `str`       | Dotted name of the referenced table                       |
 
 ### Execution record
 

--- a/src/delta_engine/application/report.py
+++ b/src/delta_engine/application/report.py
@@ -22,6 +22,7 @@ from delta_engine.application.failures import (
     ForeignKeyFailure,
     ForeignKeyFailureReason,
     ReadFailure,
+    ValidationFailure,
 )
 from delta_engine.application.planning import (
     PlanningFailed,
@@ -158,8 +159,20 @@ def _failure_facts(failure: Failure) -> dict[str, Any]:
                 "statement_index": failure.statement_index,
                 "sql": failure.statement,
             }
+        case ValidationFailure():
+            return {
+                "rule": failure.rule_name,
+                "subject": failure.subject,
+                "details": list(failure.details),
+            }
+        case ForeignKeyFailure():
+            return {
+                "reason": failure.reason.value,
+                "columns": list(failure.local_columns),
+                "references": str(failure.references),
+            }
         case _:
-            return {}
+            raise NotImplementedError(f"No wire facts for failure {type(failure).__name__}")
 
 
 def _failure_records(failures: tuple[Failure, ...]) -> list[dict[str, Any]]:

--- a/src/delta_engine/application/report.py
+++ b/src/delta_engine/application/report.py
@@ -145,7 +145,7 @@ def _rejected_change_records(planning: PlanningResult | None) -> list[dict[str, 
 
 def _failure_facts(failure: Failure) -> dict[str, Any]:
     """
-    The variant's own lossless facts, added beside the rendered ``message``.
+    Return the variant's own lossless facts, added beside the rendered ``message``.
 
     ``message`` may truncate a long backend message for display;
     ``diagnostic`` carries the complete text for the variants that have one.

--- a/src/delta_engine/application/report.py
+++ b/src/delta_engine/application/report.py
@@ -16,6 +16,7 @@ from typing import Any, Final, NamedTuple
 
 from delta_engine.application.diff_entries import DiffEntry, drift_entries, plan_entries
 from delta_engine.application.failures import (
+    ExecutionFailure,
     Failure,
     FailurePhase,
     ForeignKeyFailure,
@@ -137,13 +138,38 @@ def _rejected_change_records(planning: PlanningResult | None) -> list[dict[str, 
     return _entry_records(drift_entries(planning.diff))
 
 
-def _failure_records(failures: tuple[Failure, ...]) -> list[dict[str, str]]:
+def _failure_facts(failure: Failure) -> dict[str, Any]:
+    """
+    The variant's own lossless facts, added beside the rendered ``message``.
+
+    ``message`` may truncate a long backend message for display;
+    ``diagnostic`` carries the complete text for the variants that have one.
+    """
+    match failure:
+        case ReadFailure():
+            return {
+                "exception_type": failure.exception_type,
+                "diagnostic": failure.message,
+            }
+        case ExecutionFailure():
+            return {
+                "exception_type": failure.exception_type,
+                "diagnostic": failure.message,
+                "statement_index": failure.statement_index,
+                "sql": failure.statement,
+            }
+        case _:
+            return {}
+
+
+def _failure_records(failures: tuple[Failure, ...]) -> list[dict[str, Any]]:
     """Project failures as flat records, in phase order as carried."""
     return [
         {
             "phase": failure.phase.name,
             "type": type(failure).__name__,
             "message": " ".join(failure.format_lines()),
+            **_failure_facts(failure),
         }
         for failure in failures
     ]

--- a/src/delta_engine/application/report.py
+++ b/src/delta_engine/application/report.py
@@ -100,6 +100,10 @@ _STATUS_FOR_PHASE: Final[Mapping[FailurePhase, TableRunStatus]] = MappingProxyTy
 )
 
 
+# The versioned wire format `to_dict` emits; additive keys do not bump it.
+_SCHEMA_VERSION: Final = 2
+
+
 def _entry_records(entries: Iterable[DiffEntry]) -> list[dict[str, str]]:
     """Project interpreted diff entries as flat records, in the order given."""
     return [
@@ -499,7 +503,7 @@ class SyncReport:
     def to_dict(self) -> dict[str, Any]:
         """Project the whole run as plain, JSON-serialisable data; tables in run order."""
         return {
-            "schema_version": 2,
+            "schema_version": _SCHEMA_VERSION,
             "started_at": self.started_at.isoformat(),
             "ended_at": self.ended_at.isoformat(),
             "dry_run": self.dry_run,

--- a/tests/application/test_report.py
+++ b/tests/application/test_report.py
@@ -986,6 +986,9 @@ def test_table_to_dict_reports_failures_with_phase_and_type():
             "phase": "PLANNING",
             "type": "ValidationFailure",
             "message": "Validation failed: SomeRule - unsafe",
+            "rule": "SomeRule",
+            "subject": "",
+            "details": [],
         }
     ]
 
@@ -1027,6 +1030,43 @@ def test_an_execution_failure_record_carries_its_statement_facts():
     assert record["sql"] == statement
     # 0-based on purpose: the index addresses the sibling statement list.
     assert payload["planned_sql_statements"][record["statement_index"]] == statement
+
+
+def test_a_validation_failure_record_carries_rule_subject_and_detail_lines():
+    failure = ValidationFailure(
+        rule_name="UnmanagedAspectDrift",
+        message="observed partitioning is not declared",
+        subject="partitioning",
+        details=("partitioning: observed (a) desired ()",),
+    )
+    report = _report(
+        desired=_a_desired_table("orders"),
+        read=TablePresent(table=_an_observed_table()),
+        failures=(failure,),
+    )
+
+    (record,) = report.to_dict()["failures"]
+
+    assert record["rule"] == "UnmanagedAspectDrift"
+    assert record["subject"] == "partitioning"
+    assert record["details"] == ["partitioning: observed (a) desired ()"]
+
+
+def test_a_foreign_key_failure_record_names_its_edge_and_reason_code():
+    report = _report(
+        desired=_a_desired_table("b"),
+        read=TablePresent(table=_an_observed_table()),
+        plan=_comment_plan("b"),
+        blocked_failures=(_blocked_failure(),),
+    )
+
+    (record,) = report.to_dict()["failures"]
+
+    assert record["reason"] == "BLOCKED_BY_FAILED_DEPENDENCY"
+    assert record["columns"] == ["parent_id"]
+    assert record["references"] == "cat.schema.a"
+    # No "table" key: it would duplicate the enclosing record's "name".
+    assert "table" not in record
 
 
 def test_table_to_dict_reports_execution_counts_when_executed():

--- a/tests/application/test_report.py
+++ b/tests/application/test_report.py
@@ -990,6 +990,45 @@ def test_table_to_dict_reports_failures_with_phase_and_type():
     ]
 
 
+def test_a_read_failure_record_retains_the_full_backend_message():
+    # The display message keeps only the first five lines; the machine
+    # record must carry the whole backend message.
+    long_message = "\n".join(f"line {n}" for n in range(1, 10))
+    report = _report(
+        desired=_a_desired_table("orders"),
+        read=ReadFailure(exception_type="AnalysisException", message=long_message),
+    )
+
+    (record,) = report.to_dict()["failures"]
+
+    assert record["exception_type"] == "AnalysisException"
+    assert record["diagnostic"] == long_message
+
+
+def test_an_execution_failure_record_carries_its_statement_facts():
+    statement = "ALTER TABLE `cat`.`schema`.`orders` ALTER COLUMN id COMMENT 'x'"
+    long_message = "\n".join(f"line {n}" for n in range(1, 10))
+    plan = _plan("orders", SetTableComment(desired_comment="hello", observed_comment=""))
+    report = _report(
+        desired=_a_desired_table("orders"),
+        read=TablePresent(table=_an_observed_table()),
+        plan=plan,
+        execution=_execution(
+            plan,
+            _failed_exec(0, preview=statement, exc="DeltaAnalysisException", msg=long_message),
+        ),
+    )
+
+    payload = report.to_dict()
+    (record,) = payload["failures"]
+
+    assert record["exception_type"] == "DeltaAnalysisException"
+    assert record["diagnostic"] == long_message
+    assert record["sql"] == statement
+    # 0-based on purpose: the index addresses the sibling statement list.
+    assert payload["planned_sql_statements"][record["statement_index"]] == statement
+
+
 def test_table_to_dict_reports_execution_counts_when_executed():
     # The counts are statement-denominated: statements applied of statements planned.
     statement = "COMMENT ON TABLE `cat`.`schema`.`orders` IS 'hello'"

--- a/tests/application/test_report.py
+++ b/tests/application/test_report.py
@@ -3,9 +3,11 @@ import json
 
 import pytest
 
+from delta_engine.application.diff_entries import DiffCategory
 from delta_engine.application.failures import (
     ExecutionFailure,
     Failure,
+    FailurePhase,
     ForeignKeyFailure,
     ForeignKeyFailureReason,
     ReadFailure,
@@ -1067,6 +1069,43 @@ def test_a_foreign_key_failure_record_names_its_edge_and_reason_code():
     assert record["references"] == "cat.schema.a"
     # No "table" key: it would duplicate the enclosing record's "name".
     assert "table" not in record
+
+
+def test_the_wire_vocabulary_is_frozen():
+    # These strings are the schema_version 2 contract (reference-run-report.md).
+    # A rename that reaches this test is a wire-format change: extend the
+    # contract and the reference doc deliberately, or revert the rename.
+    # Exact equality on purpose — an addition must arrive here too.
+    assert {phase.name for phase in FailurePhase} == {
+        "READ",
+        "PLANNING",
+        "FOREIGN_KEY",
+        "EXECUTION",
+    }
+    assert {cls.__name__ for cls in Failure.__subclasses__()} == {
+        "ReadFailure",
+        "ValidationFailure",
+        "ExecutionFailure",
+        "ForeignKeyFailure",
+    }
+    assert {reason.value for reason in ForeignKeyFailureReason} == {
+        "CYCLE",
+        "UNRESOLVABLE_REFERENCE",
+        "BLOCKED_BY_FAILED_DEPENDENCY",
+        "REFERENCED_COLUMNS_NOT_A_KEY",
+        "REFERENCED_COLUMN_TYPE_MISMATCH",
+        "REFERENCED_COLUMN_CASE_MISMATCH",
+    }
+    assert {category.name.lower() for category in DiffCategory} == {
+        "columns",
+        "keys",
+        "clustering",
+        "partitioning",
+        "features",
+        "properties",
+        "tags",
+        "comments",
+    }
 
 
 def test_table_to_dict_reports_execution_counts_when_executed():

--- a/tests/application/test_report.py
+++ b/tests/application/test_report.py
@@ -1108,6 +1108,58 @@ def test_the_wire_vocabulary_is_frozen():
     }
 
 
+def _one_run_per_failure_variant() -> tuple[TableRun, ...]:
+    """One run per failure variant, for contract checks that sweep the family."""
+    read_failed = _report(
+        desired=_a_desired_table("orders"),
+        read=ReadFailure(exception_type="AnalysisException", message="line 1\nline 2"),
+    )
+    validation_failed = _report(
+        desired=_a_desired_table("orders"),
+        read=TablePresent(table=_an_observed_table()),
+        failures=(ValidationFailure(rule_name="SomeRule", message="unsafe"),),
+    )
+    plan = _comment_plan("orders")
+    execution_failed = _report(
+        desired=_a_desired_table("orders"),
+        read=TablePresent(table=_an_observed_table()),
+        plan=plan,
+        execution=_execution(plan, _failed_exec(0, exc="DeltaAnalysisException", msg="boom")),
+    )
+    blocked = _report(
+        desired=_a_desired_table("b"),
+        read=TablePresent(table=_an_observed_table()),
+        plan=_comment_plan("b"),
+        blocked_failures=(_blocked_failure(),),
+    )
+    return (read_failed, validation_failed, execution_failed, blocked)
+
+
+def test_failure_records_expose_exactly_the_documented_keys():
+    # An accidental extra key would silently grow the public contract; the
+    # reference doc's per-type tables are the source of these sets.
+    base = {"phase", "type", "message"}
+    expected_by_type = {
+        "ReadFailure": base | {"exception_type", "diagnostic"},
+        "ValidationFailure": base | {"rule", "subject", "details"},
+        "ExecutionFailure": base | {"exception_type", "diagnostic", "statement_index", "sql"},
+        "ForeignKeyFailure": base | {"reason", "columns", "references"},
+    }
+
+    records = [run.to_dict()["failures"][0] for run in _one_run_per_failure_variant()]
+
+    assert {record["type"] for record in records} == set(expected_by_type)
+    for record in records:
+        assert set(record) == expected_by_type[record["type"]]
+
+
+def test_a_payload_with_failures_is_json_serialisable():
+    # The per-type fields include a list and an int; every variant's record
+    # must stay within JSON-plain types, like the failure-free payload does.
+    for run in _one_run_per_failure_variant():
+        json.dumps(run.to_dict())  # must not raise
+
+
 def test_table_to_dict_reports_execution_counts_when_executed():
     # The counts are statement-denominated: statements applied of statements planned.
     statement = "COMMENT ON TABLE `cat`.`schema`.`orders` IS 'hello'"

--- a/tests/e2e/test_engine_e2e.py
+++ b/tests/e2e/test_engine_e2e.py
@@ -661,9 +661,7 @@ def test_dry_run_report_is_ci_consumable(spark, temp_schema):
     payload = report.to_dict()
     json.dumps(payload)  # plain types only — must not raise
     assert payload["dry_run"] is True
-    assert payload["tables"][0]["planned_sql_statements"] == list(
-        table_report.compiled.statements
-    )
+    assert payload["tables"][0]["planned_sql_statements"] == list(table_report.compiled.statements)
 
     # And nothing was created
     assert spark.catalog.tableExists(fq) is False

--- a/tests/live/test_sql_warehouse_live_types_and_layout.py
+++ b/tests/live/test_sql_warehouse_live_types_and_layout.py
@@ -127,8 +127,7 @@ def test_reader_rejects_non_default_string_collation(live_connection, live_table
     table_name = live_tables("collation")
     execute_sql(
         live_connection,
-        f"CREATE TABLE {qualified_table(table_name)} "
-        "(value STRING COLLATE UTF8_LCASE) USING DELTA",
+        f"CREATE TABLE {qualified_table(table_name)} (value STRING COLLATE UTF8_LCASE) USING DELTA",
     )
     reader = WarehouseReader(WarehouseSqlRunner(live_connection))
 
@@ -509,8 +508,7 @@ def test_variant_feature_enablement_round_trips(live_connection, live_tables):
     [table_report] = report.table_runs
     assert table_report.compiled is not None
     assert any(
-        "delta.feature.variantType" in statement
-        for statement in table_report.compiled.statements
+        "delta.feature.variantType" in statement for statement in table_report.compiled.statements
     )
     resync = engine.sync(extended).table_runs[0]
     assert resync.compiled is not None


### PR DESCRIPTION
## What

Additive schema-v2 extension of the machine report: every failure record in
`to_dict()` now carries its variant's lossless typed facts beside the existing
`phase` / `type` / `message` keys, whose values are byte-identical to before.

- `ReadFailure` / `ExecutionFailure`: `exception_type` + `diagnostic` (the
  complete backend message — the display `message` keeps truncating to five
  lines, the payload no longer loses the rest)
- `ExecutionFailure`: also `statement_index` (0-based into
  `planned_sql_statements`) + `sql`
- `ValidationFailure`: `rule`, `subject`, `details` (physical lines)
- `ForeignKeyFailure`: `reason` code, `columns`, `references`

A new wire-vocabulary pin freezes the phase names, failure type names, FK
reason codes, and entry kinds — a Python rename now fails a test instead of
silently changing the documented format. The bare `2` became `_SCHEMA_VERSION`.

## Why

Finding 9 of the complexity review (PR #312), at agreed MVP scope: the
versioned payload was built from display rendering, so CI consumers lost
diagnostics the values retain. Deliberately deferred: explicit wire codes,
TypedDict schema definitions, renderer consolidation. Unblocks the
read-failure double-log dedup follow-up.

Rides along: one `style:` commit reformats two test files that were already
unformatted on `main` (pre-existing drift, found by the format gate).

## Verification

Full suite minus live (1193 passed), ruff check + format, mypy, sphinx `-W`
docs gate — all green. Display output is untouched (`failures.py`,
`rendering.py`, `errors.py` unchanged).