### PR TITLE
feat: add SyncReport rendering methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,6 @@ and planned SQL and never applies the generated plan. See the
 ## Quickstart
 
 ```python
-from delta_engine import render_report
 from delta_engine.databricks import build_spark_engine
 from delta_engine.schema import Column, DeltaTable, Integer, String
 
@@ -89,7 +88,7 @@ customers = DeltaTable(
 
 engine = build_spark_engine(spark)
 report = engine.sync(customers)     # creates the table, or no-ops if it already matches
-print(render_report(report))
+print(report.render())
 ```
 
 A first sync that creates this table renders like this:
@@ -105,7 +104,7 @@ dev.silver.customers  SUCCESS  1/1         2 columns
 ```
 
 `sync` returns the structured `SyncReport`; it does not print this text itself.
-Use `render_report` for status, `render_diff` for semantic changes,
+Use `report.render()` for status, `report.render_diff()` for semantic changes,
 `report.planned_sql_statements` for exact DDL, or `report.to_dict()` for JSON-safe
 automation data. The [getting-started tutorial](https://tomoscorbin.github.io/delta-engine/tutorial-getting-started.html)
 shows all four and explains where declarations fit in a pipeline.

--- a/docs/how-to-preview-changes.md
+++ b/docs/how-to-preview-changes.md
@@ -22,14 +22,12 @@ or foreign-key failure — the point is to return the complete preview report.
 
 ## See what would change
 
-`render_diff` shows every table's planned changes as `+`/`-`/`~` blocks;
-`render_report` shows the per-table statuses and any failures:
+`report.render_diff()` shows every table's planned changes as `+`/`-`/`~`
+blocks; `report.render()` shows the per-table statuses and any failures:
 
 ```python
-from delta_engine import render_diff, render_report
-
-print(render_diff(report))
-print(render_report(report))
+print(report.render_diff())
+print(report.render())
 ```
 
 For example, previewing creation of the `customers` declaration from the
@@ -75,7 +73,7 @@ gate is "no failures":
 report = engine.sync(customers, orders, dry_run=True)
 
 if report.has_failures:
-    raise SystemExit(render_report(report))
+    raise SystemExit(report.render())
 ```
 
 `report.has_changes` reports whether any table has a planned change, and

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -77,7 +77,6 @@ OAuth credential providers for production workloads.
 import os
 
 from databricks import sql
-from delta_engine import render_report
 from delta_engine.databricks import build_sql_engine
 
 from myproject.tables import customers
@@ -90,7 +89,7 @@ with sql.connect(
     engine = build_sql_engine(connection)
     report = engine.sync(customers)
 
-print(render_report(report))
+print(report.render())
 ```
 
 The server hostname and HTTP path are available from the SQL warehouse's

--- a/docs/reference-run-report.md
+++ b/docs/reference-run-report.md
@@ -9,7 +9,9 @@ tags:
 `dict`, `list`, `str`, `int`, `bool`, and `None` only, so
 `json.dumps(report.to_dict())` works directly. It is the machine-readable view
 of a run, for CI gates, run-history persistence, and structured logging. The
-human-readable views are `render_report` and `render_diff`.
+human-readable views are `report.render()` and `report.render_diff()`. The
+equivalent `render_report(report)` and `render_diff(report)` functions remain
+available for callers that prefer function-style composition.
 
 `TableRun.to_dict()` projects a single table's record, the same object
 that appears in the run-level `tables` list.
@@ -74,9 +76,9 @@ table can therefore be `EXECUTION_FAILED` with either `NOT_APPLIED` or
 `PARTIALLY_APPLIED`, and an unchanged table can still carry a foreign-key
 failure. Import the enum with `from delta_engine import TableChangeState`.
 
-The human-readable renderers use these states on real runs. `render_diff`
+The human-readable views use these states on real runs. `report.render_diff()`
 marks non-empty plans that were not applied or only partially applied, while
-the `render_report` footer counts catalog outcomes. A compiled plan blocked
+the `report.render()` footer counts catalog outcomes. A compiled plan blocked
 before execution shows statement progress as `0/n`. Dry-run diff blocks and
 their changed/unchanged/failed footer keep describing planned work instead.
 

--- a/docs/tutorial-getting-started.md
+++ b/docs/tutorial-getting-started.md
@@ -89,16 +89,14 @@ Start with a dry run. It reads live catalog state, validates the change, and
 compiles exact SQL without executing it:
 
 ```python
-from delta_engine import render_diff, render_report
-
 preview = engine.sync(*all_tables, dry_run=True)
 
-print(render_diff(preview))
-print(render_report(preview))
+print(preview.render_diff())
+print(preview.render())
 ```
 
-For a missing `dev.silver.customers` table, `render_diff` shows the semantic
-change rather than SQL:
+For a missing `dev.silver.customers` table, `preview.render_diff()` shows the
+semantic change rather than SQL:
 
 ```text
 DIFF
@@ -110,8 +108,8 @@ dev.silver.customers  (CREATE)
     + name  String
 ```
 
-`render_report` shows the plan status and statement count. The `PLAN` banner is
-the visible assurance that no planned SQL ran:
+`preview.render()` shows the plan status and statement count. The `PLAN` banner
+is the visible assurance that no planned SQL ran:
 
 ```text
 SYNC REPORT
@@ -130,8 +128,8 @@ either rendering. The object supports four complementary views:
 
 | View | Use |
 | --- | --- |
-| `render_diff(preview)` | Human-readable semantic changes |
-| `render_report(preview)` | Per-table status, failures, and statement counts |
+| `preview.render_diff()` | Human-readable semantic changes |
+| `preview.render()` | Per-table status, failures, and statement counts |
 | `preview.planned_sql_statements` | Exact DDL grouped by table |
 | `preview.to_dict()` | Versioned, JSON-safe data for CI and logging |
 
@@ -154,7 +152,7 @@ preview:
 
 ```python
 report = engine.sync(*all_tables)
-print(render_report(report))
+print(report.render())
 ```
 
 The first successful application renders:
@@ -199,8 +197,9 @@ configure_logging()
 engine.sync(*all_tables)
 ```
 
-Logging is operational progress; `render_report`, `render_diff`, and
-`to_dict()` remain the stable ways to inspect the outcome.
+Logging is operational progress; `SyncReport.render()`,
+`SyncReport.render_diff()`, and `SyncReport.to_dict()` remain the stable ways to
+inspect the outcome.
 
 ## What to do when sync fails
 

--- a/src/delta_engine/application/rendering.py
+++ b/src/delta_engine/application/rendering.py
@@ -1,12 +1,14 @@
 """
 Diff and grid rendering for table and sync run reports.
 
-The report value types in report.py are pure data; all human-readable
-formatting lives here. Action interpretation (what each action means) lives
-in diff_entries.py, the shared meaning layer this module and to_dict()
-consume. The public entry points are render_report (status grid plus summary
-footer) and render_diff (per-table change blocks); render_grid,
-render_diff_block, and run_summary_footer are the building blocks they compose.
+The report value types in report.py contain run facts; all human-readable
+formatting lives here. SyncReport.render() and SyncReport.render_diff() are
+convenience views that delegate to this module. Action interpretation (what
+each action means) lives in diff_entries.py, the shared meaning layer this
+module and to_dict() consume. The public function entry points are
+render_report (status grid plus summary footer) and render_diff (per-table
+change blocks); render_grid, render_diff_block, and run_summary_footer are the
+building blocks they compose.
 """
 
 from collections import Counter

--- a/src/delta_engine/application/report.py
+++ b/src/delta_engine/application/report.py
@@ -500,6 +500,20 @@ class SyncReport:
         """Mapping of qualified table name to its failures (if any)."""
         return {run.qualified_name: run.failures for run in self.table_runs if run.has_failures}
 
+    def render(self) -> str:
+        """Render the run's status, failures, and summary as human-readable text."""
+        # rendering imports these report types, so defer the reverse dependency
+        # until callers ask for the convenience view.
+        from delta_engine.application.rendering import render_report
+
+        return render_report(self)
+
+    def render_diff(self) -> str:
+        """Render every table's planned changes as human-readable text."""
+        from delta_engine.application.rendering import render_diff
+
+        return render_diff(self)
+
     def to_dict(self) -> dict[str, Any]:
         """Project the whole run as plain, JSON-serialisable data; tables in run order."""
         return {

--- a/tests/application/test_rendering.py
+++ b/tests/application/test_rendering.py
@@ -890,6 +890,22 @@ def test_a_single_table_run_uses_the_singular_noun():
 # ---------- whole-report rendering ----------
 
 
+def test_sync_report_exposes_both_human_readable_views():
+    table = _grid_report(
+        "orders",
+        plan=_plan("orders", SetTableComment(desired_comment="new", observed_comment="old")),
+    )
+    sync = SyncReport(
+        started_at=datetime(2025, 1, 1, 0, 0, 0),
+        ended_at=datetime(2025, 1, 1, 0, 0, 3),
+        table_runs=(table,),
+        dry_run=True,
+    )
+
+    assert sync.render() == render_report(sync)
+    assert sync.render_diff() == render_diff(sync)
+
+
 def test_render_report_is_the_status_grid_followed_by_the_summary_footer():
     # Given a run over one changed and one failed table
     changed = _grid_report(


### PR DESCRIPTION
## Summary

- add `SyncReport.render()` and `SyncReport.render_diff()` convenience methods that return human-readable text
- keep `render_report(report)` and `render_diff(report)` available for compatibility and function-style composition
- update the primary documentation examples to use the discoverable object-level API

## Why

Callers currently need to import standalone renderer functions before displaying a sync result. These methods make both human-readable views discoverable from the report object while preserving composability and avoiding stdout side effects.

## Impact

Existing callers are unaffected. New callers can use `print(report.render())` and `print(report.render_diff())` without importing renderer functions.

## Validation

- `uv run pytest` — 1227 passed, 78 deselected
- `uv run ruff check src/delta_engine/application/report.py src/delta_engine/application/rendering.py tests/application/test_rendering.py`
- `uv run ruff format --check src/delta_engine/application/report.py src/delta_engine/application/rendering.py tests/application/test_rendering.py`
- `uv run mypy src/delta_engine/application/report.py src/delta_engine/application/rendering.py`
- `uv run lint-imports`
- `uv run --group docs sphinx-build -W -b html docs <temporary-output-directory>`