### PR TITLE
fix: support streaming table annotations safely

### DIFF
--- a/docs/how-to-add-action-type.md
+++ b/docs/how-to-add-action-type.md
@@ -109,18 +109,17 @@ In `src/delta_engine/adapters/databricks/sql/compile.py`, register a `singledisp
 def _compile_update_comment(action: UpdateComment, target: _Target) -> str:
     col = backtick(action.column_name)
     comment = quote_literal(action.desired_comment)
-    return f"{target.annotation_alter_clause} ALTER COLUMN {col} COMMENT {comment}"
+    return f"{target.alter_clause} ALTER COLUMN {col} COMMENT {comment}"
 ```
 
 Each handler receives a `_Target` — the table as statements address it. It
-renders the backticked table name (`target.name`) and exposes the SQL forms the
-handlers need without exposing relation kind. Use `target.alter_table_clause`
-for ordinary operations. Annotation ALTER actions use
-`target.annotation_alter_clause`, which is pre-rendered with `ALTER TABLE ...`
-or `ALTER STREAMING TABLE ...` as appropriate. Planning has already accepted
-the action before compilation. A constraint action carries its complete
-constraint (named when the `DesiredTable` was built, or read from the catalog
-for an observed one), so the handler renders
+renders the backticked table name (`target.name`) and a relation-correct
+`target.alter_clause` without exposing relation kind. The latter is
+pre-rendered with `ALTER TABLE ...` or `ALTER STREAMING TABLE ...` as
+appropriate. Planning has already accepted the action before compilation. A
+constraint action carries its complete constraint (named when the
+`DesiredTable` was built, or read from the catalog for an observed one), so
+the handler renders
 `action.constraint.constraint_name` directly rather than computing it.
 
 Use `backtick` for identifiers and `quote_literal` for string literals (both in `delta_engine/adapters/databricks/sql/dialect.py`).

--- a/docs/how-to-add-action-type.md
+++ b/docs/how-to-add-action-type.md
@@ -106,21 +106,21 @@ In `src/delta_engine/adapters/databricks/sql/compile.py`, register a `singledisp
 
 ```python
 @_compile_action.register
-def _(action: UpdateComment, target: _Target) -> str:
+def _compile_update_comment(action: UpdateComment, target: _Target) -> str:
     col = backtick(action.column_name)
     comment = quote_literal(action.desired_comment)
     return f"{target.annotation_alter_clause} ALTER COLUMN {col} COMMENT {comment}"
 ```
 
 Each handler receives a `_Target` — the table as statements address it. It
-renders the backticked table name (`target.name`) and exposes two ALTER
-clauses. Use `target.table_alter_clause` for operations supported only on an
-ordinary table. Annotation actions use `target.annotation_alter_clause`, whose
-keyword follows the plan's relation kind (`ALTER TABLE ...` or `ALTER
-STREAMING TABLE ...`). The compiler rejects any non-annotation action paired
-with a streaming-table target before dispatch. A constraint action carries its
-complete constraint (named when the `DesiredTable` was built, or read from the
-catalog for an observed one), so the handler renders
+renders the backticked table name (`target.name`) and exposes the SQL forms the
+handlers need without exposing relation kind. Use `target.alter_table_clause`
+for ordinary operations. Annotation ALTER actions use
+`target.annotation_alter_clause`, which is pre-rendered with `ALTER TABLE ...`
+or `ALTER STREAMING TABLE ...` as appropriate. Planning has already accepted
+the action before compilation. A constraint action carries its complete
+constraint (named when the `DesiredTable` was built, or read from the catalog
+for an observed one), so the handler renders
 `action.constraint.constraint_name` directly rather than computing it.
 
 Use `backtick` for identifiers and `quote_literal` for string literals (both in `delta_engine/adapters/databricks/sql/dialect.py`).

--- a/docs/how-to-add-action-type.md
+++ b/docs/how-to-add-action-type.md
@@ -109,10 +109,19 @@ In `src/delta_engine/adapters/databricks/sql/compile.py`, register a `singledisp
 def _(action: UpdateComment, target: _Target) -> str:
     col = backtick(action.column_name)
     comment = quote_literal(action.desired_comment)
-    return f"{target.alter_clause} ALTER COLUMN {col} COMMENT {comment}"
+    return f"{target.annotation_alter_clause} ALTER COLUMN {col} COMMENT {comment}"
 ```
 
-Each handler receives a `_Target` — the table as statements address it. It renders the backticked table name (`target.name`) and the ALTER clause whose keyword follows the plan's relation kind (`target.alter_clause` — `ALTER TABLE ...` or `ALTER STREAMING TABLE ...`); ALTER-family statements start from `target.alter_clause` so every action follows the observed relation kind. A constraint action carries its complete constraint (named when the `DesiredTable` was built, or read from the catalog for an observed one), so the handler renders `action.constraint.constraint_name` directly rather than computing it.
+Each handler receives a `_Target` — the table as statements address it. It
+renders the backticked table name (`target.name`) and exposes two ALTER
+clauses. Use `target.table_alter_clause` for operations supported only on an
+ordinary table. Annotation actions use `target.annotation_alter_clause`, whose
+keyword follows the plan's relation kind (`ALTER TABLE ...` or `ALTER
+STREAMING TABLE ...`). The compiler rejects any non-annotation action paired
+with a streaming-table target before dispatch. A constraint action carries its
+complete constraint (named when the `DesiredTable` was built, or read from the
+catalog for an observed one), so the handler renders
+`action.constraint.constraint_name` directly rather than computing it.
 
 Use `backtick` for identifiers and `quote_literal` for string literals (both in `delta_engine/adapters/databricks/sql/dialect.py`).
 

--- a/docs/how-to-implement-adapter.md
+++ b/docs/how-to-implement-adapter.md
@@ -75,7 +75,8 @@ both the qualified table target (`plan.target`) and the relation kind its
 actions lower against (`plan.kind`). Backends whose DDL dialect differs by
 kind read both facts from the plan; a backend with one dialect may ignore the
 kind. Databricks, for example, uses `ALTER STREAMING TABLE` for annotation
-actions on a streaming table and rejects non-annotation actions for that kind.
+actions on a streaming table. Eligibility validation ensures that wider
+streaming-table declarations never produce an accepted plan.
 
 The engine passes those same compiled statements to `execute` one at a time.
 The table they target is already baked into each statement. Returning normally

--- a/docs/how-to-implement-adapter.md
+++ b/docs/how-to-implement-adapter.md
@@ -73,8 +73,9 @@ is a pure, local operation that cannot fail against a backend, so it may raise
 on a genuine programming error rather than swallowing it. The plan carries
 both the qualified table target (`plan.target`) and the relation kind its
 actions lower against (`plan.kind`). Backends whose DDL dialect differs by
-kind (Databricks streaming tables take `ALTER STREAMING TABLE`) read both
-facts from the plan; a backend with one dialect may ignore the kind.
+kind read both facts from the plan; a backend with one dialect may ignore the
+kind. Databricks, for example, uses `ALTER STREAMING TABLE` for annotation
+actions on a streaming table and rejects non-annotation actions for that kind.
 
 The engine passes those same compiled statements to `execute` one at a time.
 The table they target is already baked into each statement. Returning normally

--- a/src/delta_engine/adapters/databricks/read.py
+++ b/src/delta_engine/adapters/databricks/read.py
@@ -54,7 +54,7 @@ class UnsupportedRelationError(Exception):
 # tables, managed or external (existing external tables can be altered;
 # creating one is not yet supported — CREATE TABLE emits no LOCATION), and
 # streaming tables, which take the ALTER STREAMING TABLE dialect and admit
-# tag changes only — the reader states the kind; validation's eligibility
+# annotation changes only — the reader states the kind; validation's eligibility
 # checks enforce the restriction. Anything else a catalog name can resolve to — a
 # view, a materialized view, a foreign table, a non-Delta format — cannot be
 # represented as engine state, so the read admits exactly these kinds and

--- a/src/delta_engine/adapters/databricks/sql/compile.py
+++ b/src/delta_engine/adapters/databricks/sql/compile.py
@@ -47,12 +47,7 @@ from delta_engine.domain.plan import (
 
 @dataclass(frozen=True, slots=True)
 class _Target:
-    """
-    A relation rendered as Databricks SQL addresses it.
-
-    Hides identifier quoting and the relation-kind-specific ALTER dialect so
-    action compilers need no knowledge of :class:`TableKind`.
-    """
+    """A relation target rendered for Databricks SQL statements."""
 
     name: str
     alter_clause: str

--- a/src/delta_engine/adapters/databricks/sql/compile.py
+++ b/src/delta_engine/adapters/databricks/sql/compile.py
@@ -45,43 +45,34 @@ from delta_engine.domain.plan import (
 )
 
 
-def _annotation_alter_keyword(kind: TableKind) -> str:
-    """Return the relation-kind-specific ALTER keyword used by annotations."""
-    match kind:
-        case TableKind.TABLE:
-            return "ALTER TABLE"
-        case TableKind.STREAMING_TABLE:
-            # ALTER STREAMING TABLE is the documented annotation dialect. Its
-            # behaviour is pinned by the streaming-table live test.
-            return "ALTER STREAMING TABLE"
-        case _ as unreachable:
-            assert_never(unreachable)
-
-
 @dataclass(frozen=True, slots=True)
 class _Target:
     """
-    The table as SQL statements address it.
+    A relation rendered as Databricks SQL addresses it.
 
-    Construction hides qualified-name quoting and the one dialect decision
-    relation kind affects. Action compilers receive rendered capabilities, not
-    the kind itself, so ordinary operations cannot accidentally depend on it.
+    Hides identifier quoting and the relation-kind-specific ALTER dialect so
+    action compilers need no knowledge of :class:`TableKind`.
     """
 
     name: str
-    annotation_alter_clause: str
+    alter_clause: str
 
     @classmethod
     def for_relation(cls, qualified_name: QualifiedName, kind: TableKind) -> "_Target":
-        """Render the target forms needed to compile actions for one relation."""
+        """Render the SQL forms needed to compile actions for one relation."""
         name = backtick_qualified_name(qualified_name)
-        annotation_alter_clause = f"{_annotation_alter_keyword(kind)} {name}"
-        return cls(name=name, annotation_alter_clause=annotation_alter_clause)
 
-    @property
-    def alter_table_clause(self) -> str:
-        """The kind-independent ALTER TABLE clause for ordinary operations."""
-        return f"ALTER TABLE {self.name}"
+        match kind:
+            case TableKind.TABLE:
+                alter_keyword = "ALTER TABLE"
+            case TableKind.STREAMING_TABLE:
+                # ALTER STREAMING TABLE is the documented annotation dialect.
+                # Its behaviour is pinned by the streaming-table live test.
+                alter_keyword = "ALTER STREAMING TABLE"
+            case _ as unreachable:
+                assert_never(unreachable)
+
+        return cls(name=name, alter_clause=f"{alter_keyword} {name}")
 
 
 def compile_plan(plan: ActionPlan) -> CompiledPlan:
@@ -89,8 +80,8 @@ def compile_plan(plan: ActionPlan) -> CompiledPlan:
     Compile an :class:`ActionPlan` into SQL statements, in plan order.
 
     Planning has already decided whether the declaration may act on the
-    relation. Compilation only lowers each accepted action; relation kind
-    selects the annotation ALTER dialect and does not affect other actions.
+    relation. Compilation only lowers each accepted action; the target hides
+    the relation-kind-specific ALTER dialect from action compilers.
     """
     target = _Target.for_relation(plan.target, plan.kind)
     compiled_actions = [
@@ -164,14 +155,14 @@ def _compile_add_column(action: AddColumn, target: _Target) -> str:
     name = backtick(action.column.name)
     dtype = render_data_type(action.column.data_type)
     comment = f" COMMENT {quote_literal(action.column.comment)}" if action.column.comment else ""
-    return f"{target.alter_table_clause} ADD COLUMN {name} {dtype}{comment}"
+    return f"{target.alter_clause} ADD COLUMN {name} {dtype}{comment}"
 
 
 @_compile_action.register
 def _compile_drop_column(action: DropColumn, target: _Target) -> str:
     """Compile an ALTER TABLE ... DROP COLUMN statement for a column name."""
     column_name = backtick(action.column.name)
-    return f"{target.alter_table_clause} DROP COLUMN {column_name}"
+    return f"{target.alter_clause} DROP COLUMN {column_name}"
 
 
 @_compile_action.register
@@ -179,7 +170,7 @@ def _compile_rename_column(action: RenameColumn, target: _Target) -> str:
     """Compile ALTER TABLE ... RENAME COLUMN."""
     old = backtick(action.old_name)
     new = backtick(action.new_name)
-    return f"{target.alter_table_clause} RENAME COLUMN {old} TO {new}"
+    return f"{target.alter_clause} RENAME COLUMN {old} TO {new}"
 
 
 @_compile_action.register
@@ -187,44 +178,44 @@ def _compile_enable_table_feature(action: EnableTableFeature, target: _Target) -
     """Compile a table-feature enablement to its documented SET TBLPROPERTIES form."""
     property_ = enable_property(action.feature)
     pair = f"{quote_literal(property_.key)}={quote_literal(property_.value)}"
-    return f"{target.alter_table_clause} SET TBLPROPERTIES ({pair})"
+    return f"{target.alter_clause} SET TBLPROPERTIES ({pair})"
 
 
 @_compile_action.register
 def _compile_set_property(action: SetProperty, target: _Target) -> str:
     pair = f"{quote_literal(action.name)}={quote_literal(action.desired_value)}"
-    return f"{target.alter_table_clause} SET TBLPROPERTIES ({pair})"
+    return f"{target.alter_clause} SET TBLPROPERTIES ({pair})"
 
 
 @_compile_action.register
 def _compile_unset_property(action: UnsetProperty, target: _Target) -> str:
     key = quote_literal(action.name)
-    return f"{target.alter_table_clause} UNSET TBLPROPERTIES IF EXISTS ({key})"
+    return f"{target.alter_clause} UNSET TBLPROPERTIES IF EXISTS ({key})"
 
 
 @_compile_action.register
 def _compile_set_table_tag(action: SetTableTag, target: _Target) -> str:
     pair = f"{quote_literal(action.name)}={quote_literal(action.desired_value)}"
-    return f"{target.annotation_alter_clause} SET TAGS ({pair})"
+    return f"{target.alter_clause} SET TAGS ({pair})"
 
 
 @_compile_action.register
 def _compile_unset_table_tag(action: UnsetTableTag, target: _Target) -> str:
-    return f"{target.annotation_alter_clause} UNSET TAGS ({quote_literal(action.name)})"
+    return f"{target.alter_clause} UNSET TAGS ({quote_literal(action.name)})"
 
 
 @_compile_action.register
 def _compile_set_column_tag(action: SetColumnTag, target: _Target) -> str:
     column = backtick(action.column_name)
     pair = f"{quote_literal(action.name)}={quote_literal(action.desired_value)}"
-    return f"{target.annotation_alter_clause} ALTER COLUMN {column} SET TAGS ({pair})"
+    return f"{target.alter_clause} ALTER COLUMN {column} SET TAGS ({pair})"
 
 
 @_compile_action.register
 def _compile_unset_column_tag(action: UnsetColumnTag, target: _Target) -> str:
     column = backtick(action.column_name)
     return (
-        f"{target.annotation_alter_clause} ALTER COLUMN {column}"
+        f"{target.alter_clause} ALTER COLUMN {column}"
         f" UNSET TAGS ({quote_literal(action.name)})"
     )
 
@@ -236,7 +227,7 @@ def _compile_set_column_comment(action: SetColumnComment, target: _Target) -> st
     # empty comment the reader observes, keeping resyncs idempotent.
     column_name = backtick(action.column_name)
     comment = quote_literal(action.desired_comment)
-    return f"{target.annotation_alter_clause} ALTER COLUMN {column_name} COMMENT {comment}"
+    return f"{target.alter_clause} ALTER COLUMN {column_name} COMMENT {comment}"
 
 
 @_compile_action.register
@@ -249,16 +240,16 @@ def _compile_set_table_comment(action: SetTableComment, target: _Target) -> str:
 def _compile_set_column_nullability(action: SetColumnNullability, target: _Target) -> str:
     column_name = backtick(action.column_name)
     sign = "DROP" if action.desired_nullable else "SET"
-    return f"{target.alter_table_clause} ALTER COLUMN {column_name} {sign} NOT NULL"
+    return f"{target.alter_clause} ALTER COLUMN {column_name} {sign} NOT NULL"
 
 
 @_compile_action.register
 def _compile_alter_clustering(action: AlterClustering, target: _Target) -> str:
     """Compile ALTER TABLE ... CLUSTER BY (...) or CLUSTER BY NONE."""
     if not action.desired_clustering:
-        return f"{target.alter_table_clause} CLUSTER BY NONE"
+        return f"{target.alter_clause} CLUSTER BY NONE"
     columns = ", ".join(backtick(column) for column in action.desired_clustering)
-    return f"{target.alter_table_clause} CLUSTER BY ({columns})"
+    return f"{target.alter_clause} CLUSTER BY ({columns})"
 
 
 @_compile_action.register
@@ -266,7 +257,7 @@ def _compile_alter_column_type(action: AlterColumnType, target: _Target) -> str:
     """Compile ALTER TABLE ... ALTER COLUMN ... TYPE for a validated type widening."""
     column_name = backtick(action.column_name)
     sql_type = render_data_type(action.desired_type)
-    return f"{target.alter_table_clause} ALTER COLUMN {column_name} TYPE {sql_type}"
+    return f"{target.alter_clause} ALTER COLUMN {column_name} TYPE {sql_type}"
 
 
 @_compile_action.register
@@ -277,7 +268,7 @@ def _compile_drop_primary_key(action: DropPrimaryKey, target: _Target) -> str:
     # out-of-band drop in the read-execute window converges instead of failing
     # the sync — whereas a table that appeared in that window has contents the
     # plan knows nothing about, so the create must surface it as a failure.
-    return f"{target.alter_table_clause} DROP PRIMARY KEY IF EXISTS"
+    return f"{target.alter_clause} DROP PRIMARY KEY IF EXISTS"
 
 
 @_compile_action.register
@@ -285,7 +276,7 @@ def _compile_set_primary_key(action: SetPrimaryKey, target: _Target) -> str:
     """Compile an ALTER TABLE ... ADD CONSTRAINT ... PRIMARY KEY statement."""
     column_clause = ", ".join(backtick(name) for name in action.primary_key.columns)
     constraint = backtick(action.primary_key.constraint_name)
-    return f"{target.alter_table_clause} ADD CONSTRAINT {constraint} PRIMARY KEY ({column_clause})"
+    return f"{target.alter_clause} ADD CONSTRAINT {constraint} PRIMARY KEY ({column_clause})"
 
 
 @_compile_action.register
@@ -293,7 +284,7 @@ def _compile_drop_foreign_key(action: DropForeignKey, target: _Target) -> str:
     """Compile ALTER TABLE ... DROP CONSTRAINT IF EXISTS for a foreign key."""
     # IF EXISTS converges like DropPrimaryKey: already absent is the end state.
     constraint = backtick(action.constraint.constraint_name)
-    return f"{target.alter_table_clause} DROP CONSTRAINT IF EXISTS {constraint}"
+    return f"{target.alter_clause} DROP CONSTRAINT IF EXISTS {constraint}"
 
 
 @_compile_action.register
@@ -304,7 +295,7 @@ def _compile_set_foreign_key(action: SetForeignKey, target: _Target) -> str:
     ref_cols = ", ".join(backtick(col) for col in action.constraint.referenced_columns)
     backticked_ref = backtick_qualified_name(action.constraint.referenced_table)
     return (
-        f"{target.alter_table_clause}"
+        f"{target.alter_clause}"
         f" ADD CONSTRAINT {constraint}"
         f" FOREIGN KEY ({local_cols}) REFERENCES {backticked_ref} ({ref_cols})"
     )

--- a/src/delta_engine/adapters/databricks/sql/compile.py
+++ b/src/delta_engine/adapters/databricks/sql/compile.py
@@ -19,6 +19,7 @@ from delta_engine.adapters.databricks.sql.dialect import (
 from delta_engine.adapters.databricks.sql.types import render_data_type
 from delta_engine.adapters.databricks.table_features import enable_property
 from delta_engine.application.ports import CompiledAction, CompiledPlan
+from delta_engine.application.scopes import ANNOTATION_ASPECTS
 from delta_engine.domain.model import DesiredColumn, QualifiedName, TableKind
 from delta_engine.domain.plan import (
     Action,
@@ -45,12 +46,12 @@ from delta_engine.domain.plan import (
     UnsetTableTag,
 )
 
-# ALTER STREAMING TABLE is the documented dialect for altering a streaming
-# table; its tag statements are pinned live in
+# ALTER STREAMING TABLE is the documented dialect for annotating a streaming
+# table; its statements are pinned live in
 # tests/live/test_sql_warehouse_live_streaming_tables.py. The platform was
 # observed tolerating plain ALTER TABLE for table-level tags (2026-07-16),
 # but the engine emits the documented form.
-_ALTER_CLAUSES: Final[Mapping[TableKind, str]] = MappingProxyType(
+_ANNOTATION_ALTER_CLAUSES: Final[Mapping[TableKind, str]] = MappingProxyType(
     {
         TableKind.TABLE: "ALTER TABLE",
         TableKind.STREAMING_TABLE: "ALTER STREAMING TABLE",
@@ -63,9 +64,9 @@ class _Target:
     """
     The table as statements address it.
 
-    Owns the rendering of the two ways a statement names its table: the bare
-    backticked name, and the ALTER clause whose keyword follows the table's
-    relation kind.
+    Owns the rendering of the ways a statement names its table: the bare
+    backticked name, the ordinary-table ALTER clause, and the annotation ALTER
+    clause whose keyword follows the relation kind.
     """
 
     qualified_name: QualifiedName
@@ -77,19 +78,39 @@ class _Target:
         return backtick_qualified_name(self.qualified_name)
 
     @property
-    def alter_clause(self) -> str:
-        """The kind-correct ALTER clause addressing this table."""
-        return f"{_ALTER_CLAUSES[self.kind]} {self.name}"
+    def table_alter_clause(self) -> str:
+        """The ALTER clause for operations supported only on ordinary tables."""
+        return f"ALTER TABLE {self.name}"
+
+    @property
+    def annotation_alter_clause(self) -> str:
+        """The kind-correct ALTER clause for comments and Unity Catalog tags."""
+        return f"{_ANNOTATION_ALTER_CLAUSES[self.kind]} {self.name}"
 
 
 def compile_plan(plan: ActionPlan) -> CompiledPlan:
     """
     Compile an :class:`ActionPlan` into SQL statements, in plan order.
 
-    The plan supplies both the qualified table target and the relation kind
-    selecting the ALTER dialect. Non-ALTER statements (CREATE TABLE, COMMENT
-    ON) use the same plan target but are unaffected by the relation kind.
+    The plan supplies both the qualified table target and the relation kind.
+    Only annotation actions can target a streaming table; all other actions are
+    rejected here as a final boundary behind application validation. Annotation
+    ALTER statements select their dialect from the kind, while COMMENT ON is
+    kind-independent.
     """
+    if plan.kind is TableKind.STREAMING_TABLE:
+        unsupported = tuple(
+            type(action).__name__
+            for action in plan
+            if action.aspect not in ANNOTATION_ASPECTS
+        )
+        if unsupported:
+            action_names = ", ".join(unsupported)
+            raise ValueError(
+                f"Cannot compile {action_names} for streaming table {plan.target}; "
+                "only annotation actions are supported"
+            )
+
     target = _Target(qualified_name=plan.target, kind=plan.kind)
     compiled_actions = [
         CompiledAction(action=action, statement=_compile_action(action, target)) for action in plan
@@ -162,14 +183,14 @@ def _(action: AddColumn, target: _Target) -> str:
     name = backtick(action.column.name)
     dtype = render_data_type(action.column.data_type)
     comment = f" COMMENT {quote_literal(action.column.comment)}" if action.column.comment else ""
-    return f"{target.alter_clause} ADD COLUMN {name} {dtype}{comment}"
+    return f"{target.table_alter_clause} ADD COLUMN {name} {dtype}{comment}"
 
 
 @_compile_action.register
 def _(action: DropColumn, target: _Target) -> str:
     """Compile an ALTER TABLE ... DROP COLUMN statement for a column name."""
     column_name = backtick(action.column.name)
-    return f"{target.alter_clause} DROP COLUMN {column_name}"
+    return f"{target.table_alter_clause} DROP COLUMN {column_name}"
 
 
 @_compile_action.register
@@ -177,7 +198,7 @@ def _(action: RenameColumn, target: _Target) -> str:
     """Compile ALTER TABLE ... RENAME COLUMN."""
     old = backtick(action.old_name)
     new = backtick(action.new_name)
-    return f"{target.alter_clause} RENAME COLUMN {old} TO {new}"
+    return f"{target.table_alter_clause} RENAME COLUMN {old} TO {new}"
 
 
 @_compile_action.register
@@ -185,43 +206,46 @@ def _(action: EnableTableFeature, target: _Target) -> str:
     """Compile a table-feature enablement to its documented SET TBLPROPERTIES form."""
     property_ = enable_property(action.feature)
     pair = f"{quote_literal(property_.key)}={quote_literal(property_.value)}"
-    return f"{target.alter_clause} SET TBLPROPERTIES ({pair})"
+    return f"{target.table_alter_clause} SET TBLPROPERTIES ({pair})"
 
 
 @_compile_action.register
 def _(action: SetProperty, target: _Target) -> str:
     pair = f"{quote_literal(action.name)}={quote_literal(action.desired_value)}"
-    return f"{target.alter_clause} SET TBLPROPERTIES ({pair})"
+    return f"{target.table_alter_clause} SET TBLPROPERTIES ({pair})"
 
 
 @_compile_action.register
 def _(action: UnsetProperty, target: _Target) -> str:
     key = quote_literal(action.name)
-    return f"{target.alter_clause} UNSET TBLPROPERTIES IF EXISTS ({key})"
+    return f"{target.table_alter_clause} UNSET TBLPROPERTIES IF EXISTS ({key})"
 
 
 @_compile_action.register
 def _(action: SetTableTag, target: _Target) -> str:
     pair = f"{quote_literal(action.name)}={quote_literal(action.desired_value)}"
-    return f"{target.alter_clause} SET TAGS ({pair})"
+    return f"{target.annotation_alter_clause} SET TAGS ({pair})"
 
 
 @_compile_action.register
 def _(action: UnsetTableTag, target: _Target) -> str:
-    return f"{target.alter_clause} UNSET TAGS ({quote_literal(action.name)})"
+    return f"{target.annotation_alter_clause} UNSET TAGS ({quote_literal(action.name)})"
 
 
 @_compile_action.register
 def _(action: SetColumnTag, target: _Target) -> str:
     column = backtick(action.column_name)
     pair = f"{quote_literal(action.name)}={quote_literal(action.desired_value)}"
-    return f"{target.alter_clause} ALTER COLUMN {column} SET TAGS ({pair})"
+    return f"{target.annotation_alter_clause} ALTER COLUMN {column} SET TAGS ({pair})"
 
 
 @_compile_action.register
 def _(action: UnsetColumnTag, target: _Target) -> str:
     column = backtick(action.column_name)
-    return f"{target.alter_clause} ALTER COLUMN {column} UNSET TAGS ({quote_literal(action.name)})"
+    return (
+        f"{target.annotation_alter_clause} ALTER COLUMN {column}"
+        f" UNSET TAGS ({quote_literal(action.name)})"
+    )
 
 
 @_compile_action.register
@@ -231,7 +255,7 @@ def _(action: SetColumnComment, target: _Target) -> str:
     # empty comment the reader observes, keeping resyncs idempotent.
     column_name = backtick(action.column_name)
     comment = quote_literal(action.desired_comment)
-    return f"{target.alter_clause} ALTER COLUMN {column_name} COMMENT {comment}"
+    return f"{target.annotation_alter_clause} ALTER COLUMN {column_name} COMMENT {comment}"
 
 
 @_compile_action.register
@@ -244,16 +268,16 @@ def _(action: SetTableComment, target: _Target) -> str:
 def _(action: SetColumnNullability, target: _Target) -> str:
     column_name = backtick(action.column_name)
     sign = "DROP" if action.desired_nullable else "SET"
-    return f"{target.alter_clause} ALTER COLUMN {column_name} {sign} NOT NULL"
+    return f"{target.table_alter_clause} ALTER COLUMN {column_name} {sign} NOT NULL"
 
 
 @_compile_action.register
 def _(action: AlterClustering, target: _Target) -> str:
     """Compile ALTER TABLE ... CLUSTER BY (...) or CLUSTER BY NONE."""
     if not action.desired_clustering:
-        return f"{target.alter_clause} CLUSTER BY NONE"
+        return f"{target.table_alter_clause} CLUSTER BY NONE"
     columns = ", ".join(backtick(column) for column in action.desired_clustering)
-    return f"{target.alter_clause} CLUSTER BY ({columns})"
+    return f"{target.table_alter_clause} CLUSTER BY ({columns})"
 
 
 @_compile_action.register
@@ -261,7 +285,7 @@ def _(action: AlterColumnType, target: _Target) -> str:
     """Compile ALTER TABLE ... ALTER COLUMN ... TYPE for a validated type widening."""
     column_name = backtick(action.column_name)
     sql_type = render_data_type(action.desired_type)
-    return f"{target.alter_clause} ALTER COLUMN {column_name} TYPE {sql_type}"
+    return f"{target.table_alter_clause} ALTER COLUMN {column_name} TYPE {sql_type}"
 
 
 @_compile_action.register
@@ -272,7 +296,7 @@ def _(action: DropPrimaryKey, target: _Target) -> str:
     # out-of-band drop in the read-execute window converges instead of failing
     # the sync — whereas a table that appeared in that window has contents the
     # plan knows nothing about, so the create must surface it as a failure.
-    return f"{target.alter_clause} DROP PRIMARY KEY IF EXISTS"
+    return f"{target.table_alter_clause} DROP PRIMARY KEY IF EXISTS"
 
 
 @_compile_action.register
@@ -280,7 +304,7 @@ def _(action: SetPrimaryKey, target: _Target) -> str:
     """Compile an ALTER TABLE ... ADD CONSTRAINT ... PRIMARY KEY statement."""
     column_clause = ", ".join(backtick(name) for name in action.primary_key.columns)
     constraint = backtick(action.primary_key.constraint_name)
-    return f"{target.alter_clause} ADD CONSTRAINT {constraint} PRIMARY KEY ({column_clause})"
+    return f"{target.table_alter_clause} ADD CONSTRAINT {constraint} PRIMARY KEY ({column_clause})"
 
 
 @_compile_action.register
@@ -288,7 +312,7 @@ def _(action: DropForeignKey, target: _Target) -> str:
     """Compile ALTER TABLE ... DROP CONSTRAINT IF EXISTS for a foreign key."""
     # IF EXISTS converges like DropPrimaryKey: already absent is the end state.
     constraint = backtick(action.constraint.constraint_name)
-    return f"{target.alter_clause} DROP CONSTRAINT IF EXISTS {constraint}"
+    return f"{target.table_alter_clause} DROP CONSTRAINT IF EXISTS {constraint}"
 
 
 @_compile_action.register
@@ -299,7 +323,7 @@ def _(action: SetForeignKey, target: _Target) -> str:
     ref_cols = ", ".join(backtick(col) for col in action.constraint.referenced_columns)
     backticked_ref = backtick_qualified_name(action.constraint.referenced_table)
     return (
-        f"{target.alter_clause}"
+        f"{target.table_alter_clause}"
         f" ADD CONSTRAINT {constraint}"
         f" FOREIGN KEY ({local_cols}) REFERENCES {backticked_ref} ({ref_cols})"
     )

--- a/src/delta_engine/adapters/databricks/sql/compile.py
+++ b/src/delta_engine/adapters/databricks/sql/compile.py
@@ -8,8 +8,7 @@ statements in plan order, ready to execute against a Spark session.
 from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
 from functools import singledispatch
-from types import MappingProxyType
-from typing import Final
+from typing import assert_never
 
 from delta_engine.adapters.databricks.sql.dialect import (
     backtick,
@@ -19,7 +18,6 @@ from delta_engine.adapters.databricks.sql.dialect import (
 from delta_engine.adapters.databricks.sql.types import render_data_type
 from delta_engine.adapters.databricks.table_features import enable_property
 from delta_engine.application.ports import CompiledAction, CompiledPlan
-from delta_engine.application.scopes import ANNOTATION_ASPECTS
 from delta_engine.domain.model import DesiredColumn, QualifiedName, TableKind
 from delta_engine.domain.plan import (
     Action,
@@ -46,72 +44,55 @@ from delta_engine.domain.plan import (
     UnsetTableTag,
 )
 
-# ALTER STREAMING TABLE is the documented dialect for annotating a streaming
-# table; its statements are pinned live in
-# tests/live/test_sql_warehouse_live_streaming_tables.py. The platform was
-# observed tolerating plain ALTER TABLE for table-level tags (2026-07-16),
-# but the engine emits the documented form.
-_ANNOTATION_ALTER_CLAUSES: Final[Mapping[TableKind, str]] = MappingProxyType(
-    {
-        TableKind.TABLE: "ALTER TABLE",
-        TableKind.STREAMING_TABLE: "ALTER STREAMING TABLE",
-    }
-)
+
+def _annotation_alter_keyword(kind: TableKind) -> str:
+    """Return the relation-kind-specific ALTER keyword used by annotations."""
+    match kind:
+        case TableKind.TABLE:
+            return "ALTER TABLE"
+        case TableKind.STREAMING_TABLE:
+            # ALTER STREAMING TABLE is the documented annotation dialect. Its
+            # behaviour is pinned by the streaming-table live test.
+            return "ALTER STREAMING TABLE"
+        case _ as unreachable:
+            assert_never(unreachable)
 
 
 @dataclass(frozen=True, slots=True)
 class _Target:
     """
-    The table as statements address it.
+    The table as SQL statements address it.
 
-    Owns the rendering of the ways a statement names its table: the bare
-    backticked name, the ordinary-table ALTER clause, and the annotation ALTER
-    clause whose keyword follows the relation kind.
+    Construction hides qualified-name quoting and the one dialect decision
+    relation kind affects. Action compilers receive rendered capabilities, not
+    the kind itself, so ordinary operations cannot accidentally depend on it.
     """
 
-    qualified_name: QualifiedName
-    kind: TableKind
+    name: str
+    annotation_alter_clause: str
+
+    @classmethod
+    def for_relation(cls, qualified_name: QualifiedName, kind: TableKind) -> "_Target":
+        """Render the target forms needed to compile actions for one relation."""
+        name = backtick_qualified_name(qualified_name)
+        annotation_alter_clause = f"{_annotation_alter_keyword(kind)} {name}"
+        return cls(name=name, annotation_alter_clause=annotation_alter_clause)
 
     @property
-    def name(self) -> str:
-        """The backticked fully qualified table name."""
-        return backtick_qualified_name(self.qualified_name)
-
-    @property
-    def table_alter_clause(self) -> str:
-        """The ALTER clause for operations supported only on ordinary tables."""
+    def alter_table_clause(self) -> str:
+        """The kind-independent ALTER TABLE clause for ordinary operations."""
         return f"ALTER TABLE {self.name}"
-
-    @property
-    def annotation_alter_clause(self) -> str:
-        """The kind-correct ALTER clause for comments and Unity Catalog tags."""
-        return f"{_ANNOTATION_ALTER_CLAUSES[self.kind]} {self.name}"
 
 
 def compile_plan(plan: ActionPlan) -> CompiledPlan:
     """
     Compile an :class:`ActionPlan` into SQL statements, in plan order.
 
-    The plan supplies both the qualified table target and the relation kind.
-    Only annotation actions can target a streaming table; all other actions are
-    rejected here as a final boundary behind application validation. Annotation
-    ALTER statements select their dialect from the kind, while COMMENT ON is
-    kind-independent.
+    Planning has already decided whether the declaration may act on the
+    relation. Compilation only lowers each accepted action; relation kind
+    selects the annotation ALTER dialect and does not affect other actions.
     """
-    if plan.kind is TableKind.STREAMING_TABLE:
-        unsupported = tuple(
-            type(action).__name__
-            for action in plan
-            if action.aspect not in ANNOTATION_ASPECTS
-        )
-        if unsupported:
-            action_names = ", ".join(unsupported)
-            raise ValueError(
-                f"Cannot compile {action_names} for streaming table {plan.target}; "
-                "only annotation actions are supported"
-            )
-
-    target = _Target(qualified_name=plan.target, kind=plan.kind)
+    target = _Target.for_relation(plan.target, plan.kind)
     compiled_actions = [
         CompiledAction(action=action, statement=_compile_action(action, target)) for action in plan
     ]
@@ -129,7 +110,7 @@ def _compile_action(action: Action, target: _Target) -> str:
 
 
 @_compile_action.register
-def _(action: CreateTable, target: _Target) -> str:
+def _compile_create_table(action: CreateTable, target: _Target) -> str:
     """Compile a CREATE TABLE statement including columns, comment, properties, and optional PK."""
     table = action.table
     column_defs = [_column_definition(column) for column in table.columns]
@@ -163,7 +144,7 @@ def _(action: CreateTable, target: _Target) -> str:
 
 
 @_compile_action.register
-def _(action: AddColumn, target: _Target) -> str:
+def _compile_add_column(action: AddColumn, target: _Target) -> str:
     """
     Compile an ALTER TABLE ... ADD COLUMN statement for a single column.
 
@@ -183,64 +164,64 @@ def _(action: AddColumn, target: _Target) -> str:
     name = backtick(action.column.name)
     dtype = render_data_type(action.column.data_type)
     comment = f" COMMENT {quote_literal(action.column.comment)}" if action.column.comment else ""
-    return f"{target.table_alter_clause} ADD COLUMN {name} {dtype}{comment}"
+    return f"{target.alter_table_clause} ADD COLUMN {name} {dtype}{comment}"
 
 
 @_compile_action.register
-def _(action: DropColumn, target: _Target) -> str:
+def _compile_drop_column(action: DropColumn, target: _Target) -> str:
     """Compile an ALTER TABLE ... DROP COLUMN statement for a column name."""
     column_name = backtick(action.column.name)
-    return f"{target.table_alter_clause} DROP COLUMN {column_name}"
+    return f"{target.alter_table_clause} DROP COLUMN {column_name}"
 
 
 @_compile_action.register
-def _(action: RenameColumn, target: _Target) -> str:
+def _compile_rename_column(action: RenameColumn, target: _Target) -> str:
     """Compile ALTER TABLE ... RENAME COLUMN."""
     old = backtick(action.old_name)
     new = backtick(action.new_name)
-    return f"{target.table_alter_clause} RENAME COLUMN {old} TO {new}"
+    return f"{target.alter_table_clause} RENAME COLUMN {old} TO {new}"
 
 
 @_compile_action.register
-def _(action: EnableTableFeature, target: _Target) -> str:
+def _compile_enable_table_feature(action: EnableTableFeature, target: _Target) -> str:
     """Compile a table-feature enablement to its documented SET TBLPROPERTIES form."""
     property_ = enable_property(action.feature)
     pair = f"{quote_literal(property_.key)}={quote_literal(property_.value)}"
-    return f"{target.table_alter_clause} SET TBLPROPERTIES ({pair})"
+    return f"{target.alter_table_clause} SET TBLPROPERTIES ({pair})"
 
 
 @_compile_action.register
-def _(action: SetProperty, target: _Target) -> str:
+def _compile_set_property(action: SetProperty, target: _Target) -> str:
     pair = f"{quote_literal(action.name)}={quote_literal(action.desired_value)}"
-    return f"{target.table_alter_clause} SET TBLPROPERTIES ({pair})"
+    return f"{target.alter_table_clause} SET TBLPROPERTIES ({pair})"
 
 
 @_compile_action.register
-def _(action: UnsetProperty, target: _Target) -> str:
+def _compile_unset_property(action: UnsetProperty, target: _Target) -> str:
     key = quote_literal(action.name)
-    return f"{target.table_alter_clause} UNSET TBLPROPERTIES IF EXISTS ({key})"
+    return f"{target.alter_table_clause} UNSET TBLPROPERTIES IF EXISTS ({key})"
 
 
 @_compile_action.register
-def _(action: SetTableTag, target: _Target) -> str:
+def _compile_set_table_tag(action: SetTableTag, target: _Target) -> str:
     pair = f"{quote_literal(action.name)}={quote_literal(action.desired_value)}"
     return f"{target.annotation_alter_clause} SET TAGS ({pair})"
 
 
 @_compile_action.register
-def _(action: UnsetTableTag, target: _Target) -> str:
+def _compile_unset_table_tag(action: UnsetTableTag, target: _Target) -> str:
     return f"{target.annotation_alter_clause} UNSET TAGS ({quote_literal(action.name)})"
 
 
 @_compile_action.register
-def _(action: SetColumnTag, target: _Target) -> str:
+def _compile_set_column_tag(action: SetColumnTag, target: _Target) -> str:
     column = backtick(action.column_name)
     pair = f"{quote_literal(action.name)}={quote_literal(action.desired_value)}"
     return f"{target.annotation_alter_clause} ALTER COLUMN {column} SET TAGS ({pair})"
 
 
 @_compile_action.register
-def _(action: UnsetColumnTag, target: _Target) -> str:
+def _compile_unset_column_tag(action: UnsetColumnTag, target: _Target) -> str:
     column = backtick(action.column_name)
     return (
         f"{target.annotation_alter_clause} ALTER COLUMN {column}"
@@ -249,7 +230,7 @@ def _(action: UnsetColumnTag, target: _Target) -> str:
 
 
 @_compile_action.register
-def _(action: SetColumnComment, target: _Target) -> str:
+def _compile_set_column_comment(action: SetColumnComment, target: _Target) -> str:
     # An empty desired comment compiles to COMMENT '' rather than UNSET
     # COMMENT: SQL warehouses reject the latter, and '' round-trips as the
     # empty comment the reader observes, keeping resyncs idempotent.
@@ -259,71 +240,71 @@ def _(action: SetColumnComment, target: _Target) -> str:
 
 
 @_compile_action.register
-def _(action: SetTableComment, target: _Target) -> str:
+def _compile_set_table_comment(action: SetTableComment, target: _Target) -> str:
     comment = quote_literal(action.desired_comment)
     return f"COMMENT ON TABLE {target.name} IS {comment}"
 
 
 @_compile_action.register
-def _(action: SetColumnNullability, target: _Target) -> str:
+def _compile_set_column_nullability(action: SetColumnNullability, target: _Target) -> str:
     column_name = backtick(action.column_name)
     sign = "DROP" if action.desired_nullable else "SET"
-    return f"{target.table_alter_clause} ALTER COLUMN {column_name} {sign} NOT NULL"
+    return f"{target.alter_table_clause} ALTER COLUMN {column_name} {sign} NOT NULL"
 
 
 @_compile_action.register
-def _(action: AlterClustering, target: _Target) -> str:
+def _compile_alter_clustering(action: AlterClustering, target: _Target) -> str:
     """Compile ALTER TABLE ... CLUSTER BY (...) or CLUSTER BY NONE."""
     if not action.desired_clustering:
-        return f"{target.table_alter_clause} CLUSTER BY NONE"
+        return f"{target.alter_table_clause} CLUSTER BY NONE"
     columns = ", ".join(backtick(column) for column in action.desired_clustering)
-    return f"{target.table_alter_clause} CLUSTER BY ({columns})"
+    return f"{target.alter_table_clause} CLUSTER BY ({columns})"
 
 
 @_compile_action.register
-def _(action: AlterColumnType, target: _Target) -> str:
+def _compile_alter_column_type(action: AlterColumnType, target: _Target) -> str:
     """Compile ALTER TABLE ... ALTER COLUMN ... TYPE for a validated type widening."""
     column_name = backtick(action.column_name)
     sql_type = render_data_type(action.desired_type)
-    return f"{target.table_alter_clause} ALTER COLUMN {column_name} TYPE {sql_type}"
+    return f"{target.alter_table_clause} ALTER COLUMN {column_name} TYPE {sql_type}"
 
 
 @_compile_action.register
-def _(action: DropPrimaryKey, target: _Target) -> str:
+def _compile_drop_primary_key(action: DropPrimaryKey, target: _Target) -> str:
     """Compile an ALTER TABLE ... DROP PRIMARY KEY IF EXISTS statement."""
     # IF EXISTS is the deliberate mirror of CreateTable's plain CREATE: a
     # constraint already gone is the end state this action wants, so an
     # out-of-band drop in the read-execute window converges instead of failing
     # the sync — whereas a table that appeared in that window has contents the
     # plan knows nothing about, so the create must surface it as a failure.
-    return f"{target.table_alter_clause} DROP PRIMARY KEY IF EXISTS"
+    return f"{target.alter_table_clause} DROP PRIMARY KEY IF EXISTS"
 
 
 @_compile_action.register
-def _(action: SetPrimaryKey, target: _Target) -> str:
+def _compile_set_primary_key(action: SetPrimaryKey, target: _Target) -> str:
     """Compile an ALTER TABLE ... ADD CONSTRAINT ... PRIMARY KEY statement."""
     column_clause = ", ".join(backtick(name) for name in action.primary_key.columns)
     constraint = backtick(action.primary_key.constraint_name)
-    return f"{target.table_alter_clause} ADD CONSTRAINT {constraint} PRIMARY KEY ({column_clause})"
+    return f"{target.alter_table_clause} ADD CONSTRAINT {constraint} PRIMARY KEY ({column_clause})"
 
 
 @_compile_action.register
-def _(action: DropForeignKey, target: _Target) -> str:
+def _compile_drop_foreign_key(action: DropForeignKey, target: _Target) -> str:
     """Compile ALTER TABLE ... DROP CONSTRAINT IF EXISTS for a foreign key."""
     # IF EXISTS converges like DropPrimaryKey: already absent is the end state.
     constraint = backtick(action.constraint.constraint_name)
-    return f"{target.table_alter_clause} DROP CONSTRAINT IF EXISTS {constraint}"
+    return f"{target.alter_table_clause} DROP CONSTRAINT IF EXISTS {constraint}"
 
 
 @_compile_action.register
-def _(action: SetForeignKey, target: _Target) -> str:
+def _compile_set_foreign_key(action: SetForeignKey, target: _Target) -> str:
     """Compile ALTER TABLE ... ADD CONSTRAINT ... FOREIGN KEY ... REFERENCES ..."""
     constraint = backtick(action.constraint.constraint_name)
     local_cols = ", ".join(backtick(col) for col in action.constraint.local_columns)
     ref_cols = ", ".join(backtick(col) for col in action.constraint.referenced_columns)
     backticked_ref = backtick_qualified_name(action.constraint.referenced_table)
     return (
-        f"{target.table_alter_clause}"
+        f"{target.alter_table_clause}"
         f" ADD CONSTRAINT {constraint}"
         f" FOREIGN KEY ({local_cols}) REFERENCES {backticked_ref} ({ref_cols})"
     )

--- a/src/delta_engine/application/validation.py
+++ b/src/delta_engine/application/validation.py
@@ -669,7 +669,7 @@ class StreamingTableAnnotationsOnly:
     name: ClassVar[str] = "StreamingTableAnnotationsOnly"
 
     def evaluate(self, diff: TableDiff) -> tuple[ValidationFailure, ...]:
-        """Flag a streaming-table declaration whose managed aspects exceed the tag aspects."""
+        """Flag a streaming-table declaration whose managed aspects exceed annotations."""
         match diff:
             case TableMissing():
                 return ()

--- a/src/delta_engine/domain/model/table.py
+++ b/src/delta_engine/domain/model/table.py
@@ -112,8 +112,9 @@ class TableKind(Enum):
 
     Discovered at read time, never declared. ``TABLE`` is an ordinary managed
     or external Delta table; ``STREAMING_TABLE`` is a pipeline-owned streaming
-    table, which takes a distinct ALTER dialect and admits tag changes only
-    (enforced by validation's eligibility checks, not here).
+    table, which takes a distinct ALTER dialect for column comments and tags
+    and admits annotation changes only (enforced by validation's eligibility
+    checks, not here).
     """
 
     TABLE = auto()

--- a/src/delta_engine/domain/plan/actions.py
+++ b/src/delta_engine/domain/plan/actions.py
@@ -454,8 +454,8 @@ class ActionPlan:
     are invariants of the plan, not context a caller has to supply later.
 
     ``kind`` is the relation kind of the table the actions lower against —
-    part of what the plan means, since the same actions compile to different
-    statements per kind. Defaults to the ordinary table kind.
+    part of what the plan means, since annotation actions use the streaming
+    table dialect for a streaming target. Defaults to the ordinary table kind.
     """
 
     target: QualifiedName

--- a/tests/adapters/databricks/sql/test_compile.py
+++ b/tests/adapters/databricks/sql/test_compile.py
@@ -4,6 +4,7 @@ from hypothesis import given
 import pytest
 
 from delta_engine.adapters.databricks.sql.compile import compile_plan
+from delta_engine.application.scopes import ANNOTATION_ASPECTS
 from delta_engine.domain.model import (
     DesiredColumn,
     DesiredTable,
@@ -638,27 +639,18 @@ def test_ordinary_tables_keep_the_alter_table_dialect():
     assert statement == "ALTER TABLE `cat`.`sch`.`tbl` SET TAGS ('owner'='gov')"
 
 
-def test_alter_statements_adopt_the_dialect_mechanically():
-    # The compiler is policy-free: validation keeps non-tag actions away from
-    # streaming tables, but a statement compiled for one still targets it.
-    statement = _compile_single(
-        AddColumn(DesiredColumn("extra", Integer())), kind=TableKind.STREAMING_TABLE
-    )
-
-    assert statement.startswith("ALTER STREAMING TABLE `cat`.`sch`.`tbl` ADD COLUMN")
-
-
-def test_non_alter_statements_ignore_the_dialect():
-    create = _compile_single(
-        _create_table(DesiredColumn("id", Integer())), kind=TableKind.STREAMING_TABLE
-    )
-    comment = _compile_single(
-        SetTableComment(desired_comment="c", observed_comment=""),
-        kind=TableKind.STREAMING_TABLE,
-    )
-
-    assert create.startswith("CREATE TABLE `cat`.`sch`.`tbl`")
-    assert comment == "COMMENT ON TABLE `cat`.`sch`.`tbl` IS 'c'"
+@pytest.mark.parametrize(
+    "action",
+    [
+        action
+        for action in _SAMPLE_ACTIONS.values()
+        if action.aspect not in ANNOTATION_ASPECTS
+    ],
+    ids=lambda action: type(action).__name__,
+)
+def test_non_annotation_actions_cannot_compile_for_streaming_tables(action):
+    with pytest.raises(ValueError):
+        _compile_single(action, kind=TableKind.STREAMING_TABLE)
 
 
 def test_compile_enable_table_feature():

--- a/tests/adapters/databricks/sql/test_compile.py
+++ b/tests/adapters/databricks/sql/test_compile.py
@@ -4,7 +4,6 @@ from hypothesis import given
 import pytest
 
 from delta_engine.adapters.databricks.sql.compile import compile_plan
-from delta_engine.application.scopes import ANNOTATION_ASPECTS
 from delta_engine.domain.model import (
     DesiredColumn,
     DesiredTable,
@@ -637,20 +636,6 @@ def test_ordinary_tables_keep_the_alter_table_dialect():
     statement = _compile_single(SetTableTag(name="owner", desired_value="gov", observed_value=None))
 
     assert statement == "ALTER TABLE `cat`.`sch`.`tbl` SET TAGS ('owner'='gov')"
-
-
-@pytest.mark.parametrize(
-    "action",
-    [
-        action
-        for action in _SAMPLE_ACTIONS.values()
-        if action.aspect not in ANNOTATION_ASPECTS
-    ],
-    ids=lambda action: type(action).__name__,
-)
-def test_non_annotation_actions_cannot_compile_for_streaming_tables(action):
-    with pytest.raises(ValueError):
-        _compile_single(action, kind=TableKind.STREAMING_TABLE)
 
 
 def test_compile_enable_table_feature():

--- a/tests/domain/plan/test_actions.py
+++ b/tests/domain/plan/test_actions.py
@@ -347,11 +347,9 @@ def test_partitioning_changed_rejects_no_difference():
 
 
 def test_tag_aspects_belong_to_exactly_the_four_tag_actions():
-    # The streaming-table eligibility check admits only the tag aspects, so the
-    # actions carrying them are the complete set of statements the engine can
-    # aim at a streaming table. Growing this set is a policy decision, not a
-    # side effect: an action added with a tag aspect flows to streaming
-    # tables automatically.
+    # The tag-only scope admits exactly these aspects. Growing the action set is
+    # a policy decision, not a side effect: an action added with a tag aspect
+    # flows into tag reconciliation automatically.
     tag_aspects = {TableAspect.TABLE_TAGS, TableAspect.COLUMN_TAGS}
     tag_actions = {
         action_type.__name__

--- a/tests/live/test_sql_warehouse_live_streaming_tables.py
+++ b/tests/live/test_sql_warehouse_live_streaming_tables.py
@@ -34,6 +34,7 @@ from delta_engine import SyncFailedError, TableRunStatus, ValidationFailure
 from delta_engine.adapters.databricks.warehouse._runner import WarehouseSqlRunner
 from delta_engine.adapters.databricks.warehouse.reader import WarehouseReader
 from delta_engine.application.ports import TablePresent
+from delta_engine.application.scopes import ScopeName
 from delta_engine.databricks import build_sql_engine
 from delta_engine.domain.model import QualifiedName, TableKind
 from delta_engine.schema import Column, DeltaTable, Integer
@@ -163,29 +164,35 @@ def test_the_engine_manages_a_streaming_tables_annotations_and_nothing_wider(
     # Anything wider than annotations is refused before planning — even when
     # the declaration mirrors the observed state exactly, so the refusal is
     # about the table's kind, not about drift.
-    full_scope = DeltaTable(
-        live_catalog(),
-        live_schema(),
-        table_name,
-        columns=(annotated_column,),
-        primary_key=["id"],
-        comment=table_comment,
-        tags=table_tags,
-    )
-    with pytest.raises(SyncFailedError) as error:
-        engine.sync(full_scope)
+    wider_scopes: tuple[ScopeName, ...] = ("metadata", "full")
+    for scope in wider_scopes:
+        wider_declaration = DeltaTable(
+            live_catalog(),
+            live_schema(),
+            table_name,
+            columns=(annotated_column,),
+            primary_key=["id"],
+            comment=table_comment,
+            tags=table_tags,
+            scope=scope,
+        )
+        with pytest.raises(SyncFailedError) as error:
+            engine.sync(wider_declaration)
 
-    [table_report] = error.value.report.table_runs
-    assert table_report.status is TableRunStatus.PLANNING_FAILED
-    assert "StreamingTableAnnotationsOnly" in {
-        failure.rule_name
-        for failure in table_report.failures
-        if isinstance(failure, ValidationFailure)
-    }
-    assert table_report.compiled is None
-    refused = read_live_table(live_connection, table_name)
-    assert refused["table_tags"] == table_tags
-    assert refused["column_tags"] == {("id", "pii"): "low"}
+        [table_report] = error.value.report.table_runs
+        assert table_report.status is TableRunStatus.PLANNING_FAILED
+        assert "StreamingTableAnnotationsOnly" in {
+            failure.rule_name
+            for failure in table_report.failures
+            if isinstance(failure, ValidationFailure)
+        }
+        assert table_report.compiled is None
+        refused = read_live_table(live_connection, table_name)
+        assert refused["comment"] == table_comment
+        assert [column["comment"] for column in refused["columns"]] == ["the id"]
+        assert refused["table_tags"] == table_tags
+        assert refused["column_tags"] == {("id", "pii"): "low"}
+        assert refused["primary_key"] == ("id",)
 
     # Clearing is the other half of managing an aspect, and the half with a
     # platform quirk: an empty desired comment compiles to COMMENT '' rather


### PR DESCRIPTION
## Summary

- recognize Databricks streaming tables as a supported observed relation kind
- reject declarations that claim pipeline-owned structure, properties, or keys while allowing annotation and tag scopes
- carry the observed relation kind into accepted action plans and render one relation-correct ALTER clause
- keep table comments on the kind-independent `COMMENT ON TABLE` syntax
- extend the existing unified live lifecycle to add, converge, and clear table/column comments and tags, then prove wider scopes are refused without mutation

## Why

A streaming table's definition is owned by its pipeline, but comments and Unity Catalog tags can be managed outside that pipeline. Relation kind was previously coupled generically to every ALTER compiler, while eligibility policy was partially duplicated at compilation time.

This change makes the boundary explicit: application validation decides whether the declaration is allowed, and the SQL compiler only lowers accepted actions. The compiler hides relation-specific SQL behind a single rendered target and does not inspect ownership scopes.

## Impact

Users can manage annotations on an externally created streaming table with `scope="annotations"` or `scope="tags"`. Wider `metadata` and `full` declarations fail during planning before SQL is compiled or executed.

## Validation

- `uv run pytest`: 1,193 passed, 74 deselected
- `uv run ruff check src tests`
- `uv run mypy src tests`
- `uv run lint-imports`: 7 contracts kept
- `uv run --group docs sphinx-build -W --keep-going docs docs/_build/html`
- unified Databricks live test: 1 passed in 139.29s