### PR TITLE
refactor: trust validated column additions

### DIFF
--- a/src/delta_engine/adapters/databricks/sql/compile.py
+++ b/src/delta_engine/adapters/databricks/sql/compile.py
@@ -131,26 +131,8 @@ def _compile_create_table(action: CreateTable, target: _Target) -> str:
 
 @_compile_action.register
 def _compile_add_column(action: AddColumn, target: _Target) -> str:
-    """
-    Compile an ALTER TABLE ... ADD COLUMN statement for a single column.
-
-    The column is always added without a NOT NULL constraint: adding a
-    non-nullable column to an existing table is rejected at validation
-    (see NonNullableColumnAdd), so this path is only reached for nullable adds.
-    The guard makes that contract loud -- it fires only if validation was
-    bypassed or a custom rule set let a NOT NULL add through, rather than
-    silently emitting an add that drops the constraint. It is an unconditional
-    ``raise`` (not ``assert``) so the invariant survives ``python -O``.
-    """
-    if not action.column.nullable:
-        raise AssertionError(
-            f"AddColumn reached the compiler with non-nullable column {action.column.name!r}; "
-            "validation (NonNullableColumnAdd) should have blocked this"
-        )
-    name = backtick(action.column.name)
-    dtype = render_data_type(action.column.data_type)
-    comment = f" COMMENT {quote_literal(action.column.comment)}" if action.column.comment else ""
-    return f"{target.alter_clause} ADD COLUMN {name} {dtype}{comment}"
+    """Compile an ALTER TABLE ... ADD COLUMN statement for a single column."""
+    return f"{target.alter_clause} ADD COLUMN {_column_definition(action.column)}"
 
 
 @_compile_action.register

--- a/tests/adapters/databricks/sql/test_compile.py
+++ b/tests/adapters/databricks/sql/test_compile.py
@@ -192,15 +192,6 @@ def test_add_column_without_comment_omits_comment_clause():
     assert statement == "ALTER TABLE `cat`.`sch`.`tbl` ADD COLUMN `age` INT"
 
 
-def test_add_column_rejects_non_nullable_column():
-    # Given an AddColumn action carrying a NOT NULL column
-    action = AddColumn(DesiredColumn("age", Integer(), nullable=False))
-
-    # When / Then compiling fails loudly rather than silently dropping NOT NULL
-    with pytest.raises(AssertionError, match="age"):
-        _compile_single(action)
-
-
 def test_create_table_renders_all_state_embedded_in_creation():
     # Given a CREATE TABLE with structure, comments, properties, partitioning, and a key
     action = _create_table(

--- a/tests/application/test_engine.py
+++ b/tests/application/test_engine.py
@@ -1824,6 +1824,7 @@ def test_a_rejected_table_still_reports_the_drift_that_was_found():
     # Then the table has no plan, but the diff that caused the rejection survives
     (table_report,) = report.table_runs
     assert table_report.plan is None
+    assert table_report.compiled is None
     assert table_report.diff is not None
     assert any(
         isinstance(action, AddColumn) and action.column.name == "order_id"


### PR DESCRIPTION
## Summary

- remove the compiler's duplicate `NonNullableColumnAdd` safety check
- lower `AddColumn` through the existing complete column-definition renderer
- assert at the engine boundary that rejected additions are never compiled
- remove the compiler-level policy test

## Why

`plan_changes` is the policy boundary: it validates the complete diff and only an accepted result carries an executable plan. The `AddColumn` compiler was the lone handler that re-decided a safety policy already enforced by planning, while every other handler trusted the accepted plan.

This keeps the compiler focused on translation. Accepted nullable additions emit the same SQL as before; a manually constructed invalid plan is rendered faithfully rather than silently losing its `NOT NULL` intent.

## Validation

- `uv run pytest` — 1194 passed, 74 deselected; 97.01% coverage
- focused compiler, planning, and engine tests — 133 passed
- `uv run ruff check .`
- `uv run mypy src`
- `uv run lint-imports` — 7 contracts kept