### PR TITLE
fix: prevent plans from accepting unresolvable drift

### DIFF
--- a/src/delta_engine/application/planning.py
+++ b/src/delta_engine/application/planning.py
@@ -22,8 +22,9 @@ class PlanningAccepted:
     The accepted diff and the validated executable plan constructed from it.
 
     The two facts are born together in :func:`plan_changes` and stay together
-    here: construction proves the plan targets the diff it was planned from,
-    so consumers never have to re-associate them.
+    here: construction proves the plan targets the diff it was planned from
+    and that the diff contains no unresolvable differences, so consumers never
+    have to re-establish either invariant.
     """
 
     diff: TableDiff
@@ -32,6 +33,8 @@ class PlanningAccepted:
     def __post_init__(self) -> None:
         if self.plan.target != self.diff.target:
             raise ValueError("Accepted plan must target the diff it was planned from")
+        if isinstance(self.diff, TableDrift) and self.diff.unresolvable:
+            raise ValueError("Accepted plan cannot contain unresolvable differences")
 
 
 @dataclass(frozen=True, slots=True)

--- a/tests/application/test_planning.py
+++ b/tests/application/test_planning.py
@@ -25,6 +25,7 @@ from delta_engine.domain.plan import (
     ActionPlan,
     AddColumn,
     AlterColumnType,
+    ColumnRenameConflict,
     CreateTable,
     DropForeignKey,
     DropPrimaryKey,
@@ -33,6 +34,7 @@ from delta_engine.domain.plan import (
     SetForeignKey,
     SetPrimaryKey,
     SetTableTag,
+    TableDrift,
     diff_table,
 )
 
@@ -172,6 +174,17 @@ def test_an_accepted_outcome_rejects_a_plan_for_another_tables_diff():
     # Then the outcome refuses to pair them
     with pytest.raises(ValueError):
         PlanningAccepted(diff=diff, plan=other_plan)
+
+
+def test_an_accepted_outcome_rejects_unresolvable_differences():
+    diff = TableDrift(
+        desired=_desired(),
+        observed=_observed(),
+        unresolvable=(ColumnRenameConflict(old_name="old", new_name="new"),),
+    )
+
+    with pytest.raises(ValueError):
+        PlanningAccepted(diff=diff, plan=ActionPlan(target=_NAME))
 
 
 def test_plan_changes_accepts_no_op_as_an_empty_plan():


### PR DESCRIPTION
## Summary

- make `PlanningAccepted` reject drift containing unresolvable differences
- document that an accepted result proves both target coherence and the absence of blockers
- cover the invariant with a constructor regression test

## Why

Validation currently owns the detailed rejection policy, but an omitted rule could allow planning to construct a successful result from only the executable actions while silently dropping an unresolvable difference. The accepted-result invariant now fails loudly instead.

## Impact

Known unresolvable differences continue through their existing specific validation failures. This change only affects an invalid accepted result, including a future unresolvable type whose validation rule was accidentally omitted.

## Validation

- `uv run pytest tests/application/test_planning.py --no-cov -q` — 28 passed
- `uv run pytest tests/application --no-cov -q` — 406 passed
- `uv run pytest --no-cov -q` — 1232 passed, 78 deselected
- `uv run ruff check .`
- `uv run mypy .`
- `git diff --check`