### PR TITLE
fix: raise on unmanaged property transition checks

### DIFF
--- a/src/delta_engine/application/engine.py
+++ b/src/delta_engine/application/engine.py
@@ -186,7 +186,7 @@ class Engine:
             dry_run=dry_run,
         )
 
-        if not dry_run and report.has_failures:  # TODO: should a dry run raise as well?
+        if not dry_run and report.has_failures:
             raise SyncFailedError(report)
 
         logger.info(

--- a/src/delta_engine/application/properties.py
+++ b/src/delta_engine/application/properties.py
@@ -191,10 +191,20 @@ class PropertyPolicy:
         observed: str | None,
         desired: str | None,
     ) -> bool:
-        """Return whether a managed property may move to its desired value."""
+        """
+        Return whether a managed property may move to its desired value.
+
+        Only managed keys can reach a transition check — declarations are
+        validated and observations projected — so an unmanaged key is a
+        programming error, not a permitted transition.
+
+        Raises:
+            ValueError: If the key is not managed by this policy.
+
+        """
         definition = self._definitions_by_name.get(name)
-        if definition is None:  # TODO: raise on unknown properties
-            return True
+        if definition is None:
+            raise ValueError(f"Property not managed by this engine: {name}")
         return definition.permits_transition(observed, desired)
 
     def permits_removal(

--- a/tests/application/test_properties.py
+++ b/tests/application/test_properties.py
@@ -122,3 +122,17 @@ def test_policy_permits_first_write_of_a_restricted_property() -> None:
 def test_policy_permits_transitions_and_removal_for_unrestricted_properties(key: str) -> None:
     assert DELTA_PROPERTY_POLICY.permits_transition(key, observed="anything", desired="else")
     assert DELTA_PROPERTY_POLICY.permits_removal(key, observed="anything")
+
+
+def test_policy_rejects_a_transition_check_on_an_unmanaged_property() -> None:
+    with pytest.raises(ValueError, match=r"not managed.*delta\.enableRowTracking"):
+        DELTA_PROPERTY_POLICY.permits_transition(
+            "delta.enableRowTracking",
+            observed="true",
+            desired="false",
+        )
+
+
+def test_policy_rejects_a_removal_check_on_an_unmanaged_property() -> None:
+    with pytest.raises(ValueError, match=r"not managed.*delta\.enableRowTracking"):
+        DELTA_PROPERTY_POLICY.permits_removal("delta.enableRowTracking", observed="true")


### PR DESCRIPTION
Resolves two parked TODOs:

- `PropertyPolicy.permits_transition` (and `permits_removal` through it) now raises `ValueError` for a key the policy does not manage, instead of silently permitting the transition. Only managed keys can legitimately reach a transition check — declarations are validated by `validate_declaration` and observations filtered by `project_observed` — so an unmanaged key there is a programming error, and permitting it hid the bug. The message matches `validate_declaration`'s wording. Two tests pin the new behaviour.
- Removes the `TODO: should a dry run raise as well?` in `Engine.sync`, resolving the question as **no**: a dry run returns its report (as the docstring already promises), and CI callers gate on `report.has_failures` themselves.

No wire-format or public-API change beyond the new exception on a path only reachable through internal misuse.

Gates: 1197 passed (97.18% coverage), mypy, ruff check/format all clean.