### PR TITLE
refactor: hide primary key column identity

### DIFF
--- a/docs/todo/code-consolidation-review.md
+++ b/docs/todo/code-consolidation-review.md
@@ -306,55 +306,52 @@ their explicit follow-up actions. Coverage exercises a populated creation in
 both semantic reporting and compiled SQL; property absence assertions are
 correctly omitted because a new table already satisfies them.
 
-## 5. Put key identity on the key values
+## 5. Put key identity behind the primary-key value
 
 ### Cause
 
-The code intentionally treats primary-key identity as its column set: physical
-constraint name and column order do not determine whether the desired and
-observed key are the same. `PrimaryKeyConstraint` does not expose that identity,
-though. Three callers reconstruct it themselves:
+The code needs two related primary-key operations: managed constraint equality
+includes the physical constraint name, while foreign-key targeting compares
+only the key's case-insensitive, order-independent column set. Initially,
+callers reconstructed the latter operation themselves:
 
 - foreign-key API lowering compares a set of referenced columns with the
   parent's key columns;
-- `_diff_primary_key` converts desired and observed columns to frozensets; and
-- dependency resolution builds a set-valued primary-key index and compares
+- `_diff_primary_key` separately compared names and column sets; and
+- dependency resolution built a set-valued primary-key index and compared
   foreign-key referenced columns against it.
 
-The neighboring `ForeignKeyConstraint` already exposes `signature`, making the
-asymmetry especially visible. Dataclass equality is not a safe substitute for
-primary keys because it includes ordered columns and `constraint_name`.
+Passing these set-valued projections around exposed the representation of key
+identity and required callers to understand its normalization rules.
 
 Relevant code:
 
 - `src/delta_engine/domain/model/constraints.py`
 - `src/delta_engine/api/delta_table.py` (`ForeignKey._to_constraint`)
 - `src/delta_engine/domain/plan/diff.py` (`_diff_primary_key`)
-- `src/delta_engine/application/dependency_resolution.py`
+- `src/delta_engine/application/relationships.py`
 
 ### Proposed consolidation
 
-Give `PrimaryKeyConstraint` a semantic `signature`, and give a foreign key a
-named projection or predicate for its referenced key:
+Give `PrimaryKeyConstraint` ordinary value equality for complete managed
+identity and an intent-level predicate for the narrower targeting question:
 
 ```python
-type KeySignature = frozenset[str]
-
-PrimaryKeyConstraint.signature -> KeySignature
-ForeignKeyConstraint.referenced_key_signature -> KeySignature
+desired_primary_key == observed_primary_key
+primary_key.matches_columns(foreign_key.referenced_columns)
 ```
 
-Diffing and resolution should compare those values. API lowering can use the
-same vocabulary even before it creates the final constraint. Ordered columns
-remain available for deterministic SQL rendering; the signature states only
-semantic identity.
+API lowering and relationship validation should carry the primary-key object
+rather than a lossy projection of it. Ordered columns remain available for
+deterministic SQL rendering and exact-spelling validation; their set identity
+stays hidden behind `matches_columns`.
 
 ### Implemented
 
-Primary-key identity is now exposed as `PrimaryKeyConstraint.signature`, with
-foreign keys exposing `referenced_key_signature`. API lowering, diffing, and
-dependency resolution use these shared projections instead of reconstructing
-set identity independently. Ordered columns remain available for SQL output.
+`PrimaryKeyConstraint` now owns semantic equality, hashing, and column-set
+matching. API lowering carries the referenced primary-key value, and
+relationship validation indexes those values directly. No signature type or
+projection escapes the constraint module.
 
 ## 6. Contain physical SQL invocation per backend
 
@@ -489,7 +486,7 @@ one module:
    This gives correctness-review item 10 a natural implementation home.
 2. Preserve observed tag values on tag actions; it is a small, local proof of
    the “actions carry their meaning” rule.
-3. Add primary-key signatures and replace caller-created sets.
+3. Put primary-key equality and column matching behind the key value.
 4. Redesign run outcome storage and put the target on successful action plans
    together; both remove parallel values from the phase chain.
 5. Make creation's affected aspects and semantic projection complete.

--- a/src/delta_engine/api/delta_table.py
+++ b/src/delta_engine/api/delta_table.py
@@ -35,7 +35,6 @@ from delta_engine.domain.model import (
     TableAspect,
     TableScope,
     Variant,
-    key_signature,
 )
 
 # Delta permits these characters in column names only under column mapping.
@@ -329,7 +328,7 @@ class _ReferencedSide(NamedTuple):
     """The referenced side of a foreign key, resolved at lowering time."""
 
     table: QualifiedName
-    key_columns: tuple[str, ...]
+    primary_key: PrimaryKeyConstraint | None
     column_types: dict[str, DataType]
 
 
@@ -391,7 +390,7 @@ class ForeignKey:
         self,
         owner_name: QualifiedName,
         owner_columns: tuple[Column, ...],
-        owner_primary_key: tuple[str, ...],
+        owner_primary_key: PrimaryKeyConstraint | None,
     ) -> ForeignKeyConstraint:
         """
         Lower this declaration into a domain constraint.
@@ -413,23 +412,24 @@ class ForeignKey:
                 " catalog."
             )
 
-        if not referenced.key_columns:
+        primary_key = referenced.primary_key
+        if primary_key is None:
             raise ValueError(
                 f"foreign key references {referenced.table}, which declares no primary key"
             )
 
         pairs = tuple(
             (Identifier(local), Identifier(parent))
-            for local, parent in self._resolve_column_pairs(referenced)
+            for local, parent in self._resolve_column_pairs(referenced.table, primary_key)
         )
         local_names = {column.name: column.name for column in owner_columns}
         referenced_names = {name: name for name in referenced.column_types}
         local_columns = tuple(local_names.get(local, local) for local, _ in pairs)
         referenced_columns = tuple(referenced_names.get(parent, parent) for _, parent in pairs)
 
-        declared = key_signature(referenced_columns)
-        key = key_signature(referenced.key_columns)
-        if declared != key:
+        if not primary_key.matches_columns(referenced_columns):
+            declared = set(referenced_columns)
+            key = set(primary_key.columns)
             missing = sorted(key - declared)
             extra = sorted(declared - key)
             details = []
@@ -439,7 +439,7 @@ class ForeignKey:
                 details.append(f"not in the key: {', '.join(extra)}")
             raise ValueError(
                 f"foreign key columns must reference {referenced.table}'s"
-                f" primary key ({', '.join(referenced.key_columns)}) exactly;"
+                f" primary key ({', '.join(primary_key.columns)}) exactly;"
                 f" {'; '.join(details)}"
             )
 
@@ -474,7 +474,7 @@ class ForeignKey:
         self,
         owner_name: QualifiedName,
         owner_columns: tuple[Column, ...],
-        owner_primary_key: tuple[str, ...],
+        owner_primary_key: PrimaryKeyConstraint | None,
     ) -> _ReferencedSide:
         """
         Resolve ``references`` to the referenced side of the constraint.
@@ -493,7 +493,7 @@ class ForeignKey:
             case DeltaTable() as target:
                 desired = target.to_desired_table()
                 types = {column.name: column.data_type for column in desired.columns}
-                return _ReferencedSide(desired.qualified_name, desired.primary_key_columns, types)
+                return _ReferencedSide(desired.qualified_name, desired.primary_key, types)
             case _:
                 raise TypeError(
                     f"foreign key references must be a DeltaTable or Self; got {self.references!r}"
@@ -501,24 +501,25 @@ class ForeignKey:
 
     def _resolve_column_pairs(
         self,
-        referenced: _ReferencedSide,
+        referenced_table: QualifiedName,
+        primary_key: PrimaryKeyConstraint,
     ) -> tuple[tuple[str, str], ...]:
         """Resolve the declaration into explicit local-to-parent column pairs."""
         if isinstance(self.columns, Mapping):
             return tuple(self.columns.items())
 
         local_columns = tuple(self.columns)
-        parent_columns = referenced.key_columns
+        parent_columns = tuple(primary_key.columns)
 
         # a single-column parent has only one possible pairing
         if len(local_columns) == 1 and len(parent_columns) == 1:
             return ((local_columns[0], parent_columns[0]),)
 
-        if key_signature(local_columns) == key_signature(parent_columns):
+        if primary_key.matches_columns(local_columns):
             return tuple((column, column) for column in local_columns)
 
         raise ValueError(
-            f"cannot infer foreign key column pairing for {referenced.table};"
+            f"cannot infer foreign key column pairing for {referenced_table};"
             f" local columns are ({', '.join(local_columns)}) and the referenced"
             f" primary key is ({', '.join(parent_columns)}). Provide an explicit"
             " mapping of {local column: referenced column}."
@@ -641,14 +642,11 @@ def _lower_declaration(declaration: _NormalizedDeclaration) -> DesiredTable:
         if primary_key_columns is not None
         else None
     )
-    owner_primary_key = (
-        tuple(primary_key_constraint.columns) if primary_key_constraint is not None else ()
-    )
     foreign_keys = [
         foreign_key._to_constraint(
             declaration.qualified_name,
             declaration.columns,
-            owner_primary_key,
+            primary_key_constraint,
         )
         for foreign_key in declaration.foreign_key_declarations
     ]

--- a/src/delta_engine/application/relationships.py
+++ b/src/delta_engine/application/relationships.py
@@ -339,29 +339,14 @@ def _classify_structural_failures(
             _foreign_key_failure(table, foreign_key, reason)
         )
 
-    # Primary-key columns of every registered table, keyed by qualified name.
+    # Primary key of every registered table, keyed by qualified name.
     # A foreign key declared through this engine always references the
     # referenced table's primary key — the API validates the mapping's values
     # against it.
     # (Databricks itself also accepts UNIQUE-constraint targets on DBR 18.2+,
-    # which this engine does not model.) Compared as sets: a primary key's
-    # declaration order is not part of its identity, and referenced_columns is
-    # aligned to local_columns, not PK order.
-    primary_key_by_name = {
-        table.qualified_name: table.primary_key.signature if table.primary_key else frozenset()
-        for table in tables
-    }
-
-    # Exact spelling of every registered primary key. The signature map above
-    # judges the key case-insensitively; this map lets the case arm state
-    # drift between two declarations precisely.
-    primary_key_spellings_by_name = {
-        table.qualified_name: frozenset(
-            str(column)
-            for column in (table.primary_key.columns if table.primary_key is not None else ())
-        )
-        for table in tables
-    }
+    # which this engine does not model.) The primary-key value owns the
+    # order-independent, case-insensitive column matching rule.
+    primary_key_by_name = {table.qualified_name: table.primary_key for table in tables}
 
     # Column types of every registered table, keyed by qualified name. A
     # foreign key's types were validated at declaration time against the
@@ -382,12 +367,17 @@ def _classify_structural_failures(
             referenced_table = foreign_key.referenced_table
             if referenced_table not in registered_names:
                 record(table, foreign_key, ForeignKeyFailureReason.UNRESOLVABLE_REFERENCE)
+                continue
+
+            primary_key = primary_key_by_name[referenced_table]
             # Structural FK-target checks run before the cycle test so that a
             # structural problem is reported per-FK even when the table also
             # participates in a cycle. The type check relies on the target
             # being the registered parent's primary key: only then is every
             # referenced column known to exist on the registered parent.
-            elif foreign_key.referenced_key_signature != primary_key_by_name[referenced_table]:
+            if primary_key is None or not primary_key.matches_columns(
+                foreign_key.referenced_columns
+            ):
                 record(table, foreign_key, ForeignKeyFailureReason.REFERENCED_COLUMNS_NOT_A_KEY)
             elif not _foreign_key_types_match(
                 foreign_key,
@@ -395,9 +385,9 @@ def _classify_structural_failures(
                 referenced_types=column_types_by_name[referenced_table],
             ):
                 record(table, foreign_key, ForeignKeyFailureReason.REFERENCED_COLUMN_TYPE_MISMATCH)
-            elif {
-                str(column) for column in foreign_key.referenced_columns
-            } != primary_key_spellings_by_name[referenced_table]:
+            elif {str(column) for column in foreign_key.referenced_columns} != {
+                str(column) for column in primary_key.columns
+            }:
                 # The NOT_A_KEY arm proved these columns ARE the key
                 # case-insensitively, so an exact-set mismatch is precisely a
                 # case drift between the declaration the FK was built against

--- a/src/delta_engine/domain/model/__init__.py
+++ b/src/delta_engine/domain/model/__init__.py
@@ -3,7 +3,6 @@ from delta_engine.domain.model.constraints import (
     ForeignKeyConstraint,
     ForeignKeyReference,
     PrimaryKeyConstraint,
-    key_signature,
 )
 from delta_engine.domain.model.data_type import (
     Array,
@@ -72,5 +71,4 @@ __all__ = [
     "Timestamp",
     "TimestampNtz",
     "Variant",
-    "key_signature",
 ]

--- a/src/delta_engine/domain/model/constraints.py
+++ b/src/delta_engine/domain/model/constraints.py
@@ -7,13 +7,6 @@ from delta_engine.domain.collection_types import ListOrTuple
 from delta_engine.domain.model.identifier import Identifier
 from delta_engine.domain.model.qualified_name import QualifiedName
 
-KeySignature = frozenset[str]
-
-
-def key_signature(columns: Iterable[str]) -> KeySignature:
-    """Return the order-independent, case-insensitive identity of a key's columns."""
-    return frozenset(Identifier(column) for column in columns)
-
 
 @dataclass(frozen=True, slots=True, eq=False)
 class PrimaryKeyConstraint:
@@ -35,14 +28,9 @@ class PrimaryKeyConstraint:
     columns: ListOrTuple[str]
     constraint_name: str
 
-    @property
-    def signature(self) -> KeySignature:
-        """Content identity, excluding physical name and declaration order."""
-        return key_signature(self.columns)
-
     def matches_columns(self, columns: Iterable[str]) -> bool:
         """Return whether columns identify this key, ignoring order and case."""
-        return self.signature == key_signature(columns)
+        return frozenset(self.columns) == frozenset(Identifier(column) for column in columns)
 
     def __eq__(self, other: object) -> bool:
         if not isinstance(other, PrimaryKeyConstraint):
@@ -50,7 +38,7 @@ class PrimaryKeyConstraint:
         return self.constraint_name == other.constraint_name and self.matches_columns(other.columns)
 
     def __hash__(self) -> int:
-        return hash((self.constraint_name, self.signature))
+        return hash((self.constraint_name, frozenset(self.columns)))
 
     def __post_init__(self) -> None:
         columns = tuple(Identifier(column) for column in self.columns)
@@ -148,11 +136,6 @@ class ForeignKeyConstraint:
         object.__setattr__(self, "local_columns", tuple(pair[0] for pair in pairs))
         object.__setattr__(self, "referenced_columns", tuple(pair[1] for pair in pairs))
         object.__setattr__(self, "constraint_name", Identifier(self.constraint_name))
-
-    @property
-    def referenced_key_signature(self) -> KeySignature:
-        """Identity of the primary key targeted by this foreign key."""
-        return key_signature(self.referenced_columns)
 
 
 @dataclass(frozen=True, slots=True)


### PR DESCRIPTION
## What changed

- remove `KeySignature`, `key_signature()`, and the primary/foreign-key signature projections
- carry `PrimaryKeyConstraint` through foreign-key lowering instead of projecting it to columns
- make registered-table FK validation ask the primary key whether referenced columns match
- remove the parallel primary-key spelling index and use the retained key value for exact-spelling validation
- update the consolidation review to describe the deeper boundary

## Why

The signature abstraction exposed the representation of primary-key column identity and required API and application callers to understand its case-insensitive, order-independent rules. `PrimaryKeyConstraint.matches_columns()` is now the single intent-level operation; callers retain the rich key value instead of passing a lossy projection.

This follows up #342 and implements the remaining key-signature item described in #341.

## Impact

Behavior is unchanged. The internal `delta_engine.domain.model.key_signature` export is removed.

## Validation

- `uv run pytest` — 1,212 passed, 78 live tests deselected
- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run mypy .`
- `uv run --group docs sphinx-build -W --keep-going -b html docs docs/_build/html`
- MyST parsing of the updated review with warnings treated as errors
- `git diff --check`