### PR TITLE
docs: add usage patterns guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Delta Engine is a reconciler, not a data pipeline or migration ledger. Existing 
 
    Every sync returns a structured `SyncReport` describing each table’s semantic changes, rejected changes, planned SQL, failures, and execution progress. The report has a stable, versioned, JSON-serialisable representation, so the same information can drive CI gates, structured logging, audit history, dashboards, and other automation rather than existing only as console output.
 
-## Choose how to run it
+## Use Delta Engine in your workflow
 
 Delta Engine runs where your release or data workflow calls it. See
 [Ways to use Delta Engine](https://tomoscorbin.github.io/delta-engine/explanation-ways-to-use-delta-engine.html)

--- a/README.md
+++ b/README.md
@@ -48,6 +48,13 @@ Delta Engine is a reconciler, not a data pipeline or migration ledger. Existing 
 
    Every sync returns a structured `SyncReport` describing each table’s semantic changes, rejected changes, planned SQL, failures, and execution progress. The report has a stable, versioned, JSON-serialisable representation, so the same information can drive CI gates, structured logging, audit history, dashboards, and other automation rather than existing only as console output.
 
+## Choose how to run it
+
+Delta Engine runs where your release or data workflow calls it. See
+[Ways to use Delta Engine](https://tomoscorbin.github.io/delta-engine/explanation-ways-to-use-delta-engine.html)
+for release-time reconciliation, ETL readiness checks, and restricted
+governance deployments.
+
 ## Install
 
 ```bash
@@ -123,6 +130,7 @@ for the model, or jump to what you need:
 
 **Concepts**
 
+- [Ways to use Delta Engine](https://tomoscorbin.github.io/delta-engine/explanation-ways-to-use-delta-engine.html) — release, ETL, and governance deployment patterns
 - [How a sync works](https://tomoscorbin.github.io/delta-engine/explanation-sync-lifecycle.html) — the phases between calling `sync` and getting a report
 - [The safety model](https://tomoscorbin.github.io/delta-engine/explanation-safety-model.html) — what the engine blocks, and why
 

--- a/docs/explanation-ways-to-use-delta-engine.md
+++ b/docs/explanation-ways-to-use-delta-engine.md
@@ -24,7 +24,8 @@ deployment for centrally managed annotations.
 | --------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------- | -------------------------------------------------------- |
 | [Pattern 1: Release table contracts](#pattern-1-release-table-contracts-with-the-application)       | Controlled production releases and continuing table estates          | A dedicated job after the application bundle is deployed |
 | [Pattern 2: Reconcile a target table](#pattern-2-reconcile-a-target-table-before-its-etl-runs)      | ETL applications that own a single target table                      | Application startup before transformations or writes     |
-| [Pattern 3: Add governance](#pattern-3-add-governance-without-taking-over-the-pipeline)             | Split ownership between data-product, platform, and governance teams | A separate restricted-scope deployment                   |
+| [Pattern 3: Reuse declarations in ETL](#pattern-3-reuse-table-declarations-throughout-etl-code)     | ETL applications that use declared schema and row identity at write time | Transformation and write code                         |
+| [Pattern 4: Add governance](#pattern-4-add-governance-without-taking-over-the-pipeline)             | Split ownership between data-product, platform, and governance teams | A separate restricted-scope deployment                   |
 
 ## Pattern 1: Release table contracts with the application
 
@@ -228,7 +229,108 @@ Use this pattern when:
 It is particularly straightforward for batch applications because the table
 check becomes part of the application's normal startup sequence.
 
-## Pattern 3: Add governance without taking over the pipeline
+## Pattern 3: Reuse table declarations throughout ETL code
+
+A `DeltaTable` declaration can also be imported throughout the ETL that
+produces it. Table names, schemas, keys, and column lists then stay in one
+place rather than being repeated across the pipeline. This works especially
+well alongside Pattern 2: reconcile the declaration at startup, then use the
+same object while producing rows.
+
+### Conform output to the declared schema
+
+Use the declaration to cast and order the final DataFrame before writing it:
+
+```python
+result = transform(source).to(to_spark_schema(customers))
+```
+
+Here, `to_spark_schema` is application code that converts a `DeltaTable` into
+a PySpark `StructType`; Delta Engine deliberately does not expose PySpark
+types from its schema API. Keeping that conversion at the Spark edge lets the
+ETL use `customers.columns` as the ordered, authoritative column list. A
+schema change consequently updates both the table contract and the final
+projection together.
+
+### Build merges from the declared primary key
+
+Use the same primary key declared on the table to construct the Delta merge
+condition. This handles composite keys without maintaining a separate join
+predicate:
+
+```python
+from functools import reduce
+from operator import and_
+
+from pyspark.sql import functions as F
+
+
+condition = reduce(
+    and_,
+    (
+        F.col(f"target.{column}") == F.col(f"source.{column}")
+        for column in customers.primary_key
+    ),
+)
+
+(
+    target.alias("target")
+    .merge(result.alias("source"), condition)
+    .whenMatchedUpdateAll()
+    .whenNotMatchedInsertAll()
+    .execute()
+)
+```
+
+Only use this pattern for a declaration with a primary key. An empty key has
+no row-identity meaning and cannot form a merge condition.
+
+### Derive update columns from the declaration
+
+When a merge should not update key columns, derive the mutable columns instead
+of maintaining another list:
+
+```python
+update_columns = [
+    column.name
+    for column in customers.columns
+    if column.name not in customers.primary_key
+]
+
+updates = {
+    column: F.col(f"source.{column}")
+    for column in update_columns
+}
+
+(
+    target.alias("target")
+    .merge(result.alias("source"), condition)
+    .whenMatchedUpdate(set=updates)
+    .whenNotMatchedInsertAll()
+    .execute()
+)
+```
+
+### Reuse the key wherever row identity matters
+
+The declared primary key can also drive deduplication, windowing, and other
+key-based ETL logic. For example, retain the latest event for each customer:
+
+```python
+from pyspark.sql import Window, functions as F
+
+
+latest = Window.partitionBy(*customers.primary_key).orderBy(
+    F.col("event_timestamp").desc()
+)
+
+result = result.withColumn("_row_number", F.row_number().over(latest))
+```
+
+The table contract remains the single definition of the output schema and row
+identity, while the ETL code consumes those facts where it needs them.
+
+## Pattern 4: Add governance without taking over the pipeline
 
 Table ownership is not always all-or-nothing. A data-product team may own the
 schema and row production while a platform or governance team owns comments,

--- a/docs/explanation-ways-to-use-delta-engine.md
+++ b/docs/explanation-ways-to-use-delta-engine.md
@@ -98,26 +98,6 @@ job should fail rather than allowing the release to continue silently.
 A Declarative Automation Bundle can deploy the project wheel and define a
 dedicated Python wheel task.
 
-The resource below is intentionally abridged; add the compute, libraries,
-permissions, and environment-specific settings required by your workspace:
-
-```yaml
-resources:
-  jobs:
-    reconcile_tables:
-      name: ${bundle.target}-reconcile-tables
-
-      tasks:
-        - task_key: reconcile_tables
-
-          python_wheel_task:
-            package_name: myproject
-            entry_point: sync-tables
-
-          libraries:
-            - whl: ../dist/*.whl
-```
-
 The release pipeline can then validate the bundle, deploy it, and run the
 reconciliation job:
 
@@ -147,15 +127,6 @@ delta-engine plan myproject.table_registry:ALL_TABLES
 
 This reads live Unity Catalog state, validates the declarations, and prints the
 semantic differences and exact planned DDL without applying them.
-
-Use separate identities for planning and application:
-
-* a read-only identity for pull-request planning;
-* a write-capable job identity for the deployment sync;
-* a deployment identity responsible for publishing the bundle.
-
-A bundle's `run_as` configuration can separate the identity that deploys the
-workflow from the service principal under which the reconciliation job runs.
 
 A real sync does not replay the dry-run output as a saved plan. It reads the
 catalog again and derives a fresh plan from the state present at deployment

--- a/docs/explanation-ways-to-use-delta-engine.md
+++ b/docs/explanation-ways-to-use-delta-engine.md
@@ -1,0 +1,461 @@
+---
+tags:
+  - explanation
+---
+
+# Ways to use Delta Engine
+
+Delta Engine is a reconciliation library rather than a deployment system or
+background controller. A sync runs only when your application, workflow, or
+deployment process calls it with a collection of table declarations.
+
+This makes Delta Engine flexible about where it fits. A team can reconcile
+table contracts as part of a release, make table readiness a prerequisite of an
+ETL workflow, or manage governance metadata around tables whose structure is
+owned elsewhere.
+
+The patterns below are not mutually exclusive. A project might plan changes in
+CI, apply them through a dedicated release job, and use a separate restricted
+deployment for centrally managed annotations.
+
+## Choose a pattern
+
+| Pattern                                                                                             | Best suited to                                                       | Where Delta Engine runs                                  |
+| --------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------- | -------------------------------------------------------- |
+| [Release table contracts with the application](#release-table-contracts-with-the-application)       | Controlled production releases and continuing table estates          | A dedicated job after the application bundle is deployed |
+| [Require table readiness before ETL](#require-table-readiness-before-etl)                           | Batch data products that must establish their tables before writing  | The first task in the data workflow                      |
+| [Add governance without taking over the pipeline](#add-governance-without-taking-over-the-pipeline) | Split ownership between data-product, platform, and governance teams | A separate restricted-scope deployment                   |
+
+## Release table contracts with the application
+
+For most production applications, the clearest pattern is to treat table
+contracts as part of the release:
+
+```mermaid
+flowchart LR
+    PR[Pull request] --> Plan[Read-only Delta Engine plan]
+    Plan --> Review[Review semantic changes and DDL]
+    Review --> Merge[Merge]
+    Merge --> Deploy[Deploy application bundle]
+    Deploy --> Sync[Run table-reconciliation job]
+    Sync --> Data[Release or run data workloads]
+```
+
+The declarations, pipeline code, and deployment configuration are versioned and
+released together. The deployment creates or updates the Databricks resources,
+then runs a dedicated job that reconciles the table declarations before the new
+data-producing workload is allowed to run.
+
+This keeps responsibilities clear:
+
+* the bundle deploys jobs, pipelines, libraries, and configuration;
+* the reconciliation job manages the declared table state;
+* the ETL workloads produce and write rows.
+
+### Keep an explicit table registry
+
+Expose the tables owned by the release through one explicit, ordered
+collection:
+
+```python
+# myproject/table_registry.py
+from myproject.tables.customers import customers
+from myproject.tables.order_items import order_items
+from myproject.tables.orders import orders
+
+ALL_TABLES = (
+    customers,
+    orders,
+    order_items,
+)
+```
+
+Prefer an explicit registry to automatically crawling packages for every
+`DeltaTable` object. The registry makes the deployment unit visible in code
+review and avoids importing arbitrary modules merely to discover declarations.
+Adding a table to the registry is an intentional decision to include it in the
+release.
+
+Larger projects can expose one registry per domain:
+
+```python
+# myproject/customers/table_registry.py
+CUSTOMER_TABLES = (
+    customers,
+    customer_preferences,
+)
+
+# myproject/orders/table_registry.py
+ORDER_TABLES = (
+    orders,
+    order_items,
+)
+```
+
+A release can then compose only the domains it owns:
+
+```python
+ALL_TABLES = (
+    *CUSTOMER_TABLES,
+    *ORDER_TABLES,
+)
+```
+
+### Add a reconciliation entry point
+
+Package the reconciliation logic with the application:
+
+```python
+# myproject/sync_tables.py
+from delta_engine import render_report
+from delta_engine.databricks import build_spark_engine
+from pyspark.sql import SparkSession
+
+from myproject.table_registry import ALL_TABLES
+
+
+def main() -> None:
+    """Reconcile every table owned by this release."""
+    spark = SparkSession.getActiveSession()
+
+    if spark is None:
+        spark = SparkSession.builder.getOrCreate()
+
+    engine = build_spark_engine(spark)
+    report = engine.sync(*ALL_TABLES)
+
+    print(render_report(report))
+```
+
+Expose the function as a wheel entry point:
+
+```toml
+[project.scripts]
+sync-tables = "myproject.sync_tables:main"
+```
+
+The job succeeds only when the sync succeeds. If reading, planning, dependency
+resolution, or execution fails, Delta Engine raises `SyncFailedError` and the
+job should fail rather than allowing the release to continue silently.
+
+### Deploy and run it through a bundle
+
+A Declarative Automation Bundle can deploy the project wheel and define a
+dedicated Python wheel task.
+
+The resource below is intentionally abridged; add the compute, libraries,
+permissions, and environment-specific settings required by your workspace:
+
+```yaml
+resources:
+  jobs:
+    reconcile_tables:
+      name: ${bundle.target}-reconcile-tables
+
+      tasks:
+        - task_key: reconcile_tables
+
+          python_wheel_task:
+            package_name: myproject
+            entry_point: sync-tables
+
+          libraries:
+            - whl: ../dist/*.whl
+```
+
+The release pipeline can then validate the bundle, deploy it, and run the
+reconciliation job:
+
+```bash
+databricks bundle validate --target production
+databricks bundle deploy --target production
+databricks bundle run --target production reconcile_tables
+```
+
+Do not trigger the new data workload unless reconciliation succeeds.
+
+Bundle deployment and table reconciliation are separate operations. If the
+bundle is deployed but the reconciliation job fails, the new job definitions
+and application artifacts may already exist in the workspace. The release
+process should stop, expose the failed `SyncReport`, and prevent the updated
+data workload from starting until the declaration or catalog problem is
+resolved.
+
+### Plan the same registry in CI
+
+The same registry can be planned during a pull request through the read-only
+CLI:
+
+```bash
+delta-engine plan myproject.table_registry:ALL_TABLES
+```
+
+This reads live Unity Catalog state, validates the declarations, and prints the
+semantic differences and exact planned DDL without applying them.
+
+Use separate identities for planning and application:
+
+* a read-only identity for pull-request planning;
+* a write-capable job identity for the deployment sync;
+* a deployment identity responsible for publishing the bundle.
+
+A bundle's `run_as` configuration can separate the identity that deploys the
+workflow from the service principal under which the reconciliation job runs.
+
+A real sync does not replay the dry-run output as a saved plan. It reads the
+catalog again and derives a fresh plan from the state present at deployment
+time. See [How to report schema plans in CI](how-to-gate-changes-in-ci.md) for
+a complete read-only workflow.
+
+## Require table readiness before ETL
+
+A batch data product can make reconciliation the first task in its Lakeflow
+Job:
+
+```mermaid
+flowchart LR
+    Sync[Reconcile tables] --> Transform[Transform data]
+    Transform --> Write[Write target tables]
+    Write --> Publish[Publish outputs]
+```
+
+Every data-producing task depends on the reconciliation task succeeding. The
+workflow itself therefore enforces the precondition:
+
+> The declared tables must be readable, valid, and successfully reconciled
+> before this run writes any rows.
+
+An abridged bundle definition might look like this:
+
+```yaml
+resources:
+  jobs:
+    customer_data_product:
+      name: ${bundle.target}-customer-data-product
+
+      tasks:
+        - task_key: reconcile_tables
+
+          python_wheel_task:
+            package_name: myproject
+            entry_point: sync-tables
+
+          libraries:
+            - whl: ../dist/*.whl
+
+        - task_key: build_customers
+
+          depends_on:
+            - task_key: reconcile_tables
+
+          python_wheel_task:
+            package_name: myproject
+            entry_point: build-customers
+
+          libraries:
+            - whl: ../dist/*.whl
+
+        - task_key: build_orders
+
+          depends_on:
+            - task_key: reconcile_tables
+
+          python_wheel_task:
+            package_name: myproject
+            entry_point: build-orders
+
+          libraries:
+            - whl: ../dist/*.whl
+```
+
+The default successful path is:
+
+```text
+reconcile_tables succeeds
+        ↓
+dependent ETL tasks start
+```
+
+If reconciliation fails, the dependent tasks do not run.
+
+### When this pattern works well
+
+Use an upstream reconciliation task when:
+
+* the workflow and its target tables form one data product;
+* the job must be able to start in an environment where a table may be absent;
+* table readiness should be checked every time the workflow begins;
+* the workflow is batch-oriented or runs at a moderate frequency;
+* the cost of reading catalog state on each workflow run is acceptable.
+
+It is also useful for an explicit release workflow:
+
+```text
+reconcile tables
+        ↓
+run deployment smoke tests
+        ↓
+trigger the production data job
+```
+
+The production data job can remain a separate resource while the release
+workflow preserves the ordering.
+
+### When not to use it
+
+Do not call `sync()` for every streaming micro-batch. Re-reading and replanning
+a stable table contract hundreds of times per hour adds work without improving
+the contract.
+
+For continuous or high-frequency pipelines, reconcile at release time before
+the pipeline is started or updated:
+
+```text
+deploy release
+        ↓
+reconcile table contracts
+        ↓
+start or update continuous pipeline
+```
+
+Also avoid enabling writer-driven schema evolution for table aspects that
+Delta Engine owns. The workflow should not simultaneously ask Delta Engine to
+enforce one column structure while allowing the writer to evolve that same
+structure independently.
+
+## Add governance without taking over the pipeline
+
+Table ownership is not always all-or-nothing. A data-product team may own the
+schema and row production while a platform or governance team owns comments,
+classifications, and ownership tags.
+
+Restricted scopes let those responsibilities remain separate:
+
+```mermaid
+flowchart TB
+    Pipeline[Pipeline or dbt project] -->|owns schema and rows| Table[Unity Catalog table]
+    Governance[Delta Engine governance deployment] -->|owns comments and tags| Table
+```
+
+For example, a pipeline can continue to define and populate an `orders` table
+while a separate declaration manages its annotations:
+
+```python
+from delta_engine.schema import Column, DeltaTable, Long, String
+
+orders_annotations = DeltaTable(
+    catalog="production",
+    schema="sales",
+    name="orders",
+    columns=[
+        Column(
+            "order_id",
+            Long(),
+            nullable=False,
+            comment="Stable identifier for an order.",
+            tags={"classification": "identifier"},
+        ),
+        Column(
+            "customer_email",
+            String(),
+            comment="Email supplied when the order was placed.",
+            tags={"classification": "personal"},
+        ),
+    ],
+    comment="Customer orders accepted by the commerce platform.",
+    tags={
+        "domain": "sales",
+        "owner": "commerce-platform",
+    },
+    scope="annotations",
+)
+```
+
+With `scope="annotations"`, Delta Engine can reconcile table and column comments
+and tags, but it cannot add, remove, or alter columns, properties, layouts, or
+constraints.
+
+Other available scopes include:
+
+| Scope         | Managed state                       |
+| ------------- | ----------------------------------- |
+| `full`        | Complete table definition           |
+| `metadata`    | Comments, tags, and key constraints |
+| `annotations` | Comments and tags                   |
+| `tags`        | Tags only                           |
+
+See [How to deploy metadata only](how-to-deploy-metadata-only.md) for the exact
+scope semantics.
+
+### Mirror the table state you do not own
+
+A restricted declaration still describes the live table accurately. Its
+columns, layout, and any keys must match the state owned by the producing
+system, even though Delta Engine is not allowed to alter those aspects.
+
+If the pipeline changes the schema and the governance declaration is not
+updated, the next sync fails rather than applying metadata against a table it
+no longer understands. This makes the ownership boundary safe, but it also
+means governance declarations must follow intentional changes made by the
+structural owner.
+
+### Use restricted scopes for streaming tables
+
+Databricks streaming tables are structurally owned by their defining pipeline.
+Delta Engine can manage their externally alterable comments and tags through
+`scope="annotations"` or `scope="tags"`, but broader scopes are rejected.
+
+Do not declare the same comment or tag in both the pipeline definition and
+Delta Engine. A pipeline refresh can reassert its own declaration, creating
+recurring drift between two competing owners.
+
+## Combine the patterns
+
+A larger project can use all three patterns:
+
+```mermaid
+flowchart TB
+    PR[Pull request] --> Plan[Read-only CI plan]
+    Plan --> Merge[Merge]
+    Merge --> Bundle[Deploy application bundle]
+    Bundle --> Reconcile[Run dedicated reconciliation job]
+    Reconcile --> ETL[Run data workflows]
+
+    GovernancePR[Governance change] --> GovernanceSync[Restricted-scope sync]
+    GovernanceSync --> Catalog[Comments and tags]
+
+    ETL --> Catalog
+```
+
+For example:
+
+1. Table declarations live in a shared Python package beside the data-product
+   code.
+2. Pull requests plan the explicit registry through a SQL warehouse using a
+   read-only identity.
+3. A merged release deploys a bundle and runs a dedicated write-capable
+   reconciliation job.
+4. Data workflows are triggered only after reconciliation succeeds.
+5. A separate governance deployment manages annotations on tables owned by
+   other pipelines.
+
+The common principle is that each table aspect has one clear owner.
+
+## Operational boundaries
+
+Whichever pattern you use:
+
+* Keep one write-capable sync per table at a time.
+* Treat a dry run as a live preview, not as an immutable saved plan.
+* Do not allow another tool to evolve an aspect that Delta Engine manages.
+* Do not run reconciliation inside every streaming micro-batch.
+* Prefer explicit table registries over implicit package crawling.
+* Do not describe a multi-statement table plan or multi-table run as
+  transactionally atomic.
+* Inspect the returned `SyncReport`; successful process startup is not a
+  substitute for checking the reconciliation result.
+
+See [Getting started](tutorial-getting-started.md) for a complete first sync,
+[How a sync works](explanation-sync-lifecycle.md) for the execution model, and
+[Capabilities and limitations](reference-limitations.md) before using
+write-capable synchronization in an unattended production workflow.

--- a/docs/explanation-ways-to-use-delta-engine.md
+++ b/docs/explanation-ways-to-use-delta-engine.md
@@ -22,11 +22,11 @@ deployment for centrally managed annotations.
 
 | Pattern                                                                                             | Best suited to                                                       | Where Delta Engine runs                                  |
 | --------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------- | -------------------------------------------------------- |
-| [Release table contracts with the application](#release-table-contracts-with-the-application)       | Controlled production releases and continuing table estates          | A dedicated job after the application bundle is deployed |
-| [Require table readiness before ETL](#require-table-readiness-before-etl)                           | Batch data products that must establish their tables before writing  | The first task in the data workflow                      |
-| [Add governance without taking over the pipeline](#add-governance-without-taking-over-the-pipeline) | Split ownership between data-product, platform, and governance teams | A separate restricted-scope deployment                   |
+| [Pattern 1: Release table contracts](#pattern-1-release-table-contracts-with-the-application)       | Controlled production releases and continuing table estates          | A dedicated job after the application bundle is deployed |
+| [Pattern 2: Require table readiness](#pattern-2-require-table-readiness-before-etl)                 | Batch data products that must establish their tables before writing  | The first task in the data workflow                      |
+| [Pattern 3: Add governance](#pattern-3-add-governance-without-taking-over-the-pipeline)             | Split ownership between data-product, platform, and governance teams | A separate restricted-scope deployment                   |
 
-## Release table contracts with the application
+## Pattern 1: Release table contracts with the application
 
 For most production applications, the clearest pattern is to treat table
 contracts as part of the release.
@@ -137,7 +137,7 @@ catalog again and derives a fresh plan from the state present at deployment
 time. See [How to report schema plans in CI](how-to-gate-changes-in-ci.md) for
 a complete read-only workflow.
 
-## Require table readiness before ETL
+## Pattern 2: Require table readiness before ETL
 
 The release-time pattern reconciles table contracts when the application is
 deployed. For batch data products that need to verify table state at the
@@ -197,7 +197,7 @@ Engine owns. The workflow should not ask Delta Engine to enforce one column
 structure while allowing the writer to evolve that same structure
 independently.
 
-## Add governance without taking over the pipeline
+## Pattern 3: Add governance without taking over the pipeline
 
 Table ownership is not always all-or-nothing. A data-product team may own the
 schema and row production while a platform or governance team owns comments,

--- a/docs/explanation-ways-to-use-delta-engine.md
+++ b/docs/explanation-ways-to-use-delta-engine.md
@@ -336,9 +336,6 @@ source = spark.createDataFrame(
 )
 ```
 
-This keeps test fixtures aligned with the schema used by the application and
-Unity Catalog.
-
 ### Assert the ETL produces the declared schema
 
 Compare the final DataFrame with the same table contract:
@@ -385,9 +382,6 @@ duplicates = (
 assert duplicates.isEmpty()
 ```
 
-The same primary key is therefore used by the table declaration, production
-ETL logic, and tests rather than being defined independently in each place.
-
 ### Test foreign-key relationships
 
 Related table declarations can also drive referential-integrity tests. For a
@@ -405,9 +399,6 @@ missing_customers = (
 
 assert missing_customers.isEmpty()
 ```
-
-Delta Engine validates that the declared relationship is structurally valid;
-the test verifies that the data produced by the ETL satisfies that relationship.
 
 ## Pattern 5: Add governance without taking over the pipeline
 

--- a/docs/explanation-ways-to-use-delta-engine.md
+++ b/docs/explanation-ways-to-use-delta-engine.md
@@ -314,38 +314,6 @@ Do not declare the same comment or tag in both the pipeline definition and
 Delta Engine. A pipeline refresh can reassert its own declaration, creating
 recurring drift between two competing owners.
 
-## Combine the patterns
-
-A larger project can use all three patterns:
-
-```mermaid
-flowchart TB
-    PR[Pull request] --> Plan[Read-only CI plan]
-    Plan --> Merge[Merge]
-    Merge --> Bundle[Deploy application bundle]
-    Bundle --> Reconcile[Run dedicated reconciliation job]
-    Reconcile --> ETL[Run data workflows]
-
-    GovernancePR[Governance change] --> GovernanceSync[Restricted-scope sync]
-    GovernanceSync --> Catalog[Comments and tags]
-
-    ETL --> Catalog
-```
-
-For example:
-
-1. Table declarations live in a shared Python package beside the data-product
-   code.
-2. Pull requests plan the explicit registry through a SQL warehouse using a
-   read-only identity.
-3. A merged release deploys a bundle and runs a dedicated write-capable
-   reconciliation job.
-4. Data workflows are triggered only after reconciliation succeeds.
-5. A separate governance deployment manages annotations on tables owned by
-   other pipelines.
-
-The common principle is that each table aspect has one clear owner.
-
 ## Operational boundaries
 
 Whichever pattern you use:

--- a/docs/explanation-ways-to-use-delta-engine.md
+++ b/docs/explanation-ways-to-use-delta-engine.md
@@ -29,15 +29,7 @@ deployment for centrally managed annotations.
 ## Release table contracts with the application
 
 For most production applications, the clearest pattern is to treat table
-contracts as part of the release:
-
-```mermaid
-flowchart LR
-    PR[Pull request] --> Review[Plan and review changes]
-    Review --> Merge[Merge]
-    Merge --> Release[Deploy and reconcile tables]
-    Release --> Data[Run data workloads]
-```
+contracts as part of the release.
 
 The declarations, pipeline code, and deployment configuration are versioned and
 released together. The deployment creates or updates the Databricks resources,
@@ -68,6 +60,10 @@ ALL_TABLES = (
 )
 ```
 
+An explicit registry makes the release boundary visible in code review: adding
+a table to the collection is an intentional decision to include it in the
+deployment.
+
 ### Add a reconciliation entry point
 
 Package the reconciliation logic with the application:
@@ -81,8 +77,10 @@ from pyspark.sql import SparkSession
 from myproject.table_registry import ALL_TABLES
 
 
-def main(spark: SparkSession) -> None:
+def main() -> None:
     """Reconcile every table owned by this release."""
+    spark = SparkSession.builder.getOrCreate()
+
     engine = build_spark_engine(spark)
     report = engine.sync(*ALL_TABLES)
 
@@ -90,13 +88,13 @@ def main(spark: SparkSession) -> None:
 ```
 
 The job succeeds only when the sync succeeds. If reading, planning, dependency
-resolution, or execution fails, Delta Engine raises `SyncFailedError` and the
+resolution, or execution fails, Delta Engine raises `SyncFailedError`, and the
 job should fail rather than allowing the release to continue silently.
 
 ### Deploy and run it through a bundle
 
-A Declarative Automation Bundle can deploy the project wheel and define a
-dedicated Python wheel task.
+A Declarative Automation Bundle can deploy the application wheel and configure
+the reconciliation entry point as a dedicated Python wheel task.
 
 The release pipeline can then validate the bundle, deploy it, and run the
 reconciliation job:

--- a/docs/explanation-ways-to-use-delta-engine.md
+++ b/docs/explanation-ways-to-use-delta-engine.md
@@ -342,10 +342,8 @@ Compare the final DataFrame with the same table contract:
 
 ```python
 def test_produces_the_declared_schema(source) -> None:
-    # When
     result = transform(source)
 
-    # Then
     assert result.schema == to_spark_schema(customers)
 ```
 
@@ -358,10 +356,8 @@ Use the declaration to derive which columns must always contain a value:
 
 ```python
 def test_produces_no_nulls_in_required_columns(source) -> None:
-    # When
     result = transform(source)
 
-    # Then
     required_columns = [
         column.name
         for column in customers.columns
@@ -378,10 +374,8 @@ The declared primary key can drive data-level key checks:
 
 ```python
 def test_produces_unique_primary_keys(source) -> None:
-    # When
     result = transform(source)
 
-    # Then
     duplicates = (
         result
         .groupBy(*customers.primary_key)

--- a/docs/explanation-ways-to-use-delta-engine.md
+++ b/docs/explanation-ways-to-use-delta-engine.md
@@ -23,7 +23,7 @@ deployment for centrally managed annotations.
 | Pattern                                                                                             | Best suited to                                                       | Where Delta Engine runs                                  |
 | --------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------- | -------------------------------------------------------- |
 | [Pattern 1: Release table contracts](#pattern-1-release-table-contracts-with-the-application)       | Controlled production releases and continuing table estates          | A dedicated job after the application bundle is deployed |
-| [Pattern 2: Require table readiness](#pattern-2-require-table-readiness-before-etl)                 | Batch data products that must establish their tables before writing  | The first task in the data workflow                      |
+| [Pattern 2: Reconcile a target table](#pattern-2-reconcile-a-target-table-before-its-etl-runs)      | ETL applications that own a single target table                      | Application startup before transformations or writes     |
 | [Pattern 3: Add governance](#pattern-3-add-governance-without-taking-over-the-pipeline)             | Split ownership between data-product, platform, and governance teams | A separate restricted-scope deployment                   |
 
 ## Pattern 1: Release table contracts with the application
@@ -137,65 +137,117 @@ catalog again and derives a fresh plan from the state present at deployment
 time. See [How to report schema plans in CI](how-to-gate-changes-in-ci.md) for
 a complete read-only workflow.
 
-## Pattern 2: Require table readiness before ETL
+## Pattern 2: Reconcile a target table before its ETL runs
 
-The release-time pattern reconciles table contracts when the application is
-deployed. For batch data products that need to verify table state at the
-beginning of every run, make reconciliation the first task in the Lakeflow Jobs
-workflow:
+When an ETL application owns a single target table, it can reconcile that table
+once at startup before performing transformations or writing any rows:
 
 ```text
-reconcile_tables
+ETL job starts
         ↓
-data-producing tasks
+reconcile target table
+        ↓
+run transformations
+        ↓
+write rows
 ```
 
-Configure each ETL task to depend on `reconcile_tables`. The workflow then
-enforces the precondition:
+Keep the table declaration alongside the ETL code and import it into the
+application entry point:
 
-> The declared tables must be readable, valid, and successfully reconciled
-> before this run writes any rows.
+```python
+# myproject/main.py
+from delta_engine.databricks import build_spark_engine
+from pyspark.sql import SparkSession
 
-If reading, planning, dependency resolution, or execution fails, the
-reconciliation task fails and the dependent ETL tasks do not run. When the
-tables already match their declarations, the sync completes without applying
-DDL and the workflow continues normally.
+from myproject.pipeline import run_pipeline
+from myproject.tables.customers import customers
+
+
+def main() -> None:
+    """Reconcile the target table, then run the ETL pipeline."""
+    spark = SparkSession.builder.getOrCreate()
+
+    engine = build_spark_engine(spark)
+    engine.sync(customers)
+
+    run_pipeline(spark)
+```
+
+If the table is missing, Delta Engine creates it. If it has safe, supported
+drift, Delta Engine reconciles it. If it already matches the declaration, the
+sync applies no DDL and the ETL continues normally.
+
+If the declaration is invalid, the live table cannot be read, the proposed
+transition is unsafe, or execution fails, `SyncFailedError` propagates and the
+ETL stops before `run_pipeline()` begins.
+
+This pattern gives the ETL application a clear startup precondition:
+
+> The target table must exist and match its declared contract before the
+> application writes any data.
+
+### Synchronize dependencies together
+
+An ETL that owns one independent target normally needs to synchronize only that
+table:
+
+```python
+engine.sync(customers)
+```
+
+Pass multiple declarations when the target has cross-table dependencies that
+Delta Engine must validate and order. For example, if `orders` declares a
+foreign key to `customers`, synchronize both declarations in the same run:
+
+```python
+engine.sync(customers, orders)
+```
+
+Delta Engine validates the relationship, places the parent before the dependent,
+and prevents `orders` from executing if `customers` cannot reach its desired
+state.
+
+There is no need to synchronize unrelated tables together merely because they
+belong to the same repository. Each ETL can reconcile its own target, while
+related tables are grouped only where their declarations depend on one another.
 
 ### When this pattern works well
 
-Use an upstream reconciliation task when:
+Use this pattern when:
 
-* the workflow and its target tables form one data product;
-* the job may run in a new environment where its tables do not yet exist;
-* table state should be checked before every batch run;
-* the workflow runs at a moderate frequency and the additional catalog reads
-  are acceptable.
+* one ETL application clearly owns one target table;
+* the application should be able to start in a new environment where the table
+  does not yet exist;
+* table validity should be checked before every ETL run;
+* the job runs at a frequency where the additional catalog read and planning
+  step are acceptable;
+* the runtime identity is permitted both to reconcile the table and write its
+  data.
 
-This creates a strong runtime boundary between table management and data
-production: the ETL logic does not need to create tables or evolve their schema
-as a side effect of writing rows.
+It is particularly straightforward for batch applications because the table
+check becomes part of the application's normal startup sequence.
 
 ### When not to use it
 
-Do not call `sync()` for every streaming micro-batch. Re-reading and replanning
-a stable table contract hundreds of times per hour adds work without improving
-the contract.
+Do not call `sync()` inside transformation functions, write helpers,
+`foreachBatch`, or individual streaming micro-batches. Reconcile the table once
+before the ETL or streaming query begins.
 
-For continuous or high-frequency pipelines, prefer release-time
-reconciliation:
+For continuous or very high-frequency workloads, release-time reconciliation
+may be a better fit:
 
 ```text
 deploy release
         ↓
-reconcile table contracts
+reconcile target table
         ↓
 start or update continuous pipeline
 ```
 
-Do not also enable writer-driven schema evolution for table aspects that Delta
-Engine owns. The workflow should not ask Delta Engine to enforce one column
-structure while allowing the writer to evolve that same structure
-independently.
+Do not also enable writer-driven schema evolution for aspects that Delta Engine
+owns. For example, a writer should not use `mergeSchema` to evolve columns while
+Delta Engine is responsible for maintaining the declared column structure.
 
 ## Pattern 3: Add governance without taking over the pipeline
 

--- a/docs/explanation-ways-to-use-delta-engine.md
+++ b/docs/explanation-ways-to-use-delta-engine.md
@@ -139,97 +139,41 @@ a complete read-only workflow.
 
 ## Require table readiness before ETL
 
-A batch data product can make reconciliation the first task in its Lakeflow
-Job:
+The release-time pattern reconciles table contracts when the application is
+deployed. For batch data products that need to verify table state at the
+beginning of every run, make reconciliation the first task in the Lakeflow Jobs
+workflow:
 
-```mermaid
-flowchart LR
-    Sync[Reconcile tables] --> Transform[Transform data]
-    Transform --> Write[Write target tables]
-    Write --> Publish[Publish outputs]
+```text
+reconcile_tables
+        ↓
+data-producing tasks
 ```
 
-Every data-producing task depends on the reconciliation task succeeding. The
-workflow itself therefore enforces the precondition:
+Configure each ETL task to depend on `reconcile_tables`. The workflow then
+enforces the precondition:
 
 > The declared tables must be readable, valid, and successfully reconciled
 > before this run writes any rows.
 
-An abridged bundle definition might look like this:
-
-```yaml
-resources:
-  jobs:
-    customer_data_product:
-      name: ${bundle.target}-customer-data-product
-
-      tasks:
-        - task_key: reconcile_tables
-
-          python_wheel_task:
-            package_name: myproject
-            entry_point: sync-tables
-
-          libraries:
-            - whl: ../dist/*.whl
-
-        - task_key: build_customers
-
-          depends_on:
-            - task_key: reconcile_tables
-
-          python_wheel_task:
-            package_name: myproject
-            entry_point: build-customers
-
-          libraries:
-            - whl: ../dist/*.whl
-
-        - task_key: build_orders
-
-          depends_on:
-            - task_key: reconcile_tables
-
-          python_wheel_task:
-            package_name: myproject
-            entry_point: build-orders
-
-          libraries:
-            - whl: ../dist/*.whl
-```
-
-The default successful path is:
-
-```text
-reconcile_tables succeeds
-        ↓
-dependent ETL tasks start
-```
-
-If reconciliation fails, the dependent tasks do not run.
+If reading, planning, dependency resolution, or execution fails, the
+reconciliation task fails and the dependent ETL tasks do not run. When the
+tables already match their declarations, the sync completes without applying
+DDL and the workflow continues normally.
 
 ### When this pattern works well
 
 Use an upstream reconciliation task when:
 
 * the workflow and its target tables form one data product;
-* the job must be able to start in an environment where a table may be absent;
-* table readiness should be checked every time the workflow begins;
-* the workflow is batch-oriented or runs at a moderate frequency;
-* the cost of reading catalog state on each workflow run is acceptable.
+* the job may run in a new environment where its tables do not yet exist;
+* table state should be checked before every batch run;
+* the workflow runs at a moderate frequency and the additional catalog reads
+  are acceptable.
 
-It is also useful for an explicit release workflow:
-
-```text
-reconcile tables
-        ↓
-run deployment smoke tests
-        ↓
-trigger the production data job
-```
-
-The production data job can remain a separate resource while the release
-workflow preserves the ordering.
+This creates a strong runtime boundary between table management and data
+production: the ETL logic does not need to create tables or evolve their schema
+as a side effect of writing rows.
 
 ### When not to use it
 
@@ -237,8 +181,8 @@ Do not call `sync()` for every streaming micro-batch. Re-reading and replanning
 a stable table contract hundreds of times per hour adds work without improving
 the contract.
 
-For continuous or high-frequency pipelines, reconcile at release time before
-the pipeline is started or updated:
+For continuous or high-frequency pipelines, prefer release-time
+reconciliation:
 
 ```text
 deploy release
@@ -248,10 +192,10 @@ reconcile table contracts
 start or update continuous pipeline
 ```
 
-Also avoid enabling writer-driven schema evolution for table aspects that
-Delta Engine owns. The workflow should not simultaneously ask Delta Engine to
-enforce one column structure while allowing the writer to evolve that same
-structure independently.
+Do not also enable writer-driven schema evolution for table aspects that Delta
+Engine owns. The workflow should not ask Delta Engine to enforce one column
+structure while allowing the writer to evolve that same structure
+independently.
 
 ## Add governance without taking over the pipeline
 

--- a/docs/explanation-ways-to-use-delta-engine.md
+++ b/docs/explanation-ways-to-use-delta-engine.md
@@ -25,7 +25,8 @@ deployment for centrally managed annotations.
 | [Pattern 1: Release table contracts](#pattern-1-release-table-contracts-with-the-application)       | Controlled production releases and continuing table estates          | A dedicated job after the application bundle is deployed |
 | [Pattern 2: Reconcile a target table](#pattern-2-reconcile-a-target-table-before-its-etl-runs)      | ETL applications that own a single target table                      | Application startup before transformations or writes     |
 | [Pattern 3: Reuse declarations in ETL](#pattern-3-reuse-table-declarations-throughout-etl-code)     | ETL applications that use declared schema and row identity at write time | Transformation and write code                         |
-| [Pattern 4: Add governance](#pattern-4-add-governance-without-taking-over-the-pipeline)             | Split ownership between data-product, platform, and governance teams | A separate restricted-scope deployment                   |
+| [Pattern 4: Use declarations in tests](#pattern-4-use-table-declarations-in-unit-tests)              | ETL applications that test schemas, required values, and relationships | Unit tests                                            |
+| [Pattern 5: Add governance](#pattern-5-add-governance-without-taking-over-the-pipeline)              | Split ownership between data-product, platform, and governance teams | A separate restricted-scope deployment                   |
 
 ## Pattern 1: Release table contracts with the application
 
@@ -330,7 +331,100 @@ result = result.withColumn("_row_number", F.row_number().over(latest))
 The table contract remains the single definition of the output schema and row
 identity, while the ETL code consumes those facts where it needs them.
 
-## Pattern 4: Add governance without taking over the pipeline
+## Pattern 4: Use table declarations in unit tests
+
+The same `DeltaTable` used by production code can define the schemas, keys,
+and relationships expected by ETL tests. Tests can therefore work from the
+real table contract instead of maintaining separate schemas and column lists.
+
+### Create test DataFrames from declared schemas
+
+Use the declared Spark schema when creating test fixtures:
+
+```python
+source = spark.createDataFrame(
+    [
+        (1, "Alice"),
+        (2, "Bob"),
+    ],
+    schema=to_spark_schema(customers),
+)
+```
+
+This keeps test fixtures aligned with the schema used by the application and
+Unity Catalog.
+
+### Assert the ETL produces the declared schema
+
+Compare the final DataFrame with the same table contract:
+
+```python
+def test_produces_the_declared_schema(source) -> None:
+    # When
+    result = transform(source)
+
+    # Then
+    assert result.schema == to_spark_schema(customers)
+```
+
+A schema change now changes the production contract and the test expectation
+in one place.
+
+### Test non-nullable columns
+
+Use the declaration to derive which columns must always contain a value:
+
+```python
+required_columns = [
+    column.name
+    for column in customers.columns
+    if not column.nullable
+]
+
+for column in required_columns:
+    assert result.filter(F.col(column).isNull()).isEmpty()
+```
+
+### Test primary-key uniqueness
+
+The declared primary key can drive data-level key checks:
+
+```python
+duplicates = (
+    result
+    .groupBy(*customers.primary_key)
+    .count()
+    .filter(F.col("count") > 1)
+)
+
+assert duplicates.isEmpty()
+```
+
+The same primary key is therefore used by the table declaration, production
+ETL logic, and tests rather than being defined independently in each place.
+
+### Test foreign-key relationships
+
+Related table declarations can also drive referential-integrity tests. For a
+foreign key whose local and referenced columns have the same names:
+
+```python
+missing_customers = (
+    orders_result
+    .join(
+        customers_result,
+        on=list(orders.foreign_keys[0].columns),
+        how="left_anti",
+    )
+)
+
+assert missing_customers.isEmpty()
+```
+
+Delta Engine validates that the declared relationship is structurally valid;
+the test verifies that the data produced by the ETL satisfies that relationship.
+
+## Pattern 5: Add governance without taking over the pipeline
 
 Table ownership is not always all-or-nothing. A data-product team may own the
 schema and row production while a platform or governance team owns comments,

--- a/docs/explanation-ways-to-use-delta-engine.md
+++ b/docs/explanation-ways-to-use-delta-engine.md
@@ -357,14 +357,19 @@ in one place.
 Use the declaration to derive which columns must always contain a value:
 
 ```python
-required_columns = [
-    column.name
-    for column in customers.columns
-    if not column.nullable
-]
+def test_produces_no_nulls_in_required_columns(source) -> None:
+    # When
+    result = transform(source)
 
-for column in required_columns:
-    assert result.filter(F.col(column).isNull()).isEmpty()
+    # Then
+    required_columns = [
+        column.name
+        for column in customers.columns
+        if not column.nullable
+    ]
+
+    for column in required_columns:
+        assert result.filter(F.col(column).isNull()).isEmpty()
 ```
 
 ### Test primary-key uniqueness
@@ -372,14 +377,19 @@ for column in required_columns:
 The declared primary key can drive data-level key checks:
 
 ```python
-duplicates = (
-    result
-    .groupBy(*customers.primary_key)
-    .count()
-    .filter(F.col("count") > 1)
-)
+def test_produces_unique_primary_keys(source) -> None:
+    # When
+    result = transform(source)
 
-assert duplicates.isEmpty()
+    # Then
+    duplicates = (
+        result
+        .groupBy(*customers.primary_key)
+        .count()
+        .filter(F.col("count") > 1)
+    )
+
+    assert duplicates.isEmpty()
 ```
 
 ### Test foreign-key relationships
@@ -388,16 +398,20 @@ Related table declarations can also drive referential-integrity tests. For a
 foreign key whose local and referenced columns have the same names:
 
 ```python
-missing_customers = (
-    orders_result
-    .join(
-        customers_result,
-        on=list(orders.foreign_keys[0].columns),
-        how="left_anti",
+def test_produces_valid_customer_references(
+    orders_result,
+    customers_result,
+) -> None:
+    missing_customers = (
+        orders_result
+        .join(
+            customers_result,
+            on=list(orders.foreign_keys[0].columns),
+            how="left_anti",
+        )
     )
-)
 
-assert missing_customers.isEmpty()
+    assert missing_customers.isEmpty()
 ```
 
 ## Pattern 5: Add governance without taking over the pipeline

--- a/docs/explanation-ways-to-use-delta-engine.md
+++ b/docs/explanation-ways-to-use-delta-engine.md
@@ -31,6 +31,14 @@ deployment for centrally managed annotations.
 For most production applications, the clearest pattern is to treat table
 contracts as part of the release.
 
+```mermaid
+flowchart LR
+    PR[Pull request] --> Review[Plan and review changes]
+    Review --> Merge[Merge]
+    Merge --> Release[Deploy and reconcile tables]
+    Release --> Data[Run data workloads]
+```
+
 The declarations, pipeline code, and deployment configuration are versioned and
 released together. The deployment creates or updates the Databricks resources,
 then runs a dedicated job that reconciles the table declarations before the new

--- a/docs/explanation-ways-to-use-delta-engine.md
+++ b/docs/explanation-ways-to-use-delta-engine.md
@@ -33,12 +33,10 @@ contracts as part of the release:
 
 ```mermaid
 flowchart LR
-    PR[Pull request] --> Plan[Read-only Delta Engine plan]
-    Plan --> Review[Review semantic changes and DDL]
+    PR[Pull request] --> Review[Plan and review changes]
     Review --> Merge[Merge]
-    Merge --> Deploy[Deploy application bundle]
-    Deploy --> Sync[Run table-reconciliation job]
-    Sync --> Data[Release or run data workloads]
+    Merge --> Release[Deploy and reconcile tables]
+    Release --> Data[Run data workloads]
 ```
 
 The declarations, pipeline code, and deployment configuration are versioned and
@@ -70,37 +68,6 @@ ALL_TABLES = (
 )
 ```
 
-Prefer an explicit registry to automatically crawling packages for every
-`DeltaTable` object. The registry makes the deployment unit visible in code
-review and avoids importing arbitrary modules merely to discover declarations.
-Adding a table to the registry is an intentional decision to include it in the
-release.
-
-Larger projects can expose one registry per domain:
-
-```python
-# myproject/customers/table_registry.py
-CUSTOMER_TABLES = (
-    customers,
-    customer_preferences,
-)
-
-# myproject/orders/table_registry.py
-ORDER_TABLES = (
-    orders,
-    order_items,
-)
-```
-
-A release can then compose only the domains it owns:
-
-```python
-ALL_TABLES = (
-    *CUSTOMER_TABLES,
-    *ORDER_TABLES,
-)
-```
-
 ### Add a reconciliation entry point
 
 Package the reconciliation logic with the application:
@@ -114,24 +81,12 @@ from pyspark.sql import SparkSession
 from myproject.table_registry import ALL_TABLES
 
 
-def main() -> None:
+def main(spark: SparkSession) -> None:
     """Reconcile every table owned by this release."""
-    spark = SparkSession.getActiveSession()
-
-    if spark is None:
-        spark = SparkSession.builder.getOrCreate()
-
     engine = build_spark_engine(spark)
     report = engine.sync(*ALL_TABLES)
 
     print(render_report(report))
-```
-
-Expose the function as a wheel entry point:
-
-```toml
-[project.scripts]
-sync-tables = "myproject.sync_tables:main"
 ```
 
 The job succeeds only when the sync succeeds. If reading, planning, dependency

--- a/docs/explanation-ways-to-use-delta-engine.md
+++ b/docs/explanation-ways-to-use-delta-engine.md
@@ -228,27 +228,6 @@ Use this pattern when:
 It is particularly straightforward for batch applications because the table
 check becomes part of the application's normal startup sequence.
 
-### When not to use it
-
-Do not call `sync()` inside transformation functions, write helpers,
-`foreachBatch`, or individual streaming micro-batches. Reconcile the table once
-before the ETL or streaming query begins.
-
-For continuous or very high-frequency workloads, release-time reconciliation
-may be a better fit:
-
-```text
-deploy release
-        ↓
-reconcile target table
-        ↓
-start or update continuous pipeline
-```
-
-Do not also enable writer-driven schema evolution for aspects that Delta Engine
-owns. For example, a writer should not use `mergeSchema` to evolve columns while
-Delta Engine is responsible for maintaining the declared column structure.
-
 ## Pattern 3: Add governance without taking over the pipeline
 
 Table ownership is not always all-or-nothing. A data-product team may own the

--- a/docs/explanation-ways-to-use-delta-engine.md
+++ b/docs/explanation-ways-to-use-delta-engine.md
@@ -234,9 +234,7 @@ check becomes part of the application's normal startup sequence.
 
 A `DeltaTable` declaration can also be imported throughout the ETL that
 produces it. Table names, schemas, keys, and column lists then stay in one
-place rather than being repeated across the pipeline. This works especially
-well alongside Pattern 2: reconcile the declaration at startup, then use the
-same object while producing rows.
+place rather than being repeated across the pipeline.
 
 ### Conform output to the declared schema
 
@@ -245,13 +243,6 @@ Use the declaration to cast and order the final DataFrame before writing it:
 ```python
 result = transform(source).to(to_spark_schema(customers))
 ```
-
-Here, `to_spark_schema` is application code that converts a `DeltaTable` into
-a PySpark `StructType`; Delta Engine deliberately does not expose PySpark
-types from its schema API. Keeping that conversion at the Spark edge lets the
-ETL use `customers.columns` as the ordered, authoritative column list. A
-schema change consequently updates both the table contract and the final
-projection together.
 
 ### Build merges from the declared primary key
 
@@ -282,9 +273,6 @@ condition = reduce(
     .execute()
 )
 ```
-
-Only use this pattern for a declaration with a primary key. An empty key has
-no row-identity meaning and cannot form a merge condition.
 
 ### Derive update columns from the declaration
 
@@ -327,9 +315,6 @@ latest = Window.partitionBy(*customers.primary_key).orderBy(
 
 result = result.withColumn("_row_number", F.row_number().over(latest))
 ```
-
-The table contract remains the single definition of the output schema and row
-identity, while the ETL code consumes those facts where it needs them.
 
 ## Pattern 4: Use table declarations in unit tests
 

--- a/docs/explanation-ways-to-use-delta-engine.md
+++ b/docs/explanation-ways-to-use-delta-engine.md
@@ -113,8 +113,6 @@ databricks bundle deploy --target production
 databricks bundle run --target production reconcile_tables
 ```
 
-Do not trigger the new data workload unless reconciliation succeeds.
-
 Bundle deployment and table reconciliation are separate operations. If the
 bundle is deployed but the reconciliation job fails, the new job definitions
 and application artifacts may already exist in the workspace. The release

--- a/docs/index.md
+++ b/docs/index.md
@@ -42,6 +42,13 @@ returns a structured report rather than printing output. The
 [getting-started tutorial](tutorial-getting-started.md) shows the report, diff,
 and exact planned SQL and explains where to keep the declaration.
 
+## Choose how to run it
+
+Delta Engine runs where your release or data workflow calls it. See
+[Ways to use Delta Engine](explanation-ways-to-use-delta-engine.md) for
+release-time reconciliation, ETL readiness checks, and restricted governance
+deployments.
+
 ## Install
 
 ```bash
@@ -81,6 +88,7 @@ for what is and isn't backend-neutral, and
 | You want to…                                   | Read                                                                            |
 | ---------------------------------------------- | ------------------------------------------------------------------------------- |
 | Install the package and sync your first table  | [Installation](installation.md), [Getting started](tutorial-getting-started.md) |
+| Choose a release or workflow pattern           | [Ways to use Delta Engine](explanation-ways-to-use-delta-engine.md)             |
 | Run read-only schema plans in GitHub Actions    | [CLI reference](reference-cli.md)                                              |
 | Understand what a sync does before running one | [How a sync works](explanation-sync-lifecycle.md)                               |
 | Check whether the engine supports something    | [Capabilities and limitations](reference-limitations.md)                        |
@@ -104,6 +112,7 @@ tutorial-getting-started
 explanation-sync-lifecycle
 explanation-safety-model
 explanation-runtime-compatibility
+explanation-ways-to-use-delta-engine
 ```
 
 ```{toctree}


### PR DESCRIPTION
## Summary

- add an explanation page covering release, ETL-readiness, and governance deployment patterns
- add the page to the documentation navigation and landing page
- link the guide from the README before Installation

## Why

Readers need guidance on where Delta Engine belongs in a release or data workflow before choosing an installation path.

## Validation

- `uv run --group docs sphinx-build -W -b html docs /tmp/delta-engine-docs-html`
- `git diff --check`