### PR TITLE
refactor!: unify outcome vocabulary

### DIFF
--- a/docs/explanation-architecture.md
+++ b/docs/explanation-architecture.md
@@ -64,15 +64,15 @@ through a sync.
 | `ObservedTable`    | Immutable domain snapshot of the current catalog state. Reader adapters produce this after normalizing backend details.                                     |
 | `CatalogState`     | A known catalog answer: `TablePresent` or `TableAbsent`. An unreadable state crosses the port as `ReadError`.                                               |
 | `ReadResult`       | The persistent read outcome retained by a table run: a `CatalogState` or the engine-created `ReadFailure`.                                                  |
-| `TableDiff`        | Typed desired/observed drift. It is either `TableMissing` or `TableDrift`; both state their remedies as `actions`, and a drift also carries `unresolvable`. |
+| `TableDiff`        | Typed desired/observed drift. It is either `TableCreation` or `TableDrift`; both state their remedies as `actions`, and a drift also carries `unresolvable`. |
 | `Unresolvable`     | A `TableDrift` difference no action can close: `ColumnRenameConflict`, `PropertyUndeclared`, or `PartitioningChanged`.                                      |
 | `TableAspect`      | One managed aspect of a table: existence, columns, comments, properties, tags, partitioning, clustering, primary key, or foreign keys. Internal enum.       |
 | `ValidationFailure` | One policy rejection: the rule that raised it and the message the user reads. `validate_diff` returns them in evaluation order, empty when the diff is valid. |
-| `PlanningResult`   | The total planning outcome: either `PlanningSucceeded(diff, plan)` or `PlanningFailed(diff, failures)`; both retain the diff they were planned from.        |
+| `PlanningResult`   | The total planning outcome: either `PlanningAccepted(diff, plan)` or `PlanningRejected(diff, failures)`; both retain the diff they were planned from.        |
 | `ActionPlan`       | The qualified table target, relation kind, and ordered actions that should be executed if the table is allowed to run.                                      |
 | `TableResolution`  | One table's static relationship facts, in dependency-first order by tuple position: the declaration it was judged from, that table's dependency edges, and its structural foreign-key verdicts.                   |
-| `ExecutionSummary` | The result of running a plan's compiled statements. It records successful statements and the first failed statement, if execution failed.                   |
-| `TableRun`   | The immutable public account of one table's run: desired state, read result, accepted plan, compiled SQL, failures, and attempted statement results.                  |
+| `ExecutionResult` | The result of running a plan's compiled statements. It records how many statements applied and the first failed statement, if execution failed.                   |
+| `TableRun`   | The immutable public record of one table's run: desired state, read result, accepted plan, compiled SQL, failures, and execution result.                  |
 | `SyncReport`       | The aggregate result for the whole sync. It is returned on success and attached to `SyncFailedError` on real-run failure.                                   |
 
 The table snapshots deliberately use domain vocabulary, not Spark vocabulary.
@@ -267,7 +267,7 @@ Before any table is planned, user-facing table sources are lowered with
 tables are sorted by qualified name so reports and sync behavior do not
 depend on the order arguments were passed.
 
-Each plan pass returns a frozen, immutable `TableRun` — the public account
+Each plan pass returns a frozen, immutable `TableRun` — the public record
 of that table's run, complete for everything the table can know alone, with
 failures and status derived from the retained outcomes. The two facts that
 depend on other tables are attached afterwards as functional updates
@@ -294,8 +294,8 @@ sequenceDiagram
         Engine->>Engine: ReadError → ReadFailure
         Engine->>Planner: plan_changes(desired, observed_or_none)
         Planner->>Differ: diff_table(desired, observed_or_none)
-        Differ-->>Planner: TableMissing / TableDrift
-        Planner-->>Engine: PlanningSucceeded(diff, plan) / PlanningFailed(diff, failures)
+        Differ-->>Planner: TableCreation / TableDrift
+        Planner-->>Engine: PlanningAccepted(diff, plan) / PlanningRejected(diff, failures)
         Engine->>Executor: compile(plan)
         Executor-->>Engine: SQL statements
         Engine->>Engine: freeze the TableRun
@@ -322,26 +322,26 @@ The full run, with reporting last:
    `plan_changes` boundary — it computes the typed `TableDiff` with
    `diff_table` (foreign-key existence included), validates the complete
    diff under the default policy, and constructs the executable plan or
-   refuses with the failures, both outcomes retaining the diff. Every
+   rejects with the failures, both outcomes retaining the diff. Every
    accepted plan is then lowered through the executor port, recording the
    exact statements used for both dry-run preview and real execution. Each
    early exit is a lifecycle rule — a failed read leaves nothing to plan, a
-   refused plan leaves nothing to compile — and the `TableRun` is frozen and
+   rejected plan leaves nothing to compile — and the `TableRun` is frozen and
    complete when the plan pass returns it.
 4. **Execute** (real runs only): one walk in dependency order over the frozen
    runs. A run with failures of its own, or with a dependency that will not
    converge, is skipped; the compiled statements of the rest are executed
    until the first failure, and each attempted run is replaced by a copy
-   carrying its execution summary. Because the plan pass is read-only, every
+   carrying its execution result. Because the plan pass is read-only, every
    table was planned against the catalog as it stood before any statement ran.
-5. **Account**: assemble the runs into `SyncReport` through `SyncReport.assemble`,
+5. **Report**: assemble the runs into `SyncReport` through `SyncReport.assemble`,
    which derives dependency blocking from the retained edges; or raise
    `SyncFailedError` with that report on real runs that failed.
 
 A table that failed read, validation, or structural foreign-key resolution is
 skipped during execution, and so is any table depending on one that will not
 converge. The engine still processes other tables. Nothing records the block:
-it is derived at accounting, so a blocked table carries no execution outcome
+it is derived at report assembly, so a blocked table carries no execution outcome
 and its `blocked_failures` name every dependency that let it down, whichever
 phase each one failed in.
 
@@ -355,7 +355,7 @@ phase each one failed in.
 | `CatalogState`     | Reader port            | Engine                           | Known present or absent state               |
 | `ReadResult`       | Engine                 | Report                           | Catalog state or persistent read failure    |
 | SQL statements     | Executor (`compile`)   | Engine, executor, report         | The DDL a plan lowers to                    |
-| `ExecutionSummary` | Engine                 | Report                           | Attempted statement outcomes                |
+| `ExecutionResult` | Engine                 | Report                           | Applied-statement count and first failure   |
 | `SyncReport`       | Engine                 | User code                        | Immutable run result                        |
 
 ## Package map
@@ -441,7 +441,7 @@ either.
 ## Diff-first planning
 
 Planning is two pure stages connected by a typed diff. `diff_table(desired,
-observed)` produces a `TableDiff` — `TableMissing` when the table does not
+observed)` produces a `TableDiff` — `TableCreation` when the table does not
 exist, else a `TableDrift` holding executable `actions` and non-action
 `unresolvable` differences as two typed tuples. Actions carry their `TableAspect` plus the
 complete desired/observed state needed by validation and reporting;
@@ -461,7 +461,7 @@ or by an add-and-backfill — the difference and its remedy stop being the
 same thing, and the vocabularies must separate again for that aspect.
 
 Both arms state the complete intended transition the same way: a
-`TableMissing` exposes its creation actions — CREATE TABLE plus tag and
+`TableCreation` exposes its creation actions — CREATE TABLE plus tag and
 foreign-key follow-ups — so accepted planning is uniformly "construct an
 `ActionPlan` from the diff's actions" for creation and drift alike.
 
@@ -483,8 +483,8 @@ actions, and the application default rules decide to reject each one.
 
 Whether a difference is permitted is application policy. `plan_changes` diffs
 the declaration against the observed state itself, always runs the default
-policy, and returns either `PlanningSucceeded(diff, plan)` or
-`PlanningFailed(diff, failures)`. Only the success arm has an `ActionPlan`,
+policy, and returns either `PlanningAccepted(diff, plan)` or
+`PlanningRejected(diff, failures)`. Only the success arm has an `ActionPlan`,
 and both diff production and plan construction are private to that boundary,
 so callers cannot plan unvalidated drift at all. `validate_diff(..., rules=...)`
 remains the lower-level interface for testing alternative rule sets; it does
@@ -507,7 +507,7 @@ naming the aspects the engine reconciles for that table. The differ
 (`diff_table`) is scope-blind for every aspect except properties — the
 properties diff runs only when the declaration manages `PROPERTIES` (see
 Diff-first planning). The `TableDrift` it produces carries the `desired`
-table itself (symmetric with `TableMissing`), so the diff is self-contained
+table itself (symmetric with `TableCreation`), so the diff is self-contained
 and `validate_diff` takes only the diff. Scope awareness lives in
 validation, as an eligibility check rather than an optional rule. Before any
 safety rule runs, `validate_diff` fails the sync once per unmanaged aspect that
@@ -535,7 +535,7 @@ never reconciles them, the same as `COLUMN_STRUCTURE` and `PARTITIONING`.
 
 `diff_table(desired, observed)` produces a `TableDiff`:
 
-- `TableMissing` means the catalog has no table at that name.
+- `TableCreation` means the catalog has no table at that name.
 - `TableDrift` means the table exists and carries its actions and unresolvable differences.
 
 The diff produces backend-neutral commands but does not decide whether they are
@@ -566,8 +566,8 @@ The authoritative list and resolution for every current rule lives in
 [safe-change rules](reference-safe-change-rules.md); keeping the inventory in
 one place prevents this architecture overview from drifting when policy grows.
 
-The engine calls `plan_changes` once per table. A `PlanningFailed` leaves the run without a
-plan and records its validation failures; a `PlanningSucceeded` supplies the
+The engine calls `plan_changes` once per table. A `PlanningRejected` leaves the run without a
+plan and records its validation failures; a `PlanningAccepted` supplies the
 only plan the compiler can receive. A successful no-op is distinct: it carries
 an empty plan with a real target and relation kind.
 
@@ -658,7 +658,7 @@ the same run.
 
 Each eligibility check implements the `EligibilityCheck` protocol over `TableDiff`; a check returns no failures when it does not apply to that diff arm. Each safety rule implements the `SafetyRule` protocol: a `name` `ClassVar[str]` and an `evaluate(drift: TableDrift) -> tuple[ValidationFailure, ...]` method. Safety rules usually scan `drift.actions` or `drift.unresolvable` directly — typically matching a specific type with `isinstance` — and return all violations at once, avoiding a fix-and-rerun cycle per failure. The eligibility checks run before any safety rule and short-circuit the safety stage on failure, so a safety rule only ever sees differences the declaration manages and does no scope filtering of its own.
 
-`validate_diff` evaluates every check in `ELIGIBILITY_CHECKS` and aggregates their failures in declaration order, which is why `ColumnSpellingMustMatchCatalog` is listed first: when a misspelling and an unmanaged difference both fire, the spelling failure leads. A `TableMissing` is eligible when table existence is managed — creating it from its full declaration is always safe, and what a declaration creates it spells freely — and fails with `MissingTableUnmanaged` when it is not, so no safety rule ever sees a missing table; a `TableDrift` is eligible when its claimed scope and observed relation kind are valid, no unmanaged aspect has drifted, and every column reference is spelled as the catalog spells it. Only then does `validate_diff` call every rule in `DEFAULT_SAFETY_RULES` with the drift and aggregate their failures into one tuple, returned empty when the diff is valid. `plan_changes` fixes that default composition in place and turns those failures into the accepted/rejected planning sum.
+`validate_diff` evaluates every check in `ELIGIBILITY_CHECKS` and aggregates their failures in declaration order, which is why `ColumnSpellingMustMatchCatalog` is listed first: when a misspelling and an unmanaged difference both fire, the spelling failure leads. A `TableCreation` is eligible when table existence is managed — creating it from its full declaration is always safe, and what a declaration creates it spells freely — and fails with `MissingTableUnmanaged` when it is not, so no safety rule ever sees a missing table; a `TableDrift` is eligible when its claimed scope and observed relation kind are valid, no unmanaged aspect has drifted, and every column reference is spelled as the catalog spells it. Only then does `validate_diff` call every rule in `DEFAULT_SAFETY_RULES` with the drift and aggregate their failures into one tuple, returned empty when the diff is valid. `plan_changes` fixes that default composition in place and turns those failures into the accepted/rejected planning sum.
 
 Two walks fold that one rule over the dependency-first order the resolver
 produced, each accumulating its own not-converged set as it goes: `_execute`
@@ -774,6 +774,31 @@ keeps downstream planning focused on schema facts.
 
 ## Reporting and failure semantics
 
+### Outcome vocabulary
+
+One word, one meaning — every outcome type uses exactly one of these:
+
+| Word        | Meaning                                                                  | Types                                              |
+| ----------- | ------------------------------------------------------------------------ | -------------------------------------------------- |
+| **Error**   | A call could not deliver what its contract promises; unwinds to a caller | `ReadError`, `ExecutionError`, `SyncFailedError`, … |
+| **Failure** | A recorded reason a table did not converge, tagged with its phase        | `ReadFailure`, `ValidationFailure`, `ExecutionFailure`, `ForeignKeyFailure` |
+| **Result**  | The recorded outcome of one lifecycle step for one table                 | `ReadResult`, `PlanningResult`, `ExecutionResult`   |
+| **Run**     | The frozen record of one table's whole sync                              | `TableRun`                                          |
+| **Report**  | The aggregate record of the whole sync                                   | `SyncReport`                                        |
+| **State**   | A condition something is in                                              | `CatalogState`, `TableChangeState`                  |
+| **Status**  | How a table's run ended: earliest failing phase, else success            | `TableRunStatus`                                    |
+
+Errors are never stored in a report; failures are never raised (`Failure`
+is not an `Exception`, so `raise` rejects it). `ReadError` and
+`ExecutionError` are translated into `ReadFailure`/`ExecutionFailure` by
+the engine at the two backend boundaries; `ValidationFailure` and
+`ForeignKeyFailure` are born as values from pure judgment. `ReadResult`
+and `PlanningResult` are unions; `ExecutionResult` is a record, because
+execution can partially succeed — `applied_count` of N statements — which
+a binary union cannot state. The read port's `TableAbsent` and the diff's
+`TableCreation` split one situation by layer: Absent is the catalog fact
+the read observed; Creation is the work the differ concluded from it.
+
 Failures are phase-tagged application values. A `TableRun` derives its
 status from the earliest failing phase, in pipeline order:
 
@@ -789,9 +814,9 @@ That matters when a table has multiple validation failures or multiple FK
 failures: callers receive the complete failure tuple without another mutable
 source of run truth. For execution, the engine stops at the first failed
 statement because it is not transactional and later statements may depend on
-earlier ones. The `ExecutionSummary` records all attempted statements up to
-that point. Dependency blocking is retained as no outcome at all: it is derived
-at accounting into `blocked_failures`, which the report flattens at the
+earlier ones. The `ExecutionResult` records the applied count up to that
+point and the failure itself. Dependency blocking is retained as no outcome
+at all: it is derived at report assembly into `blocked_failures`, which the report flattens at the
 execution position while `execution` stays `None` because no statement was
 attempted.
 

--- a/docs/explanation-safety-model.md
+++ b/docs/explanation-safety-model.md
@@ -6,7 +6,7 @@ tags:
 # The safety model
 
 delta-engine mutates shared production tables, so its default posture is
-refusal: it only applies changes it can make safely in place, and everything
+rejection: it only applies changes it can make safely in place, and everything
 else fails with a named rule before any SQL runs. This page explains the four
 layers that enforce that, and the scoping concept — managed aspects — that
 decides what a declaration is responsible for at all.
@@ -48,7 +48,7 @@ after fixing the declaration is always safe.
 Every declaration manages a defined set of _aspects_ of its table — column
 structure, comments, properties, tags, partitioning, and key constraints. For
 catalog state it can represent, the engine reconciles drift in managed aspects
-and refuses to proceed when an unmanaged aspect has drifted. It never silently
+and rejects to proceed when an unmanaged aspect has drifted. It never silently
 reconciles something a declaration did not claim responsibility for.
 
 The read boundary upholds this by failing closed: a column whose type the
@@ -141,13 +141,13 @@ converging on the declaration is always safe. Details and examples:
 
 ## When the engine says no
 
-A refused change is not a dead end; the failure message and
+A rejected change is not a dead end; the failure message and
 [safe-change rules](reference-safe-change-rules.md) name the resolution for
 each rule. The patterns are:
 
 - **Stage the migration.** Add the column nullable and backfill. The tighten
   itself is an out-of-band step (`ALTER TABLE ... SET NOT NULL` — the engine
-  refuses to run it); once applied, declare `nullable=False` and the next sync
+  rejects to run it); once applied, declare `nullable=False` and the next sync
   sees no drift.
 - **Recreate out of band.** Type and partitioning changes require a rebuild;
   do it deliberately, then re-sync.

--- a/docs/explanation-sync-lifecycle.md
+++ b/docs/explanation-sync-lifecycle.md
@@ -118,6 +118,6 @@ See [how to preview changes](how-to-preview-changes.md).
 
 ## Where to drill down
 
-- What the engine will refuse and why: [the safety model](explanation-safety-model.md)
+- What the engine will reject and why: [the safety model](explanation-safety-model.md)
 - Reading and acting on a failed run: [how to handle sync failures](how-to-handle-sync-failures.md)
 - The internals — layers, ports, adapters, planning: [architecture](explanation-architecture.md)

--- a/docs/how-to-configure-table.md
+++ b/docs/how-to-configure-table.md
@@ -143,7 +143,7 @@ Two operations on this key are blocked at validation: changing `name` back
 to `none`, and declaring it `None` (a removal is a transition to absence,
 judged by the same `PropertyTransitionNotSupported` rule). Databricks can
 remove column mapping, but doing so rewrites every data file and conflicts
-with concurrent writes, so the engine refuses it as an in-place change —
+with concurrent writes, so the engine rejects it as an in-place change —
 the same class of operation as a partitioning change. Once a table has
 column mapping, its declaration must carry
 `Property.COLUMN_MAPPING_MODE: "name"`; remove the feature out of band if

--- a/docs/how-to-implement-adapter.md
+++ b/docs/how-to-implement-adapter.md
@@ -64,7 +64,7 @@ class MyExecutor:
 ```
 
 The engine calls `compile` only with the `ActionPlan` carried by a
-`PlanningSucceeded` result, on every dry or real run, and records the
+`PlanningAccepted` result, on every dry or real run, and records the
 compiled plan on the table's report. Each `CompiledAction` pairs one source
 action with the single statement that applies it; `CompiledPlan` rejects
 missing, additional, or reordered actions. A rejected diff has no plan and
@@ -92,7 +92,7 @@ means the statement succeeded; translate an expected backend failure into
             ) from exc
 ```
 
-The application owns statement indexes, constructs the `ExecutionSummary`, and
+The application owns statement indexes, constructs the `ExecutionResult`, and
 stops after the first `ExecutionError`. It then records the partial result and
 moves on to the next independent table. Exceptions other than
 `ExecutionError` are port-contract or programming errors and propagate.

--- a/docs/reference-run-report.md
+++ b/docs/reference-run-report.md
@@ -31,6 +31,10 @@ Version 2 renamed the planning-phase status from `VALIDATION_FAILED` to
 backwards-compatible, and a reader that does not know the key sees exactly the
 payload it saw before.
 
+The 2026-08 Python renames (`PlanningAccepted`/`PlanningRejected`,
+`TableCreation`, `ExecutionResult`) changed no serialized field or value;
+`schema_version` remains 2.
+
 The per-type failure fields (2026-08-05) were likewise added without a bump:
 every failure record still carries `phase`, `type`, and `message` with
 unchanged meaning, and the additional keys sit beside them.
@@ -44,8 +48,8 @@ did not run. Empty plans and plans rejected before compilation require no
 execution result.
 
 These checks apply when constructing a report directly as well as when the
-engine assembles one. `ExecutionSummary` separately validates the statement
-history inside an execution result.
+engine assembles one. `ExecutionResult` separately validates the statement
+history it records.
 
 ## Table change states
 
@@ -104,7 +108,7 @@ Each entry in `tables`, and the whole of `TableRun.to_dict()`:
 | `has_changes`            | `bool`           | True if this table has a planned change                      |
 | `has_failures`           | `bool`           | True if this table failed a phase                            |
 | `changes`                | `list[dict]`     | Summaries of the planned changes, in plan order (see below)  |
-| `rejected_changes`       | `list[dict]`     | Differences found but refused, when the plan was rejected; empty otherwise |
+| `rejected_changes`       | `list[dict]`     | Differences the rejected plan was built from; empty when the plan was accepted |
 | `planned_sql_statements` | `list[str]`      | Full compiled DDL the plan lowers to, in order               |
 | `failures`               | `list[dict]`     | Failure records, in phase order (see below)                  |
 | `execution`              | `dict` \| `None` | Execution counts, or `None` on a dry run or a skipped table  |
@@ -128,7 +132,7 @@ description is `planned_sql_statements`:
 
 When a table's diff is rejected, no plan exists, so `changes` is empty. The
 differences the engine did find are projected into `rejected_changes` in the
-same record shape, so a reader can see *what* was refused alongside the
+same record shape, so a reader can see *what* was rejected alongside the
 `failures` list that says *why*. It includes both the actions the engine would
 have taken and the differences no action can close (a column spelled
 differently from the catalog, a property set but undeclared, a partitioning

--- a/src/delta_engine/api/delta_table.py
+++ b/src/delta_engine/api/delta_table.py
@@ -293,7 +293,7 @@ def _validate_column_names(
     permitted under column mapping, and change data feed reserves its output
     column names. Both bind only when the declaration manages column
     structure — a restricted scope mirrors columns the live table already
-    accepted, so it must be able to declare names this engine would refuse
+    accepted, so it must be able to declare names this engine would reject
     to create.
     """
     if TableAspect.COLUMN_STRUCTURE not in managed_aspects:

--- a/src/delta_engine/application/__init__.py
+++ b/src/delta_engine/application/__init__.py
@@ -2,7 +2,7 @@
 Application layer: the engine and outcome types.
 
 The root ``delta_engine`` package re-exports this runtime surface for library
-users. The per-phase result types (`CatalogState`, `ExecutionSummary`, ...)
+users. The per-phase result types (`CatalogState`, `ExecutionResult`, ...)
 remain internal, but reports, their outcome enums, and concrete failure types
 are public so callers can annotate and inspect the objects a `SyncReport`
 yields.

--- a/src/delta_engine/application/engine.py
+++ b/src/delta_engine/application/engine.py
@@ -70,8 +70,6 @@ from delta_engine.application.ports import (
     CompiledPlan,
     DesiredTableSource,
     ExecutionResult,
-    ExecutionSucceeded,
-    ExecutionSummary,
     PlanExecutor,
     TablePresent,
 )
@@ -286,42 +284,34 @@ class Engine:
                 executed.append(run)
                 continue
 
-            summary = self._execute_compiled(compiled)
-            if summary.failures:
+            result = self._execute_compiled(compiled)
+            if result.failures:
                 not_converged.add(run.qualified_name)
 
             logger.info(
                 "Executed %d statement(s) for %s (%d failed)",
-                len(summary.results),
+                result.applied_count + len(result.failures),
                 run.qualified_name,
-                len(summary.failures),
+                len(result.failures),
             )
-            executed.append(replace(run, execution=summary))
+            executed.append(replace(run, execution=result))
 
         return tuple(executed)
 
-    def _execute_compiled(self, compiled: CompiledPlan) -> ExecutionSummary:
-        """Execute statements in order and stop after the first expected failure."""
-        results: list[ExecutionResult] = []
+    def _execute_compiled(self, compiled: CompiledPlan) -> ExecutionResult:
+        """Execute statements in order and stop at the first expected failure."""
         for index, statement in enumerate(compiled.statements):
             try:
                 self.executor.execute(statement)
             except ExecutionError as error:
-                results.append(
-                    ExecutionFailure(
+                return ExecutionResult(
+                    compiled_plan=compiled,
+                    applied_count=index,
+                    failure=ExecutionFailure(
                         statement_index=index,
                         statement=statement,
                         exception_type=error.exception_type,
                         message=str(error),
-                    )
+                    ),
                 )
-                break
-
-            results.append(
-                ExecutionSucceeded(
-                    statement_index=index,
-                    statement=statement,
-                )
-            )
-
-        return ExecutionSummary(compiled_plan=compiled, results=results)
+        return ExecutionResult(compiled_plan=compiled, applied_count=len(compiled.statements))

--- a/src/delta_engine/application/engine.py
+++ b/src/delta_engine/application/engine.py
@@ -61,8 +61,8 @@ from delta_engine.application.failures import (
     ReadFailure,
 )
 from delta_engine.application.planning import (
-    PlanningFailed,
-    PlanningSucceeded,
+    PlanningAccepted,
+    PlanningRejected,
     plan_changes,
 )
 from delta_engine.application.ports import (
@@ -229,10 +229,10 @@ class Engine:
         planning = plan_changes(resolution.desired, observed)
 
         match planning:
-            case PlanningFailed():
+            case PlanningRejected():
                 logger.error("Planning failed for %s", resolution.qualified_name)
                 return TableRun(resolution=resolution, read=read, planning=planning)
-            case PlanningSucceeded(plan=plan):
+            case PlanningAccepted(plan=plan):
                 compiled = self.executor.compile(plan)
                 logger.info(
                     "Planned %s: %d action(s), %d statement(s)",

--- a/src/delta_engine/application/engine.py
+++ b/src/delta_engine/application/engine.py
@@ -18,8 +18,8 @@ The steps are:
   4. Execute  — the one cross-table walk (real runs only): fold the blocking
                 rule over the runs and attach attempted statement results
                 to each executed table
-  5. Account  — assemble the aggregate report, deriving dependency blocking
-                from the same edges
+  5. Report   — assemble the aggregate ``SyncReport``, deriving dependency
+                blocking from the same edges
 
 Because the plan pass is read-only, every table is diffed and planned
 against the catalog as it stood before any statement ran, and a dry run is
@@ -35,9 +35,9 @@ other (CYCLE, UNRESOLVABLE_REFERENCE, ...). Whether a table is *blocked* by
 another table's failure is nobody's outcome to record: it is the derived
 consequence of the dependency edges and the other tables' fates. One rule
 states it — a table did not converge if it has failures of its own or a
-dependency did not — and execution and accounting each fold that same rule
-over the dependency-ordered runs: execution to decide what not to attempt,
-accounting to say why. Because it is derived rather than recorded, blocking
+dependency did not — and execution and report assembly each fold that same
+rule over the dependency-ordered runs: execution to decide what not to
+attempt, assembly to say why. Because it is derived rather than recorded, blocking
 is equally visible in a dry run, which attempts nothing.
 
 A table that fails an early phase returns early from its plan pass with
@@ -136,7 +136,7 @@ class Engine:
         """
         Synchronize all registered tables to their desired state.
 
-        Runs lower → resolve → plan → execute → account. Resolution orders
+        Runs lower → resolve → plan → execute → report. Resolution orders
         the tables dependency-first with their static facts, the plan pass
         takes each table through its read-only steps (read, plan, compile)
         and freezes one complete ``TableRun``, execution attaches
@@ -203,7 +203,7 @@ class Engine:
 
         Straight-line, table-local, and free of catalog mutations. Each early
         return is a lifecycle rule — a failed read leaves nothing to plan, a
-        refused plan leaves nothing to compile — so every ``None`` on the
+        rejected plan leaves nothing to compile — so every ``None`` on the
         returned run means "not applicable", never "not yet". Execution itself
         is deliberately absent: whether this table may execute depends on
         other tables' fates, which is the execute walk's concern.
@@ -251,7 +251,7 @@ class Engine:
         One walk in dependency order applies the single blocking rule: a table
         with failures of its own, or with a dependency that will not converge,
         joins the not-converged set and is skipped. Nothing is recorded on a
-        skipped table — the account derives blocking from the same edges — so
+        skipped table — the report derives blocking from the same edges — so
         the two arms differ only in what they can say about the skip. Compiled
         plan emptiness gates only statement execution: a no-op table still
         joins the set through the same rule when its dependency failed, so

--- a/src/delta_engine/application/errors.py
+++ b/src/delta_engine/application/errors.py
@@ -1,9 +1,12 @@
 """
 Application-owned exception types.
 
-``ReadError`` and ``ExecutionError`` are transient signals raised by outbound
-adapters and caught by the engine. The engine turns them into persistent
-``Failure`` values for reports. ``DuplicateTableDefinitionError`` and
+An error is raised when a call cannot deliver what its contract promises,
+and unwinds to whoever can act; a failure (``application.failures``) is
+recorded when the sync carries on and the report must say why a table did
+not converge. ``ReadError`` and ``ExecutionError`` are transient signals
+raised by outbound adapters and translated into persistent failures by the
+engine at the two backend boundaries. ``DuplicateTableDefinitionError`` and
 ``SyncFailedError`` are raised from the inbound sync boundary to callers.
 """
 

--- a/src/delta_engine/application/failures.py
+++ b/src/delta_engine/application/failures.py
@@ -1,10 +1,15 @@
 """
 Failure vocabulary for engine runs.
 
-Every way a sync can fail, as one closed family: each failure knows the phase
-that produced it (`FailurePhase`) and renders itself as display lines. Reports
-derive a table's status from the earliest failing phase, so the family stays
-together rather than being scattered across its producers.
+A failure is a recorded reason a table did not converge — a frozen value in
+the table's run, never raised (it is not an ``Exception``). ``ReadFailure``
+and ``ExecutionFailure`` are born when the engine catches the corresponding
+adapter error; ``ValidationFailure`` and ``ForeignKeyFailure`` are born as
+values from pure judgment — no exception is ever involved. Each failure
+knows the phase that produced it (`FailurePhase`) and renders itself as
+display lines; reports derive a table's status from the earliest failing
+phase, so the family stays together rather than being scattered across its
+producers.
 """
 
 from abc import ABC, abstractmethod

--- a/src/delta_engine/application/planning.py
+++ b/src/delta_engine/application/planning.py
@@ -9,9 +9,9 @@ from delta_engine.domain.collection_types import ListOrTuple
 from delta_engine.domain.model import DesiredTable, ObservedTable
 from delta_engine.domain.plan import (
     ActionPlan,
+    TableCreation,
     TableDiff,
     TableDrift,
-    TableMissing,
     diff_table,
 )
 
@@ -95,8 +95,8 @@ def plan_changes(desired: DesiredTable, observed: ObservedTable | None) -> Plann
     match diff:
         case TableDrift() as drift:
             plan = ActionPlan(target=drift.target, actions=drift.actions, kind=drift.observed.kind)
-        case TableMissing() as missing:
-            plan = ActionPlan(target=missing.target, actions=missing.actions)
+        case TableCreation() as creation:
+            plan = ActionPlan(target=creation.target, actions=creation.actions)
         case _ as unreachable:
             assert_never(unreachable)
     return PlanningAccepted(diff=diff, plan=plan)

--- a/src/delta_engine/application/planning.py
+++ b/src/delta_engine/application/planning.py
@@ -17,7 +17,7 @@ from delta_engine.domain.plan import (
 
 
 @dataclass(frozen=True, slots=True)
-class PlanningSucceeded:
+class PlanningAccepted:
     """
     The accepted diff and the validated executable plan constructed from it.
 
@@ -35,7 +35,7 @@ class PlanningSucceeded:
 
 
 @dataclass(frozen=True, slots=True)
-class PlanningFailed:
+class PlanningRejected:
     """
     The rejected diff and the failures that rejected it.
 
@@ -50,7 +50,7 @@ class PlanningFailed:
         object.__setattr__(self, "failures", tuple(self.failures))
 
 
-type PlanningResult = PlanningSucceeded | PlanningFailed
+type PlanningResult = PlanningAccepted | PlanningRejected
 
 
 def accepted_plan(planning: PlanningResult | None) -> ActionPlan | None:
@@ -63,9 +63,9 @@ def accepted_plan(planning: PlanningResult | None) -> ActionPlan | None:
     each caller.
     """
     match planning:
-        case PlanningSucceeded(plan=plan):
+        case PlanningAccepted(plan=plan):
             return plan
-        case PlanningFailed() | None:
+        case PlanningRejected() | None:
             return None
         case _ as unreachable:
             assert_never(unreachable)
@@ -73,13 +73,13 @@ def accepted_plan(planning: PlanningResult | None) -> ActionPlan | None:
 
 def plan_changes(desired: DesiredTable, observed: ObservedTable | None) -> PlanningResult:
     """
-    Plan the changes that reconcile ``observed`` with ``desired``; accept or refuse.
+    Plan the changes that reconcile ``observed`` with ``desired``; accept or reject.
 
     The one boundary from state to executable plan. It diffs the declaration
     against the observed table — ``None`` means confirmed absence, so the diff
     proposes creation — and validates the complete diff, foreign-key existence
     included, so policy sees exactly one stream with no side channels. An
-    accepted result carries the validated :class:`ActionPlan`; a refused
+    accepted result carries the validated :class:`ActionPlan`; a rejected
     result carries the validation failures and deliberately has no plan,
     making execution of unvalidated drift unrepresentable. This remains the
     only boundary that constructs an ``ActionPlan``, and both outcomes retain
@@ -90,7 +90,7 @@ def plan_changes(desired: DesiredTable, observed: ObservedTable | None) -> Plann
     diff = diff_table(desired, observed)
     failures = validate_diff(diff)
     if failures:
-        return PlanningFailed(diff=diff, failures=failures)
+        return PlanningRejected(diff=diff, failures=failures)
 
     match diff:
         case TableDrift() as drift:
@@ -99,4 +99,4 @@ def plan_changes(desired: DesiredTable, observed: ObservedTable | None) -> Plann
             plan = ActionPlan(target=missing.target, actions=missing.actions)
         case _ as unreachable:
             assert_never(unreachable)
-    return PlanningSucceeded(diff=diff, plan=plan)
+    return PlanningAccepted(diff=diff, plan=plan)

--- a/src/delta_engine/application/ports.py
+++ b/src/delta_engine/application/ports.py
@@ -2,7 +2,7 @@
 Application ports: the engine's boundary contracts and the message types they exchange.
 
 Each boundary is defined in full here — the vocabulary an adapter returns
-(``CatalogState`` for reads, ``ExecutionSummary`` for execution) sits beside
+(``CatalogState`` for reads, ``ExecutionResult`` for execution) sits beside
 the Protocol that requires it, so an adapter author reads one file to learn
 the whole contract. ``DesiredTableSource`` is the inbound counterpart: the
 contract a user-facing declaration satisfies to enter a sync.
@@ -115,66 +115,41 @@ class CompiledPlan:
 
 
 @dataclass(frozen=True, slots=True)
-class ExecutionSucceeded:
+class ExecutionResult:
     """
-    A single statement that executed without error.
+    The recorded outcome of executing one table's compiled plan.
 
-    ``statement_index`` is the statement's position in the run and
-    ``statement`` is its SQL exactly as executed; neither is rendered by the
-    engine's own reports — they are carried for callers that inspect
-    ``ExecutionSummary.results`` directly.
-    """
-
-    statement_index: int
-    statement: str
-
-
-# A completed statement is either recorded as successful or as the execution
-# failure itself.
-type ExecutionResult = ExecutionSucceeded | ExecutionFailure
-
-
-@dataclass(frozen=True, slots=True)
-class ExecutionSummary:
-    """
-    The outcome of running a plan's compiled statements.
-
-    Results must cover the compiled statements in order. A successful history
-    covers the complete plan; a failed history is the prefix ending at the
-    first failed statement. Therefore ``failures`` holds at most one.
+    Execution applies statements in compiled order and stops at the first
+    failure, so the complete history is an applied prefix plus at most one
+    failure sitting immediately after it: ``applied_count`` says how far the
+    prefix ran, and ``failure`` is the statement that stopped it, ``None``
+    when the whole plan applied. The statements themselves live on
+    ``compiled_plan`` — nothing derivable is restated here.
     """
 
     compiled_plan: CompiledPlan
-    results: ListOrTuple[ExecutionResult] = ()
+    applied_count: int = 0
+    failure: ExecutionFailure | None = None
 
     def __post_init__(self) -> None:
-        """Reject result histories that the engine's execution loop cannot produce."""
-        results = tuple(self.results)
-        object.__setattr__(self, "results", results)
+        """Reject histories the engine's execution loop cannot produce."""
         statements = self.compiled_plan.statements
-        execution_failed = False
-        for expected_index, result in enumerate(results):
-            if result.statement_index != expected_index:
-                raise ValueError("Execution result indexes must be contiguous")
-            if expected_index >= len(statements) or result.statement != statements[expected_index]:
-                raise ValueError("Execution results must match the compiled statement prefix")
-            if isinstance(result, ExecutionFailure):
-                if expected_index != len(results) - 1:
-                    raise ValueError("Execution must stop at its first failure")
-                execution_failed = True
-
-        if not execution_failed and len(results) != len(statements):
-            raise ValueError("Successful execution must cover the complete compiled plan")
+        attempted = self.applied_count + (0 if self.failure is None else 1)
+        if not 0 <= self.applied_count or attempted > len(statements):
+            raise ValueError("Execution history must lie within the compiled plan")
+        if self.failure is None:
+            if self.applied_count != len(statements):
+                raise ValueError("Successful execution must cover the complete compiled plan")
+            return
+        if self.failure.statement_index != self.applied_count:
+            raise ValueError("Execution must stop at its first failure")
+        if self.failure.statement != statements[self.applied_count]:
+            raise ValueError("Execution failure must carry its compiled statement")
 
     @property
     def failures(self) -> tuple[ExecutionFailure, ...]:
-        """The failure detail from each failed statement, in execution order."""
-        return tuple(result for result in self.results if isinstance(result, ExecutionFailure))
-
-    @property
-    def applied_count(self) -> int:
-        """How many statements ran successfully."""
-        return len(self.results) - len(self.failures)
+        """The failure that stopped execution, as the tuple reports flatten."""
+        return () if self.failure is None else (self.failure,)
 
 
 class PlanExecutor(Protocol):
@@ -220,7 +195,7 @@ class PlanExecutor(Protocol):
         Execute one statement produced by :meth:`compile`.
 
         Returning normally means the statement succeeded. The application adds
-        the statement and its sequence index to the execution summary.
+        the statement and its sequence index to the execution result.
 
         Args:
             statement: The backend statement to execute verbatim.

--- a/src/delta_engine/application/properties.py
+++ b/src/delta_engine/application/properties.py
@@ -237,7 +237,7 @@ _DEFINITIONS: Final[tuple[PropertyDefinition, ...]] = (
         is_valid_value=_is_column_mapping_mode,
         # Only none -> name is permitted. Databricks can remove column
         # mapping (SET mode='none' / DROP FEATURE), but removal rewrites
-        # every data file, so the engine refuses it as an in-place change.
+        # every data file, so the engine rejects it as an in-place change.
         # The absence of any (value, None) pair blocks removal by the same
         # mechanism — declaring the key absent is a transition to None.
         permitted_transitions=frozenset({("none", "name")}),

--- a/src/delta_engine/application/rendering.py
+++ b/src/delta_engine/application/rendering.py
@@ -94,12 +94,12 @@ def _render_diff_block(report: TableRun, *, change_state: TableChangeState | Non
     plan = report.plan
     if plan is None:
         # No plan means the diff was rejected, which is not the same as having
-        # found nothing. The failures section says which rule refused; this
-        # says what it refused.
-        refused = drift_entries(report.diff) if isinstance(report.diff, TableDrift) else ()
-        if refused:
+        # found nothing. The failures section says which rule rejected; this
+        # says what it rejected.
+        rejected = drift_entries(report.diff) if isinstance(report.diff, TableDrift) else ()
+        if rejected:
             return "\n".join(
-                [f"{header}  (REJECTED — no SQL planned)", *_render_entry_groups(refused)]
+                [f"{header}  (REJECTED — no SQL planned)", *_render_entry_groups(rejected)]
             )
         return f"{header}\n  ({_NO_CHANGES} — see failures)"
 

--- a/src/delta_engine/application/report.py
+++ b/src/delta_engine/application/report.py
@@ -1,10 +1,10 @@
 """
-Run accounts: per-table and run-level outcome aggregates.
+Run records: per-table and run-level outcome aggregates.
 
-`TableRun` is the immutable account of one table's sync run, born complete
+`TableRun` is the immutable record of one table's sync run, born complete
 at the engine's plan pass and enriched afterwards with the cross-table
 facts (execution, dependency blocking); `SyncReport` aggregates those
-accounts for the whole run.
+records for the whole run.
 """
 
 from collections.abc import Iterable, Iterator, Mapping
@@ -195,7 +195,7 @@ def _failure_records(failures: tuple[Failure, ...]) -> list[dict[str, Any]]:
 @dataclass(frozen=True, slots=True)
 class TableRun:
     """
-    Frozen public account of one table's sync run.
+    Frozen public record of one table's sync run.
 
     Born complete at the engine's plan pass: everything the table can know
     alone — its resolution, read, planning outcome, and compiled SQL — is
@@ -215,7 +215,7 @@ class TableRun:
     own.
     ``diff`` is derived from the planning outcome, which retains the complete
     set of differences it planned from — actions and unresolvable differences
-    alike — so a table whose plan was refused can still show what drifted. It
+    alike — so a table whose plan was rejected can still show what drifted. It
     is ``None`` when the read failed, because planning never ran.
     """
 

--- a/src/delta_engine/application/report.py
+++ b/src/delta_engine/application/report.py
@@ -29,7 +29,7 @@ from delta_engine.application.planning import (
     PlanningResult,
     accepted_plan,
 )
-from delta_engine.application.ports import CompiledPlan, ExecutionSummary, ReadResult
+from delta_engine.application.ports import CompiledPlan, ExecutionResult, ReadResult
 from delta_engine.application.relationships import TableResolution
 from delta_engine.domain.collection_types import ListOrTuple
 from delta_engine.domain.model import DesiredTable, QualifiedName
@@ -223,7 +223,7 @@ class TableRun:
     read: ReadResult
     planning: PlanningResult | None = None
     compiled: CompiledPlan | None = None
-    execution: ExecutionSummary | None = None
+    execution: ExecutionResult | None = None
     blocked_failures: ListOrTuple[ForeignKeyFailure] = ()
 
     def __post_init__(self) -> None:

--- a/src/delta_engine/application/report.py
+++ b/src/delta_engine/application/report.py
@@ -25,7 +25,7 @@ from delta_engine.application.failures import (
     ValidationFailure,
 )
 from delta_engine.application.planning import (
-    PlanningFailed,
+    PlanningRejected,
     PlanningResult,
     accepted_plan,
 )
@@ -138,7 +138,7 @@ def _rejected_change_records(planning: PlanningResult | None) -> list[dict[str, 
     Empty for an accepted outcome: an accepted diff's differences are its
     changes, already projected by ``_change_records``.
     """
-    if not isinstance(planning, PlanningFailed) or not isinstance(planning.diff, TableDrift):
+    if not isinstance(planning, PlanningRejected) or not isinstance(planning.diff, TableDrift):
         return []
     return _entry_records(drift_entries(planning.diff))
 
@@ -229,7 +229,7 @@ class TableRun:
     def __post_init__(self) -> None:
         object.__setattr__(self, "blocked_failures", tuple(self.blocked_failures))
         read_failed = isinstance(self.read, ReadFailure)
-        planning_failed = isinstance(self.planning, PlanningFailed)
+        planning_failed = isinstance(self.planning, PlanningRejected)
         resolution_failed = bool(self.resolution.structural_failures)
 
         if read_failed and self.planning is not None:
@@ -285,7 +285,7 @@ class TableRun:
         failures.extend(self.resolution.structural_failures)
         if isinstance(self.read, ReadFailure):
             failures.append(self.read)
-        if isinstance(self.planning, PlanningFailed):
+        if isinstance(self.planning, PlanningRejected):
             failures.extend(self.planning.failures)
 
         if self.execution is not None:

--- a/src/delta_engine/application/validation.py
+++ b/src/delta_engine/application/validation.py
@@ -40,9 +40,9 @@ from delta_engine.domain.plan import (
     PropertyUndeclared,
     SetColumnNullability,
     SetProperty,
+    TableCreation,
     TableDiff,
     TableDrift,
-    TableMissing,
     Unresolvable,
     UnsetProperty,
 )
@@ -108,7 +108,7 @@ class SafetyRule(Protocol):
     a rule is only ever evaluated on a diff that is fully in scope and spelled
     as the catalog spells it, so its actions and unresolvable differences are
     exactly the ones the declaration manages — it does no scope filtering of
-    its own. Never called for a ``TableMissing`` diff.
+    its own. Never called for a ``TableCreation`` diff.
     """
 
     name: ClassVar[str]
@@ -508,7 +508,7 @@ class ColumnSpellingMustMatchCatalog:
     def evaluate(self, diff: TableDiff) -> tuple[ValidationFailure, ...]:
         """Flag every column reference spelled differently from the catalog."""
         match diff:
-            case TableMissing():
+            case TableCreation():
                 return ()
 
             case TableDrift() as drift:
@@ -576,7 +576,7 @@ class UnmanagedAspectDrift:
     def evaluate(self, diff: TableDiff) -> tuple[ValidationFailure, ...]:
         """Flag every drifted aspect the declaration does not manage."""
         match diff:
-            case TableMissing():
+            case TableCreation():
                 return ()
 
             case TableDrift() as drift:
@@ -611,7 +611,7 @@ class MissingTableUnmanaged:
     Fail creation of a table whose declaration does not manage table existence.
 
     One of the ``ELIGIBILITY_CHECKS``, and the only one that judges the
-    ``TableMissing`` arm. It shares the naming shape of a rule (its ``name``
+    ``TableCreation`` arm. It shares the naming shape of a rule (its ``name``
     supplies the failure's ``rule_name``) but not the ``SafetyRule`` protocol —
     a missing table has no changes to evaluate. Like every eligibility check it
     runs unconditionally: ``rules=()`` must not enable metadata-only creates.
@@ -625,7 +625,7 @@ class MissingTableUnmanaged:
             case TableDrift():
                 return ()
 
-            case TableMissing() as missing:
+            case TableCreation() as missing:
                 if TableAspect.TABLE_EXISTENCE in missing.desired.managed_aspects:
                     return ()
                 return (
@@ -671,7 +671,7 @@ class StreamingTableAnnotationsOnly:
     def evaluate(self, diff: TableDiff) -> tuple[ValidationFailure, ...]:
         """Flag a streaming-table declaration whose managed aspects exceed the tag aspects."""
         match diff:
-            case TableMissing():
+            case TableCreation():
                 return ()
 
             case TableDrift() as drift:
@@ -697,7 +697,7 @@ class StreamingTableAnnotationsOnly:
 # Position is report order, so a root defect leads what it causes: spelling
 # before the two it can co-fire with, then StreamingTableAnnotationsOnly before
 # UnmanagedAspectDrift. MissingTableUnmanaged sits anywhere — it alone judges
-# TableMissing, so it never co-fires.
+# TableCreation, so it never co-fires.
 ELIGIBILITY_CHECKS: Final[tuple[EligibilityCheck, ...]] = (
     ColumnSpellingMustMatchCatalog(),
     MissingTableUnmanaged(),
@@ -748,7 +748,7 @@ def validate_diff(
         return ineligible
 
     match diff:
-        case TableMissing():
+        case TableCreation():
             return ()
         case TableDrift() as drift:
             return tuple(failure for rule in rules for failure in rule.evaluate(drift))

--- a/src/delta_engine/cli/app.py
+++ b/src/delta_engine/cli/app.py
@@ -39,8 +39,8 @@ DeclarationArgument = Annotated[
 
 
 @dataclass(frozen=True, slots=True)
-class PlanResult:
-    """The safe-to-render identity and report returned by the plan service."""
+class PlanView:
+    """The safe-to-render identity and report the plan command displays."""
 
     target: Target
     declaration: DeclarationRef
@@ -74,14 +74,14 @@ def plan(declaration: DeclarationArgument) -> None:
         raise typer.Exit(code=_EXIT_FAILURE if result.report.has_failures else _EXIT_SUCCESS)
 
 
-def _plan(reference: DeclarationRef) -> PlanResult:
+def _plan(reference: DeclarationRef) -> PlanView:
     """Load one collection, authenticate, and run one read-only engine sync."""
     with _engine_logging(), redirect_stdout(sys.stderr):
         tables = load_declarations(reference)
         with open_connection() as (target, connection):
             engine = build_sql_engine(connection)
             report = engine.sync(*tables, dry_run=True)
-    return PlanResult(target=target, declaration=reference, report=report)
+    return PlanView(target=target, declaration=reference, report=report)
 
 
 @contextmanager

--- a/src/delta_engine/domain/plan/__init__.py
+++ b/src/delta_engine/domain/plan/__init__.py
@@ -24,9 +24,9 @@ from delta_engine.domain.plan.actions import (
     UnsetTableTag,
 )
 from delta_engine.domain.plan.diff import (
+    TableCreation,
     TableDiff,
     TableDrift,
-    TableMissing,
     diff_table,
 )
 from delta_engine.domain.plan.unresolvable import (
@@ -62,9 +62,9 @@ __all__ = [
     "SetProperty",
     "SetTableComment",
     "SetTableTag",
+    "TableCreation",
     "TableDiff",
     "TableDrift",
-    "TableMissing",
     "Unresolvable",
     "UnsetColumnTag",
     "UnsetProperty",

--- a/src/delta_engine/domain/plan/diff.py
+++ b/src/delta_engine/domain/plan/diff.py
@@ -67,14 +67,7 @@ _REQUIRED_FEATURE_BY_TYPE: Final[Mapping[type[DataType], TableFeature]] = {
 
 @dataclass(frozen=True, slots=True)
 class TableCreation:
-    """
-    The diff for a table with no catalog counterpart: create everything declared.
-
-    The read observed the table as absent (``TableAbsent``); this arm is the
-    differ's conclusion from that fact — the whole declaration is the gap, and
-    ``actions`` realize it. Whether creation is *allowed* is validation's
-    judgment (``MissingTableUnmanaged``), not the diff's.
-    """
+    """The diff for a table with no catalog counterpart: create everything declared."""
 
     desired: DesiredTable
 

--- a/src/delta_engine/domain/plan/diff.py
+++ b/src/delta_engine/domain/plan/diff.py
@@ -66,8 +66,15 @@ _REQUIRED_FEATURE_BY_TYPE: Final[Mapping[type[DataType], TableFeature]] = {
 
 
 @dataclass(frozen=True, slots=True)
-class TableMissing:
-    """The table does not exist in the catalog; carries what should exist."""
+class TableCreation:
+    """
+    The diff for a table with no catalog counterpart: create everything declared.
+
+    The read observed the table as absent (``TableAbsent``); this arm is the
+    differ's conclusion from that fact — the whole declaration is the gap, and
+    ``actions`` realize it. Whether creation is *allowed* is validation's
+    judgment (``MissingTableUnmanaged``), not the diff's.
+    """
 
     desired: DesiredTable
 
@@ -113,7 +120,7 @@ class TableDrift:
         return self.desired.qualified_name
 
 
-type TableDiff = TableMissing | TableDrift
+type TableDiff = TableCreation | TableDrift
 
 
 def _require_same_table(desired: DesiredTable, observed: ObservedTable) -> None:
@@ -128,7 +135,7 @@ def _require_same_table(desired: DesiredTable, observed: ObservedTable) -> None:
 def diff_table(desired: DesiredTable, observed: ObservedTable | None) -> TableDiff:
     """Describe every difference between desired and observed table state."""
     if observed is None:
-        return TableMissing(desired=desired)
+        return TableCreation(desired=desired)
 
     return _diff_existing_table(desired, observed)
 

--- a/tests/application/test_engine.py
+++ b/tests/application/test_engine.py
@@ -19,7 +19,6 @@ from delta_engine.application.failures import (
 from delta_engine.application.ports import (
     CatalogState,
     CompiledPlan,
-    ExecutionSucceeded,
     TableAbsent,
     TablePresent,
 )
@@ -744,11 +743,8 @@ def test_execution_stops_after_first_failure_and_retains_attempted_results():
     [table_report] = list(exc_info.value.report)
     assert table_report.status is TableRunStatus.EXECUTION_FAILED
     assert table_report.execution is not None
-    assert [type(result) for result in table_report.execution.results] == [
-        ExecutionSucceeded,
-        ExecutionFailure,
-    ]
-    failure = table_report.execution.results[1]
+    assert table_report.execution.applied_count == 1
+    failure = table_report.execution.failure
     assert isinstance(failure, ExecutionFailure)
     assert failure.statement_index == 1
     assert failure.statement == f"STATEMENT 1 FOR {fqn}"

--- a/tests/application/test_errors.py
+++ b/tests/application/test_errors.py
@@ -29,7 +29,7 @@ from delta_engine.application.report import (
 )
 from delta_engine.domain.model import DesiredColumn, Integer, QualifiedName
 from delta_engine.domain.model.table import DesiredTable
-from delta_engine.domain.plan import ActionPlan, SetTableComment, TableMissing
+from delta_engine.domain.plan import ActionPlan, SetTableComment, TableCreation
 from tests.builders import build_compiled_plan
 
 _AT = datetime(2026, 1, 1, tzinfo=UTC)
@@ -82,11 +82,11 @@ def _table_report(
         planning = None
         compiled = None
     elif planning_failures:
-        planning = PlanningRejected(diff=TableMissing(desired), failures=planning_failures)
+        planning = PlanningRejected(diff=TableCreation(desired), failures=planning_failures)
         compiled = None
     else:
         compiled = execution.compiled_plan if execution is not None else _compiled()
-        planning = PlanningAccepted(diff=TableMissing(desired), plan=compiled.plan)
+        planning = PlanningAccepted(diff=TableCreation(desired), plan=compiled.plan)
     resolution = TableResolution(
         desired=desired,
         dependencies=(),

--- a/tests/application/test_errors.py
+++ b/tests/application/test_errors.py
@@ -17,8 +17,7 @@ from delta_engine.application.failures import (
 from delta_engine.application.planning import PlanningAccepted, PlanningRejected
 from delta_engine.application.ports import (
     CompiledPlan,
-    ExecutionSucceeded,
-    ExecutionSummary,
+    ExecutionResult,
     ReadResult,
     TableAbsent,
 )
@@ -69,7 +68,7 @@ def _table_report(
     *,
     read: ReadResult,
     failures: tuple[Failure, ...] = (),
-    execution: ExecutionSummary | None = None,
+    execution: ExecutionResult | None = None,
 ) -> TableRun:
     desired = DesiredTable(qualified_name=_QN, columns=(DesiredColumn("id", Integer()),))
     planning_failures = tuple(
@@ -185,13 +184,10 @@ def test_message_renders_execution_failure_detail_with_sql():
     )
     report = _table_report(
         read=TableAbsent(),
-        execution=ExecutionSummary(
+        execution=ExecutionResult(
             compiled_plan=compiled,
-            results=(
-                ExecutionSucceeded(0, statements[0]),
-                ExecutionSucceeded(1, statements[1]),
-                failed_result,
-            ),
+            applied_count=2,
+            failure=failed_result,
         ),
     )
 

--- a/tests/application/test_errors.py
+++ b/tests/application/test_errors.py
@@ -14,7 +14,7 @@ from delta_engine.application.failures import (
     ReadFailure,
     ValidationFailure,
 )
-from delta_engine.application.planning import PlanningFailed, PlanningSucceeded
+from delta_engine.application.planning import PlanningAccepted, PlanningRejected
 from delta_engine.application.ports import (
     CompiledPlan,
     ExecutionSucceeded,
@@ -82,11 +82,11 @@ def _table_report(
         planning = None
         compiled = None
     elif planning_failures:
-        planning = PlanningFailed(diff=TableMissing(desired), failures=planning_failures)
+        planning = PlanningRejected(diff=TableMissing(desired), failures=planning_failures)
         compiled = None
     else:
         compiled = execution.compiled_plan if execution is not None else _compiled()
-        planning = PlanningSucceeded(diff=TableMissing(desired), plan=compiled.plan)
+        planning = PlanningAccepted(diff=TableMissing(desired), plan=compiled.plan)
     resolution = TableResolution(
         desired=desired,
         dependencies=(),

--- a/tests/application/test_planning.py
+++ b/tests/application/test_planning.py
@@ -1,8 +1,8 @@
 import pytest
 
 from delta_engine.application.planning import (
-    PlanningFailed,
-    PlanningSucceeded,
+    PlanningAccepted,
+    PlanningRejected,
     plan_changes,
 )
 from delta_engine.application.scopes import METADATA_ASPECTS
@@ -77,7 +77,7 @@ def test_plan_changes_accepts_safe_actions():
         _observed(),
     )
 
-    assert isinstance(result, PlanningSucceeded)
+    assert isinstance(result, PlanningAccepted)
     assert result.plan.target == _NAME
     assert result.plan.actions == (AddColumn(DesiredColumn("age", Integer())),)
 
@@ -93,7 +93,7 @@ def test_plan_changes_rejects_unsafe_actions():
         _observed(),
     )
 
-    assert isinstance(result, PlanningFailed)
+    assert isinstance(result, PlanningRejected)
     assert [failure.rule_name for failure in result.failures] == ["NonNullableColumnAdd"]
 
 
@@ -106,7 +106,7 @@ def test_plan_changes_rejects_unmanaged_actions():
         _observed(),
     )
 
-    assert isinstance(result, PlanningFailed)
+    assert isinstance(result, PlanningRejected)
     assert [failure.rule_name for failure in result.failures] == ["UnmanagedAspectDrift"]
 
 
@@ -136,7 +136,7 @@ def test_plan_changes_rejects_unmanaged_actions():
 def test_plan_changes_rejects_each_non_action_difference(desired, observed, expected_rule):
     result = plan_changes(desired, observed)
 
-    assert isinstance(result, PlanningFailed)
+    assert isinstance(result, PlanningRejected)
     assert expected_rule in {failure.rule_name for failure in result.failures}
 
 
@@ -146,7 +146,7 @@ def test_an_accepted_outcome_retains_the_diff_it_planned_from():
 
     result = plan_changes(desired, observed)
 
-    assert isinstance(result, PlanningSucceeded)
+    assert isinstance(result, PlanningAccepted)
     assert result.diff == diff_table(desired, observed)
 
 
@@ -161,7 +161,7 @@ def test_a_refused_outcome_retains_the_diff_it_refused():
 
     result = plan_changes(desired, observed)
 
-    assert isinstance(result, PlanningFailed)
+    assert isinstance(result, PlanningRejected)
     assert result.diff == diff_table(desired, observed)
 
 
@@ -172,13 +172,13 @@ def test_an_accepted_outcome_rejects_a_plan_for_another_tables_diff():
 
     # Then the outcome refuses to pair them
     with pytest.raises(ValueError, match="must target the diff"):
-        PlanningSucceeded(diff=diff, plan=other_plan)
+        PlanningAccepted(diff=diff, plan=other_plan)
 
 
 def test_plan_changes_accepts_no_op_as_an_empty_plan():
     result = plan_changes(_desired(), _observed())
 
-    assert isinstance(result, PlanningSucceeded)
+    assert isinstance(result, PlanningAccepted)
     assert result.plan.target == _NAME
     assert result.plan.actions == ()
 
@@ -201,7 +201,7 @@ def test_plan_changes_accepts_missing_table_and_builds_follow_up_actions():
     result = plan_changes(desired, None)
 
     # Then the create is followed by tag and constraint actions
-    assert isinstance(result, PlanningSucceeded)
+    assert isinstance(result, PlanningAccepted)
     assert result.plan.target == desired.qualified_name
     assert result.plan.actions == (
         CreateTable(desired),
@@ -216,7 +216,7 @@ def test_plan_changes_rejects_missing_table_when_table_existence_is_unmanaged():
 
     result = plan_changes(desired, None)
 
-    assert isinstance(result, PlanningFailed)
+    assert isinstance(result, PlanningRejected)
     assert [failure.rule_name for failure in result.failures] == ["MissingTableUnmanaged"]
 
 
@@ -235,7 +235,7 @@ def test_plan_changes_keeps_rename_and_residual_drift_under_the_new_name():
     result = plan_changes(desired, observed)
 
     # Then the residual drift lands under the new name
-    assert isinstance(result, PlanningSucceeded)
+    assert isinstance(result, PlanningAccepted)
     assert result.plan.actions == (
         RenameColumn(old_name="amt", new_name="amount"),
         AlterColumnType(column_name="amount", desired_type=Long(), observed_type=Integer()),
@@ -259,7 +259,7 @@ def test_plan_changes_replaces_a_primary_key_explicitly_across_a_rename():
     result = plan_changes(desired, observed)
 
     # Then the plan drops the old key, renames, then sets the new key
-    assert isinstance(result, PlanningSucceeded)
+    assert isinstance(result, PlanningAccepted)
     assert result.plan.actions == (
         DropPrimaryKey(primary_key=observed_key),
         RenameColumn("customer_nm", "customer_name"),
@@ -289,7 +289,7 @@ def test_plan_changes_rejects_rename_of_a_primary_key_referenced_by_foreign_keys
     result = plan_changes(desired, observed)
 
     # Then planning fails with the referenced-key rule
-    assert isinstance(result, PlanningFailed)
+    assert isinstance(result, PlanningRejected)
     assert [failure.rule_name for failure in result.failures] == [
         "PrimaryKeyReferencedByForeignKeys"
     ]
@@ -322,7 +322,7 @@ def test_plan_changes_replaces_a_foreign_key_explicitly_across_a_rename():
     result = plan_changes(desired, observed)
 
     # Then the plan drops the old key, renames, then sets the new key
-    assert isinstance(result, PlanningSucceeded)
+    assert isinstance(result, PlanningAccepted)
     assert result.plan.actions == (
         DropForeignKey(constraint=observed_key),
         RenameColumn("parent", "parent_id"),
@@ -360,7 +360,7 @@ def test_plan_changes_replaces_a_self_referencing_foreign_key_explicitly_across_
     result = plan_changes(desired, observed)
 
     # Then the plan drops the old key, renames, then sets the new key
-    assert isinstance(result, PlanningSucceeded)
+    assert isinstance(result, PlanningAccepted)
     assert result.plan.actions == (
         DropForeignKey(constraint=observed_key),
         RenameColumn("id", "employee_id"),
@@ -391,7 +391,7 @@ def test_plan_changes_drops_an_observed_only_foreign_key_alongside_a_rename():
     result = plan_changes(desired, observed)
 
     # Then the drop still lands alongside the rename
-    assert isinstance(result, PlanningSucceeded)
+    assert isinstance(result, PlanningAccepted)
     assert result.plan.actions == (
         DropForeignKey(constraint=unrelated_key),
         RenameColumn("customer_nm", "customer_name"),
@@ -410,7 +410,7 @@ def test_plan_carries_the_observed_relation_kind():
     result = plan_changes(desired, observed)
 
     # Then the plan knows what its actions lower against
-    assert isinstance(result, PlanningSucceeded)
+    assert isinstance(result, PlanningAccepted)
     assert result.plan.target == desired.qualified_name
     assert result.plan.kind is TableKind.STREAMING_TABLE
 
@@ -420,7 +420,7 @@ def test_creation_plan_carries_the_ordinary_table_kind():
     # only creates ordinary tables
     result = plan_changes(_desired(), None)
 
-    assert isinstance(result, PlanningSucceeded)
+    assert isinstance(result, PlanningAccepted)
     assert result.plan.target == _NAME
     assert result.plan.kind is TableKind.TABLE
 
@@ -439,7 +439,7 @@ def test_feature_enablement_outside_column_structure_scope_is_rejected():
     result = plan_changes(desired, observed)
 
     # Then the column-structure action is rejected as out of scope
-    assert isinstance(result, PlanningFailed)
+    assert isinstance(result, PlanningRejected)
     assert any("column structure" in failure.message for failure in result.failures)
 
 
@@ -460,7 +460,7 @@ def test_foreign_key_to_an_unregistered_parent_keeps_its_declared_referenced_spe
     result = plan_changes(desired, _observed())
 
     # Then the referenced spelling passes through planning untouched
-    assert isinstance(result, PlanningSucceeded)
+    assert isinstance(result, PlanningAccepted)
     [action] = [action for action in result.plan if isinstance(action, SetForeignKey)]
     assert tuple(str(c) for c in action.constraint.referenced_columns) == ("parent_id",)
 
@@ -477,7 +477,7 @@ def test_created_table_uses_its_columns_spelling_for_internal_references():
     result = plan_changes(desired, None)
 
     # Then the creation plan carries the declared spelling untouched
-    assert isinstance(result, PlanningSucceeded)
+    assert isinstance(result, PlanningAccepted)
     [create] = [action for action in result.plan if isinstance(action, CreateTable)]
     assert create.table.primary_key is not None
     assert tuple(str(c) for c in create.table.primary_key.columns) == ("requestId",)
@@ -507,7 +507,7 @@ def test_foreign_key_actions_join_the_validated_plan_in_phase_order():
     )
 
     # Then the accepted plan carries the foreign-key action
-    assert isinstance(result, PlanningSucceeded)
+    assert isinstance(result, PlanningAccepted)
     assert result.plan.actions == (SetForeignKey(constraint=fk),)
 
 
@@ -539,7 +539,7 @@ def test_pk_drop_exemption_sees_same_sync_foreign_key_drops():
 
     # Then the exemption found the drop in the same stream, and the plan
     # phases the FK drop before the PK drop
-    assert isinstance(result, PlanningSucceeded)
+    assert isinstance(result, PlanningAccepted)
     assert [type(action) for action in result.plan.actions] == [DropForeignKey, DropPrimaryKey]
 
 
@@ -564,7 +564,7 @@ def test_foreign_key_drift_on_an_unmanaged_aspect_fails_eligibility():
     )
 
     # Then the eligibility check rejects the unmanaged work
-    assert isinstance(result, PlanningFailed)
+    assert isinstance(result, PlanningRejected)
     assert [failure.rule_name for failure in result.failures] == ["UnmanagedAspectDrift"]
 
 
@@ -585,5 +585,5 @@ def test_missing_table_plan_contains_the_declared_foreign_keys():
     result = plan_changes(desired, None)
 
     # Then the accepted plan creates the table and then adds the constraint
-    assert isinstance(result, PlanningSucceeded)
+    assert isinstance(result, PlanningAccepted)
     assert [type(action) for action in result.plan.actions] == [CreateTable, SetForeignKey]

--- a/tests/application/test_ports.py
+++ b/tests/application/test_ports.py
@@ -4,16 +4,11 @@ from delta_engine.application.failures import ExecutionFailure
 from delta_engine.application.ports import (
     CompiledAction,
     CompiledPlan,
-    ExecutionSucceeded,
-    ExecutionSummary,
+    ExecutionResult,
 )
 from delta_engine.domain.model import QualifiedName
 from delta_engine.domain.plan import ActionPlan, SetTableComment
 from tests.builders import build_compiled_plan
-
-
-def _ok_exec(idx=0, preview="ALTER TABLE ..."):
-    return ExecutionSucceeded(statement_index=idx, statement=preview)
 
 
 def _failed_exec(idx=0, preview="ALTER TABLE ...", exc="ValueError", msg="boom"):
@@ -71,87 +66,69 @@ def test_compiled_plan_copies_mutable_compiled_actions_to_a_tuple():
     assert compiled.compiled_actions == (compiled_action,)
 
 
-def test_execution_summary_copies_mutable_results_to_a_tuple():
-    compiled = _compiled("SQL")
-    succeeded = _ok_exec(0, "SQL")
-    results = [succeeded]
-
-    summary = ExecutionSummary(
-        compiled_plan=compiled,
-        results=results,  # type: ignore[arg-type]
-    )
-    results.clear()
-
-    assert summary.results == (succeeded,)
-
-
-def test_execution_summary_reports_no_failure_when_every_statement_succeeds():
-    # Given a run whose statements all executed
+def test_execution_result_success_covers_the_complete_plan():
     compiled = _compiled("SQL 0", "SQL 1")
-    summary = ExecutionSummary(
-        compiled_plan=compiled,
-        results=(_ok_exec(0, "SQL 0"), _ok_exec(1, "SQL 1")),
-    )
 
-    # Then the summary reports success with no failures
-    assert not summary.failures
-    assert summary.applied_count == 2
+    result = ExecutionResult(compiled_plan=compiled, applied_count=2)
+
+    assert result.failures == ()
+    assert result.applied_count == 2
 
 
-def test_execution_summary_exposes_the_failures_among_mixed_results():
-    # Given a run whose second statement failed, leaving the third unattempted
+def test_execution_result_exposes_its_single_failure():
     compiled = _compiled("SQL 0", "SQL 1", "SQL 2")
-    summary = ExecutionSummary(
+
+    result = ExecutionResult(
         compiled_plan=compiled,
-        results=(_ok_exec(0, "SQL 0"), _failed_exec(1, "SQL 1", msg="bang")),
+        applied_count=1,
+        failure=_failed_exec(1, "SQL 1", msg="bang"),
     )
 
-    # Then the summary surfaces the single failure and the applied count
-    assert tuple(f.message for f in summary.failures) == ("bang",)
-    assert summary.applied_count == 1
+    assert tuple(f.message for f in result.failures) == ("bang",)
+    assert result.applied_count == 1
 
 
-def test_execution_summary_accepts_complete_execution_of_an_empty_plan():
-    summary = ExecutionSummary(compiled_plan=_compiled())
+def test_execution_result_accepts_complete_execution_of_an_empty_plan():
+    result = ExecutionResult(compiled_plan=_compiled())
 
-    # Then it is an empty, non-failing summary
-    assert summary.results == ()
-    assert not summary.failures
-    assert summary.applied_count == 0
+    assert result.failures == ()
+    assert result.applied_count == 0
 
 
-def test_execution_summary_rejects_non_contiguous_statement_indexes():
-    compiled = _compiled("SQL 0")
-
-    with pytest.raises(ValueError, match="contiguous"):
-        ExecutionSummary(compiled_plan=compiled, results=(_ok_exec(1, "SQL 0"),))
-
-
-def test_execution_summary_rejects_results_after_a_failure():
-    compiled = _compiled("SQL 0", "SQL 1")
-
-    with pytest.raises(ValueError, match="first failure"):
-        ExecutionSummary(
-            compiled_plan=compiled,
-            results=(_failed_exec(0, "SQL 0"), _ok_exec(1, "SQL 1")),
-        )
-
-
-def test_execution_summary_rejects_a_successful_partial_history():
-    compiled = _compiled("SQL 0", "SQL 1")
-
+def test_execution_result_rejects_a_successful_partial_history():
     with pytest.raises(ValueError, match="complete compiled plan"):
-        ExecutionSummary(
-            compiled_plan=compiled,
-            results=(_ok_exec(0, "SQL 0"),),
+        ExecutionResult(compiled_plan=_compiled("SQL 0", "SQL 1"), applied_count=1)
+
+
+def test_execution_result_rejects_an_applied_count_outside_the_plan():
+    with pytest.raises(ValueError, match="within the compiled plan"):
+        ExecutionResult(compiled_plan=_compiled("SQL 0"), applied_count=2)
+    with pytest.raises(ValueError, match="within the compiled plan"):
+        ExecutionResult(compiled_plan=_compiled("SQL 0"), applied_count=-1)
+
+
+def test_execution_result_rejects_a_failure_away_from_the_applied_prefix():
+    with pytest.raises(ValueError, match="first failure"):
+        ExecutionResult(
+            compiled_plan=_compiled("SQL 0", "SQL 1"),
+            applied_count=0,
+            failure=_failed_exec(1, "SQL 1"),
         )
 
 
-def test_execution_summary_rejects_a_statement_outside_the_compiled_plan():
-    compiled = _compiled("SQL 0")
+def test_execution_result_rejects_a_failure_for_a_different_statement():
+    with pytest.raises(ValueError, match="compiled statement"):
+        ExecutionResult(
+            compiled_plan=_compiled("SQL 0"),
+            applied_count=0,
+            failure=_failed_exec(0, "OTHER SQL"),
+        )
 
-    with pytest.raises(ValueError, match="compiled statement prefix"):
-        ExecutionSummary(
-            compiled_plan=compiled,
-            results=(_ok_exec(0, "OTHER SQL"),),
+
+def test_execution_result_rejects_a_failure_beyond_a_fully_applied_plan():
+    with pytest.raises(ValueError, match="within the compiled plan"):
+        ExecutionResult(
+            compiled_plan=_compiled("SQL 0"),
+            applied_count=1,
+            failure=_failed_exec(1, "SQL 0"),
         )

--- a/tests/application/test_rendering.py
+++ b/tests/application/test_rendering.py
@@ -18,8 +18,7 @@ from delta_engine.application.failures import (
 )
 from delta_engine.application.planning import PlanningAccepted, PlanningRejected
 from delta_engine.application.ports import (
-    ExecutionSucceeded,
-    ExecutionSummary,
+    ExecutionResult,
     TablePresent,
 )
 from delta_engine.application.relationships import TableResolution
@@ -632,32 +631,25 @@ def _grid_report(name, *, plan=None, failures=(), execution=None, blocked_failur
     )
 
 
-def _failed_execution(plan: ActionPlan, *, applied: int) -> ExecutionSummary:
-    succeeded = tuple(
-        ExecutionSucceeded(statement_index=index, statement=f"SQL {index}")
-        for index in range(applied)
-    )
-    failure = ExecutionFailure(
-        statement_index=applied,
-        exception_type="AnalysisException",
-        message="boom",
-        statement=f"SQL {applied}",
-    )
+def _failed_execution(plan: ActionPlan, *, applied: int) -> ExecutionResult:
     statements = tuple(f"SQL {index}" for index in range(len(plan)))
-    return ExecutionSummary(
+    return ExecutionResult(
         compiled_plan=build_compiled_plan(plan, statements),
-        results=(*succeeded, failure),
-    )
-
-
-def _successful_execution(plan: ActionPlan) -> ExecutionSummary:
-    statements = tuple(f"SQL {index}" for index in range(len(plan)))
-    return ExecutionSummary(
-        compiled_plan=build_compiled_plan(plan, statements),
-        results=tuple(
-            ExecutionSucceeded(statement_index=index, statement=statement)
-            for index, statement in enumerate(statements)
+        applied_count=applied,
+        failure=ExecutionFailure(
+            statement_index=applied,
+            exception_type="AnalysisException",
+            message="boom",
+            statement=f"SQL {applied}",
         ),
+    )
+
+
+def _successful_execution(plan: ActionPlan) -> ExecutionResult:
+    statements = tuple(f"SQL {index}" for index in range(len(plan)))
+    return ExecutionResult(
+        compiled_plan=build_compiled_plan(plan, statements),
+        applied_count=len(statements),
     )
 
 

--- a/tests/application/test_rendering.py
+++ b/tests/application/test_rendering.py
@@ -54,7 +54,7 @@ from delta_engine.domain.plan import (
     ColumnRenameConflict,
     PartitioningChanged,
     PropertyUndeclared,
-    TableMissing,
+    TableCreation,
     diff_table,
 )
 from delta_engine.domain.plan.actions import (
@@ -520,7 +520,7 @@ def test_diff_block_shows_plain_no_changes_when_nothing_failed():
     plan = ActionPlan(target=report.desired.qualified_name)
     healthy = TableRun(
         read=report.read,
-        planning=PlanningAccepted(diff=TableMissing(report.desired), plan=plan),
+        planning=PlanningAccepted(diff=TableCreation(report.desired), plan=plan),
         compiled=build_compiled_plan(plan, ()),
         resolution=report.resolution,
         execution=None,
@@ -606,9 +606,9 @@ def _grid_report(name, *, plan=None, failures=(), execution=None, blocked_failur
         failure for failure in failures if isinstance(failure, ValidationFailure)
     )
     planning = (
-        PlanningRejected(diff=TableMissing(desired), failures=planning_failures)
+        PlanningRejected(diff=TableCreation(desired), failures=planning_failures)
         if planning_failures
-        else PlanningAccepted(diff=TableMissing(desired), plan=plan)
+        else PlanningAccepted(diff=TableCreation(desired), plan=plan)
     )
     statements = tuple(f"SQL {index}" for index in range(len(plan) if plan is not None else 0))
     if planning_failures:

--- a/tests/application/test_rendering.py
+++ b/tests/application/test_rendering.py
@@ -16,7 +16,7 @@ from delta_engine.application.failures import (
     ReadFailure,
     ValidationFailure,
 )
-from delta_engine.application.planning import PlanningFailed, PlanningSucceeded
+from delta_engine.application.planning import PlanningAccepted, PlanningRejected
 from delta_engine.application.ports import (
     ExecutionSucceeded,
     ExecutionSummary,
@@ -496,7 +496,7 @@ def _report_with_empty_plan_and_failure() -> TableRun:
     )
     return TableRun(
         read=TablePresent(table=observed),
-        planning=PlanningFailed(
+        planning=PlanningRejected(
             diff=diff_table(desired, observed),
             failures=(ValidationFailure(rule_name="UnsupportedColumnTypeChange", message="nope"),),
         ),
@@ -520,7 +520,7 @@ def test_diff_block_shows_plain_no_changes_when_nothing_failed():
     plan = ActionPlan(target=report.desired.qualified_name)
     healthy = TableRun(
         read=report.read,
-        planning=PlanningSucceeded(diff=TableMissing(report.desired), plan=plan),
+        planning=PlanningAccepted(diff=TableMissing(report.desired), plan=plan),
         compiled=build_compiled_plan(plan, ()),
         resolution=report.resolution,
         execution=None,
@@ -606,9 +606,9 @@ def _grid_report(name, *, plan=None, failures=(), execution=None, blocked_failur
         failure for failure in failures if isinstance(failure, ValidationFailure)
     )
     planning = (
-        PlanningFailed(diff=TableMissing(desired), failures=planning_failures)
+        PlanningRejected(diff=TableMissing(desired), failures=planning_failures)
         if planning_failures
-        else PlanningSucceeded(diff=TableMissing(desired), plan=plan)
+        else PlanningAccepted(diff=TableMissing(desired), plan=plan)
     )
     statements = tuple(f"SQL {index}" for index in range(len(plan) if plan is not None else 0))
     if planning_failures:
@@ -1235,7 +1235,7 @@ def test_a_rejected_table_shows_the_drift_that_was_refused():
     )
     report = TableRun(
         read=TablePresent(table=observed),
-        planning=PlanningFailed(
+        planning=PlanningRejected(
             diff=diff_table(desired, observed),
             failures=(ValidationFailure(rule_name="NonNullableColumnAdd", message="nope"),),
         ),
@@ -1276,7 +1276,7 @@ def test_a_rejected_table_shows_the_differences_no_action_could_close():
     )
     report = TableRun(
         read=TablePresent(table=observed),
-        planning=PlanningFailed(
+        planning=PlanningRejected(
             diff=diff_table(desired, observed),
             failures=(ValidationFailure(rule_name="PartitioningIsImmutable", message="nope"),),
         ),

--- a/tests/application/test_report.py
+++ b/tests/application/test_report.py
@@ -40,7 +40,7 @@ from delta_engine.domain.model import (
     String,
     TableFeature,
 )
-from delta_engine.domain.plan import TableDiff, TableMissing, diff_table
+from delta_engine.domain.plan import TableCreation, TableDiff, diff_table
 from delta_engine.domain.plan.actions import (
     ActionPlan,
     CreateTable,
@@ -171,7 +171,7 @@ def _report(
         assert plan is None or isinstance(plan, ActionPlan)
         report_plan = plan
 
-    planning_diff = diff if diff is not None else TableMissing(desired)
+    planning_diff = diff if diff is not None else TableCreation(desired)
     if isinstance(read, ReadFailure):
         planning = None
     elif planning_failures:
@@ -559,7 +559,7 @@ def test_table_run_rejects_planning_after_a_failed_read():
         TableRun(
             read=ReadFailure("IOError", "boom"),
             planning=PlanningAccepted(
-                diff=TableMissing(desired), plan=ActionPlan(target=desired.qualified_name)
+                diff=TableCreation(desired), plan=ActionPlan(target=desired.qualified_name)
             ),
             compiled=None,
             resolution=TableResolution(desired, (), ()),
@@ -574,7 +574,7 @@ def test_table_run_rejects_successful_planning_without_compilation():
         TableRun(
             read=TableAbsent(),
             planning=PlanningAccepted(
-                diff=TableMissing(desired), plan=ActionPlan(target=desired.qualified_name)
+                diff=TableCreation(desired), plan=ActionPlan(target=desired.qualified_name)
             ),
             compiled=None,
             resolution=TableResolution(desired, (), ()),
@@ -590,7 +590,7 @@ def test_table_run_rejects_compilation_of_another_plan():
     with pytest.raises(ValueError, match="must match the successful planning outcome"):
         TableRun(
             read=TableAbsent(),
-            planning=PlanningAccepted(diff=TableMissing(desired), plan=plan),
+            planning=PlanningAccepted(diff=TableCreation(desired), plan=plan),
             compiled=build_compiled_plan(other_plan, ()),
             resolution=TableResolution(desired, (), ()),
             execution=None,
@@ -611,7 +611,7 @@ def test_table_run_rejects_execution_after_failed_resolution():
     with pytest.raises(ValueError, match="Execution cannot follow a failed earlier phase"):
         TableRun(
             read=TablePresent(table=_an_observed_table()),
-            planning=PlanningAccepted(diff=TableMissing(desired), plan=plan),
+            planning=PlanningAccepted(diff=TableCreation(desired), plan=plan),
             compiled=compiled,
             resolution=TableResolution(desired, (), (failure,)),
             execution=ExecutionSummary(
@@ -630,7 +630,7 @@ def test_table_run_rejects_execution_of_another_compiled_plan():
     with pytest.raises(ValueError, match="reported compiled plan"):
         TableRun(
             read=TablePresent(table=_an_observed_table()),
-            planning=PlanningAccepted(diff=TableMissing(desired), plan=plan),
+            planning=PlanningAccepted(diff=TableCreation(desired), plan=plan),
             compiled=reported,
             resolution=TableResolution(desired, (), ()),
             execution=ExecutionSummary(
@@ -1365,7 +1365,7 @@ def test_table_run_rejects_a_planning_outcome_targeting_another_table():
     desired = _a_desired_table("orders")
     other = _a_desired_table("other")
     other_plan = ActionPlan(target=other.qualified_name)
-    foreign_outcome = PlanningAccepted(diff=TableMissing(other), plan=other_plan)
+    foreign_outcome = PlanningAccepted(diff=TableCreation(other), plan=other_plan)
 
     # Then the run refuses to carry it
     with pytest.raises(ValueError, match="must target the reported table"):

--- a/tests/application/test_report.py
+++ b/tests/application/test_report.py
@@ -16,8 +16,6 @@ from delta_engine.application.failures import (
 from delta_engine.application.planning import PlanningAccepted, PlanningRejected
 from delta_engine.application.ports import (
     ExecutionResult,
-    ExecutionSucceeded,
-    ExecutionSummary,
     ReadResult,
     TableAbsent,
     TablePresent,
@@ -84,10 +82,6 @@ def _t1():
     return datetime(2025, 10, 2, 12, 5, 0)
 
 
-def _ok_exec(idx=0, preview="ALTER TABLE ..."):
-    return ExecutionSucceeded(statement_index=idx, statement=preview)
-
-
 def _failed_exec(idx=0, preview="ALTER TABLE ...", exc="ValueError", msg="boom"):
     return ExecutionFailure(
         statement_index=idx,
@@ -130,14 +124,23 @@ def _comment_plan(name: str, statement_count: int = 1) -> ActionPlan:
     )
 
 
-def _execution(plan: ActionPlan, *results: ExecutionResult) -> ExecutionSummary:
-    return ExecutionSummary(
-        compiled_plan=build_compiled_plan(
-            plan,
-            tuple(result.statement for result in results),
-        ),
-        results=results,
-    )
+def _execution(
+    plan: ActionPlan,
+    statements: tuple[str, ...] = (),
+    *,
+    failure: ExecutionFailure | None = None,
+) -> ExecutionResult:
+    """Build an execution result over ``plan``: complete unless ``failure`` is given."""
+    if not statements:
+        statements = tuple(
+            failure.statement
+            if failure is not None and failure.statement_index == index
+            else "ALTER TABLE ..."
+            for index in range(len(plan))
+        )
+    compiled = build_compiled_plan(plan, statements)
+    applied = len(statements) if failure is None else failure.statement_index
+    return ExecutionResult(compiled_plan=compiled, applied_count=applied, failure=failure)
 
 
 def _report(
@@ -148,7 +151,7 @@ def _report(
     statements: tuple[str, ...] = (),
     failures: tuple[Failure, ...] = (),
     dependencies: tuple[ForeignKeyConstraint, ...] = (),
-    execution: ExecutionSummary | None = None,
+    execution: ExecutionResult | None = None,
     blocked_failures: tuple[ForeignKeyFailure, ...] = (),
     diff: TableDiff | None = None,
 ) -> TableRun:
@@ -212,7 +215,7 @@ def test_table_status_success_when_all_actions_succeed():
     # Given successful read, no pre-execution failures, and only successful actions
     read = TablePresent(table=_an_observed_table())
     plan = _comment_plan("tbl", statement_count=2)
-    execution = _execution(plan, _ok_exec(0), _ok_exec(1))
+    execution = _execution(plan)
 
     # When aggregating
     report = _report(
@@ -234,12 +237,12 @@ def test_sync_report_has_failures_true_if_any_table_has_failures():
     t_ok = _report(
         desired=_a_desired_table("a"),
         read=TablePresent(table=_an_observed_table()),
-        execution=_execution(ok_plan, _ok_exec(0)),
+        execution=_execution(ok_plan),
     )
     t_bad = _report(
         desired=_a_desired_table("b"),
         read=TablePresent(table=_an_observed_table()),
-        execution=_execution(failed_plan, _failed_exec(0)),
+        execution=_execution(failed_plan, failure=_failed_exec(0)),
     )
 
     # When aggregating the sync
@@ -352,7 +355,7 @@ def test_a_failed_table_counts_as_failed_even_though_it_planned_changes():
         plan=plan,
         execution=_execution(
             plan,
-            ExecutionFailure(
+            failure=ExecutionFailure(
                 statement_index=0,
                 exception_type="SparkException",
                 message="boom",
@@ -403,7 +406,7 @@ def test_sync_report_failures_by_table_maps_only_failed_tables():
     t_ok = _report(
         desired=_a_desired_table("x"),
         read=TablePresent(table=_an_observed_table()),
-        execution=_execution(successful_plan, _ok_exec(0)),
+        execution=_execution(successful_plan),
     )
     t_bad = _report(
         desired=_a_desired_table("y"),
@@ -508,7 +511,7 @@ def test_table_run_with_no_failures_is_success():
     report = _report(
         desired=_a_desired_table("ok"),
         read=TablePresent(table=_an_observed_table()),
-        execution=_execution(plan, _ok_exec(0)),
+        execution=_execution(plan),
     )
 
     # Then it is a success and carries no failures
@@ -523,7 +526,7 @@ def test_status_reflects_the_earliest_failing_phase():
     exec_only = _report(
         desired=_a_desired_table("e"),
         read=read,
-        execution=_execution(plan, _failed_exec(0)),
+        execution=_execution(plan, failure=_failed_exec(0)),
     )
     # Then it is EXECUTION_FAILED
     assert exec_only.status is TableRunStatus.EXECUTION_FAILED
@@ -614,10 +617,7 @@ def test_table_run_rejects_execution_after_failed_resolution():
             planning=PlanningAccepted(diff=TableCreation(desired), plan=plan),
             compiled=compiled,
             resolution=TableResolution(desired, (), (failure,)),
-            execution=ExecutionSummary(
-                compiled_plan=compiled,
-                results=(_ok_exec(0, "SQL"),),
-            ),
+            execution=ExecutionResult(compiled_plan=compiled, applied_count=1),
         )
 
 
@@ -633,10 +633,7 @@ def test_table_run_rejects_execution_of_another_compiled_plan():
             planning=PlanningAccepted(diff=TableCreation(desired), plan=plan),
             compiled=reported,
             resolution=TableResolution(desired, (), ()),
-            execution=ExecutionSummary(
-                compiled_plan=executed,
-                results=(_ok_exec(0, "EXECUTED SQL"),),
-            ),
+            execution=ExecutionResult(compiled_plan=executed, applied_count=1),
         )
 
 
@@ -685,8 +682,8 @@ def test_statement_progress_counts_applied_against_planned():
         plan=plan,
         execution=_execution(
             plan,
-            ExecutionSucceeded(statement_index=0, statement=statements[0]),
-            ExecutionFailure(
+            statements,
+            failure=ExecutionFailure(
                 statement_index=1,
                 exception_type="SparkException",
                 message="boom",
@@ -795,20 +792,17 @@ def test_first_and_later_execution_failures_have_distinct_change_states():
     first_failed = _report(
         desired=_a_desired_table("first"),
         read=TablePresent(table=_an_observed_table()),
-        execution=ExecutionSummary(
+        execution=ExecutionResult(
             compiled_plan=build_compiled_plan(first_plan, statements),
-            results=(_failed_exec(0, statements[0]),),
+            applied_count=0,
+            failure=_failed_exec(0, statements[0]),
         ),
     )
     later_plan = _comment_plan("later", statement_count=2)
     later_failed = _report(
         desired=_a_desired_table("later"),
         read=TablePresent(table=_an_observed_table()),
-        execution=_execution(
-            later_plan,
-            _ok_exec(0, statements[0]),
-            _failed_exec(1, statements[1]),
-        ),
+        execution=_execution(later_plan, statements, failure=_failed_exec(1, statements[1])),
     )
 
     # When both table outcomes are aggregated in report order
@@ -832,7 +826,7 @@ def test_change_state_is_applied_after_complete_successful_execution():
     report = _report(
         desired=_a_desired_table("orders"),
         read=TablePresent(table=_an_observed_table()),
-        execution=_execution(plan, _ok_exec(0), _ok_exec(1)),
+        execution=_execution(plan),
     )
 
     # When deriving change states through the validated aggregate
@@ -851,7 +845,7 @@ def test_sync_report_rejects_execution_results_on_a_dry_run():
     executed = _report(
         desired=_a_desired_table("orders"),
         read=TablePresent(table=_an_observed_table()),
-        execution=_execution(plan, _ok_exec()),
+        execution=_execution(plan),
     )
 
     # When constructing a dry-run aggregate
@@ -1020,7 +1014,9 @@ def test_an_execution_failure_record_carries_its_statement_facts():
         plan=plan,
         execution=_execution(
             plan,
-            _failed_exec(0, preview=statement, exc="DeltaAnalysisException", msg=long_message),
+            failure=_failed_exec(
+                0, preview=statement, exc="DeltaAnalysisException", msg=long_message
+            ),
         ),
     )
 
@@ -1124,7 +1120,9 @@ def _one_run_per_failure_variant() -> tuple[TableRun, ...]:
         desired=_a_desired_table("orders"),
         read=TablePresent(table=_an_observed_table()),
         plan=plan,
-        execution=_execution(plan, _failed_exec(0, exc="DeltaAnalysisException", msg="boom")),
+        execution=_execution(
+            plan, failure=_failed_exec(0, exc="DeltaAnalysisException", msg="boom")
+        ),
     )
     blocked = _report(
         desired=_a_desired_table("b"),
@@ -1168,7 +1166,7 @@ def test_table_to_dict_reports_execution_counts_when_executed():
         desired=_a_desired_table("orders"),
         read=TablePresent(table=_an_observed_table()),
         plan=plan,
-        execution=_execution(plan, _ok_exec(0, preview=statement)),
+        execution=_execution(plan, (statement,)),
     )
     assert report.to_dict()["execution"] == {"applied": 1, "total": 1}
 

--- a/tests/application/test_report.py
+++ b/tests/application/test_report.py
@@ -13,7 +13,7 @@ from delta_engine.application.failures import (
     ReadFailure,
     ValidationFailure,
 )
-from delta_engine.application.planning import PlanningFailed, PlanningSucceeded
+from delta_engine.application.planning import PlanningAccepted, PlanningRejected
 from delta_engine.application.ports import (
     ExecutionResult,
     ExecutionSucceeded,
@@ -175,10 +175,10 @@ def _report(
     if isinstance(read, ReadFailure):
         planning = None
     elif planning_failures:
-        planning = PlanningFailed(diff=planning_diff, failures=planning_failures)
+        planning = PlanningRejected(diff=planning_diff, failures=planning_failures)
     else:
         assert isinstance(report_plan, ActionPlan)
-        planning = PlanningSucceeded(diff=planning_diff, plan=report_plan)
+        planning = PlanningAccepted(diff=planning_diff, plan=report_plan)
 
     if report_plan is None:
         compiled = None
@@ -558,7 +558,7 @@ def test_table_run_rejects_planning_after_a_failed_read():
     with pytest.raises(ValueError, match="Planning cannot follow a failed read"):
         TableRun(
             read=ReadFailure("IOError", "boom"),
-            planning=PlanningSucceeded(
+            planning=PlanningAccepted(
                 diff=TableMissing(desired), plan=ActionPlan(target=desired.qualified_name)
             ),
             compiled=None,
@@ -573,7 +573,7 @@ def test_table_run_rejects_successful_planning_without_compilation():
     with pytest.raises(ValueError, match="requires compilation"):
         TableRun(
             read=TableAbsent(),
-            planning=PlanningSucceeded(
+            planning=PlanningAccepted(
                 diff=TableMissing(desired), plan=ActionPlan(target=desired.qualified_name)
             ),
             compiled=None,
@@ -590,7 +590,7 @@ def test_table_run_rejects_compilation_of_another_plan():
     with pytest.raises(ValueError, match="must match the successful planning outcome"):
         TableRun(
             read=TableAbsent(),
-            planning=PlanningSucceeded(diff=TableMissing(desired), plan=plan),
+            planning=PlanningAccepted(diff=TableMissing(desired), plan=plan),
             compiled=build_compiled_plan(other_plan, ()),
             resolution=TableResolution(desired, (), ()),
             execution=None,
@@ -611,7 +611,7 @@ def test_table_run_rejects_execution_after_failed_resolution():
     with pytest.raises(ValueError, match="Execution cannot follow a failed earlier phase"):
         TableRun(
             read=TablePresent(table=_an_observed_table()),
-            planning=PlanningSucceeded(diff=TableMissing(desired), plan=plan),
+            planning=PlanningAccepted(diff=TableMissing(desired), plan=plan),
             compiled=compiled,
             resolution=TableResolution(desired, (), (failure,)),
             execution=ExecutionSummary(
@@ -630,7 +630,7 @@ def test_table_run_rejects_execution_of_another_compiled_plan():
     with pytest.raises(ValueError, match="reported compiled plan"):
         TableRun(
             read=TablePresent(table=_an_observed_table()),
-            planning=PlanningSucceeded(diff=TableMissing(desired), plan=plan),
+            planning=PlanningAccepted(diff=TableMissing(desired), plan=plan),
             compiled=reported,
             resolution=TableResolution(desired, (), ()),
             execution=ExecutionSummary(
@@ -1365,7 +1365,7 @@ def test_table_run_rejects_a_planning_outcome_targeting_another_table():
     desired = _a_desired_table("orders")
     other = _a_desired_table("other")
     other_plan = ActionPlan(target=other.qualified_name)
-    foreign_outcome = PlanningSucceeded(diff=TableMissing(other), plan=other_plan)
+    foreign_outcome = PlanningAccepted(diff=TableMissing(other), plan=other_plan)
 
     # Then the run refuses to carry it
     with pytest.raises(ValueError, match="must target the reported table"):

--- a/tests/domain/plan/test_diff.py
+++ b/tests/domain/plan/test_diff.py
@@ -45,8 +45,8 @@ from delta_engine.domain.plan.actions import (
     UnsetTableTag,
 )
 from delta_engine.domain.plan.diff import (
+    TableCreation,
     TableDrift,
-    TableMissing,
     diff_table,
 )
 from delta_engine.domain.plan.unresolvable import (
@@ -98,7 +98,7 @@ def test_missing_table_diffs_to_table_missing_carrying_desired():
     diff = diff_table(desired, observed=None)
 
     # Then the diff is the self-contained missing-table variant
-    assert diff == TableMissing(desired=desired)
+    assert diff == TableCreation(desired=desired)
 
 
 def test_missing_table_derives_target_from_desired_table():
@@ -106,7 +106,7 @@ def test_missing_table_derives_target_from_desired_table():
 
     diff = diff_table(desired, observed=None)
 
-    assert isinstance(diff, TableMissing)
+    assert isinstance(diff, TableCreation)
     assert diff.target == _QUALIFIED_NAME
 
 
@@ -364,7 +364,7 @@ def test_missing_table_relies_on_create_for_required_features():
     diff = diff_table(desired, None)
 
     # Then creation relies on Delta to enable the required feature
-    assert isinstance(diff, TableMissing)
+    assert isinstance(diff, TableCreation)
     assert diff.actions == (CreateTable(desired),)
 
 
@@ -790,7 +790,7 @@ def test_missing_table_actions_include_every_declared_foreign_key():
     diff = diff_table(desired, observed=None)
 
     # Then creation is stated first and every declared FK follows
-    assert isinstance(diff, TableMissing)
+    assert isinstance(diff, TableCreation)
     assert isinstance(diff.actions[0], CreateTable)
     fk_actions = [a for a in diff.actions if isinstance(a, SetForeignKey)]
     assert {str(a.constraint.constraint_name) for a in fk_actions} == {
@@ -993,7 +993,7 @@ def test_diff_missing_table_ignores_rename_hints():
 
     diff = diff_table(desired, None)
 
-    assert isinstance(diff, TableMissing)
+    assert isinstance(diff, TableCreation)
     assert diff.desired is desired
 
 


### PR DESCRIPTION
## Summary
- One word, one meaning across outcome types: Error (raised), Failure (recorded), Result (per-step), Run (per-table), Report (per-sync) — glossary added to the architecture doc
- PlanningSucceeded/PlanningFailed → PlanningAccepted/PlanningRejected; CLI PlanResult → PlanView
- TableMissing → TableCreation: both TableDiff arms name the diff's content; ends the near-synonymy with the read port's TableAbsent
- ExecutionSummary → ExecutionResult(compiled_plan, applied_count, failure); the per-statement ExecutionSucceeded markers and union are dissolved
- Failures stay frozen values by design: exceptions-as-records was prototyped and declined (value equality, pickling, contextlib traceback assignment, and un-raisability all require the value form) — decision record in docs/superpowers/specs/2026-08-06-outcome-vocabulary-design.md (local)

## Wire compatibility
No serialized key, type name, or enum value changes; `schema_version` stays 2. All to_dict()/rendering expectations pass unchanged.

## Verification
- [x] uv run pytest -q — 1195 passed, coverage 97.14% (gate 70%)
- [x] uv run mypy src — no issues in 63 files
- [x] uv run ruff check + ruff format --check — clean, 155 files formatted
- [x] uv run lint-imports — 7 contracts kept, 0 broken
- [x] uv run --group docs sphinx-build -W docs docs/_build — build succeeded