### PR TITLE
refactor: harden constraint construction

### DIFF
--- a/src/delta_engine/api/delta_table.py
+++ b/src/delta_engine/api/delta_table.py
@@ -364,13 +364,30 @@ class ForeignKey:
         frozen: tuple[str, ...] | Mapping[str, str]
         match self.columns:
             case str():
+                Identifier(self.columns)
                 frozen = (self.columns,)
             case Mapping():
-                frozen = MappingProxyType(dict(self.columns))
+                mapping = dict(self.columns)
+                if not mapping:
+                    raise ValueError("foreign key columns must not be empty")
+                if not all(
+                    isinstance(local, str) and isinstance(referenced, str)
+                    for local, referenced in mapping.items()
+                ):
+                    raise TypeError("foreign key mapping keys and values must be strings")
+                for local, referenced in mapping.items():
+                    Identifier(local)
+                    Identifier(referenced)
+                frozen = MappingProxyType(mapping)
             case list() | tuple():
-                if not all(isinstance(column, str) for column in self.columns):
+                sequence = tuple(self.columns)
+                if not sequence:
+                    raise ValueError("foreign key columns must not be empty")
+                if not all(isinstance(column, str) for column in sequence):
                     raise TypeError("foreign key columns must be strings")
-                frozen = tuple(self.columns)
+                for column in sequence:
+                    Identifier(column)
+                frozen = sequence
             case _:
                 raise TypeError(
                     "foreign key columns must be a column name,"
@@ -379,10 +396,12 @@ class ForeignKey:
                 )
 
         if self.name is not None:
-            if not isinstance(self.name, str):
-                raise TypeError("foreign key name must be a string or None")
-            if not self.name.strip():
-                raise ValueError("foreign key name must not be blank")
+            Identifier(self.name)
+
+        if not isinstance(self.references, (DeltaTable, _SelfReference)):
+            raise TypeError(
+                f"foreign key references must be a DeltaTable or Self; got {self.references!r}"
+            )
 
         object.__setattr__(self, "columns", frozen)
 
@@ -486,18 +505,13 @@ class ForeignKey:
         column: primary-key columns are validated to exist on whichever
         table declares them.
         """
-        match self.references:
-            case _SelfReference():
-                types = {column.name: column.data_type for column in owner_columns}
-                return _ReferencedSide(owner_name, owner_primary_key, types)
-            case DeltaTable() as target:
-                desired = target.to_desired_table()
-                types = {column.name: column.data_type for column in desired.columns}
-                return _ReferencedSide(desired.qualified_name, desired.primary_key, types)
-            case _:
-                raise TypeError(
-                    f"foreign key references must be a DeltaTable or Self; got {self.references!r}"
-                )
+        if isinstance(self.references, _SelfReference):
+            types = {column.name: column.data_type for column in owner_columns}
+            return _ReferencedSide(owner_name, owner_primary_key, types)
+
+        desired = self.references.to_desired_table()
+        types = {column.name: column.data_type for column in desired.columns}
+        return _ReferencedSide(desired.qualified_name, desired.primary_key, types)
 
     def _resolve_column_pairs(
         self,

--- a/src/delta_engine/domain/model/constraints.py
+++ b/src/delta_engine/domain/model/constraints.py
@@ -8,6 +8,24 @@ from delta_engine.domain.model.identifier import Identifier
 from delta_engine.domain.model.qualified_name import QualifiedName
 
 
+def _constraint_columns(columns: object, *, kind: str) -> tuple[Identifier, ...]:
+    """Normalize one non-empty, unique list or tuple of constraint columns."""
+    if isinstance(columns, str) or not isinstance(columns, (list, tuple)):
+        raise TypeError(f"{kind} columns must be a list or tuple of strings")
+    if not columns:
+        raise ValueError(f"{kind} columns must not be empty")
+    if not all(isinstance(column, str) for column in columns):
+        raise TypeError(f"{kind} column names must be strings")
+
+    normalized = tuple(Identifier(column) for column in columns)
+    seen: set[Identifier] = set()
+    for column in normalized:
+        if column in seen:
+            raise ValueError(f"Duplicate {kind} column: {column}")
+        seen.add(column)
+    return normalized
+
+
 @dataclass(frozen=True, slots=True, eq=False)
 class PrimaryKeyConstraint:
     """
@@ -41,24 +59,11 @@ class PrimaryKeyConstraint:
         return hash((self.constraint_name, frozenset(self.columns)))
 
     def __post_init__(self) -> None:
-        columns = tuple(Identifier(column) for column in self.columns)
-        if not columns:
-            raise ValueError("columns must not be empty")
-
-        seen: set[str] = set()
-        for column in columns:
-            if column in seen:
-                raise ValueError(f"Duplicate primary key column: {column}")
-            seen.add(column)
-
-        if not isinstance(self.constraint_name, str):
-            raise TypeError("constraint_name must be a string")
-
-        if not self.constraint_name.strip():
-            raise ValueError("constraint_name must not be blank")
+        columns = _constraint_columns(self.columns, kind="primary key")
+        constraint_name = Identifier(self.constraint_name)
 
         object.__setattr__(self, "columns", columns)
-        object.__setattr__(self, "constraint_name", Identifier(self.constraint_name))
+        object.__setattr__(self, "constraint_name", constraint_name)
 
 
 @dataclass(frozen=True, slots=True)
@@ -89,14 +94,11 @@ class ForeignKeyConstraint:
     constraint_name: str
 
     def __post_init__(self) -> None:
-        local_columns = tuple(Identifier(column) for column in self.local_columns)
-        referenced_columns = tuple(Identifier(column) for column in self.referenced_columns)
-
-        if not local_columns:
-            raise ValueError("local_columns must not be empty")
-
-        if not referenced_columns:
-            raise ValueError("referenced_columns must not be empty")
+        local_columns = _constraint_columns(self.local_columns, kind="foreign key local")
+        referenced_columns = _constraint_columns(
+            self.referenced_columns,
+            kind="foreign key referenced",
+        )
 
         if len(local_columns) != len(referenced_columns):
             raise ValueError(
@@ -115,27 +117,11 @@ class ForeignKeyConstraint:
             key=lambda pair: pair[0].lower(),
         )
 
-        seen_local: set[str] = set()
-        for column in local_columns:
-            if column in seen_local:
-                raise ValueError(f"Duplicate foreign key local column: {column}")
-            seen_local.add(column)
-
-        seen_referenced: set[str] = set()
-        for column in referenced_columns:
-            if column in seen_referenced:
-                raise ValueError(f"Duplicate foreign key referenced column: {column}")
-            seen_referenced.add(column)
-
-        if not isinstance(self.constraint_name, str):
-            raise TypeError("constraint_name must be a string")
-
-        if not self.constraint_name.strip():
-            raise ValueError("constraint_name must not be blank")
+        constraint_name = Identifier(self.constraint_name)
 
         object.__setattr__(self, "local_columns", tuple(pair[0] for pair in pairs))
         object.__setattr__(self, "referenced_columns", tuple(pair[1] for pair in pairs))
-        object.__setattr__(self, "constraint_name", Identifier(self.constraint_name))
+        object.__setattr__(self, "constraint_name", constraint_name)
 
 
 @dataclass(frozen=True, slots=True)
@@ -159,6 +145,4 @@ class ForeignKeyReference:
     referencing_table: QualifiedName
 
     def __post_init__(self) -> None:
-        if not self.constraint_name.strip():
-            raise ValueError("constraint_name must not be blank")
         object.__setattr__(self, "constraint_name", Identifier(self.constraint_name))

--- a/src/delta_engine/domain/model/identifier.py
+++ b/src/delta_engine/domain/model/identifier.py
@@ -24,6 +24,8 @@ class Identifier(str):
 
     def __new__(cls, spelling: str) -> Self:
         """Validate and intern the spelling; blank identifiers are invalid."""
+        if not isinstance(spelling, str):
+            raise TypeError("Identifier spelling must be a string")
         if not spelling.strip():
             raise ValueError(f"Identifier must not be blank: {spelling!r}")
         return super().__new__(cls, spelling)

--- a/tests/api/test_delta_table.py
+++ b/tests/api/test_delta_table.py
@@ -726,6 +726,32 @@ def test_foreign_key_name_rejects_invalid_values(
         )
 
 
+@pytest.mark.parametrize(
+    ("columns", "expected_error"),
+    [
+        pytest.param([], ValueError, id="empty-sequence"),
+        pytest.param({}, ValueError, id="empty-mapping"),
+        pytest.param({"customer_id"}, TypeError, id="unsupported-collection"),
+        pytest.param(["customer_id", 42], TypeError, id="non-string-sequence-entry"),
+        pytest.param({"customer_id": 42}, TypeError, id="non-string-mapping-value"),
+        pytest.param({42: "id"}, TypeError, id="non-string-mapping-key"),
+        pytest.param("  ", ValueError, id="blank-string"),
+        pytest.param(["  "], ValueError, id="blank-sequence-entry"),
+        pytest.param({"customer_id": "  "}, ValueError, id="blank-mapping-entry"),
+    ],
+)
+def test_foreign_key_rejects_invalid_column_input(
+    columns: object,
+    expected_error: type[Exception],
+) -> None:
+    # Given / When / Then invalid syntax fails before an owning table is constructed.
+    with pytest.raises(expected_error):
+        ForeignKey(
+            columns=columns,  # type: ignore[arg-type]
+            references=_customers(),
+        )
+
+
 def test_delta_table_defaults_to_no_foreign_keys():
     # Given a table with no foreign_keys argument
     table = DeltaTable(
@@ -1682,18 +1708,13 @@ def test_explicit_name_disambiguates_generated_foreign_key_name_collision():
     ) == ("orders_a_b_c_fk", "orders_parts_two_fk")
 
 
-def test_delta_table_rejects_non_table_reference():
+def test_foreign_key_rejects_non_table_reference_during_its_construction():
     # Given a reference that is neither a DeltaTable nor Self
-    # When / Then construction rejects the unsupported reference type
+    # When / Then the ForeignKey boundary rejects it without needing an owner
     with pytest.raises(TypeError):
-        DeltaTable(
-            catalog="cat",
-            schema="sch",
-            name="orders",
-            columns=[Column("customer_id", Integer())],
-            foreign_keys=[
-                ForeignKey(columns={"customer_id": "id"}, references="cat.sch.customers")  # type: ignore[arg-type]
-            ],
+        ForeignKey(
+            columns={"customer_id": "id"},
+            references="cat.sch.customers",  # type: ignore[arg-type]
         )
 
 
@@ -1817,6 +1838,22 @@ def test_foreign_key_accepts_columns_as_any_mapping():
     [constraint] = orders.to_desired_table().foreign_keys
     assert tuple(str(c) for c in constraint.local_columns) == ("customer_id",)
     assert tuple(str(c) for c in constraint.referenced_columns) == ("id",)
+
+
+def test_foreign_key_defensively_copies_mutable_column_input() -> None:
+    # Given mutable sequence and mapping declarations
+    sequence = ["customer_id"]
+    mapping = {"customer_id": "id"}
+
+    # When declarations are constructed and the inputs later change
+    sequence_declaration = ForeignKey(columns=sequence, references=_customers())
+    mapping_declaration = ForeignKey(columns=mapping, references=_customers())
+    sequence.append("tenant_id")
+    mapping["tenant_id"] = "tenant_id"
+
+    # Then each declaration retains the input snapshot from construction
+    assert sequence_declaration.columns == ("customer_id",)
+    assert dict(mapping_declaration.columns) == {"customer_id": "id"}
 
 
 def test_mapping_insertion_order_is_irrelevant():

--- a/tests/api/test_delta_table.py
+++ b/tests/api/test_delta_table.py
@@ -548,7 +548,7 @@ def test_no_primary_key_parameter_means_no_key():
 
 
 def test_primary_key_name_requires_a_primary_key():
-    # Given / When / Then a physical name without a key is rejected
+    # When a physical name is supplied without a key, then the declaration is rejected
     with pytest.raises(ValueError):
         DeltaTable(
             catalog="cat",
@@ -579,7 +579,7 @@ def test_primary_key_name_rejects_invalid_values(
         "primary_key": ["id"],
     }
 
-    # When / Then an invalid physical name is rejected clearly
+    # When the physical name is invalid, then construction fails deliberately
     with pytest.raises(expected_error):
         DeltaTable(**kwargs, primary_key_name=invalid_name)  # type: ignore[arg-type]
 
@@ -717,7 +717,7 @@ def test_foreign_key_name_rejects_invalid_values(
     invalid_name: object,
     expected_error: type[Exception],
 ):
-    # Given / When / Then an invalid physical name is rejected at declaration
+    # When the physical name is invalid, then the ForeignKey declaration rejects it
     with pytest.raises(expected_error):
         ForeignKey(
             columns="customer_id",
@@ -744,7 +744,7 @@ def test_foreign_key_rejects_invalid_column_input(
     columns: object,
     expected_error: type[Exception],
 ) -> None:
-    # Given / When / Then invalid syntax fails before an owning table is constructed.
+    # When column syntax is invalid, then ForeignKey rejects it without needing an owner
     with pytest.raises(expected_error):
         ForeignKey(
             columns=columns,  # type: ignore[arg-type]
@@ -807,7 +807,7 @@ def test_delta_table_rejects_fk_with_unknown_local_column():
         primary_key=["id"],
     )
 
-    # When / Then domain validation fires at construction time
+    # When the owner is constructed, then domain validation rejects the missing column
     with pytest.raises(ValueError):
         DeltaTable(
             catalog="cat",
@@ -968,7 +968,7 @@ def test_a_restricted_scope_still_lowers_everything_declared():
 
 def test_delta_table_rejects_unknown_scope():
     # Given a scope value outside the named scopes
-    # When / Then construction fails
+    # When the table is constructed, then the unknown scope is rejected
     with pytest.raises(ValueError):
         DeltaTable(
             catalog="dev",
@@ -1525,7 +1525,7 @@ def _customers() -> DeltaTable:
 
 
 def test_foreign_key_declaration_rejects_internal_constraint_fields():
-    # Given / When / Then the public declaration rejects lowered domain fields
+    # When lowered domain fields are supplied, then the public declaration rejects them
     with pytest.raises(TypeError):
         ForeignKey(  # type: ignore[call-arg]
             columns={"customer_id": "id"},
@@ -1603,7 +1603,7 @@ def test_delta_table_rejects_reference_to_table_with_no_primary_key():
         columns=[Column("id", Integer())],
     )
 
-    # When / Then construction fails because there is no key to infer
+    # When the child is constructed, then the missing target key prevents inference
     with pytest.raises(ValueError):
         DeltaTable(
             catalog="cat",
@@ -1615,8 +1615,7 @@ def test_delta_table_rejects_reference_to_table_with_no_primary_key():
 
 
 def test_delta_table_rejects_self_reference_without_primary_key():
-    # Given a table with no primary key that references itself
-    # When / Then construction fails because there is no key to reference
+    # When a table without a primary key references itself, then construction fails
     with pytest.raises(ValueError):
         DeltaTable(
             catalog="cat",
@@ -1637,7 +1636,8 @@ def test_delta_table_rejects_cross_catalog_foreign_key():
         primary_key=["id"],
     )
 
-    # When / Then the declaration is rejected: information_schema is
+    # When the child is declared, then the cross-catalog relationship is rejected:
+    # information_schema is
     # per-catalog, so the engine could create the constraint but never
     # observe it, and every later sync would re-plan and fail.
     with pytest.raises(ValueError):
@@ -1691,7 +1691,7 @@ def _table_with_colliding_generated_foreign_key_names(
 def test_delta_table_rejects_foreign_keys_whose_generated_names_collide():
     # Given two FKs whose distinct column sets both derive orders_a_b_c_fk
 
-    # When / Then the collision is rejected at declaration time
+    # When both are declared, then the collision is rejected
     with pytest.raises(ValueError):
         _table_with_colliding_generated_foreign_key_names()
 
@@ -1709,8 +1709,7 @@ def test_explicit_name_disambiguates_generated_foreign_key_name_collision():
 
 
 def test_foreign_key_rejects_non_table_reference_during_its_construction():
-    # Given a reference that is neither a DeltaTable nor Self
-    # When / Then the ForeignKey boundary rejects it without needing an owner
+    # When the reference is neither a DeltaTable nor Self, then ForeignKey rejects it
     with pytest.raises(TypeError):
         ForeignKey(
             columns={"customer_id": "id"},
@@ -1728,7 +1727,7 @@ def test_foreign_key_rejects_local_column_type_mismatch_with_target_primary_key(
         primary_key=["id"],
     )
 
-    # When / Then construction fails because the local column type does not match
+    # When the child is constructed, then the local-column type mismatch is rejected
     with pytest.raises(ValueError):
         DeltaTable(
             catalog="cat",
@@ -1744,8 +1743,7 @@ def test_foreign_key_rejects_local_column_type_mismatch_with_target_primary_key(
 
 
 def test_self_referential_foreign_key_rejects_type_mismatch():
-    # Given a self-referential foreign key whose local column type differs from the primary key
-    # When / Then construction fails because the local column type does not match
+    # When a self-reference has a different local type, then construction fails
     with pytest.raises(ValueError):
         DeltaTable(
             catalog="cat",
@@ -1774,7 +1772,7 @@ def test_composite_foreign_key_rejects_a_single_mismatched_column_pair():
         primary_key=["tenant_id", "id"],
     )
 
-    # When / Then construction fails because one column pair has incompatible types
+    # When the child is constructed, then the incompatible pair is rejected
     with pytest.raises(ValueError):
         DeltaTable(
             catalog="cat",

--- a/tests/domain/model/test_foreign_key.py
+++ b/tests/domain/model/test_foreign_key.py
@@ -47,7 +47,7 @@ def test_constraint_identity_includes_the_referenced_table():
 
 
 def test_rejects_empty_local_columns():
-    # Given / When / Then an empty local-column tuple is rejected
+    # When a foreign key has no local columns, then construction fails
     with pytest.raises(ValueError):
         ForeignKeyConstraint(
             local_columns=(),
@@ -58,7 +58,7 @@ def test_rejects_empty_local_columns():
 
 
 def test_rejects_empty_referenced_columns():
-    # Given / When / Then an empty referenced-column tuple is rejected
+    # When a foreign key has no referenced columns, then construction fails
     with pytest.raises(ValueError):
         ForeignKeyConstraint(
             local_columns=("customer_id",),
@@ -81,7 +81,7 @@ def test_rejects_invalid_column_collections(
     local_columns: object,
     referenced_columns: object,
 ) -> None:
-    # Given / When / Then malformed columns fail at the constraint boundary.
+    # When malformed columns are supplied, then construction fails at the value boundary
     with pytest.raises(TypeError):
         ForeignKeyConstraint(
             local_columns=local_columns,  # type: ignore[arg-type]
@@ -93,7 +93,7 @@ def test_rejects_invalid_column_collections(
 
 def test_rejects_mismatched_column_counts():
     # Given local and referenced column tuples of different lengths
-    # When / Then construction is rejected
+    # When the foreign key is constructed, then the mismatch is rejected
     with pytest.raises(ValueError):
         ForeignKeyConstraint(
             local_columns=("a", "b"),
@@ -104,7 +104,7 @@ def test_rejects_mismatched_column_counts():
 
 
 def test_rejects_duplicate_local_columns():
-    # Given / When / Then a repeated local column is rejected
+    # When a foreign key repeats a local column, then construction fails
     with pytest.raises(ValueError):
         ForeignKeyConstraint(
             local_columns=("customer_id", "customer_id"),
@@ -115,7 +115,7 @@ def test_rejects_duplicate_local_columns():
 
 
 def test_rejects_duplicate_referenced_columns():
-    # Given / When / Then a repeated referenced column is rejected
+    # When a foreign key repeats a referenced column, then construction fails
     with pytest.raises(ValueError):
         ForeignKeyConstraint(
             local_columns=("customer_id", "tenant_id"),
@@ -136,7 +136,7 @@ def test_rejects_invalid_constraint_name(
     constraint_name: object,
     expected_error: type[Exception],
 ):
-    # Given / When / Then an invalid physical name is rejected
+    # When the physical name is invalid, then construction fails deliberately
     with pytest.raises(expected_error):
         ForeignKeyConstraint(
             local_columns=("customer_id",),
@@ -147,7 +147,7 @@ def test_rejects_invalid_constraint_name(
 
 
 def test_foreign_key_reference_rejects_non_string_constraint_name() -> None:
-    # Given / When / Then an invalid name fails with a deliberate boundary error.
+    # When the physical name is not a string, then construction fails deliberately
     with pytest.raises(TypeError):
         ForeignKeyReference(
             constraint_name=42,  # type: ignore[arg-type]

--- a/tests/domain/model/test_foreign_key.py
+++ b/tests/domain/model/test_foreign_key.py
@@ -1,7 +1,7 @@
 import pytest
 
 from delta_engine.domain.model import QualifiedName
-from delta_engine.domain.model.constraints import ForeignKeyConstraint
+from delta_engine.domain.model.constraints import ForeignKeyConstraint, ForeignKeyReference
 
 
 def _customers() -> QualifiedName:
@@ -68,6 +68,29 @@ def test_rejects_empty_referenced_columns():
         )
 
 
+@pytest.mark.parametrize(
+    ("local_columns", "referenced_columns"),
+    [
+        pytest.param("customer_id", ("id",), id="bare-local-string"),
+        pytest.param(("customer_id",), "id", id="bare-referenced-string"),
+        pytest.param(("customer_id", 42), ("tenant_id", "id"), id="non-string-local"),
+        pytest.param(("customer_id", "tenant_id"), ("id", 42), id="non-string-referenced"),
+    ],
+)
+def test_rejects_invalid_column_collections(
+    local_columns: object,
+    referenced_columns: object,
+) -> None:
+    # Given / When / Then malformed columns fail at the constraint boundary.
+    with pytest.raises(TypeError):
+        ForeignKeyConstraint(
+            local_columns=local_columns,  # type: ignore[arg-type]
+            referenced_table=_customers(),
+            referenced_columns=referenced_columns,  # type: ignore[arg-type]
+            constraint_name="x_fk",
+        )
+
+
 def test_rejects_mismatched_column_counts():
     # Given local and referenced column tuples of different lengths
     # When / Then construction is rejected
@@ -120,6 +143,15 @@ def test_rejects_invalid_constraint_name(
             referenced_table=_customers(),
             referenced_columns=("id",),
             constraint_name=constraint_name,  # type: ignore[arg-type]
+        )
+
+
+def test_foreign_key_reference_rejects_non_string_constraint_name() -> None:
+    # Given / When / Then an invalid name fails with a deliberate boundary error.
+    with pytest.raises(TypeError):
+        ForeignKeyReference(
+            constraint_name=42,  # type: ignore[arg-type]
+            referencing_table=_customers(),
         )
 
 

--- a/tests/domain/model/test_identifier.py
+++ b/tests/domain/model/test_identifier.py
@@ -58,7 +58,7 @@ class TestIdentifierSpelling:
 
 class TestIdentifierConstruction:
     def test_non_string_spelling_is_rejected_deliberately(self) -> None:
-        # Given / When / Then a non-string cannot reach string operations.
+        # When a non-string spelling is supplied, then construction fails deliberately
         with pytest.raises(TypeError):
             Identifier(42)  # type: ignore[arg-type]
 

--- a/tests/domain/model/test_identifier.py
+++ b/tests/domain/model/test_identifier.py
@@ -57,8 +57,13 @@ class TestIdentifierSpelling:
 
 
 class TestIdentifierConstruction:
+    def test_non_string_spelling_is_rejected_deliberately(self) -> None:
+        # Given / When / Then a non-string cannot reach string operations.
+        with pytest.raises(TypeError):
+            Identifier(42)  # type: ignore[arg-type]
+
     def test_blank_spelling_is_rejected(self) -> None:
-        with pytest.raises(ValueError, match="must not be blank"):
+        with pytest.raises(ValueError):
             Identifier("   ")
 
     def test_wrapping_an_identifier_is_idempotent(self) -> None:

--- a/tests/domain/model/test_primary_key.py
+++ b/tests/domain/model/test_primary_key.py
@@ -4,7 +4,7 @@ from delta_engine.domain.model.constraints import PrimaryKeyConstraint
 
 
 def test_rejects_empty_columns():
-    # Given / Then constructing with no columns is an error
+    # When a primary key has no columns, then construction fails
     with pytest.raises(ValueError):
         PrimaryKeyConstraint(columns=(), constraint_name="t_pk")
 
@@ -17,7 +17,7 @@ def test_rejects_empty_columns():
     ],
 )
 def test_rejects_invalid_column_collections(columns: object) -> None:
-    # Given / When / Then malformed column input fails at the constraint boundary.
+    # When malformed columns are supplied, then construction fails at the value boundary
     with pytest.raises(TypeError):
         PrimaryKeyConstraint(
             columns=columns,  # type: ignore[arg-type]
@@ -26,7 +26,7 @@ def test_rejects_invalid_column_collections(columns: object) -> None:
 
 
 def test_rejects_duplicate_columns():
-    # Given / Then a repeated column is an error
+    # When a primary key repeats a column, then construction fails
     with pytest.raises(ValueError):
         PrimaryKeyConstraint(columns=("id", "id"), constraint_name="t_pk")
 
@@ -42,7 +42,7 @@ def test_rejects_invalid_constraint_name(
     invalid_name: object,
     expected_error: type[Exception],
 ):
-    # Given / When / Then an invalid physical name is rejected
+    # When the physical name is invalid, then construction fails deliberately
     with pytest.raises(expected_error):
         PrimaryKeyConstraint(
             columns=("id",),
@@ -109,6 +109,6 @@ def test_matches_columns_excludes_the_constraint_name_from_comparison():
 
 
 def test_rejects_columns_differing_only_by_case_as_duplicates():
-    # Given / When / Then two spellings of one identifier are rejected as duplicates
+    # When one column is repeated with different casing, then construction fails
     with pytest.raises(ValueError):
         PrimaryKeyConstraint(columns=("id", "ID"), constraint_name="t_pk")

--- a/tests/domain/model/test_primary_key.py
+++ b/tests/domain/model/test_primary_key.py
@@ -9,6 +9,22 @@ def test_rejects_empty_columns():
         PrimaryKeyConstraint(columns=(), constraint_name="t_pk")
 
 
+@pytest.mark.parametrize(
+    "columns",
+    [
+        pytest.param("id", id="bare-string"),
+        pytest.param(("id", 42), id="non-string-entry"),
+    ],
+)
+def test_rejects_invalid_column_collections(columns: object) -> None:
+    # Given / When / Then malformed column input fails at the constraint boundary.
+    with pytest.raises(TypeError):
+        PrimaryKeyConstraint(
+            columns=columns,  # type: ignore[arg-type]
+            constraint_name="t_pk",
+        )
+
+
 def test_rejects_duplicate_columns():
     # Given / Then a repeated column is an error
     with pytest.raises(ValueError):


### PR DESCRIPTION
## What changed

- make `Identifier` reject non-string input with a deliberate `TypeError`
- centralize domain constraint-column normalization, including collection shape, nonempty, string, and uniqueness invariants
- make public `ForeignKey` declarations validate and freeze column forms, names, and references during their own construction
- remove the now-unreachable invalid-reference branch from foreign-key lowering
- add black-box coverage for malformed values, early failure timing, valid catalog construction, and defensive copying

## Why

Constraint values previously relied on annotations and later lowering to catch some malformed inputs. Bare strings could become character-by-character keys, mapping values and invalid references could survive until an owning table was built, and non-string identifiers could fail incidentally through string methods.

This deepens the existing constructors instead of adding validation objects: a successfully constructed value now establishes every intrinsic invariant it has enough context to judge. Validation requiring owner columns, registered declarations, or observed state remains at the existing wider boundaries.

This implements the construction-hardening item from #341.

## Impact

Valid declarations, generated names, catalog-row translation, diffing, SQL, and relationship policy are unchanged. Invalid public foreign-key declarations now fail earlier, when the `ForeignKey` itself is constructed.

## Validation

- `uv run pytest -q` — 1,230 passed, 78 live tests deselected
- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run mypy .`
- `uv run lint-imports`
- `uv run --group docs sphinx-build -W --keep-going -b html docs docs/_build/html`
- `git diff --check`
