### PR TITLE
test: pin Databricks constraint name behavior

### DIFF
--- a/docs/reference-limitations.md
+++ b/docs/reference-limitations.md
@@ -19,10 +19,11 @@ the page with the detail.
 
 ## Identifier handling
 
-Identifiers are case-insensitive, matching the platform: Databricks resolves
-all identifiers case-insensitively (backticked or not), and Unity Catalog
-stores catalog, schema, and table names in lowercase. Object name parts are
-therefore normalized to lowercase, exactly as the catalog stores them.
+Catalog, schema, table, and ordinary column references are case-insensitive,
+whether backticked or not. Unity Catalog stores catalog, schema, and table
+names in lowercase, so object name parts are normalized to lowercase exactly
+as the catalog stores them. Constraint-name DDL has an exception described
+below.
 
 Column names and nested struct field names keep their declared or observed
 spelling. Constraint names do not: Unity Catalog stores them in lowercase.
@@ -56,10 +57,12 @@ accessor values should apply their own presentation policy.
 
 Constraint names occupy one case-insensitive namespace per schema, across
 tables and constraint kinds, and `information_schema` exposes their normalized
-lowercase spelling. Databricks generates a name when raw SQL omits one, but
-delta-engine currently supplies its own names. Databricks has no direct
-constraint-rename clause: changing a name requires dropping and recreating
-the constraint.
+lowercase spelling. Despite that case-insensitive collision rule,
+`DROP CONSTRAINT` requires the exact catalog spelling; with `IF EXISTS`, a
+case mismatch silently does nothing. Databricks generates a name when raw SQL
+omits one, but delta-engine currently supplies its own names. Databricks has no
+direct constraint-rename clause: changing a name requires dropping and
+recreating the constraint.
 
 Declared catalog, schema, and table names are validated against Unity
 Catalog's object-name rules at declaration time: at most 255 characters, and

--- a/docs/reference-limitations.md
+++ b/docs/reference-limitations.md
@@ -54,6 +54,13 @@ rule.
 `DESCRIBE TABLE` shows the spelling to copy. Callers that relied on lowercase
 accessor values should apply their own presentation policy.
 
+Constraint names occupy one case-insensitive namespace per schema, across
+tables and constraint kinds, while `information_schema` preserves their
+declared spelling. Databricks generates a name when raw SQL omits one, but
+delta-engine currently supplies its own names. Databricks has no direct
+constraint-rename clause: changing a name requires dropping and recreating the
+constraint.
+
 Declared catalog, schema, and table names are validated against Unity
 Catalog's object-name rules at declaration time: at most 255 characters, and
 no periods, spaces, forward slashes, control characters, or DEL. Column names

--- a/docs/reference-limitations.md
+++ b/docs/reference-limitations.md
@@ -24,10 +24,10 @@ all identifiers case-insensitively (backticked or not), and Unity Catalog
 stores catalog, schema, and table names in lowercase. Object name parts are
 therefore normalized to lowercase, exactly as the catalog stores them.
 
-Column names, nested struct field names, and constraint names keep their
-declared or observed spelling. Case never distinguishes two identifiers:
-names differing only in case are the same column and collide as duplicates
-within one schema.
+Column names and nested struct field names keep their declared or observed
+spelling. Constraint names do not: Unity Catalog stores them in lowercase.
+Case never distinguishes two identifiers: names differing only in case are
+the same column and collide as duplicates within one schema.
 
 **Within one declaration, case is free.** A partition, clustering,
 primary-key, or foreign-key reference may use any casing; once attached to a
@@ -55,11 +55,11 @@ rule.
 accessor values should apply their own presentation policy.
 
 Constraint names occupy one case-insensitive namespace per schema, across
-tables and constraint kinds, while `information_schema` preserves their
-declared spelling. Databricks generates a name when raw SQL omits one, but
+tables and constraint kinds, and `information_schema` exposes their normalized
+lowercase spelling. Databricks generates a name when raw SQL omits one, but
 delta-engine currently supplies its own names. Databricks has no direct
-constraint-rename clause: changing a name requires dropping and recreating the
-constraint.
+constraint-rename clause: changing a name requires dropping and recreating
+the constraint.
 
 Declared catalog, schema, and table names are validated against Unity
 Catalog's object-name rules at declaration time: at most 255 characters, and

--- a/tests/live/test_sql_warehouse_live_constraints.py
+++ b/tests/live/test_sql_warehouse_live_constraints.py
@@ -4,6 +4,8 @@ import pytest
 
 pytest.importorskip("databricks.sql")
 
+from databricks.sql.exc import ServerOperationError
+
 from delta_engine import (
     SyncFailedError,
     TableRunStatus,
@@ -191,6 +193,134 @@ def test_structurally_matching_constraints_adopt_foreign_names_without_drift(
     state = read_live_table(live_connection, table_name)
     assert state["primary_key_name"] == f"{table_name}_legacy_pk"
     assert state["foreign_keys"] == ((f"{table_name}_legacy_fk", "manager_id", table_name, "id"),)
+
+
+def test_platform_preserves_custom_constraint_names_and_drops_them_case_insensitively(
+    live_connection, live_tables
+):
+    """Custom key names retain their spelling but resolve case-insensitively when dropped."""
+    # Name spelling is display metadata, not identity. This is the platform
+    # boundary behind treating an explicitly requested name as a case-insensitive
+    # identifier while retaining its spelling for SQL and reports.
+    parent_name = live_tables("custom_name_parent")
+    child_name = live_tables("custom_name_child")
+    primary_key_name = f"{parent_name}_CustomPk"
+    foreign_key_name = f"{child_name}_CustomFk"
+    execute_sql(
+        live_connection,
+        f"CREATE TABLE {qualified_table(parent_name)} "
+        f"(id INT NOT NULL, CONSTRAINT `{primary_key_name}` PRIMARY KEY (id)) USING DELTA",
+    )
+    execute_sql(
+        live_connection,
+        f"CREATE TABLE {qualified_table(child_name)} "
+        f"(parent_id INT, CONSTRAINT `{foreign_key_name}` FOREIGN KEY (parent_id) "
+        f"REFERENCES {qualified_table(parent_name)} (id)) USING DELTA",
+    )
+
+    parent = read_live_table(live_connection, parent_name)
+    child = read_live_table(live_connection, child_name)
+    assert parent["primary_key_name"] == primary_key_name
+    assert child["foreign_keys"] == ((foreign_key_name, "parent_id", parent_name, "id"),)
+
+    # DROP CONSTRAINT is how the engine removes an observed FK. A different
+    # spelling of the same name resolves, while the engine's name-independent
+    # DROP PRIMARY KEY form also works for a custom-named PK.
+    execute_sql(
+        live_connection,
+        f"ALTER TABLE {qualified_table(child_name)} "
+        f"DROP CONSTRAINT IF EXISTS `{foreign_key_name.swapcase()}`",
+    )
+    execute_sql(
+        live_connection,
+        f"ALTER TABLE {qualified_table(parent_name)} DROP PRIMARY KEY IF EXISTS",
+    )
+    assert read_live_table(live_connection, child_name)["foreign_keys"] == ()
+    assert read_live_table(live_connection, parent_name)["primary_key"] == ()
+
+
+def test_platform_generates_names_for_unnamed_primary_and_foreign_keys(
+    live_connection, live_tables
+):
+    """Databricks accepts unnamed keys and exposes the generated names in the catalog."""
+    # The engine will continue to materialize its own default names. This pin
+    # records that raw SQL callers may omit names without making generated-name
+    # shape or stability part of the engine's contract.
+    parent_name = live_tables("unnamed_parent")
+    child_name = live_tables("unnamed_child")
+    execute_sql(
+        live_connection,
+        f"CREATE TABLE {qualified_table(parent_name)} "
+        "(id INT NOT NULL, PRIMARY KEY (id)) USING DELTA",
+    )
+    execute_sql(
+        live_connection,
+        f"CREATE TABLE {qualified_table(child_name)} "
+        f"(parent_id INT, FOREIGN KEY (parent_id) "
+        f"REFERENCES {qualified_table(parent_name)} (id)) USING DELTA",
+    )
+
+    primary_key_name = read_live_table(live_connection, parent_name)["primary_key_name"]
+    [(foreign_key_name, local_column, referenced_table, referenced_column)] = read_live_table(
+        live_connection, child_name
+    )["foreign_keys"]
+    assert isinstance(primary_key_name, str) and primary_key_name
+    assert isinstance(foreign_key_name, str) and foreign_key_name
+    assert primary_key_name.casefold() != foreign_key_name.casefold()
+    assert local_column == "parent_id"
+    assert referenced_table == parent_name
+    assert referenced_column == "id"
+
+
+def test_platform_uses_one_case_insensitive_constraint_name_namespace_per_schema(
+    live_connection, live_tables
+):
+    """PK and FK names on different tables still collide case-insensitively within a schema."""
+    parent_name = live_tables("constraint_namespace_parent")
+    child_name = live_tables("constraint_namespace_child")
+    shared_name = f"{parent_name}_SharedConstraint"
+    execute_sql(
+        live_connection,
+        f"CREATE TABLE {qualified_table(parent_name)} "
+        f"(id INT NOT NULL, CONSTRAINT `{shared_name}` PRIMARY KEY (id)) USING DELTA",
+    )
+    execute_sql(
+        live_connection,
+        f"CREATE TABLE {qualified_table(child_name)} (parent_id INT) USING DELTA",
+    )
+
+    # The conflicting name belongs to a different constraint kind and table;
+    # swapped case proves the namespace compares identifiers, not raw strings.
+    with pytest.raises(ServerOperationError):
+        execute_sql(
+            live_connection,
+            f"ALTER TABLE {qualified_table(child_name)} "
+            f"ADD CONSTRAINT `{shared_name.swapcase()}` FOREIGN KEY (parent_id) "
+            f"REFERENCES {qualified_table(parent_name)} (id)",
+        )
+
+    assert read_live_table(live_connection, child_name)["foreign_keys"] == ()
+
+
+def test_platform_does_not_offer_a_direct_constraint_rename_clause(live_connection, live_tables):
+    """Constraint names change only by dropping and recreating the constraint."""
+    table_name = live_tables("constraint_rename")
+    old_name = f"{table_name}_OldPk"
+    new_name = f"{table_name}_NewPk"
+    execute_sql(
+        live_connection,
+        f"CREATE TABLE {qualified_table(table_name)} "
+        f"(id INT NOT NULL, CONSTRAINT `{old_name}` PRIMARY KEY (id)) USING DELTA",
+    )
+
+    with pytest.raises(ServerOperationError):
+        execute_sql(
+            live_connection,
+            f"ALTER TABLE {qualified_table(table_name)} "
+            f"RENAME CONSTRAINT `{old_name}` TO `{new_name}`",
+        )
+
+    assert read_live_table(live_connection, table_name)["primary_key_name"] == old_name
 
 
 def test_primary_key_drop_is_not_blocked_by_unique_backed_foreign_keys(

--- a/tests/live/test_sql_warehouse_live_constraints.py
+++ b/tests/live/test_sql_warehouse_live_constraints.py
@@ -195,13 +195,14 @@ def test_structurally_matching_constraints_adopt_foreign_names_without_drift(
     assert state["foreign_keys"] == ((f"{table_name}_legacy_fk", "manager_id", table_name, "id"),)
 
 
-def test_platform_lowercases_custom_constraint_names_and_drops_them_case_insensitively(
+def test_platform_lowercases_custom_constraint_names_and_requires_that_case_for_named_drop(
     live_connection, live_tables
 ):
-    """Custom key names are stored lowercase and resolve case-insensitively when dropped."""
-    # Constraint name spelling is not identity or retained display metadata.
-    # This is the platform boundary behind normalizing an explicitly requested
-    # name as a case-insensitive identifier.
+    """Custom key names are stored lowercase, which named drops must spell exactly."""
+    # Constraint names collide case-insensitively (pinned separately), but
+    # information_schema does not retain display spelling and DROP CONSTRAINT
+    # is case-sensitive. This asymmetry makes observed physical identity
+    # distinct from the user's naming intent.
     parent_name = live_tables("custom_name_parent")
     child_name = live_tables("custom_name_child")
     primary_key_name = f"{parent_name}_CustomPk"
@@ -223,13 +224,22 @@ def test_platform_lowercases_custom_constraint_names_and_drops_them_case_insensi
     assert parent["primary_key_name"] == primary_key_name.lower()
     assert child["foreign_keys"] == ((foreign_key_name.lower(), "parent_id", parent_name, "id"),)
 
-    # DROP CONSTRAINT is how the engine removes an observed FK. A different
-    # spelling of the same name resolves, while the engine's name-independent
-    # DROP PRIMARY KEY form also works for a custom-named PK.
+    # IF EXISTS hides the case mismatch as an absent constraint: the FK stays.
     execute_sql(
         live_connection,
         f"ALTER TABLE {qualified_table(child_name)} "
         f"DROP CONSTRAINT IF EXISTS `{foreign_key_name.swapcase()}`",
+    )
+    assert read_live_table(live_connection, child_name)["foreign_keys"] == (
+        (foreign_key_name.lower(), "parent_id", parent_name, "id"),
+    )
+
+    # The observed catalog spelling succeeds, as does the engine's
+    # name-independent DROP PRIMARY KEY form for the custom-named PK.
+    execute_sql(
+        live_connection,
+        f"ALTER TABLE {qualified_table(child_name)} "
+        f"DROP CONSTRAINT IF EXISTS `{foreign_key_name.lower()}`",
     )
     execute_sql(
         live_connection,

--- a/tests/live/test_sql_warehouse_live_constraints.py
+++ b/tests/live/test_sql_warehouse_live_constraints.py
@@ -195,13 +195,13 @@ def test_structurally_matching_constraints_adopt_foreign_names_without_drift(
     assert state["foreign_keys"] == ((f"{table_name}_legacy_fk", "manager_id", table_name, "id"),)
 
 
-def test_platform_preserves_custom_constraint_names_and_drops_them_case_insensitively(
+def test_platform_lowercases_custom_constraint_names_and_drops_them_case_insensitively(
     live_connection, live_tables
 ):
-    """Custom key names retain their spelling but resolve case-insensitively when dropped."""
-    # Name spelling is display metadata, not identity. This is the platform
-    # boundary behind treating an explicitly requested name as a case-insensitive
-    # identifier while retaining its spelling for SQL and reports.
+    """Custom key names are stored lowercase and resolve case-insensitively when dropped."""
+    # Constraint name spelling is not identity or retained display metadata.
+    # This is the platform boundary behind normalizing an explicitly requested
+    # name as a case-insensitive identifier.
     parent_name = live_tables("custom_name_parent")
     child_name = live_tables("custom_name_child")
     primary_key_name = f"{parent_name}_CustomPk"
@@ -220,8 +220,8 @@ def test_platform_preserves_custom_constraint_names_and_drops_them_case_insensit
 
     parent = read_live_table(live_connection, parent_name)
     child = read_live_table(live_connection, child_name)
-    assert parent["primary_key_name"] == primary_key_name
-    assert child["foreign_keys"] == ((foreign_key_name, "parent_id", parent_name, "id"),)
+    assert parent["primary_key_name"] == primary_key_name.lower()
+    assert child["foreign_keys"] == ((foreign_key_name.lower(), "parent_id", parent_name, "id"),)
 
     # DROP CONSTRAINT is how the engine removes an observed FK. A different
     # spelling of the same name resolves, while the engine's name-independent
@@ -320,7 +320,7 @@ def test_platform_does_not_offer_a_direct_constraint_rename_clause(live_connecti
             f"RENAME CONSTRAINT `{old_name}` TO `{new_name}`",
         )
 
-    assert read_live_table(live_connection, table_name)["primary_key_name"] == old_name
+    assert read_live_table(live_connection, table_name)["primary_key_name"] == old_name.lower()
 
 
 def test_primary_key_drop_is_not_blocked_by_unique_backed_foreign_keys(


### PR DESCRIPTION
## Summary

- add credentialed live tests for custom and generated primary/foreign-key names
- pin Unity Catalog's schema-wide, case-insensitive constraint-name namespace
- pin the DDL asymmetry: catalog names are lowercase, while `DROP CONSTRAINT` requires that exact observed spelling
- confirm Databricks has no direct constraint-rename clause
- document the resulting platform limitations

## Why

The planned constraint naming API needs a stable platform boundary before it commits to identifier and reconciliation semantics. These tests distinguish user naming intent from the physical catalog occurrence used for execution.

## Impact

No production behavior changes. The result supports modelling desired names case-insensitively while retaining the observed catalog name for executable drops.

## Validation

- `uv run ruff check .`
- `uv run mypy .`
- `uv run lint-imports`
- `uv run pytest -q` — 1,198 passed
- `uv run --group docs sphinx-build -W -b html docs /tmp/delta-engine-pr0-docs-third`
- credentialed Databricks workflow — all four new probes passed: https://github.com/Tomoscorbin/delta-engine/actions/runs/31165735664