### PR TITLE
refactor: replace stringified type annotations

### DIFF
--- a/src/delta_engine/adapters/databricks/sql/compile.py
+++ b/src/delta_engine/adapters/databricks/sql/compile.py
@@ -8,7 +8,7 @@ statements in plan order, ready to execute against a Spark session.
 from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
 from functools import singledispatch
-from typing import assert_never
+from typing import Self, assert_never
 
 from delta_engine.adapters.databricks.sql.dialect import (
     backtick,
@@ -53,7 +53,7 @@ class _Target:
     alter_clause: str
 
     @classmethod
-    def for_relation(cls, qualified_name: QualifiedName, kind: TableKind) -> "_Target":
+    def for_relation(cls, qualified_name: QualifiedName, kind: TableKind) -> Self:
         """Render the SQL forms needed to compile actions for one relation."""
         name = backtick_qualified_name(qualified_name)
 
@@ -191,10 +191,7 @@ def _compile_set_column_tag(action: SetColumnTag, target: _Target) -> str:
 @_compile_action.register
 def _compile_unset_column_tag(action: UnsetColumnTag, target: _Target) -> str:
     column = backtick(action.column_name)
-    return (
-        f"{target.alter_clause} ALTER COLUMN {column}"
-        f" UNSET TAGS ({quote_literal(action.name)})"
-    )
+    return f"{target.alter_clause} ALTER COLUMN {column} UNSET TAGS ({quote_literal(action.name)})"
 
 
 @_compile_action.register

--- a/src/delta_engine/application/report.py
+++ b/src/delta_engine/application/report.py
@@ -12,7 +12,7 @@ from dataclasses import dataclass, replace
 from datetime import datetime
 from enum import StrEnum
 from types import MappingProxyType
-from typing import Any, Final, NamedTuple
+from typing import Any, Final, NamedTuple, Self
 
 from delta_engine.application.diff_entries import DiffEntry, drift_entries, plan_entries
 from delta_engine.application.failures import (
@@ -412,7 +412,7 @@ class SyncReport:
         ended_at: datetime,
         table_runs: ListOrTuple[TableRun],
         dry_run: bool,
-    ) -> "SyncReport":
+    ) -> Self:
         """
         Assemble the run report, deriving dependency blocking from the graph.
 

--- a/src/delta_engine/cli/connection.py
+++ b/src/delta_engine/cli/connection.py
@@ -1,5 +1,7 @@
 """Open a Databricks SQL connection through Databricks unified auth."""
 
+from __future__ import annotations
+
 from collections.abc import Iterator
 from contextlib import contextmanager
 from dataclasses import dataclass
@@ -50,7 +52,7 @@ class Target:
 
 
 @contextmanager
-def open_connection() -> Iterator[tuple[Target, "Connection"]]:
+def open_connection() -> Iterator[tuple[Target, Connection]]:
     """
     Resolve unified authentication, connect, and own the connection.
 
@@ -93,7 +95,7 @@ def _warehouse_id_from_environment() -> str:
     return warehouse_id
 
 
-def _target_from_config(config: "Config", warehouse_id: str) -> Target:
+def _target_from_config(config: Config, warehouse_id: str) -> Target:
     """Freeze the non-credential identity resolved by the SDK."""
     host = (config.host or "").strip()
     if not host:
@@ -101,7 +103,7 @@ def _target_from_config(config: "Config", warehouse_id: str) -> Target:
     return Target(host=host, warehouse_id=warehouse_id)
 
 
-def _import_backends() -> tuple[ModuleType, type["Config"]]:
+def _import_backends() -> tuple[ModuleType, type[Config]]:
     """Import the connector and SDK, translating optional-dependency failures."""
     try:
         from databricks import sql as databricks_sql
@@ -154,7 +156,7 @@ def _distribution_for(error: ImportError) -> str:
     return "databricks-sdk and databricks-sql-connector"
 
 
-def _build_config(config_class: type["Config"]) -> "Config":
+def _build_config(config_class: type[Config]) -> Config:
     """Delegate credential and workspace resolution to Databricks unified auth."""
     try:
         return config_class()
@@ -167,9 +169,9 @@ def _build_config(config_class: type["Config"]) -> "Config":
 
 def _connect(
     databricks_sql: ModuleType,
-    config: "Config",
+    config: Config,
     target: Target,
-) -> "Connection":
+) -> Connection:
     """Open the connector transport and translate its broad failure surface."""
     try:
         with _suppress_optional_pyarrow_warning():

--- a/src/delta_engine/cli/declarations.py
+++ b/src/delta_engine/cli/declarations.py
@@ -6,6 +6,7 @@ import importlib
 import os
 import sys
 from types import ModuleType
+from typing import Self
 
 from delta_engine.application.engine import lower_desired_tables
 from delta_engine.cli.errors import ConfigError
@@ -20,7 +21,7 @@ class DeclarationRef:
     attribute: str
 
     @classmethod
-    def parse(cls, text: str) -> "DeclarationRef":
+    def parse(cls, text: str) -> Self:
         """Parse exactly one importable ``MODULE:ATTRIBUTE`` reference."""
         module_name, separator, attribute = text.partition(":")
         module_is_importable = bool(separator) and all(

--- a/src/delta_engine/domain/model/identifier.py
+++ b/src/delta_engine/domain/model/identifier.py
@@ -4,6 +4,8 @@ The engine stores spelling verbatim; ``Identifier`` carries case-insensitive ide
 This module is the only place that canonicalization lives.
 """
 
+from typing import Self
+
 
 class Identifier(str):
     """
@@ -23,7 +25,7 @@ class Identifier(str):
 
     __slots__ = ()
 
-    def __new__(cls, spelling: str) -> "Identifier":
+    def __new__(cls, spelling: str) -> Self:
         """Validate and intern the spelling; blank identifiers are invalid."""
         if not spelling.strip():
             raise ValueError(f"Identifier must not be blank: {spelling!r}")


### PR DESCRIPTION
## Summary

- replace four class factory and constructor forward references with `typing.Self`
- enable postponed annotation evaluation in the CLI connection module
- remove quoted `Config` and `Connection` annotations while preserving lazy optional imports

## Why

The codebase used explicit string forward references in places where Python 3.12 offers clearer native typing constructs. `Self` also describes subclass-preserving return types more accurately than naming the enclosing class directly.

The Databricks SDK and SQL connector types must remain behind `TYPE_CHECKING` because they are optional dependencies. Postponed annotation evaluation removes the source-level quote noise without making those imports eager.

## Impact

This is a typing-only refactor with no intended runtime behavior change. An AST inventory found no remaining stringified type references; Typer's `"--version"` annotation metadata is a CLI option declaration, not a type forward reference.

## Validation

- `uv run ruff check src tests`
- `uv run ruff format --check src tests`
- `uv run mypy src tests`
- `uv run pytest -q` — 1195 passed, 74 deselected; 97.02% coverage
