### PR TITLE
refactor: make primary key equality semantic

### DIFF
--- a/src/delta_engine/domain/model/constraints.py
+++ b/src/delta_engine/domain/model/constraints.py
@@ -15,7 +15,7 @@ def key_signature(columns: Iterable[str]) -> KeySignature:
     return frozenset(Identifier(column) for column in columns)
 
 
-@dataclass(frozen=True, slots=True)
+@dataclass(frozen=True, slots=True, eq=False)
 class PrimaryKeyConstraint:
     """
     A primary key constraint declaration.
@@ -39,6 +39,18 @@ class PrimaryKeyConstraint:
     def signature(self) -> KeySignature:
         """Content identity, excluding physical name and declaration order."""
         return key_signature(self.columns)
+
+    def matches_columns(self, columns: Iterable[str]) -> bool:
+        """Return whether columns identify this key, ignoring order and case."""
+        return self.signature == key_signature(columns)
+
+    def __eq__(self, other: object) -> bool:
+        if not isinstance(other, PrimaryKeyConstraint):
+            return NotImplemented
+        return self.constraint_name == other.constraint_name and self.matches_columns(other.columns)
+
+    def __hash__(self) -> int:
+        return hash((self.constraint_name, self.signature))
 
     def __post_init__(self) -> None:
         columns = tuple(Identifier(column) for column in self.columns)

--- a/src/delta_engine/domain/plan/diff.py
+++ b/src/delta_engine/domain/plan/diff.py
@@ -526,9 +526,7 @@ def _diff_primary_key(
     if observed_key is None:
         return (SetPrimaryKey(primary_key=desired_key),)
 
-    same_name = desired_key.constraint_name == observed_key.constraint_name
-    same_columns = desired_key.signature == observed_key.signature
-    if same_name and same_columns:
+    if desired_key == observed_key:
         return ()
 
     return (

--- a/tests/domain/model/test_primary_key.py
+++ b/tests/domain/model/test_primary_key.py
@@ -43,13 +43,53 @@ def test_mixed_case_columns_and_name_are_preserved():
     assert str(pk.constraint_name) == "Orders_PK"
 
 
-def test_signature_is_identical_across_declaration_casing():
-    # Given equivalent columns with different display casing
-    camel = PrimaryKeyConstraint(columns=("RequestId",), constraint_name="t_pk")
-    lower = PrimaryKeyConstraint(columns=("requestid",), constraint_name="t_pk")
+def test_equality_uses_constraint_name_and_column_set_identity():
+    # Given equivalent constraints with different identifier casing and column order
+    desired = PrimaryKeyConstraint(columns=("TenantId", "OrderId"), constraint_name="Orders_PK")
+    observed = PrimaryKeyConstraint(columns=("orderid", "tenantid"), constraint_name="orders_pk")
 
-    # Then their content identity is the same
-    assert camel.signature == lower.signature
+    # When comparing the constraints
+    are_equal = desired == observed
+
+    # Then their physical name and semantic column set make them the same value
+    assert are_equal
+    assert hash(desired) == hash(observed)
+
+
+@pytest.mark.parametrize(
+    "other",
+    [
+        pytest.param(
+            PrimaryKeyConstraint(columns=("id",), constraint_name="legacy_pk"),
+            id="different-name",
+        ),
+        pytest.param(
+            PrimaryKeyConstraint(columns=("other_id",), constraint_name="orders_pk"),
+            id="different-columns",
+        ),
+    ],
+)
+def test_equality_rejects_different_managed_identity(other: PrimaryKeyConstraint):
+    # Given a primary key with either a different name or column set
+    key = PrimaryKeyConstraint(columns=("id",), constraint_name="orders_pk")
+
+    # When comparing the constraints
+    are_equal = key == other
+
+    # Then they are different managed values
+    assert not are_equal
+
+
+def test_matches_columns_excludes_the_constraint_name_from_comparison():
+    # Given a named, composite primary key
+    key = PrimaryKeyConstraint(columns=("TenantId", "OrderId"), constraint_name="orders_pk")
+
+    # When comparing columns with different order and identifier casing
+    matches = key.matches_columns(("orderid", "tenantid"))
+
+    # Then only the semantic column set is considered
+    assert matches
+    assert not key.matches_columns(("orderid", "customerid"))
 
 
 def test_rejects_columns_differing_only_by_case_as_duplicates():


### PR DESCRIPTION
## Summary

- define `PrimaryKeyConstraint` equality and hashing from its physical name and semantic column set
- add `matches_columns()` for the narrower name-independent comparison
- let primary-key diffing use ordinary value equality
- cover case/order equivalence and name/column inequality directly on the domain value

## Why

Primary-key identity was split between the constraint value and `_diff_primary_key`, which separately compared its name and column signature. Giving the value ordinary semantic equality keeps that knowledge behind one small interface and makes the diff read as a direct comparison of desired and observed state.

## Impact

Primary keys with the same case-insensitive physical name and column set now compare equal regardless of declared column order or identifier casing. Stored column spelling and order remain unchanged for rendering. A changed name or changed column set remains unequal and still plans a drop followed by a set.

## Validation

- `uv run pytest -q --no-cov tests/domain/model/test_primary_key.py tests/domain/plan/test_diff.py` — 90 passed
- `uv run pytest -q --no-cov` — 1212 passed, 78 deselected
- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run mypy .`
- `git diff --cached --check`

Follow-up to #341.
