### PR TITLE
feat: add Spark schema converter

### DIFF
--- a/docs/explanation-architecture.md
+++ b/docs/explanation-architecture.md
@@ -848,6 +848,8 @@ the backend it needs when called:
 
 - `build_spark_engine` imports `delta_engine.adapters.databricks.spark` on
   demand, which requires PySpark.
+- `to_spark_schema` imports the Spark schema converter on demand and translates
+  a backend-neutral desired table to PySpark's native `StructType`.
 - `build_sql_engine` imports `delta_engine.adapters.databricks.warehouse` on
   demand. That backend runs without PySpark entirely, and does not import
   `databricks-sql-connector` either — it only takes a connection the caller

--- a/docs/reference-api.md
+++ b/docs/reference-api.md
@@ -7,8 +7,8 @@ tags:
 
 The public API is reached through two import surfaces: `delta_engine.schema`
 for declaring tables (no PySpark required) and `delta_engine.databricks` for
-building an engine and running syncs. Result and error types are re-exported
-from the top-level `delta_engine` package.
+Spark conversion, building an engine, and running syncs. Result and error
+types are re-exported from the top-level `delta_engine` package.
 
 The full per-module reference is generated from the source tree; see
 {doc}`autoapi/delta_engine/index`. The entry points:
@@ -16,8 +16,26 @@ The full per-module reference is generated from the source tree; see
 | You want to…                  | Start at                                                                |
 | ----------------------------- | ----------------------------------------------------------------------- |
 | Declare tables, columns, keys | {doc}`delta_engine.schema <autoapi/delta_engine/schema/index>`          |
-| Build an engine and sync      | {doc}`delta_engine.databricks <autoapi/delta_engine/databricks/index>`  |
+| Convert for Spark or sync     | {doc}`delta_engine.databricks <autoapi/delta_engine/databricks/index>`  |
 | Inspect results and errors    | {doc}`delta_engine <autoapi/delta_engine/index>` (top-level re-exports) |
+
+## Convert a declaration to a PySpark schema
+
+Use the declaration as the authoritative DataFrame schema without coupling
+the declaration module itself to PySpark:
+
+```python
+from delta_engine.databricks import to_spark_schema
+
+result = transform(source).to(to_spark_schema(customers))
+```
+
+`to_spark_schema()` returns a PySpark `StructType` preserving declared column
+order, name spelling, data types, and nullability. Table and column comments
+and tags remain catalog annotations; they are not copied into Spark field
+metadata. Array elements and map values are nullable because declarations do
+not model their nullability separately. Importing the function does not
+require PySpark, but calling it does.
 
 ## Notes on `DeltaTable`
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -207,6 +207,7 @@ exhaustive = true
 ignore_imports = [
   # Public Databricks facade; implementation remains in adapters.
   "delta_engine.databricks -> delta_engine.adapters.databricks.spark.factory",
+  "delta_engine.databricks -> delta_engine.adapters.databricks.spark.schema",
   "delta_engine.databricks -> delta_engine.adapters.databricks.warehouse.factory",
   "delta_engine.databricks -> delta_engine.adapters.databricks.log_config",
   # Public schema facade: DeltaTable/ForeignKey/Self live in api.delta_table
@@ -235,13 +236,14 @@ source_modules = ["delta_engine.cli"]
 forbidden_modules = ["delta", "pyspark"]
 ignore_imports = [
   # The facade lazily reaches the Spark backend at runtime; the CLI itself
-  # must not. Also ignore the facade's TYPE_CHECKING-only SparkSession import
-  # (never executes; it exists only for build_spark_engine's type hint, but
-  # grimp's static analysis cannot tell that from a real import). Together
-  # these exempt exactly the facade's two static edges to Spark, keeping
+  # must not. Also ignore the facade's TYPE_CHECKING-only PySpark imports
+  # (never execute; they exist only for public type hints, but grimp's static
+  # analysis cannot tell that from real imports). Together these exempt only
+  # the facade's narrow static edges to Spark, keeping
   # indirect-import checking on for every other path (e.g. a future direct
   # cli -> adapters.databricks.spark import).
   "delta_engine.databricks -> delta_engine.adapters.databricks.spark.factory",
+  "delta_engine.databricks -> delta_engine.adapters.databricks.spark.schema",
   "delta_engine.databricks -> pyspark",
 ]
 

--- a/src/delta_engine/adapters/databricks/spark/__init__.py
+++ b/src/delta_engine/adapters/databricks/spark/__init__.py
@@ -1,9 +1,9 @@
 """
 Spark backend for the Databricks adapter.
 
-Everything PySpark-coupled lives here: the reader, the executor, and the
-engine factory. Import concrete modules directly
-(``factory``, ``reader``, ``executor``); the public user-facing
+Everything PySpark-coupled lives here: the reader, executor, engine factory,
+and native schema converter. Import concrete modules directly
+(``factory``, ``reader``, ``executor``, ``schema``); the public user-facing
 entry points live in :mod:`delta_engine.databricks`. This ``__init__`` stays
 empty so importing the package never pulls PySpark.
 """

--- a/src/delta_engine/adapters/databricks/spark/schema.py
+++ b/src/delta_engine/adapters/databricks/spark/schema.py
@@ -1,0 +1,105 @@
+"""Convert backend-neutral desired schemas to native PySpark schemas."""
+
+from pyspark.sql import types as spark_types
+
+from delta_engine.domain.model import (
+    Array,
+    Binary,
+    Boolean,
+    Byte,
+    DataType,
+    Date,
+    Decimal,
+    DesiredTable,
+    Double,
+    Float,
+    Integer,
+    Long,
+    Map,
+    Short,
+    String,
+    Struct,
+    Timestamp,
+    TimestampNtz,
+    Variant,
+)
+
+
+def _to_spark_data_type(data_type: DataType) -> spark_types.DataType:
+    """Return the native PySpark representation of one domain data type."""
+    match data_type:
+        case Integer():
+            return spark_types.IntegerType()
+        case Long():
+            return spark_types.LongType()
+        case Float():
+            return spark_types.FloatType()
+        case Double():
+            return spark_types.DoubleType()
+        case Boolean():
+            return spark_types.BooleanType()
+        case String():
+            return spark_types.StringType()
+        case Date():
+            return spark_types.DateType()
+        case Timestamp():
+            return spark_types.TimestampType()
+        case Decimal(precision, scale):
+            return spark_types.DecimalType(precision, scale)
+        case Array(element):
+            # The declaration model does not express element nullability;
+            # nullable matches Spark SQL's default ARRAY semantics.
+            return spark_types.ArrayType(_to_spark_data_type(element), containsNull=True)
+        case Map(key, value):
+            # Spark map keys are always non-null. The declaration model does
+            # not express value nullability, so use Spark SQL's nullable default.
+            return spark_types.MapType(
+                _to_spark_data_type(key),
+                _to_spark_data_type(value),
+                valueContainsNull=True,
+            )
+        case Byte():
+            return spark_types.ByteType()
+        case Short():
+            return spark_types.ShortType()
+        case Binary():
+            return spark_types.BinaryType()
+        case TimestampNtz():
+            return spark_types.TimestampNTZType()
+        case Variant():
+            return spark_types.VariantType()
+        case Struct(fields):
+            return spark_types.StructType(
+                [
+                    spark_types.StructField(
+                        str(field.name),
+                        _to_spark_data_type(field.data_type),
+                        nullable=field.nullable,
+                    )
+                    for field in fields
+                ]
+            )
+        case _:
+            raise TypeError(f"Unsupported DataType variant: {type(data_type).__name__}")
+
+
+def to_spark_schema(table: DesiredTable) -> spark_types.StructType:
+    """
+    Return the desired table's data schema as a native PySpark ``StructType``.
+
+    Column order, authored name spelling, data type, and nullability are
+    preserved. Catalog annotations such as comments and tags are deliberately
+    excluded: they are table metadata, not part of the DataFrame row schema.
+    Array elements and map values are nullable because declarations do not
+    model their nullability separately.
+    """
+    return spark_types.StructType(
+        [
+            spark_types.StructField(
+                str(column.name),
+                _to_spark_data_type(column.data_type),
+                nullable=column.nullable,
+            )
+            for column in table.columns
+        ]
+    )

--- a/src/delta_engine/databricks.py
+++ b/src/delta_engine/databricks.py
@@ -13,12 +13,14 @@ import logging
 from typing import TYPE_CHECKING, TextIO
 
 from delta_engine.application.engine import Engine
+from delta_engine.application.ports import DesiredTableSource
 
 if TYPE_CHECKING:
     from databricks.sql.client import Connection
     from pyspark.sql import SparkSession
+    from pyspark.sql.types import StructType
 
-__all__ = ["build_spark_engine", "build_sql_engine", "configure_logging"]
+__all__ = ["build_spark_engine", "build_sql_engine", "configure_logging", "to_spark_schema"]
 
 _SPARK_RUNTIME_HINT = (
     "delta-engine's Spark backend requires the PySpark supplied by a supported Databricks Runtime."
@@ -41,6 +43,27 @@ def build_spark_engine(spark: SparkSession) -> Engine:
         raise
 
     return _build_engine(spark)
+
+
+def to_spark_schema(table: DesiredTableSource) -> StructType:
+    """
+    Convert a table declaration to a native PySpark ``StructType``.
+
+    Preserves column order, authored name spelling, data type, and nullability.
+    Comments and tags remain catalog metadata and are not copied into Spark
+    field metadata. Array elements and map values are nullable because Delta
+    Engine declarations do not model their nullability separately.
+    """
+    try:
+        from delta_engine.adapters.databricks.spark.schema import (
+            to_spark_schema as _to_spark_schema,
+        )
+    except ModuleNotFoundError as error:
+        if _is_pyspark_import_error(error):
+            raise RuntimeError(_SPARK_RUNTIME_HINT) from error
+        raise
+
+    return _to_spark_schema(table.to_desired_table())
 
 
 def build_sql_engine(connection: Connection) -> Engine:

--- a/tests/adapters/databricks/spark/test_schema.py
+++ b/tests/adapters/databricks/spark/test_schema.py
@@ -60,12 +60,18 @@ def _table(*columns: DesiredColumn) -> DesiredTable:
     ],
 )
 def test_converts_each_scalar_data_type(data_type: DataType, spark_type: T.DataType) -> None:
-    schema = to_spark_schema(_table(DesiredColumn("value", data_type)))
+    # Given a desired table containing one modeled scalar type
+    table = _table(DesiredColumn("value", data_type))
 
+    # When converting its row schema to PySpark
+    schema = to_spark_schema(table)
+
+    # Then the field carries the corresponding native Spark type
     assert schema == T.StructType([T.StructField("value", spark_type, nullable=True)])
 
 
 def test_preserves_nested_structure_order_names_and_nullability() -> None:
+    # Given ordered columns with authored casing, nested types, nullability, and annotations
     table = _table(
         DesiredColumn("ID", Integer(), nullable=False, comment="catalog annotation"),
         DesiredColumn(
@@ -81,8 +87,10 @@ def test_preserves_nested_structure_order_names_and_nullability() -> None:
         ),
     )
 
+    # When converting the desired row schema to PySpark
     schema = to_spark_schema(table)
 
+    # Then row structure is preserved while catalog annotations stay out of field metadata
     assert schema == T.StructType(
         [
             T.StructField("ID", T.IntegerType(), nullable=False),
@@ -111,6 +119,7 @@ def test_preserves_nested_structure_order_names_and_nullability() -> None:
 
 
 def test_public_converter_accepts_a_delta_table_declaration() -> None:
+    # Given a public DeltaTable declaration
     table = DeltaTable(
         catalog="catalog",
         schema="schema",
@@ -118,7 +127,11 @@ def test_public_converter_accepts_a_delta_table_declaration() -> None:
         columns=[Column("id", Long(), nullable=False), Column("name", String())],
     )
 
-    assert public_to_spark_schema(table) == T.StructType(
+    # When converting it through the public Databricks facade
+    schema = public_to_spark_schema(table)
+
+    # Then the facade returns the declaration's native Spark row schema
+    assert schema == T.StructType(
         [
             T.StructField("id", T.LongType(), nullable=False),
             T.StructField("name", T.StringType(), nullable=True),
@@ -127,14 +140,22 @@ def test_public_converter_accepts_a_delta_table_declaration() -> None:
 
 
 def test_rejects_an_unmapped_data_type() -> None:
+    # Given a desired table containing a DataType outside the closed modeled set
     class CustomType(DataType):
         pass
 
-    with pytest.raises(TypeError, match="Unsupported DataType variant: CustomType"):
-        to_spark_schema(_table(DesiredColumn("value", CustomType())))
+    table = _table(DesiredColumn("value", CustomType()))
+
+    # When converting the desired row schema to PySpark
+    with pytest.raises(TypeError) as raised:
+        to_spark_schema(table)
+
+    # Then conversion fails explicitly at the unsupported type
+    assert str(raised.value) == "Unsupported DataType variant: CustomType"
 
 
 def test_public_converter_explains_when_pyspark_is_unavailable() -> None:
+    # Given a fresh interpreter where PySpark cannot be imported
     program = """
 import sys
 
@@ -152,7 +173,9 @@ else:
     raise AssertionError("conversion unexpectedly succeeded without PySpark")
 """
 
+    # When calling the public converter in that interpreter
     result = subprocess.run([sys.executable, "-c", program], capture_output=True, text=True)
 
+    # Then the failure explains the supported runtime requirement
     assert result.returncode == 0, result.stderr
     assert "requires the PySpark supplied by a supported Databricks Runtime" in result.stdout

--- a/tests/adapters/databricks/spark/test_schema.py
+++ b/tests/adapters/databricks/spark/test_schema.py
@@ -1,0 +1,158 @@
+import subprocess
+import sys
+
+import pyspark.sql.types as T
+import pytest
+
+from delta_engine.adapters.databricks.spark.schema import to_spark_schema
+from delta_engine.databricks import to_spark_schema as public_to_spark_schema
+from delta_engine.domain.model import (
+    Array,
+    Binary,
+    Boolean,
+    Byte,
+    DataType,
+    Date,
+    Decimal,
+    DesiredColumn,
+    DesiredTable,
+    Double,
+    Float,
+    Integer,
+    Long,
+    Map,
+    QualifiedName,
+    Short,
+    String,
+    Struct,
+    StructField,
+    Timestamp,
+    TimestampNtz,
+    Variant,
+)
+from delta_engine.schema import Column, DeltaTable
+
+
+def _table(*columns: DesiredColumn) -> DesiredTable:
+    return DesiredTable(
+        qualified_name=QualifiedName("catalog", "schema", "table"),
+        columns=columns,
+    )
+
+
+@pytest.mark.parametrize(
+    ("data_type", "spark_type"),
+    [
+        (Integer(), T.IntegerType()),
+        (Long(), T.LongType()),
+        (Float(), T.FloatType()),
+        (Double(), T.DoubleType()),
+        (Boolean(), T.BooleanType()),
+        (String(), T.StringType()),
+        (Date(), T.DateType()),
+        (Timestamp(), T.TimestampType()),
+        (Decimal(20, 4), T.DecimalType(20, 4)),
+        (Byte(), T.ByteType()),
+        (Short(), T.ShortType()),
+        (Binary(), T.BinaryType()),
+        (TimestampNtz(), T.TimestampNTZType()),
+        (Variant(), T.VariantType()),
+    ],
+)
+def test_converts_each_scalar_data_type(data_type: DataType, spark_type: T.DataType) -> None:
+    schema = to_spark_schema(_table(DesiredColumn("value", data_type)))
+
+    assert schema == T.StructType([T.StructField("value", spark_type, nullable=True)])
+
+
+def test_preserves_nested_structure_order_names_and_nullability() -> None:
+    table = _table(
+        DesiredColumn("ID", Integer(), nullable=False, comment="catalog annotation"),
+        DesiredColumn(
+            "payload",
+            Struct(
+                (
+                    StructField("label", String(), nullable=False),
+                    StructField("scores", Array(Decimal(8, 2))),
+                    StructField("lookup", Map(String(), Long())),
+                )
+            ),
+            tags={"classification": "internal"},
+        ),
+    )
+
+    schema = to_spark_schema(table)
+
+    assert schema == T.StructType(
+        [
+            T.StructField("ID", T.IntegerType(), nullable=False),
+            T.StructField(
+                "payload",
+                T.StructType(
+                    [
+                        T.StructField("label", T.StringType(), nullable=False),
+                        T.StructField(
+                            "scores",
+                            T.ArrayType(T.DecimalType(8, 2), containsNull=True),
+                            nullable=True,
+                        ),
+                        T.StructField(
+                            "lookup",
+                            T.MapType(T.StringType(), T.LongType(), valueContainsNull=True),
+                            nullable=True,
+                        ),
+                    ]
+                ),
+                nullable=True,
+            ),
+        ]
+    )
+    assert all(field.metadata == {} for field in schema.fields)
+
+
+def test_public_converter_accepts_a_delta_table_declaration() -> None:
+    table = DeltaTable(
+        catalog="catalog",
+        schema="schema",
+        name="table",
+        columns=[Column("id", Long(), nullable=False), Column("name", String())],
+    )
+
+    assert public_to_spark_schema(table) == T.StructType(
+        [
+            T.StructField("id", T.LongType(), nullable=False),
+            T.StructField("name", T.StringType(), nullable=True),
+        ]
+    )
+
+
+def test_rejects_an_unmapped_data_type() -> None:
+    class CustomType(DataType):
+        pass
+
+    with pytest.raises(TypeError, match="Unsupported DataType variant: CustomType"):
+        to_spark_schema(_table(DesiredColumn("value", CustomType())))
+
+
+def test_public_converter_explains_when_pyspark_is_unavailable() -> None:
+    program = """
+import sys
+
+sys.modules["pyspark"] = None
+
+from delta_engine.databricks import to_spark_schema
+from delta_engine.schema import Column, DeltaTable, Integer
+
+table = DeltaTable("catalog", "schema", "table", [Column("id", Integer())])
+try:
+    to_spark_schema(table)
+except RuntimeError as error:
+    print(error)
+else:
+    raise AssertionError("conversion unexpectedly succeeded without PySpark")
+"""
+
+    result = subprocess.run([sys.executable, "-c", program], capture_output=True, text=True)
+
+    assert result.returncode == 0, result.stderr
+    assert "requires the PySpark supplied by a supported Databricks Runtime" in result.stdout

--- a/tests/test_public_imports.py
+++ b/tests/test_public_imports.py
@@ -112,6 +112,7 @@ def test_databricks_import_path_exposes_backend_entry_points():
         "build_spark_engine",
         "build_sql_engine",
         "configure_logging",
+        "to_spark_schema",
     }
 
 
@@ -124,7 +125,7 @@ def test_preferred_pure_imports_and_databricks_module_import_do_not_require_pysp
         "    Engine, Failure, SyncFailedError, SyncReport, TableChangeState, TableRunStatus,\n"
         ")\n"
         "from delta_engine.databricks import (\n"
-        "    build_spark_engine, build_sql_engine, configure_logging,\n"
+        "    build_spark_engine, build_sql_engine, configure_logging, to_spark_schema,\n"
         ")\n"
         "print('ok')\n"
     )

--- a/tests/test_public_imports.py
+++ b/tests/test_public_imports.py
@@ -107,8 +107,11 @@ def test_api_package_does_not_export_the_user_schema_surface():
 def test_databricks_import_path_exposes_backend_entry_points():
     # Given the preferred user-facing Databricks import path
 
+    # When inspecting its declared public surface
+    exports = set(databricks.__all__)
+
     # Then it exposes exactly the supported backend entry points
-    assert set(databricks.__all__) == {
+    assert exports == {
         "build_spark_engine",
         "build_sql_engine",
         "configure_logging",


### PR DESCRIPTION
## Summary

- add `delta_engine.databricks.to_spark_schema()` as a lazy public Spark interop helper
- keep native PySpark conversion inside the Spark adapter while preserving column order, spelling, types, and modeled nullability
- document metadata and array/map nullability semantics and preserve the dependency-free declaration/import surface
- cover every modeled scalar type, nested schemas, unsupported types, public imports, and missing-PySpark behavior

## Why

ETL code can now reuse a `DeltaTable` declaration as its authoritative DataFrame schema without adding PySpark to `DeltaTable` or leaking Spark types into the backend-neutral schema API.

## Validation

- `uv run pytest` — 1,245 passed, 78 deselected; 97.15% coverage
- `uv run ruff check src tests`
- `uv run ruff format --check src tests`
- `uv run mypy src`
- `uv run lint-imports` — all 7 contracts kept
- `uv run --group docs sphinx-build -W -b html docs <temporary-output>`