### PR TITLE
refactor: model table scopes explicitly

### DIFF
--- a/docs/explanation-architecture.md
+++ b/docs/explanation-architecture.md
@@ -67,6 +67,7 @@ through a sync.
 | `TableDiff`        | Typed desired/observed drift. It is either `TableCreation` or `TableDrift`; both state their remedies as `actions`, and a drift also carries `unresolvable`. |
 | `Unresolvable`     | A `TableDrift` difference no action can close: `ColumnRenameConflict`, `PropertyUndeclared`, or `PartitioningChanged`.                                      |
 | `TableAspect`      | One managed aspect of a table: existence, columns, comments, properties, tags, partitioning, clustering, primary key, or foreign keys. Internal enum.       |
+| `TableScope`       | The closed ownership policy carried by a desired table. It answers whether an aspect is managed and whether one scope fits within another.                  |
 | `ValidationFailure` | One policy rejection: the rule that raised it and the message the user reads. `validate_diff` returns them in evaluation order, empty when the diff is valid. |
 | `PlanningResult`   | The total planning outcome: either `PlanningAccepted(diff, plan)` or `PlanningRejected(diff, failures)`; both retain the diff they were planned from.        |
 | `ActionPlan`       | The qualified table target, relation kind, and ordered actions that should be executed if the table is allowed to run.                                      |
@@ -502,8 +503,10 @@ unset).
 
 ## Managed aspects
 
-Every `DesiredTable` carries a `managed_aspects` field: a `frozenset[TableAspect]`
-naming the aspects the engine reconciles for that table. The differ
+Every `DesiredTable` carries a closed `TableScope` value. It owns the questions
+of whether an aspect is managed and whether one scope fits within another, so
+callers do not interpret a permission bitmap themselves and arbitrary scope
+combinations cannot enter the domain. The differ
 (`diff_table`) is scope-blind for every aspect except properties — the
 properties diff runs only when the declaration manages `PROPERTIES` (see
 Diff-first planning). The `TableDrift` it produces carries the `desired`
@@ -880,9 +883,9 @@ dependency cost.
 - Keep the domain backend-free, immutable, and deterministic.
 - Make immutability real, not conventional: frozen dataclasses copy their
   collection fields in `__post_init__` — sequences into tuples, mappings into
-  read-only views (`MappingProxyType`), aspect sets into `frozenset` — so an
-  object cannot change after construction through a collection the caller
-  still holds. This applies at the public boundary too: `ForeignKey.columns`
+  read-only views (`MappingProxyType`) — so an object cannot change after
+  construction through a collection the caller still holds. This applies at
+  the public boundary too: `ForeignKey.columns`
   and `Column.tags` copy what the user passed, so mutating the original
   mapping later does not alter the declaration.
 - Put orchestration, safety policy, relationship resolution, and failure

--- a/docs/explanation-safety-model.md
+++ b/docs/explanation-safety-model.md
@@ -68,6 +68,11 @@ ever drops authority:
 | `"annotations"`        | Table and column comments, table and column tags                                        | Documenting and tagging a table whose structure and keys belong elsewhere — including streaming tables            |
 | `"tags"`               | Table and column tags only                                                              | Tag governance alone, where even a comment would be too much authority to claim                                   |
 
+Inside the engine these names resolve once to a closed `TableScope` value.
+That value owns scope policy; the rest of the system asks it whether an aspect
+is managed instead of interpreting sets of permissions or constructing new
+scope combinations.
+
 See [how to deploy metadata only](how-to-deploy-metadata-only.md) for the
 metadata scope in practice, and
 [annotations](how-to-configure-table.md#manage-comments-and-tags-only) and

--- a/src/delta_engine/api/delta_table.py
+++ b/src/delta_engine/api/delta_table.py
@@ -17,7 +17,7 @@ from types import MappingProxyType
 from typing import Final, NamedTuple
 
 from delta_engine.application.properties import DELTA_PROPERTY_POLICY, Property
-from delta_engine.application.scopes import ScopeName, managed_aspects_for
+from delta_engine.application.scopes import ScopeName, table_scope_for
 from delta_engine.domain.collection_types import ListOrTuple
 from delta_engine.domain.model import (
     Array,
@@ -33,6 +33,7 @@ from delta_engine.domain.model import (
     QualifiedName,
     Struct,
     TableAspect,
+    TableScope,
     Variant,
     key_signature,
 )
@@ -284,7 +285,7 @@ def _validate_renames(columns: tuple[Column, ...], properties: Mapping[str, str 
 def _validate_column_names(
     columns: tuple[Column, ...],
     properties: Mapping[str, str | None],
-    managed_aspects: frozenset[TableAspect],
+    scope: TableScope,
 ) -> None:
     """
     Reject column names the declared properties make invalid on Delta.
@@ -296,7 +297,7 @@ def _validate_column_names(
     accepted, so it must be able to declare names this engine would reject
     to create.
     """
-    if TableAspect.COLUMN_STRUCTURE not in managed_aspects:
+    if not scope.manages(TableAspect.COLUMN_STRUCTURE):
         return
 
     if properties.get(Property.COLUMN_MAPPING_MODE) != "name":
@@ -524,7 +525,7 @@ class _NormalizedDeclaration:
     clustered_by: tuple[Identifier, ...]
     primary_key: tuple[Identifier, ...] | None
     foreign_key_declarations: tuple[ForeignKey, ...]
-    managed_aspects: frozenset[TableAspect]
+    scope: TableScope
 
 
 def _normalize_declaration(
@@ -569,7 +570,7 @@ def _normalize_declaration(
             tuple(Identifier(name) for name in primary_key) if primary_key is not None else None
         ),
         foreign_key_declarations=tuple(foreign_keys or ()),
-        managed_aspects=managed_aspects_for(scope),
+        scope=table_scope_for(scope),
     )
 
 
@@ -584,7 +585,7 @@ def _validate_declaration(declaration: _NormalizedDeclaration) -> None:
     _validate_column_names(
         declaration.columns,
         declaration.properties,
-        declaration.managed_aspects,
+        declaration.scope,
     )
     _validate_renames(declaration.columns, declaration.properties)
 
@@ -636,7 +637,7 @@ def _lower_declaration(declaration: _NormalizedDeclaration) -> DesiredTable:
         clustered_by=[column_names.get(name, name) for name in declaration.clustered_by],
         primary_key=primary_key_constraint,
         foreign_keys=foreign_keys,
-        managed_aspects=declaration.managed_aspects,
+        scope=declaration.scope,
     )
 
 

--- a/src/delta_engine/application/relationships.py
+++ b/src/delta_engine/application/relationships.py
@@ -140,7 +140,7 @@ def resolve(tables: tuple[DesiredTable, ...]) -> tuple[TableResolution, ...]:
 
 def _managed_foreign_keys(table: DesiredTable) -> Sequence[ForeignKeyConstraint]:
     """Return foreign keys this declaration is responsible for reconciling."""
-    if TableAspect.FOREIGN_KEYS not in table.managed_aspects:
+    if not table.scope.manages(TableAspect.FOREIGN_KEYS):
         return ()
     return table.foreign_keys
 

--- a/src/delta_engine/application/scopes.py
+++ b/src/delta_engine/application/scopes.py
@@ -1,62 +1,30 @@
-"""
-Named ownership scopes for Delta table declarations.
-
-The domain defines the complete ``TableAspect`` vocabulary. This module owns
-the supported public combinations and resolves a scope name at the API boundary.
-"""
+"""Resolve public scope names into the domain's table-scope policy."""
 
 from typing import Final, Literal
 
-from delta_engine.domain.model import ALL_ASPECTS, TableAspect
+from delta_engine.domain.model import TableScope
 
 type ScopeName = Literal["full", "metadata", "annotations", "tags"]
 
-METADATA_ASPECTS: Final[frozenset[TableAspect]] = frozenset(
-    {
-        TableAspect.TABLE_COMMENT,
-        TableAspect.COLUMN_COMMENTS,
-        TableAspect.TABLE_TAGS,
-        TableAspect.COLUMN_TAGS,
-        TableAspect.PRIMARY_KEY,
-        TableAspect.FOREIGN_KEYS,
-    }
-)
-
-ANNOTATION_ASPECTS: Final[frozenset[TableAspect]] = frozenset(
-    {
-        TableAspect.TABLE_COMMENT,
-        TableAspect.COLUMN_COMMENTS,
-        TableAspect.TABLE_TAGS,
-        TableAspect.COLUMN_TAGS,
-    }
-)
-
-TAG_ASPECTS: Final[frozenset[TableAspect]] = frozenset(
-    {
-        TableAspect.TABLE_TAGS,
-        TableAspect.COLUMN_TAGS,
-    }
-)
-
-_ASPECTS_BY_SCOPE: Final[dict[ScopeName, frozenset[TableAspect]]] = {
-    "full": ALL_ASPECTS,
-    "metadata": METADATA_ASPECTS,
-    "annotations": ANNOTATION_ASPECTS,
-    "tags": TAG_ASPECTS,
+_SCOPE_BY_NAME: Final[dict[ScopeName, TableScope]] = {
+    "full": TableScope.FULL,
+    "metadata": TableScope.METADATA,
+    "annotations": TableScope.ANNOTATIONS,
+    "tags": TableScope.TAGS,
 }
 
 
-def managed_aspects_for(scope: ScopeName) -> frozenset[TableAspect]:
+def table_scope_for(scope: ScopeName) -> TableScope:
     """
-    Return the aspects managed by a public scope name.
+    Resolve a public scope name.
 
     Raises:
         ValueError: If an untyped caller supplies an unknown scope name.
 
     """
     # Keep the runtime check for untyped callers.
-    if scope not in _ASPECTS_BY_SCOPE:
-        expected = ", ".join(repr(name) for name in _ASPECTS_BY_SCOPE)
+    if scope not in _SCOPE_BY_NAME:
+        expected = ", ".join(repr(name) for name in _SCOPE_BY_NAME)
         raise ValueError(f"Unknown scope {scope!r}; expected one of: {expected}")
 
-    return _ASPECTS_BY_SCOPE[scope]
+    return _SCOPE_BY_NAME[scope]

--- a/src/delta_engine/application/validation.py
+++ b/src/delta_engine/application/validation.py
@@ -12,7 +12,6 @@ from delta_engine.application.properties import (
     Property,
     PropertyPolicy,
 )
-from delta_engine.application.scopes import ANNOTATION_ASPECTS
 from delta_engine.domain.model import (
     Byte,
     DataType,
@@ -25,6 +24,7 @@ from delta_engine.domain.model import (
     Short,
     TableAspect,
     TableKind,
+    TableScope,
     TimestampNtz,
 )
 from delta_engine.domain.plan import (
@@ -584,7 +584,7 @@ class UnmanagedAspectDrift:
                 for difference in (*drift.actions, *drift.unresolvable):
                     if isinstance(difference, ColumnCaseDrift):
                         continue
-                    if difference.aspect in drift.desired.managed_aspects:
+                    if drift.desired.scope.manages(difference.aspect):
                         continue
                     lines_by_aspect.setdefault(difference.aspect, []).extend(
                         _difference_lines(difference)
@@ -626,7 +626,7 @@ class MissingTableUnmanaged:
                 return ()
 
             case TableCreation() as missing:
-                if TableAspect.TABLE_EXISTENCE in missing.desired.managed_aspects:
+                if missing.desired.scope.manages(TableAspect.TABLE_EXISTENCE):
                     return ()
                 return (
                     ValidationFailure(
@@ -656,8 +656,8 @@ class StreamingTableAnnotationsOnly:
     ``COMMENT ON`` reach. It judges the declaration's claimed aspects against
     the observed kind — not the drift — so it fires even when the table is
     currently in sync, and a dry run surfaces the misdeclaration immediately.
-    ``ANNOTATION_ASPECTS`` is shared with the public ``"annotations"`` scope so
-    the two policies cannot diverge.
+    The comparison uses the same domain scope policy as the public
+    ``"annotations"`` scope, so the two decisions cannot diverge.
 
     Keys are excluded rather than silently ignored: a declaration mirrors the
     pipeline's key to keep the aspect quiet, exactly as it already mirrors the
@@ -677,7 +677,7 @@ class StreamingTableAnnotationsOnly:
             case TableDrift() as drift:
                 if drift.observed.kind is not TableKind.STREAMING_TABLE:
                     return ()
-                if drift.desired.managed_aspects <= ANNOTATION_ASPECTS:
+                if drift.desired.scope.is_within(TableScope.ANNOTATIONS):
                     return ()
                 return (
                     ValidationFailure(

--- a/src/delta_engine/domain/model/__init__.py
+++ b/src/delta_engine/domain/model/__init__.py
@@ -34,6 +34,7 @@ from delta_engine.domain.model.table import (
     ObservedTable,
     TableAspect,
     TableKind,
+    TableScope,
 )
 from delta_engine.domain.model.table_feature import TableFeature
 
@@ -67,6 +68,7 @@ __all__ = [
     "TableAspect",
     "TableFeature",
     "TableKind",
+    "TableScope",
     "Timestamp",
     "TimestampNtz",
     "Variant",

--- a/src/delta_engine/domain/model/table.py
+++ b/src/delta_engine/domain/model/table.py
@@ -4,7 +4,7 @@ from collections.abc import Mapping, Sequence, Set
 from dataclasses import dataclass, field
 from enum import Enum, auto
 from types import MappingProxyType
-from typing import Final
+from typing import Final, Self
 
 from delta_engine.domain.collection_types import ListOrTuple
 from delta_engine.domain.model.column import DesiredColumn, ObservedColumn
@@ -118,7 +118,7 @@ class TableScope(Enum):
         """Return whether this scope manages ``aspect``."""
         return self.value >= _MINIMUM_SCOPE_BY_ASPECT[aspect].value
 
-    def is_within(self, other: "TableScope") -> bool:
+    def is_within(self, other: Self) -> bool:
         """Return whether this scope grants no more authority than ``other``."""
         return self.value <= other.value
 

--- a/src/delta_engine/domain/model/table.py
+++ b/src/delta_engine/domain/model/table.py
@@ -109,10 +109,10 @@ ALL_ASPECTS: Final[frozenset[TableAspect]] = frozenset(TableAspect)
 class TableScope(Enum):
     """The portion of a desired table managed by the engine."""
 
-    TAGS = auto()
-    ANNOTATIONS = auto()
-    METADATA = auto()
-    FULL = auto()
+    TAGS = 1
+    ANNOTATIONS = 2
+    METADATA = 3
+    FULL = 4
 
     def manages(self, aspect: TableAspect) -> bool:
         """Return whether this scope manages ``aspect``."""

--- a/src/delta_engine/domain/model/table.py
+++ b/src/delta_engine/domain/model/table.py
@@ -123,6 +123,7 @@ class TableScope(Enum):
         return self.value <= other.value
 
 
+# Each aspect records the narrowest scope allowed to manage it.
 _MINIMUM_SCOPE_BY_ASPECT: Final[Mapping[TableAspect, TableScope]] = MappingProxyType(
     {
         TableAspect.TABLE_TAGS: TableScope.TAGS,

--- a/src/delta_engine/domain/model/table.py
+++ b/src/delta_engine/domain/model/table.py
@@ -106,6 +106,40 @@ class TableAspect(Enum):
 ALL_ASPECTS: Final[frozenset[TableAspect]] = frozenset(TableAspect)
 
 
+class TableScope(Enum):
+    """The portion of a desired table managed by the engine."""
+
+    TAGS = auto()
+    ANNOTATIONS = auto()
+    METADATA = auto()
+    FULL = auto()
+
+    def manages(self, aspect: TableAspect) -> bool:
+        """Return whether this scope manages ``aspect``."""
+        return self.value >= _MINIMUM_SCOPE_BY_ASPECT[aspect].value
+
+    def is_within(self, other: "TableScope") -> bool:
+        """Return whether this scope grants no more authority than ``other``."""
+        return self.value <= other.value
+
+
+_MINIMUM_SCOPE_BY_ASPECT: Final[Mapping[TableAspect, TableScope]] = MappingProxyType(
+    {
+        TableAspect.TABLE_TAGS: TableScope.TAGS,
+        TableAspect.COLUMN_TAGS: TableScope.TAGS,
+        TableAspect.TABLE_COMMENT: TableScope.ANNOTATIONS,
+        TableAspect.COLUMN_COMMENTS: TableScope.ANNOTATIONS,
+        TableAspect.PRIMARY_KEY: TableScope.METADATA,
+        TableAspect.FOREIGN_KEYS: TableScope.METADATA,
+        TableAspect.TABLE_EXISTENCE: TableScope.FULL,
+        TableAspect.COLUMN_STRUCTURE: TableScope.FULL,
+        TableAspect.PROPERTIES: TableScope.FULL,
+        TableAspect.PARTITIONING: TableScope.FULL,
+        TableAspect.CLUSTERING: TableScope.FULL,
+    }
+)
+
+
 class TableKind(Enum):
     """
     The catalog relation kind an observed table resolved to.
@@ -137,7 +171,7 @@ class DesiredTable:
         foreign_keys: Foreign key constraints owned by this table.
         properties: Table properties; a ``None`` value asserts the key must be
             absent from the table.
-        managed_aspects: The table aspects this declaration manages.
+        scope: The portion of the table this declaration manages.
 
     A desired table contains only declared state. Table features implied by
     its column types are derived at the application planning boundary when an
@@ -154,7 +188,7 @@ class DesiredTable:
     primary_key: PrimaryKeyConstraint | None = None
     foreign_keys: ListOrTuple[ForeignKeyConstraint] = ()
     properties: Mapping[str, str | None] = field(default_factory=dict)
-    managed_aspects: Set[TableAspect] = field(default_factory=lambda: ALL_ASPECTS)
+    scope: TableScope = TableScope.FULL
 
     @property
     def primary_key_columns(self) -> tuple[str, ...]:
@@ -186,6 +220,9 @@ class DesiredTable:
         representable.
 
         """
+        if not isinstance(self.scope, TableScope):
+            raise TypeError(f"scope must be a TableScope, got {type(self.scope).__name__}")
+
         object.__setattr__(self, "columns", tuple(self.columns))
         object.__setattr__(self, "tags", MappingProxyType(dict(self.tags)))
         partitioned_by = tuple(self.partitioned_by)
@@ -194,8 +231,6 @@ class DesiredTable:
         object.__setattr__(self, "clustered_by", tuple(Identifier(n) for n in clustered_by))
         object.__setattr__(self, "foreign_keys", tuple(self.foreign_keys))
         object.__setattr__(self, "properties", MappingProxyType(dict(self.properties)))
-        object.__setattr__(self, "managed_aspects", frozenset(self.managed_aspects))
-
         _validate_table_structure(
             columns=self.columns,
             tags=self.tags,
@@ -205,11 +240,6 @@ class DesiredTable:
             foreign_keys=self.foreign_keys,
         )
 
-        if not self.managed_aspects:
-            raise ValueError(
-                "managed_aspects must not be empty: a table that manages no aspect"
-                " declares nothing for the engine to do"
-            )
         seen: set[frozenset[str]] = set()
         local_columns_by_constraint_name: dict[str, Sequence[str]] = {}
         for foreign_key in self.foreign_keys:
@@ -252,7 +282,7 @@ class DesiredTable:
             source = column.renamed_from
             if source is None:
                 continue
-            if TableAspect.COLUMN_STRUCTURE not in self.managed_aspects:
+            if not self.scope.manages(TableAspect.COLUMN_STRUCTURE):
                 raise ValueError(
                     f"Column {column.name!r} declares renamed_from, but this"
                     " declaration does not manage column structure"

--- a/src/delta_engine/domain/plan/diff.py
+++ b/src/delta_engine/domain/plan/diff.py
@@ -592,7 +592,7 @@ def _diff_properties(
     tuple[PropertyUndeclared, ...],
 ]:
     """Return all differences implied by exact property declarations."""
-    if TableAspect.PROPERTIES not in desired.managed_aspects:
+    if not desired.scope.manages(TableAspect.PROPERTIES):
         return (), ()
 
     actions: list[SetProperty | UnsetProperty] = []

--- a/src/delta_engine/domain/plan/diff.py
+++ b/src/delta_engine/domain/plan/diff.py
@@ -89,12 +89,13 @@ class TableDrift:
 
     ``actions`` are remedied differences, each carrying the executable
     operation that closes its gap. ``unresolvable`` are differences no action
-    can close; they exist to be judged by validation. Both state every
-    difference regardless of scope; deciding which the declaration is
-    allowed to make is validation's eligibility check, not the diff's concern.
+    can close; they exist to be judged by validation. Diffing is scope-blind
+    except for properties, which are not compared when the declaration does
+    not manage them. Validation's eligibility checks decide whether every
+    other difference is within the declaration's scope.
     ``desired`` and ``observed`` are the two endpoints the differences
-    separate, carried as judging context: the declaration's side (managed
-    aspects, declared properties) and the catalog's side (observed facts such
+    separate, carried as judging context: the declaration's side (scope and
+    declared properties) and the catalog's side (observed facts such
     as the relation kind).
     """
 

--- a/tests/api/test_delta_table.py
+++ b/tests/api/test_delta_table.py
@@ -2,12 +2,11 @@ from types import MappingProxyType
 
 import pytest
 
-from delta_engine.application.scopes import ANNOTATION_ASPECTS, METADATA_ASPECTS, TAG_ASPECTS
 from delta_engine.domain.model import (
-    ALL_ASPECTS,
     DesiredColumn as DomainColumn,
     QualifiedName,
     TableAspect,
+    TableScope,
 )
 from delta_engine.domain.model.constraints import PrimaryKeyConstraint
 from delta_engine.schema import (
@@ -799,16 +798,16 @@ def test_delta_table_manages_all_aspects_by_default():
     )
 
     # Then the lowered desired table manages everything
-    assert table.to_desired_table().managed_aspects == ALL_ASPECTS
+    assert table.to_desired_table().scope is TableScope.FULL
 
 
 @pytest.mark.parametrize(
     ("scope", "expected"),
     [
-        ("full", ALL_ASPECTS),
-        ("metadata", METADATA_ASPECTS),
-        ("annotations", ANNOTATION_ASPECTS),
-        ("tags", TAG_ASPECTS),
+        ("full", TableScope.FULL),
+        ("metadata", TableScope.METADATA),
+        ("annotations", TableScope.ANNOTATIONS),
+        ("tags", TableScope.TAGS),
     ],
 )
 def test_a_scope_name_narrows_what_the_declaration_manages(scope, expected):
@@ -821,10 +820,8 @@ def test_a_scope_name_narrows_what_the_declaration_manages(scope, expected):
         scope=scope,
     )
 
-    # Then it lowers to exactly that scope's aspects. What each set contains is
-    # pinned in tests/application/test_scopes.py; this is the wiring from the
-    # public name to it
-    assert table.to_desired_table().managed_aspects == expected
+    # Then the public name becomes the corresponding closed domain scope.
+    assert table.to_desired_table().scope is expected
 
 
 def test_a_restricted_scope_still_lowers_everything_declared():
@@ -885,7 +882,7 @@ def test_metadata_scope_carries_properties_without_deploying_them():
     # Then the declaration carries the property; PROPERTIES stays unmanaged
     desired = table.to_desired_table()
     assert desired.properties == {Property.CHANGE_DATA_FEED.value: "true"}
-    assert TableAspect.PROPERTIES not in desired.managed_aspects
+    assert not desired.scope.manages(TableAspect.PROPERTIES)
 
 
 def test_tag_scope_carries_foreign_keys_without_managing_them():
@@ -913,7 +910,7 @@ def test_tag_scope_carries_foreign_keys_without_managing_them():
     # Then the declaration carries the key; FOREIGN_KEYS stays unmanaged
     desired = table.to_desired_table()
     assert len(desired.foreign_keys) == 1
-    assert TableAspect.FOREIGN_KEYS not in desired.managed_aspects
+    assert not desired.scope.manages(TableAspect.FOREIGN_KEYS)
 
 
 def test_annotations_scope_carries_a_mirrored_primary_key_without_managing_it():
@@ -933,7 +930,7 @@ def test_annotations_scope_carries_a_mirrored_primary_key_without_managing_it():
     # Omitting it would instead read as a drop this scope cannot authorise
     desired = table.to_desired_table()
     assert desired.primary_key is not None
-    assert TableAspect.PRIMARY_KEY not in desired.managed_aspects
+    assert not desired.scope.manages(TableAspect.PRIMARY_KEY)
 
 
 def test_no_properties_are_injected_by_default():

--- a/tests/application/test_planning.py
+++ b/tests/application/test_planning.py
@@ -5,7 +5,6 @@ from delta_engine.application.planning import (
     PlanningRejected,
     plan_changes,
 )
-from delta_engine.application.scopes import METADATA_ASPECTS
 from delta_engine.domain.model import (
     DesiredColumn,
     DesiredTable,
@@ -18,8 +17,8 @@ from delta_engine.domain.model import (
     PrimaryKeyConstraint,
     QualifiedName,
     String,
-    TableAspect,
     TableKind,
+    TableScope,
     TimestampNtz,
 )
 from delta_engine.domain.plan import (
@@ -101,7 +100,7 @@ def test_plan_changes_rejects_unmanaged_actions():
     result = plan_changes(
         _desired(
             columns=(DesiredColumn("id", Integer()), DesiredColumn("age", Integer())),
-            managed_aspects=frozenset({TableAspect.TABLE_COMMENT}),
+            scope=TableScope.ANNOTATIONS,
         ),
         _observed(),
     )
@@ -212,7 +211,7 @@ def test_plan_changes_accepts_missing_table_and_builds_follow_up_actions():
 
 
 def test_plan_changes_rejects_missing_table_when_table_existence_is_unmanaged():
-    desired = _desired(managed_aspects=frozenset({TableAspect.TABLE_COMMENT}))
+    desired = _desired(scope=TableScope.ANNOTATIONS)
 
     result = plan_changes(desired, None)
 
@@ -402,7 +401,7 @@ def test_plan_carries_the_observed_relation_kind():
     # Given tag drift against a streaming table, under a tags-only declaration
     desired = _desired(
         columns=(DesiredColumn("id", Integer(), tags={"pii": "low"}),),
-        managed_aspects=frozenset({TableAspect.TABLE_TAGS, TableAspect.COLUMN_TAGS}),
+        scope=TableScope.TAGS,
     )
     observed = _observed(kind=TableKind.STREAMING_TABLE)
 
@@ -431,7 +430,7 @@ def test_feature_enablement_outside_column_structure_scope_is_rejected():
     # come from its aspect, which a metadata-scoped declaration excludes.
     desired = _desired(
         columns=(DesiredColumn("seen_at", TimestampNtz()),),
-        managed_aspects=METADATA_ASPECTS,
+        scope=TableScope.METADATA,
     )
     observed = _observed(columns=(ObservedColumn("seen_at", TimestampNtz()),))
 
@@ -556,7 +555,7 @@ def test_foreign_key_drift_on_an_unmanaged_aspect_fails_eligibility():
         _desired(
             columns=(DesiredColumn("id", Integer()), DesiredColumn("customer_id", Integer())),
             foreign_keys=(fk,),
-            managed_aspects=frozenset({TableAspect.TABLE_COMMENT}),
+            scope=TableScope.ANNOTATIONS,
         ),
         _observed(
             columns=(ObservedColumn("id", Integer()), ObservedColumn("customer_id", Integer())),

--- a/tests/application/test_scopes.py
+++ b/tests/application/test_scopes.py
@@ -1,65 +1,22 @@
 import pytest
 
-from delta_engine.application.scopes import (
-    ANNOTATION_ASPECTS,
-    METADATA_ASPECTS,
-    TAG_ASPECTS,
-    managed_aspects_for,
-)
-from delta_engine.domain.model import ALL_ASPECTS, TableAspect
-
-COMMENTS = frozenset({TableAspect.TABLE_COMMENT, TableAspect.COLUMN_COMMENTS})
-TAGS = frozenset({TableAspect.TABLE_TAGS, TableAspect.COLUMN_TAGS})
-KEYS = frozenset({TableAspect.PRIMARY_KEY, TableAspect.FOREIGN_KEYS})
+from delta_engine.application.scopes import table_scope_for
+from delta_engine.domain.model import TableScope
 
 
 @pytest.mark.parametrize(
-    ("scope", "expected"),
+    ("name", "expected"),
     [
-        ("full", ALL_ASPECTS),
-        ("metadata", COMMENTS | TAGS | KEYS),
-        ("annotations", COMMENTS | TAGS),
-        ("tags", TAGS),
+        ("full", TableScope.FULL),
+        ("metadata", TableScope.METADATA),
+        ("annotations", TableScope.ANNOTATIONS),
+        ("tags", TableScope.TAGS),
     ],
 )
-def test_each_scope_name_resolves_to_its_aspects(scope, expected):
-    # Built from groups named here rather than from the module's own constants,
-    # so this states each scope's definition instead of restating it
-    assert managed_aspects_for(scope) == expected
+def test_each_public_name_resolves_to_its_domain_scope(name, expected):
+    assert table_scope_for(name) is expected
 
 
 def test_unknown_scope_is_rejected():
     with pytest.raises(ValueError):
-        managed_aspects_for("everything")
-
-
-def test_the_scopes_form_a_containment_lattice():
-    # Given the four public scopes
-    # Then each is contained by the next, so a caller who narrows a
-    # scope can only ever lose authority, never trade it sideways
-    assert TAG_ASPECTS < ANNOTATION_ASPECTS
-    assert ANNOTATION_ASPECTS < METADATA_ASPECTS
-    assert METADATA_ASPECTS < ALL_ASPECTS
-
-
-def test_metadata_excludes_existence_and_physical_aspects():
-    # Stated as a subtraction on purpose: a new TableAspect added to the domain
-    # fails this test until someone decides whether metadata governs it. The
-    # enumerated cases above would keep passing, since neither side of them grows.
-    assert METADATA_ASPECTS == ALL_ASPECTS - frozenset(
-        {
-            TableAspect.TABLE_EXISTENCE,
-            TableAspect.COLUMN_STRUCTURE,
-            TableAspect.PROPERTIES,
-            TableAspect.PARTITIONING,
-            TableAspect.CLUSTERING,
-        }
-    )
-
-
-def test_annotations_scope_does_not_manage_keys():
-    # Keys are why "annotations" sits below "metadata": a streaming table's
-    # defining SQL owns them, and a refresh can revert a change made from
-    # outside the pipeline. Comments and tags survive one.
-    assert TableAspect.PRIMARY_KEY not in ANNOTATION_ASPECTS
-    assert TableAspect.FOREIGN_KEYS not in ANNOTATION_ASPECTS
+        table_scope_for("everything")

--- a/tests/application/test_validation.py
+++ b/tests/application/test_validation.py
@@ -3,7 +3,6 @@ from typing import ClassVar
 import pytest
 
 from delta_engine.application.failures import ValidationFailure
-from delta_engine.application.scopes import ANNOTATION_ASPECTS, METADATA_ASPECTS, TAG_ASPECTS
 from delta_engine.application.validation import (
     DEFAULT_SAFETY_RULES,
     ELIGIBILITY_CHECKS,
@@ -11,7 +10,6 @@ from delta_engine.application.validation import (
     validate_diff,
 )
 from delta_engine.domain.model import (
-    ALL_ASPECTS,
     Byte,
     DataType,
     Date,
@@ -32,8 +30,8 @@ from delta_engine.domain.model import (
     String,
     Struct,
     StructField,
-    TableAspect,
     TableKind,
+    TableScope,
     TimestampNtz,
 )
 from delta_engine.domain.plan import (
@@ -68,7 +66,7 @@ def _desired_table(
     properties: dict[str, str | None] | None = None,
     partitioned_by: tuple[str, ...] = (),
     clustered_by: tuple[str, ...] = (),
-    managed_aspects: frozenset[TableAspect] = ALL_ASPECTS,
+    scope: TableScope = TableScope.FULL,
     primary_key: PrimaryKeyConstraint | None = None,
 ) -> DesiredTable:
     return DesiredTable(
@@ -77,7 +75,7 @@ def _desired_table(
         properties={} if properties is None else properties,
         partitioned_by=partitioned_by,
         clustered_by=clustered_by,
-        managed_aspects=managed_aspects,
+        scope=scope,
         primary_key=primary_key,
     )
 
@@ -107,13 +105,13 @@ def _observed_table(
 
 def _drift(
     *differences: Action | Unresolvable,
-    managed_aspects: frozenset[TableAspect] = ALL_ASPECTS,
+    scope: TableScope = TableScope.FULL,
     desired: DesiredTable | None = None,
     observed: ObservedTable | None = None,
     kind: TableKind = TableKind.TABLE,
 ) -> TableDrift:
     if desired is None:
-        desired = _desired_table(managed_aspects=managed_aspects)
+        desired = _desired_table(scope=scope)
     if observed is None:
         observed = _observed_table(kind=kind)
     actions = tuple(item for item in differences if isinstance(item, Action))
@@ -267,7 +265,7 @@ def test_missing_table_with_non_nullable_columns_passes_when_table_existence_is_
     # Given a missing table with a NOT NULL column
     desired = _desired_table(
         columns=(DesiredColumn("id", Integer(), nullable=False),),
-        managed_aspects=ALL_ASPECTS,
+        scope=TableScope.FULL,
     )
 
     # Then creating the table is safe
@@ -277,7 +275,7 @@ def test_missing_table_with_non_nullable_columns_passes_when_table_existence_is_
 def test_validate_diff_fails_table_missing_when_table_existence_unmanaged():
     # Given a metadata-only definition for a table that does not exist
     desired = _desired_table(
-        managed_aspects=frozenset({TableAspect.TABLE_COMMENT, TableAspect.TABLE_TAGS})
+        scope=TableScope.ANNOTATIONS,
     )
 
     # When validating
@@ -290,7 +288,7 @@ def test_validate_diff_fails_table_missing_when_table_existence_unmanaged():
 
 def test_validate_diff_passes_table_missing_when_table_existence_managed():
     # Given a fully managed definition for a missing table
-    desired = _desired_table(managed_aspects=ALL_ASPECTS)
+    desired = _desired_table(scope=TableScope.FULL)
 
     # When validating
     failures = validate_diff(diff_table(desired, None))
@@ -302,7 +300,7 @@ def test_validate_diff_passes_table_missing_when_table_existence_managed():
 def test_missing_table_unmanaged_cannot_be_suppressed_by_empty_rules():
     # Given a missing table whose declaration does not manage table existence
     desired = _desired_table(
-        managed_aspects=frozenset({TableAspect.TABLE_COMMENT, TableAspect.TABLE_TAGS})
+        scope=TableScope.ANNOTATIONS,
     )
 
     # When validating with no safety rules
@@ -602,7 +600,7 @@ def test_unmanaged_aspect_drift_fails_when_unmanaged_aspect_has_drifted():
     # Given a declaration that only manages table tags, but column structure has drifted
     diff = _drift(
         AddColumn(DesiredColumn("extra", Integer())),
-        managed_aspects=frozenset({TableAspect.TABLE_TAGS}),
+        scope=TableScope.TAGS,
     )
 
     # When validating
@@ -620,7 +618,7 @@ def test_unmanaged_aspect_drift_produces_one_failure_per_drifted_unmanaged_aspec
         AddColumn(DesiredColumn("extra", Integer())),
         AddColumn(DesiredColumn("more", Integer())),
         SetTableComment(desired_comment="new", observed_comment="old"),
-        managed_aspects=frozenset({TableAspect.TABLE_TAGS}),
+        scope=TableScope.TAGS,
     )
 
     # When validating
@@ -636,7 +634,7 @@ def test_unmanaged_aspect_drift_cannot_be_suppressed_by_empty_rules():
     # Given unmanaged drift and an empty rule set
     diff = _drift(
         AddColumn(DesiredColumn("extra", Integer())),
-        managed_aspects=frozenset({TableAspect.TABLE_TAGS}),
+        scope=TableScope.TAGS,
     )
 
     # When validating
@@ -650,7 +648,7 @@ def test_unmanaged_drift_does_not_also_trip_safety_rules():
     # Given a metadata-only declaration whose live table has a type mismatch
     diff = _drift(
         _type_drift("id"),
-        managed_aspects=frozenset({TableAspect.TABLE_COMMENT}),
+        scope=TableScope.ANNOTATIONS,
     )
 
     # When validating
@@ -663,7 +661,7 @@ def test_unmanaged_drift_does_not_also_trip_safety_rules():
 
 def test_managed_drift_still_trips_safety_rules():
     # Given a fully managed drift with a type change
-    diff = _drift(_type_drift("id"), managed_aspects=ALL_ASPECTS)
+    diff = _drift(_type_drift("id"), scope=TableScope.FULL)
 
     # When validating
     failures = validate_diff(diff)
@@ -673,27 +671,11 @@ def test_managed_drift_still_trips_safety_rules():
     assert failures[0].rule_name == "TypeWideningRequiredForTypeChange"
 
 
-def test_out_of_scope_drift_short_circuits_safety_rules():
-    # Given a declaration that manages column structure but not table comment,
-    # with both a managed-and-unsafe column add and out-of-scope comment drift
-    diff = _drift(
-        AddColumn(DesiredColumn("x", Integer(), nullable=False)),
-        SetTableComment(desired_comment="new", observed_comment="old"),
-        managed_aspects=frozenset({TableAspect.COLUMN_STRUCTURE}),
-    )
-
-    # When validating
-    failures = validate_diff(diff)
-
-    # Then the scope violation is reported alone; the safety rule never runs
-    assert [failure.rule_name for failure in failures] == ["UnmanagedAspectDrift"]
-
-
 def test_drift_passes_when_no_unmanaged_aspect_has_drifted():
     # Given a metadata-only drift where only a managed aspect drifted
     diff = _drift(
         SetTableComment(desired_comment="new", observed_comment="old"),
-        managed_aspects=frozenset({TableAspect.TABLE_COMMENT}),
+        scope=TableScope.ANNOTATIONS,
     )
 
     # Then validation passes
@@ -702,7 +684,7 @@ def test_drift_passes_when_no_unmanaged_aspect_has_drifted():
 
 def test_drift_passes_when_all_aspects_managed():
     # Given a fully managed drift with a nullable column addition
-    diff = _drift(AddColumn(DesiredColumn("extra", Integer())), managed_aspects=ALL_ASPECTS)
+    diff = _drift(AddColumn(DesiredColumn("extra", Integer())), scope=TableScope.FULL)
 
     # Then validation passes
     assert not validate_diff(diff)
@@ -712,7 +694,7 @@ def test_unmanaged_column_drop_does_not_require_column_mapping():
     # Given column structure drift on a declaration that does not manage column structure
     diff = _drift(
         DropColumn(ObservedColumn("stale", Integer())),
-        managed_aspects=frozenset({TableAspect.TABLE_COMMENT}),
+        scope=TableScope.ANNOTATIONS,
     )
 
     # When validating
@@ -728,7 +710,7 @@ def test_tag_only_scope_passes_when_only_table_and_column_tags_drift():
         qualified_name=_QUALIFIED_NAME,
         columns=(DesiredColumn("id", Integer(), tags={"pii": "false"}),),
         tags={"domain": "sales"},
-        managed_aspects=frozenset({TableAspect.TABLE_TAGS, TableAspect.COLUMN_TAGS}),
+        scope=TableScope.TAGS,
     )
     observed = ObservedTable(
         qualified_name=_QUALIFIED_NAME,
@@ -747,7 +729,7 @@ def test_tag_only_scope_fails_when_table_comment_drifts():
     # Given a tag-only declaration with comment drift
     diff = _drift(
         SetTableComment(desired_comment="new", observed_comment="old"),
-        managed_aspects=frozenset({TableAspect.TABLE_TAGS, TableAspect.COLUMN_TAGS}),
+        scope=TableScope.TAGS,
     )
 
     # When validating
@@ -763,7 +745,7 @@ def test_tag_only_scope_fails_when_column_comment_drifts():
     diff = _drift(
         SetColumnTag(column_name="id", name="pii", desired_value="true", observed_value=None),
         SetColumnComment(column_name="id", desired_comment="new", observed_comment="old"),
-        managed_aspects=frozenset({TableAspect.TABLE_TAGS, TableAspect.COLUMN_TAGS}),
+        scope=TableScope.TAGS,
     )
 
     # When validating
@@ -777,7 +759,7 @@ def test_tag_only_scope_fails_when_column_structure_drifts():
     # Given a tag-only declaration whose live table has an extra, undeclared column
     desired = _desired_table(
         columns=(DesiredColumn("id", Integer()),),
-        managed_aspects=frozenset({TableAspect.TABLE_TAGS, TableAspect.COLUMN_TAGS}),
+        scope=TableScope.TAGS,
     )
     observed = _observed_table(
         columns=(DesiredColumn("id", Integer()), DesiredColumn("extra", String()))
@@ -1063,7 +1045,7 @@ def test_column_case_drift_is_named_at_a_scope_that_does_not_manage_columns():
     # keys or comments to a table someone else created
     drift = _drift(
         ColumnCaseDrift(declared_name="requestid", observed_name="requestId"),
-        managed_aspects=METADATA_ASPECTS,
+        scope=TableScope.METADATA,
     )
 
     # When the diff is validated
@@ -1105,7 +1087,7 @@ def test_column_spelling_check_reports_before_unmanaged_aspect_drift():
     drift = _drift(
         ColumnCaseDrift(declared_name="requestid", observed_name="requestId"),
         AddColumn(DesiredColumn("extra", Integer())),
-        managed_aspects=METADATA_ASPECTS,
+        scope=TableScope.METADATA,
     )
 
     failures = validate_diff(drift)
@@ -1125,7 +1107,7 @@ def test_column_spelling_check_reports_before_the_streaming_table_check():
     # and kind checks against each other
     diff = _drift(
         ColumnCaseDrift(declared_name="requestid", observed_name="requestId"),
-        managed_aspects=METADATA_ASPECTS,
+        scope=TableScope.METADATA,
         kind=TableKind.STREAMING_TABLE,
     )
 
@@ -1149,25 +1131,21 @@ _PIPELINE_KEY = PrimaryKeyConstraint(("id",), "test_pk")
 _KEYED_COLUMNS = (DesiredColumn("id", Integer(), nullable=False),)
 
 
-@pytest.mark.parametrize(
-    "managed_aspects", [TAG_ASPECTS, ANNOTATION_ASPECTS], ids=["tags", "annotations"]
-)
-def test_streaming_table_admits_a_declaration_within_annotations(managed_aspects):
+@pytest.mark.parametrize("scope", [TableScope.TAGS, TableScope.ANNOTATIONS])
+def test_streaming_table_admits_a_declaration_within_annotations(scope):
     # Given a declaration claiming no more than comments and tags — the aspects
     # a pipeline does not own
-    diff = _drift(managed_aspects=managed_aspects, kind=TableKind.STREAMING_TABLE)
+    diff = _drift(scope=scope, kind=TableKind.STREAMING_TABLE)
 
     # Then the engine may manage them
     assert not validate_diff(diff)
 
 
-@pytest.mark.parametrize(
-    "managed_aspects", [METADATA_ASPECTS, ALL_ASPECTS], ids=["metadata", "full"]
-)
-def test_streaming_table_refuses_a_declaration_beyond_annotations(managed_aspects):
+@pytest.mark.parametrize("scope", [TableScope.METADATA, TableScope.FULL])
+def test_streaming_table_refuses_a_declaration_beyond_annotations(scope):
     # Given a declaration claiming keys as well, over an in-sync table — zero
     # drift, so there is nothing to do either way
-    diff = _drift(managed_aspects=managed_aspects, kind=TableKind.STREAMING_TABLE)
+    diff = _drift(scope=scope, kind=TableKind.STREAMING_TABLE)
 
     # When validating
     failures = validate_diff(diff)
@@ -1183,7 +1161,7 @@ def test_streaming_table_check_reports_before_unmanaged_aspect_drift():
     # both eligibility checks fire, kind first
     diff = _drift(
         AddColumn(DesiredColumn("extra", Integer())),
-        managed_aspects=METADATA_ASPECTS,
+        scope=TableScope.METADATA,
         kind=TableKind.STREAMING_TABLE,
     )
 
@@ -1198,7 +1176,7 @@ def test_streaming_table_check_reports_before_unmanaged_aspect_drift():
 def test_annotations_scope_refuses_to_drop_a_pipeline_declared_key():
     # Given a streaming table whose key was declared in the pipeline's defining
     # SQL, and an annotations-scope declaration that does not restate it
-    desired = _desired_table(columns=_KEYED_COLUMNS, managed_aspects=ANNOTATION_ASPECTS)
+    desired = _desired_table(columns=_KEYED_COLUMNS, scope=TableScope.ANNOTATIONS)
     observed = _observed_table(
         columns=_KEYED_COLUMNS, kind=TableKind.STREAMING_TABLE, primary_key=_PIPELINE_KEY
     )
@@ -1215,7 +1193,7 @@ def test_annotations_scope_refuses_to_drop_a_pipeline_declared_key():
 def test_a_declaration_mirroring_the_pipeline_key_leaves_it_alone():
     # Given the same table, with the declaration restating the pipeline's key
     desired = _desired_table(
-        columns=_KEYED_COLUMNS, managed_aspects=ANNOTATION_ASPECTS, primary_key=_PIPELINE_KEY
+        columns=_KEYED_COLUMNS, scope=TableScope.ANNOTATIONS, primary_key=_PIPELINE_KEY
     )
     observed = _observed_table(
         columns=_KEYED_COLUMNS, kind=TableKind.STREAMING_TABLE, primary_key=_PIPELINE_KEY
@@ -1236,7 +1214,7 @@ def test_scope_failure_prevents_safety_evaluation():
 
     diff = _drift(
         AddColumn(DesiredColumn("extra", Integer())),
-        managed_aspects=frozenset({TableAspect.TABLE_TAGS}),
+        scope=TableScope.TAGS,
     )
 
     failures = validate_diff(diff, rules=(MustNotRun(),))
@@ -1249,7 +1227,7 @@ def test_unmanaged_drift_names_the_differences_that_drifted():
     diff = _drift(
         AddColumn(DesiredColumn("legacy_region", String())),
         AlterColumnType(column_name="amount", desired_type=Long(), observed_type=Integer()),
-        managed_aspects=METADATA_ASPECTS,
+        scope=TableScope.METADATA,
     )
 
     # When the eligibility check judges it
@@ -1267,7 +1245,7 @@ def test_unmanaged_drift_names_differences_no_action_could_close():
     # Given drift a plan action cannot express
     diff = _drift(
         PartitioningChanged(desired_partitioning=("region",), observed_partitioning=("country",)),
-        managed_aspects=METADATA_ASPECTS,
+        scope=TableScope.METADATA,
     )
 
     # When the check judges it
@@ -1282,7 +1260,7 @@ def test_unmanaged_drift_reports_one_failure_per_aspect():
     diff = _drift(
         AddColumn(DesiredColumn("legacy_region", String())),
         PartitioningChanged(desired_partitioning=("region",), observed_partitioning=("country",)),
-        managed_aspects=METADATA_ASPECTS,
+        scope=TableScope.METADATA,
     )
 
     # When the check judges it
@@ -1301,7 +1279,7 @@ def test_unmanaged_drift_still_passes_over_a_column_spelled_differently():
     # Given case drift, which ColumnSpellingMustMatchCatalog owns at every scope
     diff = _drift(
         ColumnCaseDrift(declared_name="SKU", observed_name="sku"),
-        managed_aspects=METADATA_ASPECTS,
+        scope=TableScope.METADATA,
     )
 
     # Then this check says nothing about it

--- a/tests/domain/model/test_table.py
+++ b/tests/domain/model/test_table.py
@@ -1,7 +1,6 @@
 import pytest
 
 from delta_engine.domain.model import (
-    ALL_ASPECTS,
     Date,
     DesiredColumn,
     DesiredTable,
@@ -11,8 +10,8 @@ from delta_engine.domain.model import (
     ObservedTable,
     QualifiedName,
     String,
-    TableAspect,
     TableKind,
+    TableScope,
 )
 from delta_engine.domain.model.constraints import ForeignKeyConstraint, PrimaryKeyConstraint
 from tests.builders import as_observed_columns
@@ -481,7 +480,7 @@ def test_observed_table_stores_tags():
     assert dict(table.tags) == {"env": "prod"}
 
 
-# ---------- managed_aspects ----------
+# ---------- scope ----------
 
 
 def test_desired_table_manages_all_aspects_by_default():
@@ -492,28 +491,28 @@ def test_desired_table_manages_all_aspects_by_default():
     )
 
     # Then every aspect is managed (full-management behaviour)
-    assert table.managed_aspects == ALL_ASPECTS
+    assert table.scope is TableScope.FULL
 
 
-def test_desired_table_accepts_a_partial_aspect_set():
+def test_desired_table_accepts_a_restricted_scope():
     # Given a desired table managing only tags
     table = DesiredTable(
         qualified_name=_QUALIFIED_NAME,
         columns=(_COL,),
-        managed_aspects=frozenset({TableAspect.TABLE_TAGS, TableAspect.COLUMN_TAGS}),
+        scope=TableScope.TAGS,
     )
 
     # Then the declared scope is preserved
-    assert table.managed_aspects == frozenset({TableAspect.TABLE_TAGS, TableAspect.COLUMN_TAGS})
+    assert table.scope is TableScope.TAGS
 
 
-def test_desired_table_rejects_empty_aspect_set():
-    # Given an empty scope — an engine that manages nothing is a declaration error
-    with pytest.raises(ValueError, match="managed_aspects"):
+def test_desired_table_rejects_a_raw_scope_name():
+    # Public strings are resolved before entering the domain.
+    with pytest.raises(TypeError, match="TableScope"):
         DesiredTable(
             qualified_name=_QUALIFIED_NAME,
             columns=(_COL,),
-            managed_aspects=frozenset(),
+            scope="tags",  # type: ignore[arg-type]
         )
 
 
@@ -683,21 +682,11 @@ def test_desired_table_rejects_duplicate_rename_sources() -> None:
 def test_desired_table_rejects_renames_outside_column_structure_scope() -> None:
     # Given a declaration managing only metadata aspects — renames imply
     # column-structure changes, which this scope does not manage
-    metadata_aspects = frozenset(
-        {
-            TableAspect.TABLE_COMMENT,
-            TableAspect.COLUMN_COMMENTS,
-            TableAspect.COLUMN_TAGS,
-            TableAspect.TABLE_TAGS,
-            TableAspect.PRIMARY_KEY,
-            TableAspect.FOREIGN_KEYS,
-        }
-    )
     with pytest.raises(ValueError, match="column structure"):
         DesiredTable(
             qualified_name=_QN,
             columns=(DesiredColumn("customer_name", String(), renamed_from="customer_nm"),),
-            managed_aspects=metadata_aspects,
+            scope=TableScope.METADATA,
         )
 
 

--- a/tests/domain/model/test_table_aspect.py
+++ b/tests/domain/model/test_table_aspect.py
@@ -2,7 +2,7 @@ from delta_engine.domain.model import ALL_ASPECTS, TableAspect
 
 
 def test_all_aspects_contains_every_aspect():
-    # Given the canonical full-management set
+    # Given the canonical aspect vocabulary
     # Then it equals the full enum
     assert ALL_ASPECTS == frozenset(TableAspect)
 
@@ -36,6 +36,6 @@ def test_aspect_declaration_order_is_canonical():
 
 def test_clustering_is_a_managed_aspect():
     # Given the clustering aspect
-    # Then it is part of the full managed-aspect set and has a readable label
+    # Then it is part of the aspect vocabulary and has a readable label
     assert TableAspect.CLUSTERING in ALL_ASPECTS
     assert TableAspect.CLUSTERING.label == "clustering"

--- a/tests/domain/model/test_table_scope.py
+++ b/tests/domain/model/test_table_scope.py
@@ -1,0 +1,42 @@
+import pytest
+
+from delta_engine.domain.model import TableAspect, TableScope
+
+TAGS = frozenset({TableAspect.TABLE_TAGS, TableAspect.COLUMN_TAGS})
+COMMENTS = frozenset({TableAspect.TABLE_COMMENT, TableAspect.COLUMN_COMMENTS})
+KEYS = frozenset({TableAspect.PRIMARY_KEY, TableAspect.FOREIGN_KEYS})
+STRUCTURE = frozenset(
+    {
+        TableAspect.TABLE_EXISTENCE,
+        TableAspect.COLUMN_STRUCTURE,
+        TableAspect.PROPERTIES,
+        TableAspect.PARTITIONING,
+        TableAspect.CLUSTERING,
+    }
+)
+
+
+@pytest.mark.parametrize(
+    ("scope", "managed"),
+    [
+        (TableScope.TAGS, TAGS),
+        (TableScope.ANNOTATIONS, TAGS | COMMENTS),
+        (TableScope.METADATA, TAGS | COMMENTS | KEYS),
+        (TableScope.FULL, TAGS | COMMENTS | KEYS | STRUCTURE),
+    ],
+)
+def test_each_scope_manages_its_part_of_the_table(scope, managed):
+    assert {aspect for aspect in TableAspect if scope.manages(aspect)} == managed
+
+
+@pytest.mark.parametrize(
+    ("scope", "limit", "expected"),
+    [
+        (TableScope.TAGS, TableScope.ANNOTATIONS, True),
+        (TableScope.ANNOTATIONS, TableScope.ANNOTATIONS, True),
+        (TableScope.METADATA, TableScope.ANNOTATIONS, False),
+        (TableScope.FULL, TableScope.ANNOTATIONS, False),
+    ],
+)
+def test_scope_knows_whether_it_fits_within_an_authority_limit(scope, limit, expected):
+    assert scope.is_within(limit) is expected

--- a/tests/domain/plan/test_diff.py
+++ b/tests/domain/plan/test_diff.py
@@ -1,7 +1,6 @@
 import pytest
 
 from delta_engine.domain.model import (
-    ALL_ASPECTS,
     Array,
     DesiredColumn,
     DesiredTable,
@@ -15,9 +14,9 @@ from delta_engine.domain.model import (
     String,
     Struct,
     StructField,
-    TableAspect,
     TableFeature,
     TableKind,
+    TableScope,
     TimestampNtz,
     Variant,
 )
@@ -553,9 +552,8 @@ def test_every_observed_key_without_declaration_produces_a_finding():
 def test_properties_diff_is_skipped_when_properties_unmanaged():
     # Given a declaration that does not manage properties (metadata-only style)
     # over a catalog carrying an undeclared managed key
-    managed = ALL_ASPECTS - frozenset({TableAspect.PROPERTIES})
     diff = diff_table(
-        _desired(properties={}, managed_aspects=managed),
+        _desired(properties={}, scope=TableScope.METADATA),
         _observed(properties={"delta.columnMapping.mode": "name"}),
     )
 
@@ -568,9 +566,8 @@ def test_properties_diff_is_skipped_when_properties_unmanaged():
 def test_declared_properties_are_not_compared_when_properties_unmanaged():
     # Given a declaration that carries a property but does not manage
     # properties, over a catalog where that property is absent
-    managed = ALL_ASPECTS - frozenset({TableAspect.PROPERTIES})
     diff = diff_table(
-        _desired(properties={"delta.enableChangeDataFeed": "true"}, managed_aspects=managed),
+        _desired(properties={"delta.enableChangeDataFeed": "true"}, scope=TableScope.METADATA),
         _observed(properties={}),
     )
 
@@ -805,7 +802,7 @@ def test_foreign_key_drift_is_stated_even_when_unmanaged():
     desired = _desired(
         columns=(DesiredColumn("customer_id", String()),),
         foreign_keys=(declared,),
-        managed_aspects=ALL_ASPECTS - frozenset({TableAspect.FOREIGN_KEYS}),
+        scope=TableScope.ANNOTATIONS,
     )
     observed = _observed(columns=(ObservedColumn("customer_id", String()),))
 


### PR DESCRIPTION
## Summary

- replace `DesiredTable.managed_aspects` and the named aspect-set constants with a closed `TableScope` domain value
- centralize scope questions behind `manages()` and `is_within()`, resolving public scope strings once at the API boundary
- update planning, validation, relationship resolution, tests, and architecture documentation to use the scope policy

## Why

The raw `frozenset[TableAspect]` representation leaked permission checks throughout the codebase and allowed arbitrary combinations that the public API could never produce. A closed scope model makes those invalid states unrepresentable and gives future scope logic one owner.

## Impact

The public `DeltaTable(scope=...)` API and synchronization behavior are unchanged. Internally, desired tables carry one of the four supported scopes instead of a permission bitmap. Tests that previously constructed impossible aspect combinations now exercise real named scopes.

## Validation

- `uv run pytest` — 1,198 passed, 74 deselected; 97.01% coverage
- `uv run ruff check .`
- `uv run mypy src`
- `uv run lint-imports` — all 7 contracts kept
- `uv run --group docs sphinx-build -W -b html docs /tmp/delta-engine-model-table-scope-docs`
- Ruff formatting check for all changed Python files