### PR TITLE
fix: report comments on added columns

### DIFF
--- a/src/delta_engine/application/diff_entries.py
+++ b/src/delta_engine/application/diff_entries.py
@@ -169,6 +169,16 @@ def _column_add_entry(column: DesiredColumn) -> DiffEntry:
     return DiffEntry(DiffCategory.COLUMNS, DiffOperation.ADD, subject=column.name, detail=detail)
 
 
+def _column_comment_entry(column: DesiredColumn) -> DiffEntry:
+    """Build a '+' comments entry for a created column."""
+    return DiffEntry(
+        DiffCategory.COMMENTS,
+        DiffOperation.ADD,
+        subject=f"column {column.name}",
+        detail=(f"'{column.comment}'",),
+    )
+
+
 def _named_value_entry(
     category: DiffCategory, subject: str, desired_value: str, observed_value: str | None
 ) -> DiffEntry:
@@ -272,14 +282,7 @@ def _(action: CreateTable) -> tuple[DiffEntry, ...]:
     )
 
     entries.extend(
-        DiffEntry(
-            DiffCategory.COMMENTS,
-            DiffOperation.ADD,
-            subject=f"column {column.name}",
-            detail=(f"'{column.comment}'",),
-        )
-        for column in action.table.columns
-        if column.comment
+        _column_comment_entry(column) for column in action.table.columns if column.comment
     )
     if action.table.comment:
         entries.append(
@@ -296,7 +299,10 @@ def _(action: CreateTable) -> tuple[DiffEntry, ...]:
 
 @action_entries.register
 def _(action: AddColumn) -> tuple[DiffEntry, ...]:
-    return (_column_add_entry(action.column),)
+    entries = [_column_add_entry(action.column)]
+    if action.column.comment:
+        entries.append(_column_comment_entry(action.column))
+    return tuple(entries)
 
 
 @action_entries.register

--- a/tests/application/test_rendering.py
+++ b/tests/application/test_rendering.py
@@ -120,6 +120,18 @@ def _plan(name: str, *actions: Action) -> ActionPlan:
             (DiffEntry(DiffCategory.COLUMNS, DiffOperation.ADD, "age", ("Integer", "NOT NULL")),),
         ),
         (
+            AddColumn(DesiredColumn("age", Integer(), comment="Age in years")),
+            (
+                DiffEntry(DiffCategory.COLUMNS, DiffOperation.ADD, "age", ("Integer",)),
+                DiffEntry(
+                    DiffCategory.COMMENTS,
+                    DiffOperation.ADD,
+                    "column age",
+                    ("'Age in years'",),
+                ),
+            ),
+        ),
+        (
             DropColumn(column=ObservedColumn("legacy", Integer())),
             (DiffEntry(DiffCategory.COLUMNS, DiffOperation.REMOVE, "legacy"),),
         ),


### PR DESCRIPTION
## Summary

- report comments carried by `AddColumn` actions
- share the existing added-column comment projection with `CreateTable`
- cover the action-to-report projection with a focused regression case

## Why

`AddColumn` compiles the complete desired column, including its comment, but reporting previously emitted only the structural column entry. Human and structured reports therefore omitted a change that the generated SQL would apply.

## Impact

Reporting only. Added-column comments now appear in both text and structured change summaries; planning, SQL compilation, and execution behaviour are unchanged.

## Validation

- `uv run pytest tests/application/test_rendering.py --no-cov -q`
- `uv run pytest tests/application --no-cov -q`
- `uv run pytest --no-cov -q`
- `uv run ruff check .`
- `uv run mypy .`
- `git diff --check`